### PR TITLE
Embed all templates in a config

### DIFF
--- a/enmasse-template.jsonnet
+++ b/enmasse-template.jsonnet
@@ -1,6 +1,8 @@
 local template = import "include/enmasse-template.jsonnet";
+local kubernetes = import "include/enmasse-kubernetes.jsonnet";
 {
     "enmasse-template.json": template.generate(false, false, true, false),
+    "enmasse-kubernetes.json": kubernetes.generate(false, false, true, false),
     "tls-enmasse-template.json": template.generate(true, false, true, false),
     "enmasse-template-full.json": template.generate(false, false, false, false),
     "tls-enmasse-template-full.json": template.generate(true, false, false, false),

--- a/generated/enmasse-kubernetes.yaml
+++ b/generated/enmasse-kubernetes.yaml
@@ -1,11 +1,6 @@
 ---
 apiVersion: v1
-kind: Template
-metadata:
-  labels:
-    app: enmasse
-  name: enmasse-infra
-objects:
+items:
 - apiVersion: v1
   data:
     enmasse-instance-infra.json: '{"apiVersion": "v1", "kind": "Template", "metadata":
@@ -103,43 +98,21 @@ objects:
       "name": "admin"}, "spec": {"ports": [{"name": "ragent", "port": 55672}, {"name":
       "configuration", "port": 5672}, {"name": "queue-scheduler", "port": 55667},
       {"name": "console-ws", "port": 56720}, {"name": "console-http", "port": 8080}],
-      "selector": {"instance": "${INSTANCE}", "name": "admin"}}}, {"apiVersion": "v1",
-      "kind": "Service", "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"},
-      "name": "amqp-kafka-bridge"}, "spec": {"ports": [{"name": "amqp", "port": 5672,
-      "protocol": "TCP", "targetPort": 5672}], "selector": {"capability": "bridge",
-      "instance": "${INSTANCE}"}}}, {"apiVersion": "extensions/v1beta1", "kind": "Deployment",
-      "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}", "name":
-      "amqp-kafka-bridge"}, "name": "amqp-kafka-bridge"}, "spec": {"replicas": 1,
-      "template": {"metadata": {"labels": {"app": "enmasse", "capability": "bridge",
-      "instance": "${INSTANCE}", "name": "amqp-kafka-bridge"}}, "spec": {"containers":
-      [{"env": [{"name": "KAFKA_BOOTSTRAP_SERVERS", "value": "${KAFKA_BOOTSTRAP_SERVERS}"}],
-      "image": "${AMQP_KAFKA_BRIDGE_REPO}:latest", "name": "amqp-kafka-bridge", "resources":
-      {"limits": {"memory": "512Mi"}, "requests": {"memory": "512Mi"}}}]}}}}, {"apiVersion":
-      "v1", "kind": "Route", "metadata": {"labels": {"app": "enmasse", "instance":
-      "${INSTANCE}"}, "name": "messaging"}, "spec": {"host": "${MESSAGING_HOSTNAME}",
-      "port": {"targetPort": "amqps"}, "tls": {"termination": "passthrough"}, "to":
-      {"kind": "Service", "name": "messaging", "weight": 100}}}, {"apiVersion": "v1",
-      "kind": "Route", "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"},
-      "name": "mqtt"}, "spec": {"host": "${MQTT_GATEWAY_HOSTNAME}", "port": {"targetPort":
-      "secure-mqtt"}, "tls": {"termination": "passthrough"}, "to": {"kind": "Service",
-      "name": "mqtt", "weight": 100}}}, {"apiVersion": "v1", "kind": "Route", "metadata":
-      {"labels": {"app": "enmasse"}, "name": "console"}, "spec": {"host": "${CONSOLE_HOSTNAME}",
-      "port": {"targetPort": "console-http"}, "to": {"kind": "Service", "name": "admin"}}}],
-      "parameters": [{"description": "The image to use for the router", "name": "ROUTER_REPO",
-      "value": "enmasseproject/qdrouterd"}, {"description": "The link capacity setting
-      for router", "name": "ROUTER_LINK_CAPACITY", "value": "50"}, {"description":
-      "The image to use for the configuration service", "name": "CONFIGSERV_REPO",
-      "value": "enmasseproject/configserv"}, {"description": "The docker image to
-      use for the queue scheduler", "name": "QUEUE_SCHEDULER_REPO", "value": "enmasseproject/queue-scheduler"},
-      {"description": "The image to use for the router agent", "name": "RAGENT_REPO",
-      "value": "enmasseproject/ragent"}, {"description": "The image to use for the
-      subscription services", "name": "SUBSERV_REPO", "value": "enmasseproject/subserv"},
-      {"description": "The image to use for the console", "name": "CONSOLE_REPO",
-      "value": "enmasseproject/console"}, {"description": "The hostname to use for
-      the exposed route for messaging (TLS only)", "name": "MESSAGING_HOSTNAME"},
-      {"description": "The image to use for the MQTT gateway", "name": "MQTT_GATEWAY_REPO",
-      "value": "enmasseproject/mqtt-gateway"}, {"description": "The hostname to use
-      for the exposed route for MQTT (TLS only)", "name": "MQTT_GATEWAY_HOSTNAME"},
+      "selector": {"instance": "${INSTANCE}", "name": "admin"}}}], "parameters": [{"description":
+      "The image to use for the router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"},
+      {"description": "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY",
+      "value": "50"}, {"description": "The image to use for the configuration service",
+      "name": "CONFIGSERV_REPO", "value": "enmasseproject/configserv"}, {"description":
+      "The docker image to use for the queue scheduler", "name": "QUEUE_SCHEDULER_REPO",
+      "value": "enmasseproject/queue-scheduler"}, {"description": "The image to use
+      for the router agent", "name": "RAGENT_REPO", "value": "enmasseproject/ragent"},
+      {"description": "The image to use for the subscription services", "name": "SUBSERV_REPO",
+      "value": "enmasseproject/subserv"}, {"description": "The image to use for the
+      console", "name": "CONSOLE_REPO", "value": "enmasseproject/console"}, {"description":
+      "The hostname to use for the exposed route for messaging (TLS only)", "name":
+      "MESSAGING_HOSTNAME"}, {"description": "The image to use for the MQTT gateway",
+      "name": "MQTT_GATEWAY_REPO", "value": "enmasseproject/mqtt-gateway"}, {"description":
+      "The hostname to use for the exposed route for MQTT (TLS only)", "name": "MQTT_GATEWAY_HOSTNAME"},
       {"description": "The hostname to use for the exposed route for the messaging
       console", "name": "CONSOLE_HOSTNAME"}, {"description": "The image to use for
       the MQTT LWT", "name": "MQTT_LWT_REPO", "value": "enmasseproject/mqtt-lwt"},
@@ -299,43 +272,21 @@ objects:
       "name": "admin"}, "spec": {"ports": [{"name": "ragent", "port": 55672}, {"name":
       "configuration", "port": 5672}, {"name": "queue-scheduler", "port": 55667},
       {"name": "console-ws", "port": 56720}, {"name": "console-http", "port": 8080}],
-      "selector": {"instance": "${INSTANCE}", "name": "admin"}}}, {"apiVersion": "v1",
-      "kind": "Service", "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"},
-      "name": "amqp-kafka-bridge"}, "spec": {"ports": [{"name": "amqp", "port": 5672,
-      "protocol": "TCP", "targetPort": 5672}], "selector": {"capability": "bridge",
-      "instance": "${INSTANCE}"}}}, {"apiVersion": "extensions/v1beta1", "kind": "Deployment",
-      "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}", "name":
-      "amqp-kafka-bridge"}, "name": "amqp-kafka-bridge"}, "spec": {"replicas": 1,
-      "template": {"metadata": {"labels": {"app": "enmasse", "capability": "bridge",
-      "instance": "${INSTANCE}", "name": "amqp-kafka-bridge"}}, "spec": {"containers":
-      [{"env": [{"name": "KAFKA_BOOTSTRAP_SERVERS", "value": "${KAFKA_BOOTSTRAP_SERVERS}"}],
-      "image": "${AMQP_KAFKA_BRIDGE_REPO}:latest", "name": "amqp-kafka-bridge", "resources":
-      {"limits": {"memory": "512Mi"}, "requests": {"memory": "512Mi"}}}]}}}}, {"apiVersion":
-      "v1", "kind": "Route", "metadata": {"labels": {"app": "enmasse", "instance":
-      "${INSTANCE}"}, "name": "messaging"}, "spec": {"host": "${MESSAGING_HOSTNAME}",
-      "port": {"targetPort": "amqps"}, "tls": {"termination": "passthrough"}, "to":
-      {"kind": "Service", "name": "messaging", "weight": 100}}}, {"apiVersion": "v1",
-      "kind": "Route", "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"},
-      "name": "mqtt"}, "spec": {"host": "${MQTT_GATEWAY_HOSTNAME}", "port": {"targetPort":
-      "secure-mqtt"}, "tls": {"termination": "passthrough"}, "to": {"kind": "Service",
-      "name": "mqtt", "weight": 100}}}, {"apiVersion": "v1", "kind": "Route", "metadata":
-      {"labels": {"app": "enmasse"}, "name": "console"}, "spec": {"host": "${CONSOLE_HOSTNAME}",
-      "port": {"targetPort": "console-http"}, "to": {"kind": "Service", "name": "admin"}}}],
-      "parameters": [{"description": "The image to use for the router", "name": "ROUTER_REPO",
-      "value": "enmasseproject/qdrouterd"}, {"description": "The link capacity setting
-      for router", "name": "ROUTER_LINK_CAPACITY", "value": "50"}, {"description":
-      "The image to use for the configuration service", "name": "CONFIGSERV_REPO",
-      "value": "enmasseproject/configserv"}, {"description": "The docker image to
-      use for the queue scheduler", "name": "QUEUE_SCHEDULER_REPO", "value": "enmasseproject/queue-scheduler"},
-      {"description": "The image to use for the router agent", "name": "RAGENT_REPO",
-      "value": "enmasseproject/ragent"}, {"description": "The image to use for the
-      subscription services", "name": "SUBSERV_REPO", "value": "enmasseproject/subserv"},
-      {"description": "The image to use for the console", "name": "CONSOLE_REPO",
-      "value": "enmasseproject/console"}, {"description": "The hostname to use for
-      the exposed route for messaging (TLS only)", "name": "MESSAGING_HOSTNAME"},
-      {"description": "The image to use for the MQTT gateway", "name": "MQTT_GATEWAY_REPO",
-      "value": "enmasseproject/mqtt-gateway"}, {"description": "The hostname to use
-      for the exposed route for MQTT (TLS only)", "name": "MQTT_GATEWAY_HOSTNAME"},
+      "selector": {"instance": "${INSTANCE}", "name": "admin"}}}], "parameters": [{"description":
+      "The image to use for the router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"},
+      {"description": "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY",
+      "value": "50"}, {"description": "The image to use for the configuration service",
+      "name": "CONFIGSERV_REPO", "value": "enmasseproject/configserv"}, {"description":
+      "The docker image to use for the queue scheduler", "name": "QUEUE_SCHEDULER_REPO",
+      "value": "enmasseproject/queue-scheduler"}, {"description": "The image to use
+      for the router agent", "name": "RAGENT_REPO", "value": "enmasseproject/ragent"},
+      {"description": "The image to use for the subscription services", "name": "SUBSERV_REPO",
+      "value": "enmasseproject/subserv"}, {"description": "The image to use for the
+      console", "name": "CONSOLE_REPO", "value": "enmasseproject/console"}, {"description":
+      "The hostname to use for the exposed route for messaging (TLS only)", "name":
+      "MESSAGING_HOSTNAME"}, {"description": "The image to use for the MQTT gateway",
+      "name": "MQTT_GATEWAY_REPO", "value": "enmasseproject/mqtt-gateway"}, {"description":
+      "The hostname to use for the exposed route for MQTT (TLS only)", "name": "MQTT_GATEWAY_HOSTNAME"},
       {"description": "The hostname to use for the exposed route for the messaging
       console", "name": "CONSOLE_HOSTNAME"}, {"description": "The image to use for
       the MQTT LWT", "name": "MQTT_LWT_REPO", "value": "enmasseproject/mqtt-lwt"},
@@ -585,10 +536,10 @@ objects:
         containers:
         - env:
           - name: MULTIINSTANCE
-            value: "${MULTIINSTANCE}"
+            value: 'false'
           - name: TLS
             value: 'false'
-          image: "${ADDRESS_CONTROLLER_REPO}:latest"
+          image: enmasseproject/address-controller:latest
           livenessProbe:
             tcpSocket:
               port: amqp
@@ -632,20 +583,6 @@ objects:
     selector:
       name: address-controller
 - apiVersion: v1
-  kind: Route
-  metadata:
-    labels:
-      app: enmasse
-    name: restapi
-  spec:
-    host: "${RESTAPI_HOSTNAME}"
-    path: "/v3"
-    port:
-      targetPort: http
-    to:
-      kind: Service
-      name: address-controller
-- apiVersion: v1
   data:
     json: '[{"description": "Simple in memory queue", "name": "vanilla-queue", "templateName":
       "queue-inmemory", "type": "queue", "uuid": "83fc2eaf-d968-4f7d-bbcd-da697ca9232c"},
@@ -668,13 +605,4 @@ objects:
     labels:
       app: enmasse
     name: flavor
-parameters:
-- description: The hostname to use for the exposed route for the REST API
-  name: RESTAPI_HOSTNAME
-- description: If set to true, the address controller will deploy infrastructure to
-    separate namespaces
-  name: MULTIINSTANCE
-  value: 'false'
-- description: The docker image to use for the address controller
-  name: ADDRESS_CONTROLLER_REPO
-  value: enmasseproject/address-controller
+kind: List

--- a/generated/enmasse-template-with-kafka.yaml
+++ b/generated/enmasse-template-with-kafka.yaml
@@ -7,876 +7,566 @@ metadata:
   name: enmasse-infra
 objects:
 - apiVersion: v1
-  kind: Template
+  data:
+    enmasse-instance-infra.json: '{"apiVersion": "v1", "kind": "Template", "metadata":
+      {"labels": {"app": "enmasse"}, "name": "tls-enmasse-instance-infra"}, "objects":
+      [{"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels":
+      {"app": "enmasse", "instance": "${INSTANCE}", "name": "qdrouterd"}, "name":
+      "qdrouterd"}, "spec": {"replicas": 1, "template": {"metadata": {"labels": {"app":
+      "enmasse", "capability": "router", "instance": "${INSTANCE}", "name": "qdrouterd"}},
+      "spec": {"containers": [{"env": [{"name": "LINK_CAPACITY", "value": "${ROUTER_LINK_CAPACITY}"}],
+      "image": "${ROUTER_REPO}:latest", "livenessProbe": {"tcpSocket": {"port": "amqp"}},
+      "name": "router", "ports": [{"containerPort": 5672, "name": "amqp", "protocol":
+      "TCP"}, {"containerPort": 55673, "name": "internal", "protocol": "TCP"}, {"containerPort":
+      5671, "name": "amqps", "protocol": "TCP"}], "volumeMounts": [{"mountPath": "/etc/qpid-dispatch/ssl",
+      "name": "ssl-certs", "readOnly": true}]}], "volumes": [{"name": "ssl-certs",
+      "secret": {"secretName": "qdrouterd-certs"}}]}}}}, {"apiVersion": "v1", "kind":
+      "Service", "metadata": {"annotations": {"service.alpha.openshift.io/dependencies":
+      "[{\"kind\": \"Service\", \"name\": \"admin\", \"namespace\": \"\"}, {\"kind\":
+      \"Service\", \"name\": \"subscription\", \"namespace\": \"\"}, {\"kind\": \"Service\",
+      \"name\": \"mqtt\", \"namespace\": \"\"}]", "service.alpha.openshift.io/infrastructure":
+      "true"}, "labels": {"app": "enmasse", "instance": "${INSTANCE}"}, "name": "messaging"},
+      "spec": {"ports": [{"name": "amqp", "port": 5672, "protocol": "TCP", "targetPort":
+      5672}, {"name": "amqps", "port": 5671, "protocol": "TCP", "targetPort": 5671},
+      {"name": "internal", "port": 55673, "protocol": "TCP", "targetPort": 55673}],
+      "selector": {"capability": "router", "instance": "${INSTANCE}"}}}, {"apiVersion":
+      "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels": {"app": "enmasse",
+      "instance": "${INSTANCE}", "name": "subserv"}, "name": "subserv"}, "spec": {"replicas":
+      1, "template": {"metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}",
+      "name": "subserv"}}, "spec": {"containers": [{"env": [ ], "image": "${SUBSERV_REPO}:latest",
+      "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name": "subserv", "ports":
+      [{"containerPort": 5672, "name": "amqp", "protocol": "TCP"}], "resources": {"limits":
+      {"memory": "64Mi"}, "requests": {"memory": "64Mi"}}}]}}}}, {"apiVersion": "v1",
+      "kind": "Service", "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"},
+      "name": "subscription"}, "spec": {"ports": [{"name": "amqp", "port": 5672, "protocol":
+      "TCP", "targetPort": 5672}], "selector": {"instance": "${INSTANCE}", "name":
+      "subserv"}}}, {"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata":
+      {"labels": {"app": "enmasse", "instance": "${INSTANCE}", "name": "mqtt-gateway"},
+      "name": "mqtt-gateway"}, "spec": {"replicas": 1, "template": {"metadata": {"labels":
+      {"app": "enmasse", "instance": "${INSTANCE}", "name": "mqtt-gateway"}}, "spec":
+      {"containers": [{"image": "${MQTT_GATEWAY_REPO}:latest", "livenessProbe": {"initialDelaySeconds":
+      60, "tcpSocket": {"port": "secure-mqtt"}}, "name": "mqtt-gateway-tls", "ports":
+      [{"containerPort": 8883, "name": "secure-mqtt", "protocol": "TCP"}], "volumeMounts":
+      [{"mountPath": "/etc/mqtt-gateway/ssl", "name": "ssl-certs", "readOnly": true}]},
+      {"image": "${MQTT_GATEWAY_REPO}:latest", "livenessProbe": {"initialDelaySeconds":
+      60, "tcpSocket": {"port": "mqtt"}}, "name": "mqtt-gateway", "ports": [{"containerPort":
+      1883, "name": "mqtt", "protocol": "TCP"}]}], "volumes": [{"name": "ssl-certs",
+      "secret": {"secretName": "mqtt-certs"}}]}}}}, {"apiVersion": "v1", "kind": "Service",
+      "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"}, "name":
+      "mqtt"}, "spec": {"ports": [{"name": "mqtt", "port": 1883, "protocol": "TCP",
+      "targetPort": 1883}, {"name": "secure-mqtt", "port": 8883, "protocol": "TCP",
+      "targetPort": 8883}], "selector": {"instance": "${INSTANCE}", "name": "mqtt-gateway"}}},
+      {"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels":
+      {"app": "enmasse", "instance": "${INSTANCE}", "name": "mqtt-lwt"}, "name": "mqtt-lwt"},
+      "spec": {"replicas": 1, "template": {"metadata": {"labels": {"app": "enmasse",
+      "instance": "${INSTANCE}", "name": "mqtt-lwt"}}, "spec": {"containers": [{"image":
+      "${MQTT_LWT_REPO}:latest", "name": "mqtt-lwt"}]}}}}, {"apiVersion": "v1", "kind":
+      "Route", "metadata": {"labels": {"app": "enmasse"}, "name": "console"}, "spec":
+      {"host": "${CONSOLE_HOSTNAME}", "port": {"targetPort": "console-http"}, "to":
+      {"kind": "Service", "name": "admin"}}}, {"apiVersion": "v1", "data": {"hawkular-openshift-agent":
+      "{\"endpoints\": [{\"collection_interval\": \"60s\", \"metrics\": [{\"id\":
+      \"broker.threadCount\", \"name\": \"java.lang:type=Threading#ThreadCount\",
+      \"tags\": {\"messagingComponent\": \"broker\", \"messagingMetricType\": \"threadCount\"},
+      \"type\": \"counter\"}, {\"id\": \"broker.memoryHeapUsage\", \"name\": \"java.lang:type=Memory#HeapMemoryUsage#used\",
+      \"tags\": {\"messagingComponent\": \"broker\", \"messagingMetricType\": \"heapUsage\"},
+      \"type\": \"gauge\"}, {\"description\": \"Queue depth for ${address}\", \"id\":
+      \"${address}.${queue}.${broker}.queueDepth\", \"name\": \"org.apache.activemq.artemis:address=*,broker=*,component=addresses,queue=*,routing-type=*,subcomponent=queues#MessageCount\",
+      \"tags\": {\"messagingAddress\": \"${address}\", \"messagingBroker\": \"{broker}\",
+      \"messagingMetricType\": \"queueDepth\", \"messagingQueue\": \"${queue}\"},
+      \"type\": \"gauge\"}, {\"description\": \"Number of consumers for ${address}\",
+      \"id\": \"${address}.${queue}.${broker}.numConsumers\", \"name\": \"org.apache.activemq.artemis:address=*,broker=*,component=addresses,queue=*,routing-type=*,subcomponent=queues#ConsumerCount\",
+      \"tags\": {\"messagingAddress\": \"${address}\", \"messagingBroker\": \"{broker}\",
+      \"messagingMetricType\": \"numConsumers\", \"messagingQueue\": \"${queue}\"},
+      \"type\": \"gauge\"}], \"path\": \"/jolokia/\", \"port\": 8161, \"protocol\":
+      \"http\", \"type\": \"jolokia\"}]}"}, "kind": "ConfigMap", "metadata": {"name":
+      "hawkular-broker-config"}}, {"apiVersion": "extensions/v1beta1", "kind": "Deployment",
+      "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}", "name":
+      "admin"}, "name": "admin"}, "spec": {"replicas": 1, "template": {"metadata":
+      {"labels": {"app": "enmasse", "instance": "${INSTANCE}", "name": "admin"}},
+      "spec": {"containers": [{"env": [{"name": "CONFIGURATION_SERVICE_HOST", "value":
+      "localhost"}, {"name": "CONFIGURATION_SERVICE_PORT", "value": "5672"}], "image":
+      "${RAGENT_REPO}:latest", "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name":
+      "ragent", "ports": [{"containerPort": 55672, "name": "amqp", "protocol": "TCP"}],
+      "resources": {"limits": {"memory": "64Mi"}, "requests": {"memory": "64Mi"}}},
+      {"env": [{"name": "CONFIGURATION_SERVICE_HOST", "value": "localhost"}, {"name":
+      "CONFIGURATION_SERVICE_PORT", "value": "5672"}], "image": "${QUEUE_SCHEDULER_REPO}:latest",
+      "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name": "queue-scheduler",
+      "ports": [{"containerPort": 55667, "name": "amqp", "protocol": "TCP"}], "resources":
+      {"limits": {"memory": "128Mi"}, "requests": {"memory": "128Mi"}}}, {"env": [{"name":
+      "CONFIGURATION_SERVICE_HOST", "value": "localhost"}, {"name": "CONFIGURATION_SERVICE_PORT",
+      "value": "5672"}], "image": "${CONSOLE_REPO}:latest", "livenessProbe": {"tcpSocket":
+      {"port": "http"}}, "name": "console", "ports": [{"containerPort": 8080, "name":
+      "http", "protocol": "TCP"}, {"containerPort": 56720, "name": "amqp-ws", "protocol":
+      "TCP"}], "resources": {"limits": {"memory": "64Mi"}, "requests": {"memory":
+      "64Mi"}}}, {"env": [ ], "image": "${CONFIGSERV_REPO}:latest", "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "configserv", "ports": [{"containerPort":
+      5672, "name": "amqp", "protocol": "TCP"}], "resources": {"limits": {"memory":
+      "256Mi"}, "requests": {"memory": "256Mi"}}}]}}}}, {"apiVersion": "v1", "kind":
+      "Service", "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"},
+      "name": "admin"}, "spec": {"ports": [{"name": "ragent", "port": 55672}, {"name":
+      "configuration", "port": 5672}, {"name": "queue-scheduler", "port": 55667},
+      {"name": "console-ws", "port": 56720}, {"name": "console-http", "port": 8080}],
+      "selector": {"instance": "${INSTANCE}", "name": "admin"}}}, {"apiVersion": "v1",
+      "kind": "Service", "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"},
+      "name": "amqp-kafka-bridge"}, "spec": {"ports": [{"name": "amqp", "port": 5672,
+      "protocol": "TCP", "targetPort": 5672}], "selector": {"capability": "bridge",
+      "instance": "${INSTANCE}"}}}, {"apiVersion": "extensions/v1beta1", "kind": "Deployment",
+      "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}", "name":
+      "amqp-kafka-bridge"}, "name": "amqp-kafka-bridge"}, "spec": {"replicas": 1,
+      "template": {"metadata": {"labels": {"app": "enmasse", "capability": "bridge",
+      "instance": "${INSTANCE}", "name": "amqp-kafka-bridge"}}, "spec": {"containers":
+      [{"env": [{"name": "KAFKA_BOOTSTRAP_SERVERS", "value": "${KAFKA_BOOTSTRAP_SERVERS}"}],
+      "image": "${AMQP_KAFKA_BRIDGE_REPO}:latest", "name": "amqp-kafka-bridge", "resources":
+      {"limits": {"memory": "512Mi"}, "requests": {"memory": "512Mi"}}}]}}}}, {"apiVersion":
+      "v1", "kind": "Route", "metadata": {"labels": {"app": "enmasse", "instance":
+      "${INSTANCE}"}, "name": "messaging"}, "spec": {"host": "${MESSAGING_HOSTNAME}",
+      "port": {"targetPort": "amqps"}, "tls": {"termination": "passthrough"}, "to":
+      {"kind": "Service", "name": "messaging", "weight": 100}}}, {"apiVersion": "v1",
+      "kind": "Route", "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"},
+      "name": "mqtt"}, "spec": {"host": "${MQTT_GATEWAY_HOSTNAME}", "port": {"targetPort":
+      "secure-mqtt"}, "tls": {"termination": "passthrough"}, "to": {"kind": "Service",
+      "name": "mqtt", "weight": 100}}}], "parameters": [{"description": "The image
+      to use for the router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"},
+      {"description": "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY",
+      "value": "50"}, {"description": "The image to use for the configuration service",
+      "name": "CONFIGSERV_REPO", "value": "enmasseproject/configserv"}, {"description":
+      "The docker image to use for the queue scheduler", "name": "QUEUE_SCHEDULER_REPO",
+      "value": "enmasseproject/queue-scheduler"}, {"description": "The image to use
+      for the router agent", "name": "RAGENT_REPO", "value": "enmasseproject/ragent"},
+      {"description": "The image to use for the subscription services", "name": "SUBSERV_REPO",
+      "value": "enmasseproject/subserv"}, {"description": "The image to use for the
+      console", "name": "CONSOLE_REPO", "value": "enmasseproject/console"}, {"description":
+      "The hostname to use for the exposed route for messaging (TLS only)", "name":
+      "MESSAGING_HOSTNAME"}, {"description": "The image to use for the MQTT gateway",
+      "name": "MQTT_GATEWAY_REPO", "value": "enmasseproject/mqtt-gateway"}, {"description":
+      "The hostname to use for the exposed route for MQTT (TLS only)", "name": "MQTT_GATEWAY_HOSTNAME"},
+      {"description": "The hostname to use for the exposed route for the messaging
+      console", "name": "CONSOLE_HOSTNAME"}, {"description": "The image to use for
+      the MQTT LWT", "name": "MQTT_LWT_REPO", "value": "enmasseproject/mqtt-lwt"},
+      {"description": "The image to use for the AMQP Kafka Bridge", "name": "AMQP_KAFKA_BRIDGE_REPO",
+      "value": "enmasseproject/amqp-kafka-bridge"}, {"description": "A list of host/port
+      pairs to use for establishing the initial connection to the Kafka cluster",
+      "name": "KAFKA_BOOTSTRAP_SERVERS"}, {"description": "The instance this infrastructure
+      is deployed for", "name": "INSTANCE", "required": true}]}'
+    queue-inmemory.json: '{"apiVersion": "v1", "kind": "Template", "metadata": {"labels":
+      {"app": "enmasse"}, "name": "queue-inmemory"}, "objects": [{"apiVersion": "extensions/v1beta1",
+      "kind": "Deployment", "metadata": {"labels": {"address_config": "address-config-${INSTANCE}-${NAME}",
+      "app": "enmasse", "group_id": "${NAME}", "instance": "${INSTANCE}"}, "name":
+      "${NAME}"}, "spec": {"replicas": 1, "template": {"metadata": {"labels": {"app":
+      "enmasse", "group_id": "${NAME}", "instance": "${INSTANCE}", "role": "broker"}},
+      "spec": {"containers": [{"env": [{"name": "QUEUE_NAME", "value": "${ADDRESS}"},
+      {"name": "GROUP_ID", "value": "${NAME}"}], "image": "${BROKER_REPO}:latest",
+      "lifecycle": {"preStop": {"exec": {"command": ["/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"]}}},
+      "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name": "broker", "ports":
+      [{"containerPort": 5673, "name": "amqp"}, {"containerPort": 61616, "name": "core"},
+      {"containerPort": 8161, "name": "jolokia"}], "readinessProbe": {"tcpSocket":
+      {"port": "amqp"}}, "volumeMounts": [{"mountPath": "/var/run/artemis", "name":
+      "vol-${NAME}"}]}], "volumes": [{"emptyDir": { }, "name": "vol-${NAME}"}, {"configMap":
+      {"name": "hawkular-broker-config"}, "name": "hawkular-openshift-agent"}]}}}}],
+      "parameters": [{"description": "Storage capacity required for volume claims",
+      "name": "STORAGE_CAPACITY", "value": "2Gi"}, {"description": "The docker image
+      to use for the message broker", "name": "BROKER_REPO", "value": "enmasseproject/artemis"},
+      {"description": "The default image to use as topic forwarder", "name": "TOPIC_FORWARDER_REPO",
+      "value": "enmasseproject/topic-forwarder"}, {"description": "The image to use
+      for the router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"},
+      {"description": "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY",
+      "value": "50"}, {"description": "A valid instance name for the instance", "name":
+      "INSTANCE", "required": true}, {"description": "A valid name for the instance",
+      "name": "NAME", "required": true}, {"description": "The address to use for the
+      queue", "name": "ADDRESS", "required": true}]}'
+    queue-persisted.json: '{"apiVersion": "v1", "kind": "Template", "metadata": {"labels":
+      {"app": "enmasse"}, "name": "queue-persisted"}, "objects": [{"apiVersion": "v1",
+      "kind": "PersistentVolumeClaim", "metadata": {"labels": {"app": "enmasse", "group_id":
+      "${NAME}", "instance": "${INSTANCE}"}, "name": "pvc-${NAME}"}, "spec": {"accessModes":
+      ["ReadWriteMany"], "resources": {"requests": {"storage": "${STORAGE_CAPACITY}"}}}},
+      {"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels":
+      {"address_config": "address-config-${INSTANCE}-${NAME}", "app": "enmasse", "group_id":
+      "${NAME}", "instance": "${INSTANCE}"}, "name": "${NAME}"}, "spec": {"replicas":
+      1, "template": {"metadata": {"labels": {"app": "enmasse", "group_id": "${NAME}",
+      "instance": "${INSTANCE}", "role": "broker"}}, "spec": {"containers": [{"env":
+      [{"name": "QUEUE_NAME", "value": "${ADDRESS}"}, {"name": "GROUP_ID", "value":
+      "${NAME}"}], "image": "${BROKER_REPO}:latest", "lifecycle": {"preStop": {"exec":
+      {"command": ["/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"]}}}, "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "broker", "ports": [{"containerPort":
+      5673, "name": "amqp"}, {"containerPort": 61616, "name": "core"}, {"containerPort":
+      8161, "name": "jolokia"}], "readinessProbe": {"tcpSocket": {"port": "amqp"}},
+      "volumeMounts": [{"mountPath": "/var/run/artemis", "name": "vol-${NAME}"}]}],
+      "volumes": [{"name": "vol-${NAME}", "persistentVolumeClaim": {"claimName": "pvc-${NAME}"}},
+      {"configMap": {"name": "hawkular-broker-config"}, "name": "hawkular-openshift-agent"}]}}}}],
+      "parameters": [{"description": "Storage capacity required for volume claims",
+      "name": "STORAGE_CAPACITY", "value": "2Gi"}, {"description": "The docker image
+      to use for the message broker", "name": "BROKER_REPO", "value": "enmasseproject/artemis"},
+      {"description": "The default image to use as topic forwarder", "name": "TOPIC_FORWARDER_REPO",
+      "value": "enmasseproject/topic-forwarder"}, {"description": "The image to use
+      for the router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"},
+      {"description": "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY",
+      "value": "50"}, {"description": "A valid instance name for the instance", "name":
+      "INSTANCE", "required": true}, {"description": "A valid name for the instance",
+      "name": "NAME", "required": true}, {"description": "The address to use for the
+      queue", "name": "ADDRESS", "required": true}]}'
+    tls-enmasse-instance-infra.json: '{"apiVersion": "v1", "kind": "Template", "metadata":
+      {"labels": {"app": "enmasse"}, "name": "tls-enmasse-instance-infra"}, "objects":
+      [{"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels":
+      {"app": "enmasse", "instance": "${INSTANCE}", "name": "qdrouterd"}, "name":
+      "qdrouterd"}, "spec": {"replicas": 1, "template": {"metadata": {"labels": {"app":
+      "enmasse", "capability": "router", "instance": "${INSTANCE}", "name": "qdrouterd"}},
+      "spec": {"containers": [{"env": [{"name": "LINK_CAPACITY", "value": "${ROUTER_LINK_CAPACITY}"}],
+      "image": "${ROUTER_REPO}:latest", "livenessProbe": {"tcpSocket": {"port": "amqp"}},
+      "name": "router", "ports": [{"containerPort": 5672, "name": "amqp", "protocol":
+      "TCP"}, {"containerPort": 55673, "name": "internal", "protocol": "TCP"}, {"containerPort":
+      5671, "name": "amqps", "protocol": "TCP"}], "volumeMounts": [{"mountPath": "/etc/qpid-dispatch/ssl",
+      "name": "ssl-certs", "readOnly": true}]}], "volumes": [{"name": "ssl-certs",
+      "secret": {"secretName": "qdrouterd-certs"}}]}}}}, {"apiVersion": "v1", "kind":
+      "Service", "metadata": {"annotations": {"service.alpha.openshift.io/dependencies":
+      "[{\"kind\": \"Service\", \"name\": \"admin\", \"namespace\": \"\"}, {\"kind\":
+      \"Service\", \"name\": \"subscription\", \"namespace\": \"\"}, {\"kind\": \"Service\",
+      \"name\": \"mqtt\", \"namespace\": \"\"}]", "service.alpha.openshift.io/infrastructure":
+      "true"}, "labels": {"app": "enmasse", "instance": "${INSTANCE}"}, "name": "messaging"},
+      "spec": {"ports": [{"name": "amqp", "port": 5672, "protocol": "TCP", "targetPort":
+      5672}, {"name": "amqps", "port": 5671, "protocol": "TCP", "targetPort": 5671},
+      {"name": "internal", "port": 55673, "protocol": "TCP", "targetPort": 55673}],
+      "selector": {"capability": "router", "instance": "${INSTANCE}"}}}, {"apiVersion":
+      "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels": {"app": "enmasse",
+      "instance": "${INSTANCE}", "name": "subserv"}, "name": "subserv"}, "spec": {"replicas":
+      1, "template": {"metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}",
+      "name": "subserv"}}, "spec": {"containers": [{"env": [ ], "image": "${SUBSERV_REPO}:latest",
+      "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name": "subserv", "ports":
+      [{"containerPort": 5672, "name": "amqp", "protocol": "TCP"}], "resources": {"limits":
+      {"memory": "64Mi"}, "requests": {"memory": "64Mi"}}}]}}}}, {"apiVersion": "v1",
+      "kind": "Service", "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"},
+      "name": "subscription"}, "spec": {"ports": [{"name": "amqp", "port": 5672, "protocol":
+      "TCP", "targetPort": 5672}], "selector": {"instance": "${INSTANCE}", "name":
+      "subserv"}}}, {"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata":
+      {"labels": {"app": "enmasse", "instance": "${INSTANCE}", "name": "mqtt-gateway"},
+      "name": "mqtt-gateway"}, "spec": {"replicas": 1, "template": {"metadata": {"labels":
+      {"app": "enmasse", "instance": "${INSTANCE}", "name": "mqtt-gateway"}}, "spec":
+      {"containers": [{"image": "${MQTT_GATEWAY_REPO}:latest", "livenessProbe": {"initialDelaySeconds":
+      60, "tcpSocket": {"port": "secure-mqtt"}}, "name": "mqtt-gateway-tls", "ports":
+      [{"containerPort": 8883, "name": "secure-mqtt", "protocol": "TCP"}], "volumeMounts":
+      [{"mountPath": "/etc/mqtt-gateway/ssl", "name": "ssl-certs", "readOnly": true}]},
+      {"image": "${MQTT_GATEWAY_REPO}:latest", "livenessProbe": {"initialDelaySeconds":
+      60, "tcpSocket": {"port": "mqtt"}}, "name": "mqtt-gateway", "ports": [{"containerPort":
+      1883, "name": "mqtt", "protocol": "TCP"}]}], "volumes": [{"name": "ssl-certs",
+      "secret": {"secretName": "mqtt-certs"}}]}}}}, {"apiVersion": "v1", "kind": "Service",
+      "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"}, "name":
+      "mqtt"}, "spec": {"ports": [{"name": "mqtt", "port": 1883, "protocol": "TCP",
+      "targetPort": 1883}, {"name": "secure-mqtt", "port": 8883, "protocol": "TCP",
+      "targetPort": 8883}], "selector": {"instance": "${INSTANCE}", "name": "mqtt-gateway"}}},
+      {"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels":
+      {"app": "enmasse", "instance": "${INSTANCE}", "name": "mqtt-lwt"}, "name": "mqtt-lwt"},
+      "spec": {"replicas": 1, "template": {"metadata": {"labels": {"app": "enmasse",
+      "instance": "${INSTANCE}", "name": "mqtt-lwt"}}, "spec": {"containers": [{"image":
+      "${MQTT_LWT_REPO}:latest", "name": "mqtt-lwt"}]}}}}, {"apiVersion": "v1", "kind":
+      "Route", "metadata": {"labels": {"app": "enmasse"}, "name": "console"}, "spec":
+      {"host": "${CONSOLE_HOSTNAME}", "port": {"targetPort": "console-http"}, "to":
+      {"kind": "Service", "name": "admin"}}}, {"apiVersion": "v1", "data": {"hawkular-openshift-agent":
+      "{\"endpoints\": [{\"collection_interval\": \"60s\", \"metrics\": [{\"id\":
+      \"broker.threadCount\", \"name\": \"java.lang:type=Threading#ThreadCount\",
+      \"tags\": {\"messagingComponent\": \"broker\", \"messagingMetricType\": \"threadCount\"},
+      \"type\": \"counter\"}, {\"id\": \"broker.memoryHeapUsage\", \"name\": \"java.lang:type=Memory#HeapMemoryUsage#used\",
+      \"tags\": {\"messagingComponent\": \"broker\", \"messagingMetricType\": \"heapUsage\"},
+      \"type\": \"gauge\"}, {\"description\": \"Queue depth for ${address}\", \"id\":
+      \"${address}.${queue}.${broker}.queueDepth\", \"name\": \"org.apache.activemq.artemis:address=*,broker=*,component=addresses,queue=*,routing-type=*,subcomponent=queues#MessageCount\",
+      \"tags\": {\"messagingAddress\": \"${address}\", \"messagingBroker\": \"{broker}\",
+      \"messagingMetricType\": \"queueDepth\", \"messagingQueue\": \"${queue}\"},
+      \"type\": \"gauge\"}, {\"description\": \"Number of consumers for ${address}\",
+      \"id\": \"${address}.${queue}.${broker}.numConsumers\", \"name\": \"org.apache.activemq.artemis:address=*,broker=*,component=addresses,queue=*,routing-type=*,subcomponent=queues#ConsumerCount\",
+      \"tags\": {\"messagingAddress\": \"${address}\", \"messagingBroker\": \"{broker}\",
+      \"messagingMetricType\": \"numConsumers\", \"messagingQueue\": \"${queue}\"},
+      \"type\": \"gauge\"}], \"path\": \"/jolokia/\", \"port\": 8161, \"protocol\":
+      \"http\", \"type\": \"jolokia\"}]}"}, "kind": "ConfigMap", "metadata": {"name":
+      "hawkular-broker-config"}}, {"apiVersion": "extensions/v1beta1", "kind": "Deployment",
+      "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}", "name":
+      "admin"}, "name": "admin"}, "spec": {"replicas": 1, "template": {"metadata":
+      {"labels": {"app": "enmasse", "instance": "${INSTANCE}", "name": "admin"}},
+      "spec": {"containers": [{"env": [{"name": "CONFIGURATION_SERVICE_HOST", "value":
+      "localhost"}, {"name": "CONFIGURATION_SERVICE_PORT", "value": "5672"}], "image":
+      "${RAGENT_REPO}:latest", "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name":
+      "ragent", "ports": [{"containerPort": 55672, "name": "amqp", "protocol": "TCP"}],
+      "resources": {"limits": {"memory": "64Mi"}, "requests": {"memory": "64Mi"}}},
+      {"env": [{"name": "CONFIGURATION_SERVICE_HOST", "value": "localhost"}, {"name":
+      "CONFIGURATION_SERVICE_PORT", "value": "5672"}], "image": "${QUEUE_SCHEDULER_REPO}:latest",
+      "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name": "queue-scheduler",
+      "ports": [{"containerPort": 55667, "name": "amqp", "protocol": "TCP"}], "resources":
+      {"limits": {"memory": "128Mi"}, "requests": {"memory": "128Mi"}}}, {"env": [{"name":
+      "CONFIGURATION_SERVICE_HOST", "value": "localhost"}, {"name": "CONFIGURATION_SERVICE_PORT",
+      "value": "5672"}], "image": "${CONSOLE_REPO}:latest", "livenessProbe": {"tcpSocket":
+      {"port": "http"}}, "name": "console", "ports": [{"containerPort": 8080, "name":
+      "http", "protocol": "TCP"}, {"containerPort": 56720, "name": "amqp-ws", "protocol":
+      "TCP"}], "resources": {"limits": {"memory": "64Mi"}, "requests": {"memory":
+      "64Mi"}}}, {"env": [ ], "image": "${CONFIGSERV_REPO}:latest", "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "configserv", "ports": [{"containerPort":
+      5672, "name": "amqp", "protocol": "TCP"}], "resources": {"limits": {"memory":
+      "256Mi"}, "requests": {"memory": "256Mi"}}}]}}}}, {"apiVersion": "v1", "kind":
+      "Service", "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"},
+      "name": "admin"}, "spec": {"ports": [{"name": "ragent", "port": 55672}, {"name":
+      "configuration", "port": 5672}, {"name": "queue-scheduler", "port": 55667},
+      {"name": "console-ws", "port": 56720}, {"name": "console-http", "port": 8080}],
+      "selector": {"instance": "${INSTANCE}", "name": "admin"}}}, {"apiVersion": "v1",
+      "kind": "Service", "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"},
+      "name": "amqp-kafka-bridge"}, "spec": {"ports": [{"name": "amqp", "port": 5672,
+      "protocol": "TCP", "targetPort": 5672}], "selector": {"capability": "bridge",
+      "instance": "${INSTANCE}"}}}, {"apiVersion": "extensions/v1beta1", "kind": "Deployment",
+      "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}", "name":
+      "amqp-kafka-bridge"}, "name": "amqp-kafka-bridge"}, "spec": {"replicas": 1,
+      "template": {"metadata": {"labels": {"app": "enmasse", "capability": "bridge",
+      "instance": "${INSTANCE}", "name": "amqp-kafka-bridge"}}, "spec": {"containers":
+      [{"env": [{"name": "KAFKA_BOOTSTRAP_SERVERS", "value": "${KAFKA_BOOTSTRAP_SERVERS}"}],
+      "image": "${AMQP_KAFKA_BRIDGE_REPO}:latest", "name": "amqp-kafka-bridge", "resources":
+      {"limits": {"memory": "512Mi"}, "requests": {"memory": "512Mi"}}}]}}}}, {"apiVersion":
+      "v1", "kind": "Route", "metadata": {"labels": {"app": "enmasse", "instance":
+      "${INSTANCE}"}, "name": "messaging"}, "spec": {"host": "${MESSAGING_HOSTNAME}",
+      "port": {"targetPort": "amqps"}, "tls": {"termination": "passthrough"}, "to":
+      {"kind": "Service", "name": "messaging", "weight": 100}}}, {"apiVersion": "v1",
+      "kind": "Route", "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"},
+      "name": "mqtt"}, "spec": {"host": "${MQTT_GATEWAY_HOSTNAME}", "port": {"targetPort":
+      "secure-mqtt"}, "tls": {"termination": "passthrough"}, "to": {"kind": "Service",
+      "name": "mqtt", "weight": 100}}}], "parameters": [{"description": "The image
+      to use for the router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"},
+      {"description": "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY",
+      "value": "50"}, {"description": "The image to use for the configuration service",
+      "name": "CONFIGSERV_REPO", "value": "enmasseproject/configserv"}, {"description":
+      "The docker image to use for the queue scheduler", "name": "QUEUE_SCHEDULER_REPO",
+      "value": "enmasseproject/queue-scheduler"}, {"description": "The image to use
+      for the router agent", "name": "RAGENT_REPO", "value": "enmasseproject/ragent"},
+      {"description": "The image to use for the subscription services", "name": "SUBSERV_REPO",
+      "value": "enmasseproject/subserv"}, {"description": "The image to use for the
+      console", "name": "CONSOLE_REPO", "value": "enmasseproject/console"}, {"description":
+      "The hostname to use for the exposed route for messaging (TLS only)", "name":
+      "MESSAGING_HOSTNAME"}, {"description": "The image to use for the MQTT gateway",
+      "name": "MQTT_GATEWAY_REPO", "value": "enmasseproject/mqtt-gateway"}, {"description":
+      "The hostname to use for the exposed route for MQTT (TLS only)", "name": "MQTT_GATEWAY_HOSTNAME"},
+      {"description": "The hostname to use for the exposed route for the messaging
+      console", "name": "CONSOLE_HOSTNAME"}, {"description": "The image to use for
+      the MQTT LWT", "name": "MQTT_LWT_REPO", "value": "enmasseproject/mqtt-lwt"},
+      {"description": "The image to use for the AMQP Kafka Bridge", "name": "AMQP_KAFKA_BRIDGE_REPO",
+      "value": "enmasseproject/amqp-kafka-bridge"}, {"description": "A list of host/port
+      pairs to use for establishing the initial connection to the Kafka cluster",
+      "name": "KAFKA_BOOTSTRAP_SERVERS"}, {"description": "The instance this infrastructure
+      is deployed for", "name": "INSTANCE", "required": true}]}'
+    tls-queue-inmemory.json: '{"apiVersion": "v1", "kind": "Template", "metadata":
+      {"labels": {"app": "enmasse"}, "name": "tls-queue-inmemory"}, "objects": [{"apiVersion":
+      "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels": {"address_config":
+      "address-config-${INSTANCE}-${NAME}", "app": "enmasse", "group_id": "${NAME}",
+      "instance": "${INSTANCE}"}, "name": "${NAME}"}, "spec": {"replicas": 1, "template":
+      {"metadata": {"labels": {"app": "enmasse", "group_id": "${NAME}", "instance":
+      "${INSTANCE}", "role": "broker"}}, "spec": {"containers": [{"env": [{"name":
+      "QUEUE_NAME", "value": "${ADDRESS}"}, {"name": "GROUP_ID", "value": "${NAME}"}],
+      "image": "${BROKER_REPO}:latest", "lifecycle": {"preStop": {"exec": {"command":
+      ["/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"]}}}, "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "broker", "ports": [{"containerPort":
+      5673, "name": "amqp"}, {"containerPort": 61616, "name": "core"}, {"containerPort":
+      8161, "name": "jolokia"}], "readinessProbe": {"tcpSocket": {"port": "amqp"}},
+      "volumeMounts": [{"mountPath": "/var/run/artemis", "name": "vol-${NAME}"}]}],
+      "volumes": [{"emptyDir": { }, "name": "vol-${NAME}"}, {"name": "ssl-certs",
+      "secret": {"secretName": "qdrouterd-certs"}}, {"configMap": {"name": "hawkular-broker-config"},
+      "name": "hawkular-openshift-agent"}]}}}}], "parameters": [{"description": "Storage
+      capacity required for volume claims", "name": "STORAGE_CAPACITY", "value": "2Gi"},
+      {"description": "The docker image to use for the message broker", "name": "BROKER_REPO",
+      "value": "enmasseproject/artemis"}, {"description": "The default image to use
+      as topic forwarder", "name": "TOPIC_FORWARDER_REPO", "value": "enmasseproject/topic-forwarder"},
+      {"description": "The image to use for the router", "name": "ROUTER_REPO", "value":
+      "enmasseproject/qdrouterd"}, {"description": "The link capacity setting for
+      router", "name": "ROUTER_LINK_CAPACITY", "value": "50"}, {"description": "A
+      valid instance name for the instance", "name": "INSTANCE", "required": true},
+      {"description": "A valid name for the instance", "name": "NAME", "required":
+      true}, {"description": "The address to use for the queue", "name": "ADDRESS",
+      "required": true}]}'
+    tls-queue-persisted.json: '{"apiVersion": "v1", "kind": "Template", "metadata":
+      {"labels": {"app": "enmasse"}, "name": "tls-queue-persisted"}, "objects": [{"apiVersion":
+      "v1", "kind": "PersistentVolumeClaim", "metadata": {"labels": {"app": "enmasse",
+      "group_id": "${NAME}", "instance": "${INSTANCE}"}, "name": "pvc-${NAME}"}, "spec":
+      {"accessModes": ["ReadWriteMany"], "resources": {"requests": {"storage": "${STORAGE_CAPACITY}"}}}},
+      {"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels":
+      {"address_config": "address-config-${INSTANCE}-${NAME}", "app": "enmasse", "group_id":
+      "${NAME}", "instance": "${INSTANCE}"}, "name": "${NAME}"}, "spec": {"replicas":
+      1, "template": {"metadata": {"labels": {"app": "enmasse", "group_id": "${NAME}",
+      "instance": "${INSTANCE}", "role": "broker"}}, "spec": {"containers": [{"env":
+      [{"name": "QUEUE_NAME", "value": "${ADDRESS}"}, {"name": "GROUP_ID", "value":
+      "${NAME}"}], "image": "${BROKER_REPO}:latest", "lifecycle": {"preStop": {"exec":
+      {"command": ["/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"]}}}, "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "broker", "ports": [{"containerPort":
+      5673, "name": "amqp"}, {"containerPort": 61616, "name": "core"}, {"containerPort":
+      8161, "name": "jolokia"}], "readinessProbe": {"tcpSocket": {"port": "amqp"}},
+      "volumeMounts": [{"mountPath": "/var/run/artemis", "name": "vol-${NAME}"}]}],
+      "volumes": [{"name": "vol-${NAME}", "persistentVolumeClaim": {"claimName": "pvc-${NAME}"}},
+      {"name": "ssl-certs", "secret": {"secretName": "qdrouterd-certs"}}, {"configMap":
+      {"name": "hawkular-broker-config"}, "name": "hawkular-openshift-agent"}]}}}}],
+      "parameters": [{"description": "Storage capacity required for volume claims",
+      "name": "STORAGE_CAPACITY", "value": "2Gi"}, {"description": "The docker image
+      to use for the message broker", "name": "BROKER_REPO", "value": "enmasseproject/artemis"},
+      {"description": "The default image to use as topic forwarder", "name": "TOPIC_FORWARDER_REPO",
+      "value": "enmasseproject/topic-forwarder"}, {"description": "The image to use
+      for the router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"},
+      {"description": "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY",
+      "value": "50"}, {"description": "A valid instance name for the instance", "name":
+      "INSTANCE", "required": true}, {"description": "A valid name for the instance",
+      "name": "NAME", "required": true}, {"description": "The address to use for the
+      queue", "name": "ADDRESS", "required": true}]}'
+    tls-topic-inmemory.json: '{"apiVersion": "v1", "kind": "Template", "metadata":
+      {"labels": {"app": "enmasse"}, "name": "tls-topic-inmemory"}, "objects": [{"apiVersion":
+      "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels": {"address_config":
+      "address-config-${INSTANCE}-${NAME}", "app": "enmasse", "group_id": "${NAME}",
+      "instance": "${INSTANCE}"}, "name": "${NAME}"}, "spec": {"replicas": 1, "template":
+      {"metadata": {"labels": {"app": "enmasse", "group_id": "${NAME}", "instance":
+      "${INSTANCE}", "role": "broker"}}, "spec": {"containers": [{"env": [{"name":
+      "TOPIC_NAME", "value": "${ADDRESS}"}, {"name": "GROUP_ID", "value": "${NAME}"}],
+      "image": "${BROKER_REPO}:latest", "lifecycle": {"preStop": {"exec": {"command":
+      ["/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"]}}}, "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "broker", "ports": [{"containerPort":
+      5673, "name": "amqp"}, {"containerPort": 61616, "name": "core"}, {"containerPort":
+      8161, "name": "jolokia"}], "readinessProbe": {"tcpSocket": {"port": "amqp"}},
+      "volumeMounts": [{"mountPath": "/var/run/artemis", "name": "vol-${NAME}"}]},
+      {"env": [{"name": "LINK_CAPACITY", "value": "${ROUTER_LINK_CAPACITY}"}, {"name":
+      "TOPIC_NAME", "value": "${ADDRESS}"}], "image": "${ROUTER_REPO}:latest", "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "router", "ports": [{"containerPort":
+      5672, "name": "amqp", "protocol": "TCP"}, {"containerPort": 55673, "name": "internal",
+      "protocol": "TCP"}, {"containerPort": 5671, "name": "amqps", "protocol": "TCP"}],
+      "resources": {"limits": {"memory": "256Mi"}, "requests": {"memory": "256Mi"}},
+      "volumeMounts": [{"mountPath": "/etc/qpid-dispatch/ssl", "name": "ssl-certs",
+      "readOnly": true}]}, {"env": [{"name": "TOPIC_NAME", "value": "${ADDRESS}"},
+      {"name": "GROUP_ID", "value": "${NAME}"}], "image": "${TOPIC_FORWARDER_REPO}:latest",
+      "livenessProbe": {"httpGet": {"path": "/health", "port": "health"}}, "name":
+      "forwarder", "ports": [{"containerPort": 8080, "name": "health"}], "resources":
+      {"limits": {"memory": "128Mi"}, "requests": {"memory": "128Mi"}}}], "volumes":
+      [{"emptyDir": { }, "name": "vol-${NAME}"}, {"name": "ssl-certs", "secret": {"secretName":
+      "qdrouterd-certs"}}, {"configMap": {"name": "hawkular-broker-config"}, "name":
+      "hawkular-openshift-agent"}]}}}}], "parameters": [{"description": "Storage capacity
+      required for volume claims", "name": "STORAGE_CAPACITY", "value": "2Gi"}, {"description":
+      "The docker image to use for the message broker", "name": "BROKER_REPO", "value":
+      "enmasseproject/artemis"}, {"description": "The default image to use as topic
+      forwarder", "name": "TOPIC_FORWARDER_REPO", "value": "enmasseproject/topic-forwarder"},
+      {"description": "The image to use for the router", "name": "ROUTER_REPO", "value":
+      "enmasseproject/qdrouterd"}, {"description": "The link capacity setting for
+      router", "name": "ROUTER_LINK_CAPACITY", "value": "50"}, {"description": "A
+      valid instance name for the instance", "name": "INSTANCE", "required": true},
+      {"description": "A valid name for the instance", "name": "NAME", "required":
+      true}, {"description": "The address to use for the topic", "name": "ADDRESS",
+      "required": true}]}'
+    tls-topic-persisted.json: '{"apiVersion": "v1", "kind": "Template", "metadata":
+      {"labels": {"app": "enmasse"}, "name": "tls-topic-persisted"}, "objects": [{"apiVersion":
+      "v1", "kind": "PersistentVolumeClaim", "metadata": {"labels": {"app": "enmasse",
+      "group_id": "${NAME}", "instance": "${INSTANCE}"}, "name": "pvc-${NAME}"}, "spec":
+      {"accessModes": ["ReadWriteMany"], "resources": {"requests": {"storage": "${STORAGE_CAPACITY}"}}}},
+      {"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels":
+      {"address_config": "address-config-${INSTANCE}-${NAME}", "app": "enmasse", "group_id":
+      "${NAME}", "instance": "${INSTANCE}"}, "name": "${NAME}"}, "spec": {"replicas":
+      1, "template": {"metadata": {"labels": {"app": "enmasse", "group_id": "${NAME}",
+      "instance": "${INSTANCE}", "role": "broker"}}, "spec": {"containers": [{"env":
+      [{"name": "TOPIC_NAME", "value": "${ADDRESS}"}, {"name": "GROUP_ID", "value":
+      "${NAME}"}], "image": "${BROKER_REPO}:latest", "lifecycle": {"preStop": {"exec":
+      {"command": ["/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"]}}}, "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "broker", "ports": [{"containerPort":
+      5673, "name": "amqp"}, {"containerPort": 61616, "name": "core"}, {"containerPort":
+      8161, "name": "jolokia"}], "readinessProbe": {"tcpSocket": {"port": "amqp"}},
+      "volumeMounts": [{"mountPath": "/var/run/artemis", "name": "vol-${NAME}"}]},
+      {"env": [{"name": "LINK_CAPACITY", "value": "${ROUTER_LINK_CAPACITY}"}, {"name":
+      "TOPIC_NAME", "value": "${ADDRESS}"}], "image": "${ROUTER_REPO}:latest", "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "router", "ports": [{"containerPort":
+      5672, "name": "amqp", "protocol": "TCP"}, {"containerPort": 55673, "name": "internal",
+      "protocol": "TCP"}, {"containerPort": 5671, "name": "amqps", "protocol": "TCP"}],
+      "resources": {"limits": {"memory": "256Mi"}, "requests": {"memory": "256Mi"}},
+      "volumeMounts": [{"mountPath": "/etc/qpid-dispatch/ssl", "name": "ssl-certs",
+      "readOnly": true}]}, {"env": [{"name": "TOPIC_NAME", "value": "${ADDRESS}"},
+      {"name": "GROUP_ID", "value": "${NAME}"}], "image": "${TOPIC_FORWARDER_REPO}:latest",
+      "livenessProbe": {"httpGet": {"path": "/health", "port": "health"}}, "name":
+      "forwarder", "ports": [{"containerPort": 8080, "name": "health"}], "resources":
+      {"limits": {"memory": "128Mi"}, "requests": {"memory": "128Mi"}}}], "volumes":
+      [{"name": "vol-${NAME}", "persistentVolumeClaim": {"claimName": "pvc-${NAME}"}},
+      {"name": "ssl-certs", "secret": {"secretName": "qdrouterd-certs"}}, {"configMap":
+      {"name": "hawkular-broker-config"}, "name": "hawkular-openshift-agent"}]}}}}],
+      "parameters": [{"description": "Storage capacity required for volume claims",
+      "name": "STORAGE_CAPACITY", "value": "2Gi"}, {"description": "The docker image
+      to use for the message broker", "name": "BROKER_REPO", "value": "enmasseproject/artemis"},
+      {"description": "The default image to use as topic forwarder", "name": "TOPIC_FORWARDER_REPO",
+      "value": "enmasseproject/topic-forwarder"}, {"description": "The image to use
+      for the router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"},
+      {"description": "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY",
+      "value": "50"}, {"description": "A valid instance name for the instance", "name":
+      "INSTANCE", "required": true}, {"description": "A valid name for the instance",
+      "name": "NAME", "required": true}, {"description": "The address to use for the
+      topic", "name": "ADDRESS", "required": true}]}'
+    topic-inmemory.json: '{"apiVersion": "v1", "kind": "Template", "metadata": {"labels":
+      {"app": "enmasse"}, "name": "topic-inmemory"}, "objects": [{"apiVersion": "extensions/v1beta1",
+      "kind": "Deployment", "metadata": {"labels": {"address_config": "address-config-${INSTANCE}-${NAME}",
+      "app": "enmasse", "group_id": "${NAME}", "instance": "${INSTANCE}"}, "name":
+      "${NAME}"}, "spec": {"replicas": 1, "template": {"metadata": {"labels": {"app":
+      "enmasse", "group_id": "${NAME}", "instance": "${INSTANCE}", "role": "broker"}},
+      "spec": {"containers": [{"env": [{"name": "TOPIC_NAME", "value": "${ADDRESS}"},
+      {"name": "GROUP_ID", "value": "${NAME}"}], "image": "${BROKER_REPO}:latest",
+      "lifecycle": {"preStop": {"exec": {"command": ["/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"]}}},
+      "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name": "broker", "ports":
+      [{"containerPort": 5673, "name": "amqp"}, {"containerPort": 61616, "name": "core"},
+      {"containerPort": 8161, "name": "jolokia"}], "readinessProbe": {"tcpSocket":
+      {"port": "amqp"}}, "volumeMounts": [{"mountPath": "/var/run/artemis", "name":
+      "vol-${NAME}"}]}, {"env": [{"name": "LINK_CAPACITY", "value": "${ROUTER_LINK_CAPACITY}"},
+      {"name": "TOPIC_NAME", "value": "${ADDRESS}"}], "image": "${ROUTER_REPO}:latest",
+      "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name": "router", "ports":
+      [{"containerPort": 5672, "name": "amqp", "protocol": "TCP"}, {"containerPort":
+      55673, "name": "internal", "protocol": "TCP"}], "resources": {"limits": {"memory":
+      "256Mi"}, "requests": {"memory": "256Mi"}}}, {"env": [{"name": "TOPIC_NAME",
+      "value": "${ADDRESS}"}, {"name": "GROUP_ID", "value": "${NAME}"}], "image":
+      "${TOPIC_FORWARDER_REPO}:latest", "livenessProbe": {"httpGet": {"path": "/health",
+      "port": "health"}}, "name": "forwarder", "ports": [{"containerPort": 8080, "name":
+      "health"}], "resources": {"limits": {"memory": "128Mi"}, "requests": {"memory":
+      "128Mi"}}}], "volumes": [{"emptyDir": { }, "name": "vol-${NAME}"}, {"configMap":
+      {"name": "hawkular-broker-config"}, "name": "hawkular-openshift-agent"}]}}}}],
+      "parameters": [{"description": "Storage capacity required for volume claims",
+      "name": "STORAGE_CAPACITY", "value": "2Gi"}, {"description": "The docker image
+      to use for the message broker", "name": "BROKER_REPO", "value": "enmasseproject/artemis"},
+      {"description": "The default image to use as topic forwarder", "name": "TOPIC_FORWARDER_REPO",
+      "value": "enmasseproject/topic-forwarder"}, {"description": "The image to use
+      for the router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"},
+      {"description": "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY",
+      "value": "50"}, {"description": "A valid instance name for the instance", "name":
+      "INSTANCE", "required": true}, {"description": "A valid name for the instance",
+      "name": "NAME", "required": true}, {"description": "The address to use for the
+      topic", "name": "ADDRESS", "required": true}]}'
+    topic-persisted.json: '{"apiVersion": "v1", "kind": "Template", "metadata": {"labels":
+      {"app": "enmasse"}, "name": "topic-persisted"}, "objects": [{"apiVersion": "v1",
+      "kind": "PersistentVolumeClaim", "metadata": {"labels": {"app": "enmasse", "group_id":
+      "${NAME}", "instance": "${INSTANCE}"}, "name": "pvc-${NAME}"}, "spec": {"accessModes":
+      ["ReadWriteMany"], "resources": {"requests": {"storage": "${STORAGE_CAPACITY}"}}}},
+      {"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels":
+      {"address_config": "address-config-${INSTANCE}-${NAME}", "app": "enmasse", "group_id":
+      "${NAME}", "instance": "${INSTANCE}"}, "name": "${NAME}"}, "spec": {"replicas":
+      1, "template": {"metadata": {"labels": {"app": "enmasse", "group_id": "${NAME}",
+      "instance": "${INSTANCE}", "role": "broker"}}, "spec": {"containers": [{"env":
+      [{"name": "TOPIC_NAME", "value": "${ADDRESS}"}, {"name": "GROUP_ID", "value":
+      "${NAME}"}], "image": "${BROKER_REPO}:latest", "lifecycle": {"preStop": {"exec":
+      {"command": ["/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"]}}}, "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "broker", "ports": [{"containerPort":
+      5673, "name": "amqp"}, {"containerPort": 61616, "name": "core"}, {"containerPort":
+      8161, "name": "jolokia"}], "readinessProbe": {"tcpSocket": {"port": "amqp"}},
+      "volumeMounts": [{"mountPath": "/var/run/artemis", "name": "vol-${NAME}"}]},
+      {"env": [{"name": "LINK_CAPACITY", "value": "${ROUTER_LINK_CAPACITY}"}, {"name":
+      "TOPIC_NAME", "value": "${ADDRESS}"}], "image": "${ROUTER_REPO}:latest", "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "router", "ports": [{"containerPort":
+      5672, "name": "amqp", "protocol": "TCP"}, {"containerPort": 55673, "name": "internal",
+      "protocol": "TCP"}], "resources": {"limits": {"memory": "256Mi"}, "requests":
+      {"memory": "256Mi"}}}, {"env": [{"name": "TOPIC_NAME", "value": "${ADDRESS}"},
+      {"name": "GROUP_ID", "value": "${NAME}"}], "image": "${TOPIC_FORWARDER_REPO}:latest",
+      "livenessProbe": {"httpGet": {"path": "/health", "port": "health"}}, "name":
+      "forwarder", "ports": [{"containerPort": 8080, "name": "health"}], "resources":
+      {"limits": {"memory": "128Mi"}, "requests": {"memory": "128Mi"}}}], "volumes":
+      [{"name": "vol-${NAME}", "persistentVolumeClaim": {"claimName": "pvc-${NAME}"}},
+      {"configMap": {"name": "hawkular-broker-config"}, "name": "hawkular-openshift-agent"}]}}}}],
+      "parameters": [{"description": "Storage capacity required for volume claims",
+      "name": "STORAGE_CAPACITY", "value": "2Gi"}, {"description": "The docker image
+      to use for the message broker", "name": "BROKER_REPO", "value": "enmasseproject/artemis"},
+      {"description": "The default image to use as topic forwarder", "name": "TOPIC_FORWARDER_REPO",
+      "value": "enmasseproject/topic-forwarder"}, {"description": "The image to use
+      for the router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"},
+      {"description": "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY",
+      "value": "50"}, {"description": "A valid instance name for the instance", "name":
+      "INSTANCE", "required": true}, {"description": "A valid name for the instance",
+      "name": "NAME", "required": true}, {"description": "The address to use for the
+      topic", "name": "ADDRESS", "required": true}]}'
+  kind: ConfigMap
   metadata:
     labels:
       app: enmasse
-    name: queue-inmemory
-  objects:
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        address_config: address-config-${INSTANCE}-${NAME}
-        app: enmasse
-        group_id: "${NAME}"
-        instance: "${INSTANCE}"
-      name: "${NAME}"
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            group_id: "${NAME}"
-            instance: "${INSTANCE}"
-            role: broker
-        spec:
-          containers:
-          - env:
-            - name: QUEUE_NAME
-              value: "${ADDRESS}"
-            - name: GROUP_ID
-              value: "${NAME}"
-            image: "${BROKER_REPO}:latest"
-            lifecycle:
-              preStop:
-                exec:
-                  command:
-                  - "/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: broker
-            ports:
-            - containerPort: 5673
-              name: amqp
-            - containerPort: 61616
-              name: core
-            - containerPort: 8161
-              name: jolokia
-            readinessProbe:
-              tcpSocket:
-                port: amqp
-            volumeMounts:
-            - mountPath: "/var/run/artemis"
-              name: vol-${NAME}
-          volumes:
-          - emptyDir: {}
-            name: vol-${NAME}
-          - configMap:
-              name: hawkular-broker-config
-            name: hawkular-openshift-agent
-  parameters:
-  - description: Storage capacity required for volume claims
-    name: STORAGE_CAPACITY
-    value: 2Gi
-  - description: The docker image to use for the message broker
-    name: BROKER_REPO
-    value: enmasseproject/artemis
-  - description: The default image to use as topic forwarder
-    name: TOPIC_FORWARDER_REPO
-    value: enmasseproject/topic-forwarder
-  - description: The image to use for the router
-    name: ROUTER_REPO
-    value: enmasseproject/qdrouterd
-  - description: The link capacity setting for router
-    name: ROUTER_LINK_CAPACITY
-    value: '50'
-  - description: A valid instance name for the instance
-    name: INSTANCE
-    required: true
-  - description: A valid name for the instance
-    name: NAME
-    required: true
-  - description: The address to use for the queue
-    name: ADDRESS
-    required: true
-- apiVersion: v1
-  kind: Template
-  metadata:
-    labels:
-      app: enmasse
-    name: queue-persisted
-  objects:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
-    metadata:
-      labels:
-        app: enmasse
-        group_id: "${NAME}"
-        instance: "${INSTANCE}"
-      name: pvc-${NAME}
-    spec:
-      accessModes:
-      - ReadWriteMany
-      resources:
-        requests:
-          storage: "${STORAGE_CAPACITY}"
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        address_config: address-config-${INSTANCE}-${NAME}
-        app: enmasse
-        group_id: "${NAME}"
-        instance: "${INSTANCE}"
-      name: "${NAME}"
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            group_id: "${NAME}"
-            instance: "${INSTANCE}"
-            role: broker
-        spec:
-          containers:
-          - env:
-            - name: QUEUE_NAME
-              value: "${ADDRESS}"
-            - name: GROUP_ID
-              value: "${NAME}"
-            image: "${BROKER_REPO}:latest"
-            lifecycle:
-              preStop:
-                exec:
-                  command:
-                  - "/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: broker
-            ports:
-            - containerPort: 5673
-              name: amqp
-            - containerPort: 61616
-              name: core
-            - containerPort: 8161
-              name: jolokia
-            readinessProbe:
-              tcpSocket:
-                port: amqp
-            volumeMounts:
-            - mountPath: "/var/run/artemis"
-              name: vol-${NAME}
-          volumes:
-          - name: vol-${NAME}
-            persistentVolumeClaim:
-              claimName: pvc-${NAME}
-          - configMap:
-              name: hawkular-broker-config
-            name: hawkular-openshift-agent
-  parameters:
-  - description: Storage capacity required for volume claims
-    name: STORAGE_CAPACITY
-    value: 2Gi
-  - description: The docker image to use for the message broker
-    name: BROKER_REPO
-    value: enmasseproject/artemis
-  - description: The default image to use as topic forwarder
-    name: TOPIC_FORWARDER_REPO
-    value: enmasseproject/topic-forwarder
-  - description: The image to use for the router
-    name: ROUTER_REPO
-    value: enmasseproject/qdrouterd
-  - description: The link capacity setting for router
-    name: ROUTER_LINK_CAPACITY
-    value: '50'
-  - description: A valid instance name for the instance
-    name: INSTANCE
-    required: true
-  - description: A valid name for the instance
-    name: NAME
-    required: true
-  - description: The address to use for the queue
-    name: ADDRESS
-    required: true
-- apiVersion: v1
-  kind: Template
-  metadata:
-    labels:
-      app: enmasse
-    name: topic-inmemory
-  objects:
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        address_config: address-config-${INSTANCE}-${NAME}
-        app: enmasse
-        group_id: "${NAME}"
-        instance: "${INSTANCE}"
-      name: "${NAME}"
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            group_id: "${NAME}"
-            instance: "${INSTANCE}"
-            role: broker
-        spec:
-          containers:
-          - env:
-            - name: TOPIC_NAME
-              value: "${ADDRESS}"
-            - name: GROUP_ID
-              value: "${NAME}"
-            image: "${BROKER_REPO}:latest"
-            lifecycle:
-              preStop:
-                exec:
-                  command:
-                  - "/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: broker
-            ports:
-            - containerPort: 5673
-              name: amqp
-            - containerPort: 61616
-              name: core
-            - containerPort: 8161
-              name: jolokia
-            readinessProbe:
-              tcpSocket:
-                port: amqp
-            volumeMounts:
-            - mountPath: "/var/run/artemis"
-              name: vol-${NAME}
-          - env:
-            - name: LINK_CAPACITY
-              value: "${ROUTER_LINK_CAPACITY}"
-            - name: TOPIC_NAME
-              value: "${ADDRESS}"
-            image: "${ROUTER_REPO}:latest"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: router
-            ports:
-            - containerPort: 5672
-              name: amqp
-              protocol: TCP
-            - containerPort: 55673
-              name: internal
-              protocol: TCP
-            resources:
-              limits:
-                memory: 256Mi
-              requests:
-                memory: 256Mi
-          - env:
-            - name: TOPIC_NAME
-              value: "${ADDRESS}"
-            - name: GROUP_ID
-              value: "${NAME}"
-            image: "${TOPIC_FORWARDER_REPO}:latest"
-            livenessProbe:
-              httpGet:
-                path: "/health"
-                port: health
-            name: forwarder
-            ports:
-            - containerPort: 8080
-              name: health
-            resources:
-              limits:
-                memory: 128Mi
-              requests:
-                memory: 128Mi
-          volumes:
-          - emptyDir: {}
-            name: vol-${NAME}
-          - configMap:
-              name: hawkular-broker-config
-            name: hawkular-openshift-agent
-  parameters:
-  - description: Storage capacity required for volume claims
-    name: STORAGE_CAPACITY
-    value: 2Gi
-  - description: The docker image to use for the message broker
-    name: BROKER_REPO
-    value: enmasseproject/artemis
-  - description: The default image to use as topic forwarder
-    name: TOPIC_FORWARDER_REPO
-    value: enmasseproject/topic-forwarder
-  - description: The image to use for the router
-    name: ROUTER_REPO
-    value: enmasseproject/qdrouterd
-  - description: The link capacity setting for router
-    name: ROUTER_LINK_CAPACITY
-    value: '50'
-  - description: A valid instance name for the instance
-    name: INSTANCE
-    required: true
-  - description: A valid name for the instance
-    name: NAME
-    required: true
-  - description: The address to use for the topic
-    name: ADDRESS
-    required: true
-- apiVersion: v1
-  kind: Template
-  metadata:
-    labels:
-      app: enmasse
-    name: topic-persisted
-  objects:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
-    metadata:
-      labels:
-        app: enmasse
-        group_id: "${NAME}"
-        instance: "${INSTANCE}"
-      name: pvc-${NAME}
-    spec:
-      accessModes:
-      - ReadWriteMany
-      resources:
-        requests:
-          storage: "${STORAGE_CAPACITY}"
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        address_config: address-config-${INSTANCE}-${NAME}
-        app: enmasse
-        group_id: "${NAME}"
-        instance: "${INSTANCE}"
-      name: "${NAME}"
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            group_id: "${NAME}"
-            instance: "${INSTANCE}"
-            role: broker
-        spec:
-          containers:
-          - env:
-            - name: TOPIC_NAME
-              value: "${ADDRESS}"
-            - name: GROUP_ID
-              value: "${NAME}"
-            image: "${BROKER_REPO}:latest"
-            lifecycle:
-              preStop:
-                exec:
-                  command:
-                  - "/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: broker
-            ports:
-            - containerPort: 5673
-              name: amqp
-            - containerPort: 61616
-              name: core
-            - containerPort: 8161
-              name: jolokia
-            readinessProbe:
-              tcpSocket:
-                port: amqp
-            volumeMounts:
-            - mountPath: "/var/run/artemis"
-              name: vol-${NAME}
-          - env:
-            - name: LINK_CAPACITY
-              value: "${ROUTER_LINK_CAPACITY}"
-            - name: TOPIC_NAME
-              value: "${ADDRESS}"
-            image: "${ROUTER_REPO}:latest"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: router
-            ports:
-            - containerPort: 5672
-              name: amqp
-              protocol: TCP
-            - containerPort: 55673
-              name: internal
-              protocol: TCP
-            resources:
-              limits:
-                memory: 256Mi
-              requests:
-                memory: 256Mi
-          - env:
-            - name: TOPIC_NAME
-              value: "${ADDRESS}"
-            - name: GROUP_ID
-              value: "${NAME}"
-            image: "${TOPIC_FORWARDER_REPO}:latest"
-            livenessProbe:
-              httpGet:
-                path: "/health"
-                port: health
-            name: forwarder
-            ports:
-            - containerPort: 8080
-              name: health
-            resources:
-              limits:
-                memory: 128Mi
-              requests:
-                memory: 128Mi
-          volumes:
-          - name: vol-${NAME}
-            persistentVolumeClaim:
-              claimName: pvc-${NAME}
-          - configMap:
-              name: hawkular-broker-config
-            name: hawkular-openshift-agent
-  parameters:
-  - description: Storage capacity required for volume claims
-    name: STORAGE_CAPACITY
-    value: 2Gi
-  - description: The docker image to use for the message broker
-    name: BROKER_REPO
-    value: enmasseproject/artemis
-  - description: The default image to use as topic forwarder
-    name: TOPIC_FORWARDER_REPO
-    value: enmasseproject/topic-forwarder
-  - description: The image to use for the router
-    name: ROUTER_REPO
-    value: enmasseproject/qdrouterd
-  - description: The link capacity setting for router
-    name: ROUTER_LINK_CAPACITY
-    value: '50'
-  - description: A valid instance name for the instance
-    name: INSTANCE
-    required: true
-  - description: A valid name for the instance
-    name: NAME
-    required: true
-  - description: The address to use for the topic
-    name: ADDRESS
-    required: true
-- apiVersion: v1
-  kind: Template
-  metadata:
-    labels:
-      app: enmasse
-    name: enmasse-instance-infra
-  objects:
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-        name: qdrouterd
-      name: qdrouterd
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            capability: router
-            instance: "${INSTANCE}"
-            name: qdrouterd
-        spec:
-          containers:
-          - env:
-            - name: LINK_CAPACITY
-              value: "${ROUTER_LINK_CAPACITY}"
-            image: "${ROUTER_REPO}:latest"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: router
-            ports:
-            - containerPort: 5672
-              name: amqp
-              protocol: TCP
-            - containerPort: 55673
-              name: internal
-              protocol: TCP
-  - apiVersion: v1
-    kind: Service
-    metadata:
-      annotations:
-        service.alpha.openshift.io/dependencies: '[{"kind": "Service", "name": "admin",
-          "namespace": ""}, {"kind": "Service", "name": "subscription", "namespace":
-          ""}, {"kind": "Service", "name": "mqtt", "namespace": ""}]'
-        service.alpha.openshift.io/infrastructure: 'true'
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-      name: messaging
-    spec:
-      ports:
-      - name: amqp
-        port: 5672
-        protocol: TCP
-        targetPort: 5672
-      - name: internal
-        port: 55673
-        protocol: TCP
-        targetPort: 55673
-      selector:
-        capability: router
-        instance: "${INSTANCE}"
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-        name: subserv
-      name: subserv
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            instance: "${INSTANCE}"
-            name: subserv
-        spec:
-          containers:
-          - env: []
-            image: "${SUBSERV_REPO}:latest"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: subserv
-            ports:
-            - containerPort: 5672
-              name: amqp
-              protocol: TCP
-            resources:
-              limits:
-                memory: 64Mi
-              requests:
-                memory: 64Mi
-  - apiVersion: v1
-    kind: Service
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-      name: subscription
-    spec:
-      ports:
-      - name: amqp
-        port: 5672
-        protocol: TCP
-        targetPort: 5672
-      selector:
-        instance: "${INSTANCE}"
-        name: subserv
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-        name: mqtt-gateway
-      name: mqtt-gateway
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            instance: "${INSTANCE}"
-            name: mqtt-gateway
-        spec:
-          containers:
-          - image: "${MQTT_GATEWAY_REPO}:latest"
-            livenessProbe:
-              initialDelaySeconds: 60
-              tcpSocket:
-                port: mqtt
-            name: mqtt-gateway
-            ports:
-            - containerPort: 1883
-              name: mqtt
-              protocol: TCP
-  - apiVersion: v1
-    kind: Service
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-      name: mqtt
-    spec:
-      ports:
-      - name: mqtt
-        port: 1883
-        protocol: TCP
-        targetPort: 1883
-      selector:
-        instance: "${INSTANCE}"
-        name: mqtt-gateway
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-        name: mqtt-lwt
-      name: mqtt-lwt
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            instance: "${INSTANCE}"
-            name: mqtt-lwt
-        spec:
-          containers:
-          - image: "${MQTT_LWT_REPO}:latest"
-            name: mqtt-lwt
-  - apiVersion: v1
-    kind: Route
-    metadata:
-      labels:
-        app: enmasse
-      name: console
-    spec:
-      host: "${CONSOLE_HOSTNAME}"
-      port:
-        targetPort: console-http
-      to:
-        kind: Service
-        name: admin
-  - apiVersion: v1
-    data:
-      hawkular-openshift-agent: '{"endpoints": [{"collection_interval": "60s", "metrics":
-        [{"id": "broker.threadCount", "name": "java.lang:type=Threading#ThreadCount",
-        "tags": {"messagingComponent": "broker", "messagingMetricType": "threadCount"},
-        "type": "counter"}, {"id": "broker.memoryHeapUsage", "name": "java.lang:type=Memory#HeapMemoryUsage#used",
-        "tags": {"messagingComponent": "broker", "messagingMetricType": "heapUsage"},
-        "type": "gauge"}, {"description": "Queue depth for ${address}", "id": "${address}.${queue}.${broker}.queueDepth",
-        "name": "org.apache.activemq.artemis:address=*,broker=*,component=addresses,queue=*,routing-type=*,subcomponent=queues#MessageCount",
-        "tags": {"messagingAddress": "${address}", "messagingBroker": "{broker}",
-        "messagingMetricType": "queueDepth", "messagingQueue": "${queue}"}, "type":
-        "gauge"}, {"description": "Number of consumers for ${address}", "id": "${address}.${queue}.${broker}.numConsumers",
-        "name": "org.apache.activemq.artemis:address=*,broker=*,component=addresses,queue=*,routing-type=*,subcomponent=queues#ConsumerCount",
-        "tags": {"messagingAddress": "${address}", "messagingBroker": "{broker}",
-        "messagingMetricType": "numConsumers", "messagingQueue": "${queue}"}, "type":
-        "gauge"}], "path": "/jolokia/", "port": 8161, "protocol": "http", "type":
-        "jolokia"}]}'
-    kind: ConfigMap
-    metadata:
-      name: hawkular-broker-config
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-        name: admin
-      name: admin
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            instance: "${INSTANCE}"
-            name: admin
-        spec:
-          containers:
-          - env:
-            - name: CONFIGURATION_SERVICE_HOST
-              value: localhost
-            - name: CONFIGURATION_SERVICE_PORT
-              value: '5672'
-            image: "${RAGENT_REPO}:latest"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: ragent
-            ports:
-            - containerPort: 55672
-              name: amqp
-              protocol: TCP
-            resources:
-              limits:
-                memory: 64Mi
-              requests:
-                memory: 64Mi
-          - env:
-            - name: CONFIGURATION_SERVICE_HOST
-              value: localhost
-            - name: CONFIGURATION_SERVICE_PORT
-              value: '5672'
-            image: "${QUEUE_SCHEDULER_REPO}:latest"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: queue-scheduler
-            ports:
-            - containerPort: 55667
-              name: amqp
-              protocol: TCP
-            resources:
-              limits:
-                memory: 128Mi
-              requests:
-                memory: 128Mi
-          - env:
-            - name: CONFIGURATION_SERVICE_HOST
-              value: localhost
-            - name: CONFIGURATION_SERVICE_PORT
-              value: '5672'
-            image: "${CONSOLE_REPO}:latest"
-            livenessProbe:
-              tcpSocket:
-                port: http
-            name: console
-            ports:
-            - containerPort: 8080
-              name: http
-              protocol: TCP
-            - containerPort: 56720
-              name: amqp-ws
-              protocol: TCP
-            resources:
-              limits:
-                memory: 64Mi
-              requests:
-                memory: 64Mi
-          - env: []
-            image: "${CONFIGSERV_REPO}:latest"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: configserv
-            ports:
-            - containerPort: 5672
-              name: amqp
-              protocol: TCP
-            resources:
-              limits:
-                memory: 256Mi
-              requests:
-                memory: 256Mi
-  - apiVersion: v1
-    kind: Service
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-      name: admin
-    spec:
-      ports:
-      - name: ragent
-        port: 55672
-      - name: configuration
-        port: 5672
-      - name: queue-scheduler
-        port: 55667
-      - name: console-ws
-        port: 56720
-      - name: console-http
-        port: 8080
-      selector:
-        instance: "${INSTANCE}"
-        name: admin
-  - apiVersion: v1
-    kind: Service
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-      name: amqp-kafka-bridge
-    spec:
-      ports:
-      - name: amqp
-        port: 5672
-        protocol: TCP
-        targetPort: 5672
-      selector:
-        capability: bridge
-        instance: "${INSTANCE}"
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-        name: amqp-kafka-bridge
-      name: amqp-kafka-bridge
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            capability: bridge
-            instance: "${INSTANCE}"
-            name: amqp-kafka-bridge
-        spec:
-          containers:
-          - env:
-            - name: KAFKA_BOOTSTRAP_SERVERS
-              value: "${KAFKA_BOOTSTRAP_SERVERS}"
-            image: "${AMQP_KAFKA_BRIDGE_REPO}:latest"
-            name: amqp-kafka-bridge
-            resources:
-              limits:
-                memory: 512Mi
-              requests:
-                memory: 512Mi
-  parameters:
-  - description: The image to use for the router
-    name: ROUTER_REPO
-    value: enmasseproject/qdrouterd
-  - description: The link capacity setting for router
-    name: ROUTER_LINK_CAPACITY
-    value: '50'
-  - description: The image to use for the configuration service
-    name: CONFIGSERV_REPO
-    value: enmasseproject/configserv
-  - description: The docker image to use for the queue scheduler
-    name: QUEUE_SCHEDULER_REPO
-    value: enmasseproject/queue-scheduler
-  - description: The image to use for the router agent
-    name: RAGENT_REPO
-    value: enmasseproject/ragent
-  - description: The image to use for the subscription services
-    name: SUBSERV_REPO
-    value: enmasseproject/subserv
-  - description: The image to use for the console
-    name: CONSOLE_REPO
-    value: enmasseproject/console
-  - description: The hostname to use for the exposed route for messaging (TLS only)
-    name: MESSAGING_HOSTNAME
-  - description: The image to use for the MQTT gateway
-    name: MQTT_GATEWAY_REPO
-    value: enmasseproject/mqtt-gateway
-  - description: The hostname to use for the exposed route for MQTT (TLS only)
-    name: MQTT_GATEWAY_HOSTNAME
-  - description: The hostname to use for the exposed route for the messaging console
-    name: CONSOLE_HOSTNAME
-  - description: The image to use for the MQTT LWT
-    name: MQTT_LWT_REPO
-    value: enmasseproject/mqtt-lwt
-  - description: The image to use for the AMQP Kafka Bridge
-    name: AMQP_KAFKA_BRIDGE_REPO
-    value: enmasseproject/amqp-kafka-bridge
-  - description: A list of host/port pairs to use for establishing the initial connection
-      to the Kafka cluster
-    name: KAFKA_BOOTSTRAP_SERVERS
-  - description: The instance this infrastructure is deployed for
-    name: INSTANCE
-    required: true
+    name: enmasse-template-config
 - apiVersion: extensions/v1beta1
   kind: Deployment
   metadata:
@@ -915,7 +605,14 @@ objects:
               memory: 256Mi
             requests:
               memory: 256Mi
+          volumeMounts:
+          - mountPath: "/templates"
+            name: templates
         serviceAccount: enmasse-service-account
+        volumes:
+        - configMap:
+            name: enmasse-template-config
+          name: templates
 - apiVersion: v1
   kind: Service
   metadata:

--- a/generated/enmasse-template.yaml
+++ b/generated/enmasse-template.yaml
@@ -60,12 +60,9 @@ objects:
       {"app": "enmasse", "instance": "${INSTANCE}", "name": "mqtt-lwt"}, "name": "mqtt-lwt"},
       "spec": {"replicas": 1, "template": {"metadata": {"labels": {"app": "enmasse",
       "instance": "${INSTANCE}", "name": "mqtt-lwt"}}, "spec": {"containers": [{"image":
-      "${MQTT_LWT_REPO}:latest", "name": "mqtt-lwt"}]}}}}, {"apiVersion": "v1", "kind":
-      "Route", "metadata": {"labels": {"app": "enmasse"}, "name": "console"}, "spec":
-      {"host": "${CONSOLE_HOSTNAME}", "port": {"targetPort": "console-http"}, "to":
-      {"kind": "Service", "name": "admin"}}}, {"apiVersion": "v1", "data": {"hawkular-openshift-agent":
-      "{\"endpoints\": [{\"collection_interval\": \"60s\", \"metrics\": [{\"id\":
-      \"broker.threadCount\", \"name\": \"java.lang:type=Threading#ThreadCount\",
+      "${MQTT_LWT_REPO}:latest", "name": "mqtt-lwt"}]}}}}, {"apiVersion": "v1", "data":
+      {"hawkular-openshift-agent": "{\"endpoints\": [{\"collection_interval\": \"60s\",
+      \"metrics\": [{\"id\": \"broker.threadCount\", \"name\": \"java.lang:type=Threading#ThreadCount\",
       \"tags\": {\"messagingComponent\": \"broker\", \"messagingMetricType\": \"threadCount\"},
       \"type\": \"counter\"}, {\"id\": \"broker.memoryHeapUsage\", \"name\": \"java.lang:type=Memory#HeapMemoryUsage#used\",
       \"tags\": {\"messagingComponent\": \"broker\", \"messagingMetricType\": \"heapUsage\"},
@@ -114,21 +111,24 @@ objects:
       {"labels": {"app": "enmasse", "instance": "${INSTANCE}"}, "name": "mqtt"}, "spec":
       {"host": "${MQTT_GATEWAY_HOSTNAME}", "port": {"targetPort": "secure-mqtt"},
       "tls": {"termination": "passthrough"}, "to": {"kind": "Service", "name": "mqtt",
-      "weight": 100}}}], "parameters": [{"description": "The image to use for the
-      router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"}, {"description":
-      "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY", "value":
-      "50"}, {"description": "The image to use for the configuration service", "name":
-      "CONFIGSERV_REPO", "value": "enmasseproject/configserv"}, {"description": "The
-      docker image to use for the queue scheduler", "name": "QUEUE_SCHEDULER_REPO",
-      "value": "enmasseproject/queue-scheduler"}, {"description": "The image to use
-      for the router agent", "name": "RAGENT_REPO", "value": "enmasseproject/ragent"},
-      {"description": "The image to use for the subscription services", "name": "SUBSERV_REPO",
-      "value": "enmasseproject/subserv"}, {"description": "The image to use for the
-      console", "name": "CONSOLE_REPO", "value": "enmasseproject/console"}, {"description":
-      "The hostname to use for the exposed route for messaging (TLS only)", "name":
-      "MESSAGING_HOSTNAME"}, {"description": "The image to use for the MQTT gateway",
-      "name": "MQTT_GATEWAY_REPO", "value": "enmasseproject/mqtt-gateway"}, {"description":
-      "The hostname to use for the exposed route for MQTT (TLS only)", "name": "MQTT_GATEWAY_HOSTNAME"},
+      "weight": 100}}}, {"apiVersion": "v1", "kind": "Route", "metadata": {"labels":
+      {"app": "enmasse"}, "name": "console"}, "spec": {"host": "${CONSOLE_HOSTNAME}",
+      "port": {"targetPort": "console-http"}, "to": {"kind": "Service", "name": "admin"}}}],
+      "parameters": [{"description": "The image to use for the router", "name": "ROUTER_REPO",
+      "value": "enmasseproject/qdrouterd"}, {"description": "The link capacity setting
+      for router", "name": "ROUTER_LINK_CAPACITY", "value": "50"}, {"description":
+      "The image to use for the configuration service", "name": "CONFIGSERV_REPO",
+      "value": "enmasseproject/configserv"}, {"description": "The docker image to
+      use for the queue scheduler", "name": "QUEUE_SCHEDULER_REPO", "value": "enmasseproject/queue-scheduler"},
+      {"description": "The image to use for the router agent", "name": "RAGENT_REPO",
+      "value": "enmasseproject/ragent"}, {"description": "The image to use for the
+      subscription services", "name": "SUBSERV_REPO", "value": "enmasseproject/subserv"},
+      {"description": "The image to use for the console", "name": "CONSOLE_REPO",
+      "value": "enmasseproject/console"}, {"description": "The hostname to use for
+      the exposed route for messaging (TLS only)", "name": "MESSAGING_HOSTNAME"},
+      {"description": "The image to use for the MQTT gateway", "name": "MQTT_GATEWAY_REPO",
+      "value": "enmasseproject/mqtt-gateway"}, {"description": "The hostname to use
+      for the exposed route for MQTT (TLS only)", "name": "MQTT_GATEWAY_HOSTNAME"},
       {"description": "The hostname to use for the exposed route for the messaging
       console", "name": "CONSOLE_HOSTNAME"}, {"description": "The image to use for
       the MQTT LWT", "name": "MQTT_LWT_REPO", "value": "enmasseproject/mqtt-lwt"},
@@ -245,12 +245,9 @@ objects:
       {"app": "enmasse", "instance": "${INSTANCE}", "name": "mqtt-lwt"}, "name": "mqtt-lwt"},
       "spec": {"replicas": 1, "template": {"metadata": {"labels": {"app": "enmasse",
       "instance": "${INSTANCE}", "name": "mqtt-lwt"}}, "spec": {"containers": [{"image":
-      "${MQTT_LWT_REPO}:latest", "name": "mqtt-lwt"}]}}}}, {"apiVersion": "v1", "kind":
-      "Route", "metadata": {"labels": {"app": "enmasse"}, "name": "console"}, "spec":
-      {"host": "${CONSOLE_HOSTNAME}", "port": {"targetPort": "console-http"}, "to":
-      {"kind": "Service", "name": "admin"}}}, {"apiVersion": "v1", "data": {"hawkular-openshift-agent":
-      "{\"endpoints\": [{\"collection_interval\": \"60s\", \"metrics\": [{\"id\":
-      \"broker.threadCount\", \"name\": \"java.lang:type=Threading#ThreadCount\",
+      "${MQTT_LWT_REPO}:latest", "name": "mqtt-lwt"}]}}}}, {"apiVersion": "v1", "data":
+      {"hawkular-openshift-agent": "{\"endpoints\": [{\"collection_interval\": \"60s\",
+      \"metrics\": [{\"id\": \"broker.threadCount\", \"name\": \"java.lang:type=Threading#ThreadCount\",
       \"tags\": {\"messagingComponent\": \"broker\", \"messagingMetricType\": \"threadCount\"},
       \"type\": \"counter\"}, {\"id\": \"broker.memoryHeapUsage\", \"name\": \"java.lang:type=Memory#HeapMemoryUsage#used\",
       \"tags\": {\"messagingComponent\": \"broker\", \"messagingMetricType\": \"heapUsage\"},
@@ -299,21 +296,24 @@ objects:
       {"labels": {"app": "enmasse", "instance": "${INSTANCE}"}, "name": "mqtt"}, "spec":
       {"host": "${MQTT_GATEWAY_HOSTNAME}", "port": {"targetPort": "secure-mqtt"},
       "tls": {"termination": "passthrough"}, "to": {"kind": "Service", "name": "mqtt",
-      "weight": 100}}}], "parameters": [{"description": "The image to use for the
-      router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"}, {"description":
-      "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY", "value":
-      "50"}, {"description": "The image to use for the configuration service", "name":
-      "CONFIGSERV_REPO", "value": "enmasseproject/configserv"}, {"description": "The
-      docker image to use for the queue scheduler", "name": "QUEUE_SCHEDULER_REPO",
-      "value": "enmasseproject/queue-scheduler"}, {"description": "The image to use
-      for the router agent", "name": "RAGENT_REPO", "value": "enmasseproject/ragent"},
-      {"description": "The image to use for the subscription services", "name": "SUBSERV_REPO",
-      "value": "enmasseproject/subserv"}, {"description": "The image to use for the
-      console", "name": "CONSOLE_REPO", "value": "enmasseproject/console"}, {"description":
-      "The hostname to use for the exposed route for messaging (TLS only)", "name":
-      "MESSAGING_HOSTNAME"}, {"description": "The image to use for the MQTT gateway",
-      "name": "MQTT_GATEWAY_REPO", "value": "enmasseproject/mqtt-gateway"}, {"description":
-      "The hostname to use for the exposed route for MQTT (TLS only)", "name": "MQTT_GATEWAY_HOSTNAME"},
+      "weight": 100}}}, {"apiVersion": "v1", "kind": "Route", "metadata": {"labels":
+      {"app": "enmasse"}, "name": "console"}, "spec": {"host": "${CONSOLE_HOSTNAME}",
+      "port": {"targetPort": "console-http"}, "to": {"kind": "Service", "name": "admin"}}}],
+      "parameters": [{"description": "The image to use for the router", "name": "ROUTER_REPO",
+      "value": "enmasseproject/qdrouterd"}, {"description": "The link capacity setting
+      for router", "name": "ROUTER_LINK_CAPACITY", "value": "50"}, {"description":
+      "The image to use for the configuration service", "name": "CONFIGSERV_REPO",
+      "value": "enmasseproject/configserv"}, {"description": "The docker image to
+      use for the queue scheduler", "name": "QUEUE_SCHEDULER_REPO", "value": "enmasseproject/queue-scheduler"},
+      {"description": "The image to use for the router agent", "name": "RAGENT_REPO",
+      "value": "enmasseproject/ragent"}, {"description": "The image to use for the
+      subscription services", "name": "SUBSERV_REPO", "value": "enmasseproject/subserv"},
+      {"description": "The image to use for the console", "name": "CONSOLE_REPO",
+      "value": "enmasseproject/console"}, {"description": "The hostname to use for
+      the exposed route for messaging (TLS only)", "name": "MESSAGING_HOSTNAME"},
+      {"description": "The image to use for the MQTT gateway", "name": "MQTT_GATEWAY_REPO",
+      "value": "enmasseproject/mqtt-gateway"}, {"description": "The hostname to use
+      for the exposed route for MQTT (TLS only)", "name": "MQTT_GATEWAY_HOSTNAME"},
       {"description": "The hostname to use for the exposed route for the messaging
       console", "name": "CONSOLE_HOSTNAME"}, {"description": "The image to use for
       the MQTT LWT", "name": "MQTT_LWT_REPO", "value": "enmasseproject/mqtt-lwt"},

--- a/generated/enmasse-template.yaml
+++ b/generated/enmasse-template.yaml
@@ -7,831 +7,544 @@ metadata:
   name: enmasse-infra
 objects:
 - apiVersion: v1
-  kind: Template
+  data:
+    enmasse-instance-infra.json: '{"apiVersion": "v1", "kind": "Template", "metadata":
+      {"labels": {"app": "enmasse"}, "name": "tls-enmasse-instance-infra"}, "objects":
+      [{"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels":
+      {"app": "enmasse", "instance": "${INSTANCE}", "name": "qdrouterd"}, "name":
+      "qdrouterd"}, "spec": {"replicas": 1, "template": {"metadata": {"labels": {"app":
+      "enmasse", "capability": "router", "instance": "${INSTANCE}", "name": "qdrouterd"}},
+      "spec": {"containers": [{"env": [{"name": "LINK_CAPACITY", "value": "${ROUTER_LINK_CAPACITY}"}],
+      "image": "${ROUTER_REPO}:latest", "livenessProbe": {"tcpSocket": {"port": "amqp"}},
+      "name": "router", "ports": [{"containerPort": 5672, "name": "amqp", "protocol":
+      "TCP"}, {"containerPort": 55673, "name": "internal", "protocol": "TCP"}, {"containerPort":
+      5671, "name": "amqps", "protocol": "TCP"}], "volumeMounts": [{"mountPath": "/etc/qpid-dispatch/ssl",
+      "name": "ssl-certs", "readOnly": true}]}], "volumes": [{"name": "ssl-certs",
+      "secret": {"secretName": "qdrouterd-certs"}}]}}}}, {"apiVersion": "v1", "kind":
+      "Service", "metadata": {"annotations": {"service.alpha.openshift.io/dependencies":
+      "[{\"kind\": \"Service\", \"name\": \"admin\", \"namespace\": \"\"}, {\"kind\":
+      \"Service\", \"name\": \"subscription\", \"namespace\": \"\"}, {\"kind\": \"Service\",
+      \"name\": \"mqtt\", \"namespace\": \"\"}]", "service.alpha.openshift.io/infrastructure":
+      "true"}, "labels": {"app": "enmasse", "instance": "${INSTANCE}"}, "name": "messaging"},
+      "spec": {"ports": [{"name": "amqp", "port": 5672, "protocol": "TCP", "targetPort":
+      5672}, {"name": "amqps", "port": 5671, "protocol": "TCP", "targetPort": 5671},
+      {"name": "internal", "port": 55673, "protocol": "TCP", "targetPort": 55673}],
+      "selector": {"capability": "router", "instance": "${INSTANCE}"}}}, {"apiVersion":
+      "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels": {"app": "enmasse",
+      "instance": "${INSTANCE}", "name": "subserv"}, "name": "subserv"}, "spec": {"replicas":
+      1, "template": {"metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}",
+      "name": "subserv"}}, "spec": {"containers": [{"env": [ ], "image": "${SUBSERV_REPO}:latest",
+      "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name": "subserv", "ports":
+      [{"containerPort": 5672, "name": "amqp", "protocol": "TCP"}], "resources": {"limits":
+      {"memory": "64Mi"}, "requests": {"memory": "64Mi"}}}]}}}}, {"apiVersion": "v1",
+      "kind": "Service", "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"},
+      "name": "subscription"}, "spec": {"ports": [{"name": "amqp", "port": 5672, "protocol":
+      "TCP", "targetPort": 5672}], "selector": {"instance": "${INSTANCE}", "name":
+      "subserv"}}}, {"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata":
+      {"labels": {"app": "enmasse", "instance": "${INSTANCE}", "name": "mqtt-gateway"},
+      "name": "mqtt-gateway"}, "spec": {"replicas": 1, "template": {"metadata": {"labels":
+      {"app": "enmasse", "instance": "${INSTANCE}", "name": "mqtt-gateway"}}, "spec":
+      {"containers": [{"image": "${MQTT_GATEWAY_REPO}:latest", "livenessProbe": {"initialDelaySeconds":
+      60, "tcpSocket": {"port": "secure-mqtt"}}, "name": "mqtt-gateway-tls", "ports":
+      [{"containerPort": 8883, "name": "secure-mqtt", "protocol": "TCP"}], "volumeMounts":
+      [{"mountPath": "/etc/mqtt-gateway/ssl", "name": "ssl-certs", "readOnly": true}]},
+      {"image": "${MQTT_GATEWAY_REPO}:latest", "livenessProbe": {"initialDelaySeconds":
+      60, "tcpSocket": {"port": "mqtt"}}, "name": "mqtt-gateway", "ports": [{"containerPort":
+      1883, "name": "mqtt", "protocol": "TCP"}]}], "volumes": [{"name": "ssl-certs",
+      "secret": {"secretName": "mqtt-certs"}}]}}}}, {"apiVersion": "v1", "kind": "Service",
+      "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"}, "name":
+      "mqtt"}, "spec": {"ports": [{"name": "mqtt", "port": 1883, "protocol": "TCP",
+      "targetPort": 1883}, {"name": "secure-mqtt", "port": 8883, "protocol": "TCP",
+      "targetPort": 8883}], "selector": {"instance": "${INSTANCE}", "name": "mqtt-gateway"}}},
+      {"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels":
+      {"app": "enmasse", "instance": "${INSTANCE}", "name": "mqtt-lwt"}, "name": "mqtt-lwt"},
+      "spec": {"replicas": 1, "template": {"metadata": {"labels": {"app": "enmasse",
+      "instance": "${INSTANCE}", "name": "mqtt-lwt"}}, "spec": {"containers": [{"image":
+      "${MQTT_LWT_REPO}:latest", "name": "mqtt-lwt"}]}}}}, {"apiVersion": "v1", "kind":
+      "Route", "metadata": {"labels": {"app": "enmasse"}, "name": "console"}, "spec":
+      {"host": "${CONSOLE_HOSTNAME}", "port": {"targetPort": "console-http"}, "to":
+      {"kind": "Service", "name": "admin"}}}, {"apiVersion": "v1", "data": {"hawkular-openshift-agent":
+      "{\"endpoints\": [{\"collection_interval\": \"60s\", \"metrics\": [{\"id\":
+      \"broker.threadCount\", \"name\": \"java.lang:type=Threading#ThreadCount\",
+      \"tags\": {\"messagingComponent\": \"broker\", \"messagingMetricType\": \"threadCount\"},
+      \"type\": \"counter\"}, {\"id\": \"broker.memoryHeapUsage\", \"name\": \"java.lang:type=Memory#HeapMemoryUsage#used\",
+      \"tags\": {\"messagingComponent\": \"broker\", \"messagingMetricType\": \"heapUsage\"},
+      \"type\": \"gauge\"}, {\"description\": \"Queue depth for ${address}\", \"id\":
+      \"${address}.${queue}.${broker}.queueDepth\", \"name\": \"org.apache.activemq.artemis:address=*,broker=*,component=addresses,queue=*,routing-type=*,subcomponent=queues#MessageCount\",
+      \"tags\": {\"messagingAddress\": \"${address}\", \"messagingBroker\": \"{broker}\",
+      \"messagingMetricType\": \"queueDepth\", \"messagingQueue\": \"${queue}\"},
+      \"type\": \"gauge\"}, {\"description\": \"Number of consumers for ${address}\",
+      \"id\": \"${address}.${queue}.${broker}.numConsumers\", \"name\": \"org.apache.activemq.artemis:address=*,broker=*,component=addresses,queue=*,routing-type=*,subcomponent=queues#ConsumerCount\",
+      \"tags\": {\"messagingAddress\": \"${address}\", \"messagingBroker\": \"{broker}\",
+      \"messagingMetricType\": \"numConsumers\", \"messagingQueue\": \"${queue}\"},
+      \"type\": \"gauge\"}], \"path\": \"/jolokia/\", \"port\": 8161, \"protocol\":
+      \"http\", \"type\": \"jolokia\"}]}"}, "kind": "ConfigMap", "metadata": {"name":
+      "hawkular-broker-config"}}, {"apiVersion": "extensions/v1beta1", "kind": "Deployment",
+      "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}", "name":
+      "admin"}, "name": "admin"}, "spec": {"replicas": 1, "template": {"metadata":
+      {"labels": {"app": "enmasse", "instance": "${INSTANCE}", "name": "admin"}},
+      "spec": {"containers": [{"env": [{"name": "CONFIGURATION_SERVICE_HOST", "value":
+      "localhost"}, {"name": "CONFIGURATION_SERVICE_PORT", "value": "5672"}], "image":
+      "${RAGENT_REPO}:latest", "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name":
+      "ragent", "ports": [{"containerPort": 55672, "name": "amqp", "protocol": "TCP"}],
+      "resources": {"limits": {"memory": "64Mi"}, "requests": {"memory": "64Mi"}}},
+      {"env": [{"name": "CONFIGURATION_SERVICE_HOST", "value": "localhost"}, {"name":
+      "CONFIGURATION_SERVICE_PORT", "value": "5672"}], "image": "${QUEUE_SCHEDULER_REPO}:latest",
+      "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name": "queue-scheduler",
+      "ports": [{"containerPort": 55667, "name": "amqp", "protocol": "TCP"}], "resources":
+      {"limits": {"memory": "128Mi"}, "requests": {"memory": "128Mi"}}}, {"env": [{"name":
+      "CONFIGURATION_SERVICE_HOST", "value": "localhost"}, {"name": "CONFIGURATION_SERVICE_PORT",
+      "value": "5672"}], "image": "${CONSOLE_REPO}:latest", "livenessProbe": {"tcpSocket":
+      {"port": "http"}}, "name": "console", "ports": [{"containerPort": 8080, "name":
+      "http", "protocol": "TCP"}, {"containerPort": 56720, "name": "amqp-ws", "protocol":
+      "TCP"}], "resources": {"limits": {"memory": "64Mi"}, "requests": {"memory":
+      "64Mi"}}}, {"env": [ ], "image": "${CONFIGSERV_REPO}:latest", "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "configserv", "ports": [{"containerPort":
+      5672, "name": "amqp", "protocol": "TCP"}], "resources": {"limits": {"memory":
+      "256Mi"}, "requests": {"memory": "256Mi"}}}]}}}}, {"apiVersion": "v1", "kind":
+      "Service", "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"},
+      "name": "admin"}, "spec": {"ports": [{"name": "ragent", "port": 55672}, {"name":
+      "configuration", "port": 5672}, {"name": "queue-scheduler", "port": 55667},
+      {"name": "console-ws", "port": 56720}, {"name": "console-http", "port": 8080}],
+      "selector": {"instance": "${INSTANCE}", "name": "admin"}}}, {"apiVersion": "v1",
+      "kind": "Route", "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"},
+      "name": "messaging"}, "spec": {"host": "${MESSAGING_HOSTNAME}", "port": {"targetPort":
+      "amqps"}, "tls": {"termination": "passthrough"}, "to": {"kind": "Service", "name":
+      "messaging", "weight": 100}}}, {"apiVersion": "v1", "kind": "Route", "metadata":
+      {"labels": {"app": "enmasse", "instance": "${INSTANCE}"}, "name": "mqtt"}, "spec":
+      {"host": "${MQTT_GATEWAY_HOSTNAME}", "port": {"targetPort": "secure-mqtt"},
+      "tls": {"termination": "passthrough"}, "to": {"kind": "Service", "name": "mqtt",
+      "weight": 100}}}], "parameters": [{"description": "The image to use for the
+      router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"}, {"description":
+      "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY", "value":
+      "50"}, {"description": "The image to use for the configuration service", "name":
+      "CONFIGSERV_REPO", "value": "enmasseproject/configserv"}, {"description": "The
+      docker image to use for the queue scheduler", "name": "QUEUE_SCHEDULER_REPO",
+      "value": "enmasseproject/queue-scheduler"}, {"description": "The image to use
+      for the router agent", "name": "RAGENT_REPO", "value": "enmasseproject/ragent"},
+      {"description": "The image to use for the subscription services", "name": "SUBSERV_REPO",
+      "value": "enmasseproject/subserv"}, {"description": "The image to use for the
+      console", "name": "CONSOLE_REPO", "value": "enmasseproject/console"}, {"description":
+      "The hostname to use for the exposed route for messaging (TLS only)", "name":
+      "MESSAGING_HOSTNAME"}, {"description": "The image to use for the MQTT gateway",
+      "name": "MQTT_GATEWAY_REPO", "value": "enmasseproject/mqtt-gateway"}, {"description":
+      "The hostname to use for the exposed route for MQTT (TLS only)", "name": "MQTT_GATEWAY_HOSTNAME"},
+      {"description": "The hostname to use for the exposed route for the messaging
+      console", "name": "CONSOLE_HOSTNAME"}, {"description": "The image to use for
+      the MQTT LWT", "name": "MQTT_LWT_REPO", "value": "enmasseproject/mqtt-lwt"},
+      {"description": "The image to use for the AMQP Kafka Bridge", "name": "AMQP_KAFKA_BRIDGE_REPO",
+      "value": "enmasseproject/amqp-kafka-bridge"}, {"description": "A list of host/port
+      pairs to use for establishing the initial connection to the Kafka cluster",
+      "name": "KAFKA_BOOTSTRAP_SERVERS"}, {"description": "The instance this infrastructure
+      is deployed for", "name": "INSTANCE", "required": true}]}'
+    queue-inmemory.json: '{"apiVersion": "v1", "kind": "Template", "metadata": {"labels":
+      {"app": "enmasse"}, "name": "queue-inmemory"}, "objects": [{"apiVersion": "extensions/v1beta1",
+      "kind": "Deployment", "metadata": {"labels": {"address_config": "address-config-${INSTANCE}-${NAME}",
+      "app": "enmasse", "group_id": "${NAME}", "instance": "${INSTANCE}"}, "name":
+      "${NAME}"}, "spec": {"replicas": 1, "template": {"metadata": {"labels": {"app":
+      "enmasse", "group_id": "${NAME}", "instance": "${INSTANCE}", "role": "broker"}},
+      "spec": {"containers": [{"env": [{"name": "QUEUE_NAME", "value": "${ADDRESS}"},
+      {"name": "GROUP_ID", "value": "${NAME}"}], "image": "${BROKER_REPO}:latest",
+      "lifecycle": {"preStop": {"exec": {"command": ["/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"]}}},
+      "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name": "broker", "ports":
+      [{"containerPort": 5673, "name": "amqp"}, {"containerPort": 61616, "name": "core"},
+      {"containerPort": 8161, "name": "jolokia"}], "readinessProbe": {"tcpSocket":
+      {"port": "amqp"}}, "volumeMounts": [{"mountPath": "/var/run/artemis", "name":
+      "vol-${NAME}"}]}], "volumes": [{"emptyDir": { }, "name": "vol-${NAME}"}, {"configMap":
+      {"name": "hawkular-broker-config"}, "name": "hawkular-openshift-agent"}]}}}}],
+      "parameters": [{"description": "Storage capacity required for volume claims",
+      "name": "STORAGE_CAPACITY", "value": "2Gi"}, {"description": "The docker image
+      to use for the message broker", "name": "BROKER_REPO", "value": "enmasseproject/artemis"},
+      {"description": "The default image to use as topic forwarder", "name": "TOPIC_FORWARDER_REPO",
+      "value": "enmasseproject/topic-forwarder"}, {"description": "The image to use
+      for the router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"},
+      {"description": "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY",
+      "value": "50"}, {"description": "A valid instance name for the instance", "name":
+      "INSTANCE", "required": true}, {"description": "A valid name for the instance",
+      "name": "NAME", "required": true}, {"description": "The address to use for the
+      queue", "name": "ADDRESS", "required": true}]}'
+    queue-persisted.json: '{"apiVersion": "v1", "kind": "Template", "metadata": {"labels":
+      {"app": "enmasse"}, "name": "queue-persisted"}, "objects": [{"apiVersion": "v1",
+      "kind": "PersistentVolumeClaim", "metadata": {"labels": {"app": "enmasse", "group_id":
+      "${NAME}", "instance": "${INSTANCE}"}, "name": "pvc-${NAME}"}, "spec": {"accessModes":
+      ["ReadWriteMany"], "resources": {"requests": {"storage": "${STORAGE_CAPACITY}"}}}},
+      {"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels":
+      {"address_config": "address-config-${INSTANCE}-${NAME}", "app": "enmasse", "group_id":
+      "${NAME}", "instance": "${INSTANCE}"}, "name": "${NAME}"}, "spec": {"replicas":
+      1, "template": {"metadata": {"labels": {"app": "enmasse", "group_id": "${NAME}",
+      "instance": "${INSTANCE}", "role": "broker"}}, "spec": {"containers": [{"env":
+      [{"name": "QUEUE_NAME", "value": "${ADDRESS}"}, {"name": "GROUP_ID", "value":
+      "${NAME}"}], "image": "${BROKER_REPO}:latest", "lifecycle": {"preStop": {"exec":
+      {"command": ["/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"]}}}, "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "broker", "ports": [{"containerPort":
+      5673, "name": "amqp"}, {"containerPort": 61616, "name": "core"}, {"containerPort":
+      8161, "name": "jolokia"}], "readinessProbe": {"tcpSocket": {"port": "amqp"}},
+      "volumeMounts": [{"mountPath": "/var/run/artemis", "name": "vol-${NAME}"}]}],
+      "volumes": [{"name": "vol-${NAME}", "persistentVolumeClaim": {"claimName": "pvc-${NAME}"}},
+      {"configMap": {"name": "hawkular-broker-config"}, "name": "hawkular-openshift-agent"}]}}}}],
+      "parameters": [{"description": "Storage capacity required for volume claims",
+      "name": "STORAGE_CAPACITY", "value": "2Gi"}, {"description": "The docker image
+      to use for the message broker", "name": "BROKER_REPO", "value": "enmasseproject/artemis"},
+      {"description": "The default image to use as topic forwarder", "name": "TOPIC_FORWARDER_REPO",
+      "value": "enmasseproject/topic-forwarder"}, {"description": "The image to use
+      for the router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"},
+      {"description": "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY",
+      "value": "50"}, {"description": "A valid instance name for the instance", "name":
+      "INSTANCE", "required": true}, {"description": "A valid name for the instance",
+      "name": "NAME", "required": true}, {"description": "The address to use for the
+      queue", "name": "ADDRESS", "required": true}]}'
+    tls-enmasse-instance-infra.json: '{"apiVersion": "v1", "kind": "Template", "metadata":
+      {"labels": {"app": "enmasse"}, "name": "tls-enmasse-instance-infra"}, "objects":
+      [{"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels":
+      {"app": "enmasse", "instance": "${INSTANCE}", "name": "qdrouterd"}, "name":
+      "qdrouterd"}, "spec": {"replicas": 1, "template": {"metadata": {"labels": {"app":
+      "enmasse", "capability": "router", "instance": "${INSTANCE}", "name": "qdrouterd"}},
+      "spec": {"containers": [{"env": [{"name": "LINK_CAPACITY", "value": "${ROUTER_LINK_CAPACITY}"}],
+      "image": "${ROUTER_REPO}:latest", "livenessProbe": {"tcpSocket": {"port": "amqp"}},
+      "name": "router", "ports": [{"containerPort": 5672, "name": "amqp", "protocol":
+      "TCP"}, {"containerPort": 55673, "name": "internal", "protocol": "TCP"}, {"containerPort":
+      5671, "name": "amqps", "protocol": "TCP"}], "volumeMounts": [{"mountPath": "/etc/qpid-dispatch/ssl",
+      "name": "ssl-certs", "readOnly": true}]}], "volumes": [{"name": "ssl-certs",
+      "secret": {"secretName": "qdrouterd-certs"}}]}}}}, {"apiVersion": "v1", "kind":
+      "Service", "metadata": {"annotations": {"service.alpha.openshift.io/dependencies":
+      "[{\"kind\": \"Service\", \"name\": \"admin\", \"namespace\": \"\"}, {\"kind\":
+      \"Service\", \"name\": \"subscription\", \"namespace\": \"\"}, {\"kind\": \"Service\",
+      \"name\": \"mqtt\", \"namespace\": \"\"}]", "service.alpha.openshift.io/infrastructure":
+      "true"}, "labels": {"app": "enmasse", "instance": "${INSTANCE}"}, "name": "messaging"},
+      "spec": {"ports": [{"name": "amqp", "port": 5672, "protocol": "TCP", "targetPort":
+      5672}, {"name": "amqps", "port": 5671, "protocol": "TCP", "targetPort": 5671},
+      {"name": "internal", "port": 55673, "protocol": "TCP", "targetPort": 55673}],
+      "selector": {"capability": "router", "instance": "${INSTANCE}"}}}, {"apiVersion":
+      "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels": {"app": "enmasse",
+      "instance": "${INSTANCE}", "name": "subserv"}, "name": "subserv"}, "spec": {"replicas":
+      1, "template": {"metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}",
+      "name": "subserv"}}, "spec": {"containers": [{"env": [ ], "image": "${SUBSERV_REPO}:latest",
+      "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name": "subserv", "ports":
+      [{"containerPort": 5672, "name": "amqp", "protocol": "TCP"}], "resources": {"limits":
+      {"memory": "64Mi"}, "requests": {"memory": "64Mi"}}}]}}}}, {"apiVersion": "v1",
+      "kind": "Service", "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"},
+      "name": "subscription"}, "spec": {"ports": [{"name": "amqp", "port": 5672, "protocol":
+      "TCP", "targetPort": 5672}], "selector": {"instance": "${INSTANCE}", "name":
+      "subserv"}}}, {"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata":
+      {"labels": {"app": "enmasse", "instance": "${INSTANCE}", "name": "mqtt-gateway"},
+      "name": "mqtt-gateway"}, "spec": {"replicas": 1, "template": {"metadata": {"labels":
+      {"app": "enmasse", "instance": "${INSTANCE}", "name": "mqtt-gateway"}}, "spec":
+      {"containers": [{"image": "${MQTT_GATEWAY_REPO}:latest", "livenessProbe": {"initialDelaySeconds":
+      60, "tcpSocket": {"port": "secure-mqtt"}}, "name": "mqtt-gateway-tls", "ports":
+      [{"containerPort": 8883, "name": "secure-mqtt", "protocol": "TCP"}], "volumeMounts":
+      [{"mountPath": "/etc/mqtt-gateway/ssl", "name": "ssl-certs", "readOnly": true}]},
+      {"image": "${MQTT_GATEWAY_REPO}:latest", "livenessProbe": {"initialDelaySeconds":
+      60, "tcpSocket": {"port": "mqtt"}}, "name": "mqtt-gateway", "ports": [{"containerPort":
+      1883, "name": "mqtt", "protocol": "TCP"}]}], "volumes": [{"name": "ssl-certs",
+      "secret": {"secretName": "mqtt-certs"}}]}}}}, {"apiVersion": "v1", "kind": "Service",
+      "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"}, "name":
+      "mqtt"}, "spec": {"ports": [{"name": "mqtt", "port": 1883, "protocol": "TCP",
+      "targetPort": 1883}, {"name": "secure-mqtt", "port": 8883, "protocol": "TCP",
+      "targetPort": 8883}], "selector": {"instance": "${INSTANCE}", "name": "mqtt-gateway"}}},
+      {"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels":
+      {"app": "enmasse", "instance": "${INSTANCE}", "name": "mqtt-lwt"}, "name": "mqtt-lwt"},
+      "spec": {"replicas": 1, "template": {"metadata": {"labels": {"app": "enmasse",
+      "instance": "${INSTANCE}", "name": "mqtt-lwt"}}, "spec": {"containers": [{"image":
+      "${MQTT_LWT_REPO}:latest", "name": "mqtt-lwt"}]}}}}, {"apiVersion": "v1", "kind":
+      "Route", "metadata": {"labels": {"app": "enmasse"}, "name": "console"}, "spec":
+      {"host": "${CONSOLE_HOSTNAME}", "port": {"targetPort": "console-http"}, "to":
+      {"kind": "Service", "name": "admin"}}}, {"apiVersion": "v1", "data": {"hawkular-openshift-agent":
+      "{\"endpoints\": [{\"collection_interval\": \"60s\", \"metrics\": [{\"id\":
+      \"broker.threadCount\", \"name\": \"java.lang:type=Threading#ThreadCount\",
+      \"tags\": {\"messagingComponent\": \"broker\", \"messagingMetricType\": \"threadCount\"},
+      \"type\": \"counter\"}, {\"id\": \"broker.memoryHeapUsage\", \"name\": \"java.lang:type=Memory#HeapMemoryUsage#used\",
+      \"tags\": {\"messagingComponent\": \"broker\", \"messagingMetricType\": \"heapUsage\"},
+      \"type\": \"gauge\"}, {\"description\": \"Queue depth for ${address}\", \"id\":
+      \"${address}.${queue}.${broker}.queueDepth\", \"name\": \"org.apache.activemq.artemis:address=*,broker=*,component=addresses,queue=*,routing-type=*,subcomponent=queues#MessageCount\",
+      \"tags\": {\"messagingAddress\": \"${address}\", \"messagingBroker\": \"{broker}\",
+      \"messagingMetricType\": \"queueDepth\", \"messagingQueue\": \"${queue}\"},
+      \"type\": \"gauge\"}, {\"description\": \"Number of consumers for ${address}\",
+      \"id\": \"${address}.${queue}.${broker}.numConsumers\", \"name\": \"org.apache.activemq.artemis:address=*,broker=*,component=addresses,queue=*,routing-type=*,subcomponent=queues#ConsumerCount\",
+      \"tags\": {\"messagingAddress\": \"${address}\", \"messagingBroker\": \"{broker}\",
+      \"messagingMetricType\": \"numConsumers\", \"messagingQueue\": \"${queue}\"},
+      \"type\": \"gauge\"}], \"path\": \"/jolokia/\", \"port\": 8161, \"protocol\":
+      \"http\", \"type\": \"jolokia\"}]}"}, "kind": "ConfigMap", "metadata": {"name":
+      "hawkular-broker-config"}}, {"apiVersion": "extensions/v1beta1", "kind": "Deployment",
+      "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}", "name":
+      "admin"}, "name": "admin"}, "spec": {"replicas": 1, "template": {"metadata":
+      {"labels": {"app": "enmasse", "instance": "${INSTANCE}", "name": "admin"}},
+      "spec": {"containers": [{"env": [{"name": "CONFIGURATION_SERVICE_HOST", "value":
+      "localhost"}, {"name": "CONFIGURATION_SERVICE_PORT", "value": "5672"}], "image":
+      "${RAGENT_REPO}:latest", "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name":
+      "ragent", "ports": [{"containerPort": 55672, "name": "amqp", "protocol": "TCP"}],
+      "resources": {"limits": {"memory": "64Mi"}, "requests": {"memory": "64Mi"}}},
+      {"env": [{"name": "CONFIGURATION_SERVICE_HOST", "value": "localhost"}, {"name":
+      "CONFIGURATION_SERVICE_PORT", "value": "5672"}], "image": "${QUEUE_SCHEDULER_REPO}:latest",
+      "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name": "queue-scheduler",
+      "ports": [{"containerPort": 55667, "name": "amqp", "protocol": "TCP"}], "resources":
+      {"limits": {"memory": "128Mi"}, "requests": {"memory": "128Mi"}}}, {"env": [{"name":
+      "CONFIGURATION_SERVICE_HOST", "value": "localhost"}, {"name": "CONFIGURATION_SERVICE_PORT",
+      "value": "5672"}], "image": "${CONSOLE_REPO}:latest", "livenessProbe": {"tcpSocket":
+      {"port": "http"}}, "name": "console", "ports": [{"containerPort": 8080, "name":
+      "http", "protocol": "TCP"}, {"containerPort": 56720, "name": "amqp-ws", "protocol":
+      "TCP"}], "resources": {"limits": {"memory": "64Mi"}, "requests": {"memory":
+      "64Mi"}}}, {"env": [ ], "image": "${CONFIGSERV_REPO}:latest", "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "configserv", "ports": [{"containerPort":
+      5672, "name": "amqp", "protocol": "TCP"}], "resources": {"limits": {"memory":
+      "256Mi"}, "requests": {"memory": "256Mi"}}}]}}}}, {"apiVersion": "v1", "kind":
+      "Service", "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"},
+      "name": "admin"}, "spec": {"ports": [{"name": "ragent", "port": 55672}, {"name":
+      "configuration", "port": 5672}, {"name": "queue-scheduler", "port": 55667},
+      {"name": "console-ws", "port": 56720}, {"name": "console-http", "port": 8080}],
+      "selector": {"instance": "${INSTANCE}", "name": "admin"}}}, {"apiVersion": "v1",
+      "kind": "Route", "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"},
+      "name": "messaging"}, "spec": {"host": "${MESSAGING_HOSTNAME}", "port": {"targetPort":
+      "amqps"}, "tls": {"termination": "passthrough"}, "to": {"kind": "Service", "name":
+      "messaging", "weight": 100}}}, {"apiVersion": "v1", "kind": "Route", "metadata":
+      {"labels": {"app": "enmasse", "instance": "${INSTANCE}"}, "name": "mqtt"}, "spec":
+      {"host": "${MQTT_GATEWAY_HOSTNAME}", "port": {"targetPort": "secure-mqtt"},
+      "tls": {"termination": "passthrough"}, "to": {"kind": "Service", "name": "mqtt",
+      "weight": 100}}}], "parameters": [{"description": "The image to use for the
+      router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"}, {"description":
+      "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY", "value":
+      "50"}, {"description": "The image to use for the configuration service", "name":
+      "CONFIGSERV_REPO", "value": "enmasseproject/configserv"}, {"description": "The
+      docker image to use for the queue scheduler", "name": "QUEUE_SCHEDULER_REPO",
+      "value": "enmasseproject/queue-scheduler"}, {"description": "The image to use
+      for the router agent", "name": "RAGENT_REPO", "value": "enmasseproject/ragent"},
+      {"description": "The image to use for the subscription services", "name": "SUBSERV_REPO",
+      "value": "enmasseproject/subserv"}, {"description": "The image to use for the
+      console", "name": "CONSOLE_REPO", "value": "enmasseproject/console"}, {"description":
+      "The hostname to use for the exposed route for messaging (TLS only)", "name":
+      "MESSAGING_HOSTNAME"}, {"description": "The image to use for the MQTT gateway",
+      "name": "MQTT_GATEWAY_REPO", "value": "enmasseproject/mqtt-gateway"}, {"description":
+      "The hostname to use for the exposed route for MQTT (TLS only)", "name": "MQTT_GATEWAY_HOSTNAME"},
+      {"description": "The hostname to use for the exposed route for the messaging
+      console", "name": "CONSOLE_HOSTNAME"}, {"description": "The image to use for
+      the MQTT LWT", "name": "MQTT_LWT_REPO", "value": "enmasseproject/mqtt-lwt"},
+      {"description": "The image to use for the AMQP Kafka Bridge", "name": "AMQP_KAFKA_BRIDGE_REPO",
+      "value": "enmasseproject/amqp-kafka-bridge"}, {"description": "A list of host/port
+      pairs to use for establishing the initial connection to the Kafka cluster",
+      "name": "KAFKA_BOOTSTRAP_SERVERS"}, {"description": "The instance this infrastructure
+      is deployed for", "name": "INSTANCE", "required": true}]}'
+    tls-queue-inmemory.json: '{"apiVersion": "v1", "kind": "Template", "metadata":
+      {"labels": {"app": "enmasse"}, "name": "tls-queue-inmemory"}, "objects": [{"apiVersion":
+      "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels": {"address_config":
+      "address-config-${INSTANCE}-${NAME}", "app": "enmasse", "group_id": "${NAME}",
+      "instance": "${INSTANCE}"}, "name": "${NAME}"}, "spec": {"replicas": 1, "template":
+      {"metadata": {"labels": {"app": "enmasse", "group_id": "${NAME}", "instance":
+      "${INSTANCE}", "role": "broker"}}, "spec": {"containers": [{"env": [{"name":
+      "QUEUE_NAME", "value": "${ADDRESS}"}, {"name": "GROUP_ID", "value": "${NAME}"}],
+      "image": "${BROKER_REPO}:latest", "lifecycle": {"preStop": {"exec": {"command":
+      ["/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"]}}}, "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "broker", "ports": [{"containerPort":
+      5673, "name": "amqp"}, {"containerPort": 61616, "name": "core"}, {"containerPort":
+      8161, "name": "jolokia"}], "readinessProbe": {"tcpSocket": {"port": "amqp"}},
+      "volumeMounts": [{"mountPath": "/var/run/artemis", "name": "vol-${NAME}"}]}],
+      "volumes": [{"emptyDir": { }, "name": "vol-${NAME}"}, {"name": "ssl-certs",
+      "secret": {"secretName": "qdrouterd-certs"}}, {"configMap": {"name": "hawkular-broker-config"},
+      "name": "hawkular-openshift-agent"}]}}}}], "parameters": [{"description": "Storage
+      capacity required for volume claims", "name": "STORAGE_CAPACITY", "value": "2Gi"},
+      {"description": "The docker image to use for the message broker", "name": "BROKER_REPO",
+      "value": "enmasseproject/artemis"}, {"description": "The default image to use
+      as topic forwarder", "name": "TOPIC_FORWARDER_REPO", "value": "enmasseproject/topic-forwarder"},
+      {"description": "The image to use for the router", "name": "ROUTER_REPO", "value":
+      "enmasseproject/qdrouterd"}, {"description": "The link capacity setting for
+      router", "name": "ROUTER_LINK_CAPACITY", "value": "50"}, {"description": "A
+      valid instance name for the instance", "name": "INSTANCE", "required": true},
+      {"description": "A valid name for the instance", "name": "NAME", "required":
+      true}, {"description": "The address to use for the queue", "name": "ADDRESS",
+      "required": true}]}'
+    tls-queue-persisted.json: '{"apiVersion": "v1", "kind": "Template", "metadata":
+      {"labels": {"app": "enmasse"}, "name": "tls-queue-persisted"}, "objects": [{"apiVersion":
+      "v1", "kind": "PersistentVolumeClaim", "metadata": {"labels": {"app": "enmasse",
+      "group_id": "${NAME}", "instance": "${INSTANCE}"}, "name": "pvc-${NAME}"}, "spec":
+      {"accessModes": ["ReadWriteMany"], "resources": {"requests": {"storage": "${STORAGE_CAPACITY}"}}}},
+      {"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels":
+      {"address_config": "address-config-${INSTANCE}-${NAME}", "app": "enmasse", "group_id":
+      "${NAME}", "instance": "${INSTANCE}"}, "name": "${NAME}"}, "spec": {"replicas":
+      1, "template": {"metadata": {"labels": {"app": "enmasse", "group_id": "${NAME}",
+      "instance": "${INSTANCE}", "role": "broker"}}, "spec": {"containers": [{"env":
+      [{"name": "QUEUE_NAME", "value": "${ADDRESS}"}, {"name": "GROUP_ID", "value":
+      "${NAME}"}], "image": "${BROKER_REPO}:latest", "lifecycle": {"preStop": {"exec":
+      {"command": ["/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"]}}}, "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "broker", "ports": [{"containerPort":
+      5673, "name": "amqp"}, {"containerPort": 61616, "name": "core"}, {"containerPort":
+      8161, "name": "jolokia"}], "readinessProbe": {"tcpSocket": {"port": "amqp"}},
+      "volumeMounts": [{"mountPath": "/var/run/artemis", "name": "vol-${NAME}"}]}],
+      "volumes": [{"name": "vol-${NAME}", "persistentVolumeClaim": {"claimName": "pvc-${NAME}"}},
+      {"name": "ssl-certs", "secret": {"secretName": "qdrouterd-certs"}}, {"configMap":
+      {"name": "hawkular-broker-config"}, "name": "hawkular-openshift-agent"}]}}}}],
+      "parameters": [{"description": "Storage capacity required for volume claims",
+      "name": "STORAGE_CAPACITY", "value": "2Gi"}, {"description": "The docker image
+      to use for the message broker", "name": "BROKER_REPO", "value": "enmasseproject/artemis"},
+      {"description": "The default image to use as topic forwarder", "name": "TOPIC_FORWARDER_REPO",
+      "value": "enmasseproject/topic-forwarder"}, {"description": "The image to use
+      for the router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"},
+      {"description": "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY",
+      "value": "50"}, {"description": "A valid instance name for the instance", "name":
+      "INSTANCE", "required": true}, {"description": "A valid name for the instance",
+      "name": "NAME", "required": true}, {"description": "The address to use for the
+      queue", "name": "ADDRESS", "required": true}]}'
+    tls-topic-inmemory.json: '{"apiVersion": "v1", "kind": "Template", "metadata":
+      {"labels": {"app": "enmasse"}, "name": "tls-topic-inmemory"}, "objects": [{"apiVersion":
+      "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels": {"address_config":
+      "address-config-${INSTANCE}-${NAME}", "app": "enmasse", "group_id": "${NAME}",
+      "instance": "${INSTANCE}"}, "name": "${NAME}"}, "spec": {"replicas": 1, "template":
+      {"metadata": {"labels": {"app": "enmasse", "group_id": "${NAME}", "instance":
+      "${INSTANCE}", "role": "broker"}}, "spec": {"containers": [{"env": [{"name":
+      "TOPIC_NAME", "value": "${ADDRESS}"}, {"name": "GROUP_ID", "value": "${NAME}"}],
+      "image": "${BROKER_REPO}:latest", "lifecycle": {"preStop": {"exec": {"command":
+      ["/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"]}}}, "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "broker", "ports": [{"containerPort":
+      5673, "name": "amqp"}, {"containerPort": 61616, "name": "core"}, {"containerPort":
+      8161, "name": "jolokia"}], "readinessProbe": {"tcpSocket": {"port": "amqp"}},
+      "volumeMounts": [{"mountPath": "/var/run/artemis", "name": "vol-${NAME}"}]},
+      {"env": [{"name": "LINK_CAPACITY", "value": "${ROUTER_LINK_CAPACITY}"}, {"name":
+      "TOPIC_NAME", "value": "${ADDRESS}"}], "image": "${ROUTER_REPO}:latest", "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "router", "ports": [{"containerPort":
+      5672, "name": "amqp", "protocol": "TCP"}, {"containerPort": 55673, "name": "internal",
+      "protocol": "TCP"}, {"containerPort": 5671, "name": "amqps", "protocol": "TCP"}],
+      "resources": {"limits": {"memory": "256Mi"}, "requests": {"memory": "256Mi"}},
+      "volumeMounts": [{"mountPath": "/etc/qpid-dispatch/ssl", "name": "ssl-certs",
+      "readOnly": true}]}, {"env": [{"name": "TOPIC_NAME", "value": "${ADDRESS}"},
+      {"name": "GROUP_ID", "value": "${NAME}"}], "image": "${TOPIC_FORWARDER_REPO}:latest",
+      "livenessProbe": {"httpGet": {"path": "/health", "port": "health"}}, "name":
+      "forwarder", "ports": [{"containerPort": 8080, "name": "health"}], "resources":
+      {"limits": {"memory": "128Mi"}, "requests": {"memory": "128Mi"}}}], "volumes":
+      [{"emptyDir": { }, "name": "vol-${NAME}"}, {"name": "ssl-certs", "secret": {"secretName":
+      "qdrouterd-certs"}}, {"configMap": {"name": "hawkular-broker-config"}, "name":
+      "hawkular-openshift-agent"}]}}}}], "parameters": [{"description": "Storage capacity
+      required for volume claims", "name": "STORAGE_CAPACITY", "value": "2Gi"}, {"description":
+      "The docker image to use for the message broker", "name": "BROKER_REPO", "value":
+      "enmasseproject/artemis"}, {"description": "The default image to use as topic
+      forwarder", "name": "TOPIC_FORWARDER_REPO", "value": "enmasseproject/topic-forwarder"},
+      {"description": "The image to use for the router", "name": "ROUTER_REPO", "value":
+      "enmasseproject/qdrouterd"}, {"description": "The link capacity setting for
+      router", "name": "ROUTER_LINK_CAPACITY", "value": "50"}, {"description": "A
+      valid instance name for the instance", "name": "INSTANCE", "required": true},
+      {"description": "A valid name for the instance", "name": "NAME", "required":
+      true}, {"description": "The address to use for the topic", "name": "ADDRESS",
+      "required": true}]}'
+    tls-topic-persisted.json: '{"apiVersion": "v1", "kind": "Template", "metadata":
+      {"labels": {"app": "enmasse"}, "name": "tls-topic-persisted"}, "objects": [{"apiVersion":
+      "v1", "kind": "PersistentVolumeClaim", "metadata": {"labels": {"app": "enmasse",
+      "group_id": "${NAME}", "instance": "${INSTANCE}"}, "name": "pvc-${NAME}"}, "spec":
+      {"accessModes": ["ReadWriteMany"], "resources": {"requests": {"storage": "${STORAGE_CAPACITY}"}}}},
+      {"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels":
+      {"address_config": "address-config-${INSTANCE}-${NAME}", "app": "enmasse", "group_id":
+      "${NAME}", "instance": "${INSTANCE}"}, "name": "${NAME}"}, "spec": {"replicas":
+      1, "template": {"metadata": {"labels": {"app": "enmasse", "group_id": "${NAME}",
+      "instance": "${INSTANCE}", "role": "broker"}}, "spec": {"containers": [{"env":
+      [{"name": "TOPIC_NAME", "value": "${ADDRESS}"}, {"name": "GROUP_ID", "value":
+      "${NAME}"}], "image": "${BROKER_REPO}:latest", "lifecycle": {"preStop": {"exec":
+      {"command": ["/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"]}}}, "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "broker", "ports": [{"containerPort":
+      5673, "name": "amqp"}, {"containerPort": 61616, "name": "core"}, {"containerPort":
+      8161, "name": "jolokia"}], "readinessProbe": {"tcpSocket": {"port": "amqp"}},
+      "volumeMounts": [{"mountPath": "/var/run/artemis", "name": "vol-${NAME}"}]},
+      {"env": [{"name": "LINK_CAPACITY", "value": "${ROUTER_LINK_CAPACITY}"}, {"name":
+      "TOPIC_NAME", "value": "${ADDRESS}"}], "image": "${ROUTER_REPO}:latest", "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "router", "ports": [{"containerPort":
+      5672, "name": "amqp", "protocol": "TCP"}, {"containerPort": 55673, "name": "internal",
+      "protocol": "TCP"}, {"containerPort": 5671, "name": "amqps", "protocol": "TCP"}],
+      "resources": {"limits": {"memory": "256Mi"}, "requests": {"memory": "256Mi"}},
+      "volumeMounts": [{"mountPath": "/etc/qpid-dispatch/ssl", "name": "ssl-certs",
+      "readOnly": true}]}, {"env": [{"name": "TOPIC_NAME", "value": "${ADDRESS}"},
+      {"name": "GROUP_ID", "value": "${NAME}"}], "image": "${TOPIC_FORWARDER_REPO}:latest",
+      "livenessProbe": {"httpGet": {"path": "/health", "port": "health"}}, "name":
+      "forwarder", "ports": [{"containerPort": 8080, "name": "health"}], "resources":
+      {"limits": {"memory": "128Mi"}, "requests": {"memory": "128Mi"}}}], "volumes":
+      [{"name": "vol-${NAME}", "persistentVolumeClaim": {"claimName": "pvc-${NAME}"}},
+      {"name": "ssl-certs", "secret": {"secretName": "qdrouterd-certs"}}, {"configMap":
+      {"name": "hawkular-broker-config"}, "name": "hawkular-openshift-agent"}]}}}}],
+      "parameters": [{"description": "Storage capacity required for volume claims",
+      "name": "STORAGE_CAPACITY", "value": "2Gi"}, {"description": "The docker image
+      to use for the message broker", "name": "BROKER_REPO", "value": "enmasseproject/artemis"},
+      {"description": "The default image to use as topic forwarder", "name": "TOPIC_FORWARDER_REPO",
+      "value": "enmasseproject/topic-forwarder"}, {"description": "The image to use
+      for the router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"},
+      {"description": "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY",
+      "value": "50"}, {"description": "A valid instance name for the instance", "name":
+      "INSTANCE", "required": true}, {"description": "A valid name for the instance",
+      "name": "NAME", "required": true}, {"description": "The address to use for the
+      topic", "name": "ADDRESS", "required": true}]}'
+    topic-inmemory.json: '{"apiVersion": "v1", "kind": "Template", "metadata": {"labels":
+      {"app": "enmasse"}, "name": "topic-inmemory"}, "objects": [{"apiVersion": "extensions/v1beta1",
+      "kind": "Deployment", "metadata": {"labels": {"address_config": "address-config-${INSTANCE}-${NAME}",
+      "app": "enmasse", "group_id": "${NAME}", "instance": "${INSTANCE}"}, "name":
+      "${NAME}"}, "spec": {"replicas": 1, "template": {"metadata": {"labels": {"app":
+      "enmasse", "group_id": "${NAME}", "instance": "${INSTANCE}", "role": "broker"}},
+      "spec": {"containers": [{"env": [{"name": "TOPIC_NAME", "value": "${ADDRESS}"},
+      {"name": "GROUP_ID", "value": "${NAME}"}], "image": "${BROKER_REPO}:latest",
+      "lifecycle": {"preStop": {"exec": {"command": ["/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"]}}},
+      "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name": "broker", "ports":
+      [{"containerPort": 5673, "name": "amqp"}, {"containerPort": 61616, "name": "core"},
+      {"containerPort": 8161, "name": "jolokia"}], "readinessProbe": {"tcpSocket":
+      {"port": "amqp"}}, "volumeMounts": [{"mountPath": "/var/run/artemis", "name":
+      "vol-${NAME}"}]}, {"env": [{"name": "LINK_CAPACITY", "value": "${ROUTER_LINK_CAPACITY}"},
+      {"name": "TOPIC_NAME", "value": "${ADDRESS}"}], "image": "${ROUTER_REPO}:latest",
+      "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name": "router", "ports":
+      [{"containerPort": 5672, "name": "amqp", "protocol": "TCP"}, {"containerPort":
+      55673, "name": "internal", "protocol": "TCP"}], "resources": {"limits": {"memory":
+      "256Mi"}, "requests": {"memory": "256Mi"}}}, {"env": [{"name": "TOPIC_NAME",
+      "value": "${ADDRESS}"}, {"name": "GROUP_ID", "value": "${NAME}"}], "image":
+      "${TOPIC_FORWARDER_REPO}:latest", "livenessProbe": {"httpGet": {"path": "/health",
+      "port": "health"}}, "name": "forwarder", "ports": [{"containerPort": 8080, "name":
+      "health"}], "resources": {"limits": {"memory": "128Mi"}, "requests": {"memory":
+      "128Mi"}}}], "volumes": [{"emptyDir": { }, "name": "vol-${NAME}"}, {"configMap":
+      {"name": "hawkular-broker-config"}, "name": "hawkular-openshift-agent"}]}}}}],
+      "parameters": [{"description": "Storage capacity required for volume claims",
+      "name": "STORAGE_CAPACITY", "value": "2Gi"}, {"description": "The docker image
+      to use for the message broker", "name": "BROKER_REPO", "value": "enmasseproject/artemis"},
+      {"description": "The default image to use as topic forwarder", "name": "TOPIC_FORWARDER_REPO",
+      "value": "enmasseproject/topic-forwarder"}, {"description": "The image to use
+      for the router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"},
+      {"description": "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY",
+      "value": "50"}, {"description": "A valid instance name for the instance", "name":
+      "INSTANCE", "required": true}, {"description": "A valid name for the instance",
+      "name": "NAME", "required": true}, {"description": "The address to use for the
+      topic", "name": "ADDRESS", "required": true}]}'
+    topic-persisted.json: '{"apiVersion": "v1", "kind": "Template", "metadata": {"labels":
+      {"app": "enmasse"}, "name": "topic-persisted"}, "objects": [{"apiVersion": "v1",
+      "kind": "PersistentVolumeClaim", "metadata": {"labels": {"app": "enmasse", "group_id":
+      "${NAME}", "instance": "${INSTANCE}"}, "name": "pvc-${NAME}"}, "spec": {"accessModes":
+      ["ReadWriteMany"], "resources": {"requests": {"storage": "${STORAGE_CAPACITY}"}}}},
+      {"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels":
+      {"address_config": "address-config-${INSTANCE}-${NAME}", "app": "enmasse", "group_id":
+      "${NAME}", "instance": "${INSTANCE}"}, "name": "${NAME}"}, "spec": {"replicas":
+      1, "template": {"metadata": {"labels": {"app": "enmasse", "group_id": "${NAME}",
+      "instance": "${INSTANCE}", "role": "broker"}}, "spec": {"containers": [{"env":
+      [{"name": "TOPIC_NAME", "value": "${ADDRESS}"}, {"name": "GROUP_ID", "value":
+      "${NAME}"}], "image": "${BROKER_REPO}:latest", "lifecycle": {"preStop": {"exec":
+      {"command": ["/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"]}}}, "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "broker", "ports": [{"containerPort":
+      5673, "name": "amqp"}, {"containerPort": 61616, "name": "core"}, {"containerPort":
+      8161, "name": "jolokia"}], "readinessProbe": {"tcpSocket": {"port": "amqp"}},
+      "volumeMounts": [{"mountPath": "/var/run/artemis", "name": "vol-${NAME}"}]},
+      {"env": [{"name": "LINK_CAPACITY", "value": "${ROUTER_LINK_CAPACITY}"}, {"name":
+      "TOPIC_NAME", "value": "${ADDRESS}"}], "image": "${ROUTER_REPO}:latest", "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "router", "ports": [{"containerPort":
+      5672, "name": "amqp", "protocol": "TCP"}, {"containerPort": 55673, "name": "internal",
+      "protocol": "TCP"}], "resources": {"limits": {"memory": "256Mi"}, "requests":
+      {"memory": "256Mi"}}}, {"env": [{"name": "TOPIC_NAME", "value": "${ADDRESS}"},
+      {"name": "GROUP_ID", "value": "${NAME}"}], "image": "${TOPIC_FORWARDER_REPO}:latest",
+      "livenessProbe": {"httpGet": {"path": "/health", "port": "health"}}, "name":
+      "forwarder", "ports": [{"containerPort": 8080, "name": "health"}], "resources":
+      {"limits": {"memory": "128Mi"}, "requests": {"memory": "128Mi"}}}], "volumes":
+      [{"name": "vol-${NAME}", "persistentVolumeClaim": {"claimName": "pvc-${NAME}"}},
+      {"configMap": {"name": "hawkular-broker-config"}, "name": "hawkular-openshift-agent"}]}}}}],
+      "parameters": [{"description": "Storage capacity required for volume claims",
+      "name": "STORAGE_CAPACITY", "value": "2Gi"}, {"description": "The docker image
+      to use for the message broker", "name": "BROKER_REPO", "value": "enmasseproject/artemis"},
+      {"description": "The default image to use as topic forwarder", "name": "TOPIC_FORWARDER_REPO",
+      "value": "enmasseproject/topic-forwarder"}, {"description": "The image to use
+      for the router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"},
+      {"description": "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY",
+      "value": "50"}, {"description": "A valid instance name for the instance", "name":
+      "INSTANCE", "required": true}, {"description": "A valid name for the instance",
+      "name": "NAME", "required": true}, {"description": "The address to use for the
+      topic", "name": "ADDRESS", "required": true}]}'
+  kind: ConfigMap
   metadata:
     labels:
       app: enmasse
-    name: queue-inmemory
-  objects:
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        address_config: address-config-${INSTANCE}-${NAME}
-        app: enmasse
-        group_id: "${NAME}"
-        instance: "${INSTANCE}"
-      name: "${NAME}"
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            group_id: "${NAME}"
-            instance: "${INSTANCE}"
-            role: broker
-        spec:
-          containers:
-          - env:
-            - name: QUEUE_NAME
-              value: "${ADDRESS}"
-            - name: GROUP_ID
-              value: "${NAME}"
-            image: "${BROKER_REPO}:latest"
-            lifecycle:
-              preStop:
-                exec:
-                  command:
-                  - "/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: broker
-            ports:
-            - containerPort: 5673
-              name: amqp
-            - containerPort: 61616
-              name: core
-            - containerPort: 8161
-              name: jolokia
-            readinessProbe:
-              tcpSocket:
-                port: amqp
-            volumeMounts:
-            - mountPath: "/var/run/artemis"
-              name: vol-${NAME}
-          volumes:
-          - emptyDir: {}
-            name: vol-${NAME}
-          - configMap:
-              name: hawkular-broker-config
-            name: hawkular-openshift-agent
-  parameters:
-  - description: Storage capacity required for volume claims
-    name: STORAGE_CAPACITY
-    value: 2Gi
-  - description: The docker image to use for the message broker
-    name: BROKER_REPO
-    value: enmasseproject/artemis
-  - description: The default image to use as topic forwarder
-    name: TOPIC_FORWARDER_REPO
-    value: enmasseproject/topic-forwarder
-  - description: The image to use for the router
-    name: ROUTER_REPO
-    value: enmasseproject/qdrouterd
-  - description: The link capacity setting for router
-    name: ROUTER_LINK_CAPACITY
-    value: '50'
-  - description: A valid instance name for the instance
-    name: INSTANCE
-    required: true
-  - description: A valid name for the instance
-    name: NAME
-    required: true
-  - description: The address to use for the queue
-    name: ADDRESS
-    required: true
-- apiVersion: v1
-  kind: Template
-  metadata:
-    labels:
-      app: enmasse
-    name: queue-persisted
-  objects:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
-    metadata:
-      labels:
-        app: enmasse
-        group_id: "${NAME}"
-        instance: "${INSTANCE}"
-      name: pvc-${NAME}
-    spec:
-      accessModes:
-      - ReadWriteMany
-      resources:
-        requests:
-          storage: "${STORAGE_CAPACITY}"
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        address_config: address-config-${INSTANCE}-${NAME}
-        app: enmasse
-        group_id: "${NAME}"
-        instance: "${INSTANCE}"
-      name: "${NAME}"
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            group_id: "${NAME}"
-            instance: "${INSTANCE}"
-            role: broker
-        spec:
-          containers:
-          - env:
-            - name: QUEUE_NAME
-              value: "${ADDRESS}"
-            - name: GROUP_ID
-              value: "${NAME}"
-            image: "${BROKER_REPO}:latest"
-            lifecycle:
-              preStop:
-                exec:
-                  command:
-                  - "/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: broker
-            ports:
-            - containerPort: 5673
-              name: amqp
-            - containerPort: 61616
-              name: core
-            - containerPort: 8161
-              name: jolokia
-            readinessProbe:
-              tcpSocket:
-                port: amqp
-            volumeMounts:
-            - mountPath: "/var/run/artemis"
-              name: vol-${NAME}
-          volumes:
-          - name: vol-${NAME}
-            persistentVolumeClaim:
-              claimName: pvc-${NAME}
-          - configMap:
-              name: hawkular-broker-config
-            name: hawkular-openshift-agent
-  parameters:
-  - description: Storage capacity required for volume claims
-    name: STORAGE_CAPACITY
-    value: 2Gi
-  - description: The docker image to use for the message broker
-    name: BROKER_REPO
-    value: enmasseproject/artemis
-  - description: The default image to use as topic forwarder
-    name: TOPIC_FORWARDER_REPO
-    value: enmasseproject/topic-forwarder
-  - description: The image to use for the router
-    name: ROUTER_REPO
-    value: enmasseproject/qdrouterd
-  - description: The link capacity setting for router
-    name: ROUTER_LINK_CAPACITY
-    value: '50'
-  - description: A valid instance name for the instance
-    name: INSTANCE
-    required: true
-  - description: A valid name for the instance
-    name: NAME
-    required: true
-  - description: The address to use for the queue
-    name: ADDRESS
-    required: true
-- apiVersion: v1
-  kind: Template
-  metadata:
-    labels:
-      app: enmasse
-    name: topic-inmemory
-  objects:
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        address_config: address-config-${INSTANCE}-${NAME}
-        app: enmasse
-        group_id: "${NAME}"
-        instance: "${INSTANCE}"
-      name: "${NAME}"
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            group_id: "${NAME}"
-            instance: "${INSTANCE}"
-            role: broker
-        spec:
-          containers:
-          - env:
-            - name: TOPIC_NAME
-              value: "${ADDRESS}"
-            - name: GROUP_ID
-              value: "${NAME}"
-            image: "${BROKER_REPO}:latest"
-            lifecycle:
-              preStop:
-                exec:
-                  command:
-                  - "/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: broker
-            ports:
-            - containerPort: 5673
-              name: amqp
-            - containerPort: 61616
-              name: core
-            - containerPort: 8161
-              name: jolokia
-            readinessProbe:
-              tcpSocket:
-                port: amqp
-            volumeMounts:
-            - mountPath: "/var/run/artemis"
-              name: vol-${NAME}
-          - env:
-            - name: LINK_CAPACITY
-              value: "${ROUTER_LINK_CAPACITY}"
-            - name: TOPIC_NAME
-              value: "${ADDRESS}"
-            image: "${ROUTER_REPO}:latest"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: router
-            ports:
-            - containerPort: 5672
-              name: amqp
-              protocol: TCP
-            - containerPort: 55673
-              name: internal
-              protocol: TCP
-            resources:
-              limits:
-                memory: 256Mi
-              requests:
-                memory: 256Mi
-          - env:
-            - name: TOPIC_NAME
-              value: "${ADDRESS}"
-            - name: GROUP_ID
-              value: "${NAME}"
-            image: "${TOPIC_FORWARDER_REPO}:latest"
-            livenessProbe:
-              httpGet:
-                path: "/health"
-                port: health
-            name: forwarder
-            ports:
-            - containerPort: 8080
-              name: health
-            resources:
-              limits:
-                memory: 128Mi
-              requests:
-                memory: 128Mi
-          volumes:
-          - emptyDir: {}
-            name: vol-${NAME}
-          - configMap:
-              name: hawkular-broker-config
-            name: hawkular-openshift-agent
-  parameters:
-  - description: Storage capacity required for volume claims
-    name: STORAGE_CAPACITY
-    value: 2Gi
-  - description: The docker image to use for the message broker
-    name: BROKER_REPO
-    value: enmasseproject/artemis
-  - description: The default image to use as topic forwarder
-    name: TOPIC_FORWARDER_REPO
-    value: enmasseproject/topic-forwarder
-  - description: The image to use for the router
-    name: ROUTER_REPO
-    value: enmasseproject/qdrouterd
-  - description: The link capacity setting for router
-    name: ROUTER_LINK_CAPACITY
-    value: '50'
-  - description: A valid instance name for the instance
-    name: INSTANCE
-    required: true
-  - description: A valid name for the instance
-    name: NAME
-    required: true
-  - description: The address to use for the topic
-    name: ADDRESS
-    required: true
-- apiVersion: v1
-  kind: Template
-  metadata:
-    labels:
-      app: enmasse
-    name: topic-persisted
-  objects:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
-    metadata:
-      labels:
-        app: enmasse
-        group_id: "${NAME}"
-        instance: "${INSTANCE}"
-      name: pvc-${NAME}
-    spec:
-      accessModes:
-      - ReadWriteMany
-      resources:
-        requests:
-          storage: "${STORAGE_CAPACITY}"
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        address_config: address-config-${INSTANCE}-${NAME}
-        app: enmasse
-        group_id: "${NAME}"
-        instance: "${INSTANCE}"
-      name: "${NAME}"
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            group_id: "${NAME}"
-            instance: "${INSTANCE}"
-            role: broker
-        spec:
-          containers:
-          - env:
-            - name: TOPIC_NAME
-              value: "${ADDRESS}"
-            - name: GROUP_ID
-              value: "${NAME}"
-            image: "${BROKER_REPO}:latest"
-            lifecycle:
-              preStop:
-                exec:
-                  command:
-                  - "/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: broker
-            ports:
-            - containerPort: 5673
-              name: amqp
-            - containerPort: 61616
-              name: core
-            - containerPort: 8161
-              name: jolokia
-            readinessProbe:
-              tcpSocket:
-                port: amqp
-            volumeMounts:
-            - mountPath: "/var/run/artemis"
-              name: vol-${NAME}
-          - env:
-            - name: LINK_CAPACITY
-              value: "${ROUTER_LINK_CAPACITY}"
-            - name: TOPIC_NAME
-              value: "${ADDRESS}"
-            image: "${ROUTER_REPO}:latest"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: router
-            ports:
-            - containerPort: 5672
-              name: amqp
-              protocol: TCP
-            - containerPort: 55673
-              name: internal
-              protocol: TCP
-            resources:
-              limits:
-                memory: 256Mi
-              requests:
-                memory: 256Mi
-          - env:
-            - name: TOPIC_NAME
-              value: "${ADDRESS}"
-            - name: GROUP_ID
-              value: "${NAME}"
-            image: "${TOPIC_FORWARDER_REPO}:latest"
-            livenessProbe:
-              httpGet:
-                path: "/health"
-                port: health
-            name: forwarder
-            ports:
-            - containerPort: 8080
-              name: health
-            resources:
-              limits:
-                memory: 128Mi
-              requests:
-                memory: 128Mi
-          volumes:
-          - name: vol-${NAME}
-            persistentVolumeClaim:
-              claimName: pvc-${NAME}
-          - configMap:
-              name: hawkular-broker-config
-            name: hawkular-openshift-agent
-  parameters:
-  - description: Storage capacity required for volume claims
-    name: STORAGE_CAPACITY
-    value: 2Gi
-  - description: The docker image to use for the message broker
-    name: BROKER_REPO
-    value: enmasseproject/artemis
-  - description: The default image to use as topic forwarder
-    name: TOPIC_FORWARDER_REPO
-    value: enmasseproject/topic-forwarder
-  - description: The image to use for the router
-    name: ROUTER_REPO
-    value: enmasseproject/qdrouterd
-  - description: The link capacity setting for router
-    name: ROUTER_LINK_CAPACITY
-    value: '50'
-  - description: A valid instance name for the instance
-    name: INSTANCE
-    required: true
-  - description: A valid name for the instance
-    name: NAME
-    required: true
-  - description: The address to use for the topic
-    name: ADDRESS
-    required: true
-- apiVersion: v1
-  kind: Template
-  metadata:
-    labels:
-      app: enmasse
-    name: enmasse-instance-infra
-  objects:
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-        name: qdrouterd
-      name: qdrouterd
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            capability: router
-            instance: "${INSTANCE}"
-            name: qdrouterd
-        spec:
-          containers:
-          - env:
-            - name: LINK_CAPACITY
-              value: "${ROUTER_LINK_CAPACITY}"
-            image: "${ROUTER_REPO}:latest"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: router
-            ports:
-            - containerPort: 5672
-              name: amqp
-              protocol: TCP
-            - containerPort: 55673
-              name: internal
-              protocol: TCP
-  - apiVersion: v1
-    kind: Service
-    metadata:
-      annotations:
-        service.alpha.openshift.io/dependencies: '[{"kind": "Service", "name": "admin",
-          "namespace": ""}, {"kind": "Service", "name": "subscription", "namespace":
-          ""}, {"kind": "Service", "name": "mqtt", "namespace": ""}]'
-        service.alpha.openshift.io/infrastructure: 'true'
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-      name: messaging
-    spec:
-      ports:
-      - name: amqp
-        port: 5672
-        protocol: TCP
-        targetPort: 5672
-      - name: internal
-        port: 55673
-        protocol: TCP
-        targetPort: 55673
-      selector:
-        capability: router
-        instance: "${INSTANCE}"
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-        name: subserv
-      name: subserv
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            instance: "${INSTANCE}"
-            name: subserv
-        spec:
-          containers:
-          - env: []
-            image: "${SUBSERV_REPO}:latest"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: subserv
-            ports:
-            - containerPort: 5672
-              name: amqp
-              protocol: TCP
-            resources:
-              limits:
-                memory: 64Mi
-              requests:
-                memory: 64Mi
-  - apiVersion: v1
-    kind: Service
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-      name: subscription
-    spec:
-      ports:
-      - name: amqp
-        port: 5672
-        protocol: TCP
-        targetPort: 5672
-      selector:
-        instance: "${INSTANCE}"
-        name: subserv
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-        name: mqtt-gateway
-      name: mqtt-gateway
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            instance: "${INSTANCE}"
-            name: mqtt-gateway
-        spec:
-          containers:
-          - image: "${MQTT_GATEWAY_REPO}:latest"
-            livenessProbe:
-              initialDelaySeconds: 60
-              tcpSocket:
-                port: mqtt
-            name: mqtt-gateway
-            ports:
-            - containerPort: 1883
-              name: mqtt
-              protocol: TCP
-  - apiVersion: v1
-    kind: Service
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-      name: mqtt
-    spec:
-      ports:
-      - name: mqtt
-        port: 1883
-        protocol: TCP
-        targetPort: 1883
-      selector:
-        instance: "${INSTANCE}"
-        name: mqtt-gateway
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-        name: mqtt-lwt
-      name: mqtt-lwt
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            instance: "${INSTANCE}"
-            name: mqtt-lwt
-        spec:
-          containers:
-          - image: "${MQTT_LWT_REPO}:latest"
-            name: mqtt-lwt
-  - apiVersion: v1
-    kind: Route
-    metadata:
-      labels:
-        app: enmasse
-      name: console
-    spec:
-      host: "${CONSOLE_HOSTNAME}"
-      port:
-        targetPort: console-http
-      to:
-        kind: Service
-        name: admin
-  - apiVersion: v1
-    data:
-      hawkular-openshift-agent: '{"endpoints": [{"collection_interval": "60s", "metrics":
-        [{"id": "broker.threadCount", "name": "java.lang:type=Threading#ThreadCount",
-        "tags": {"messagingComponent": "broker", "messagingMetricType": "threadCount"},
-        "type": "counter"}, {"id": "broker.memoryHeapUsage", "name": "java.lang:type=Memory#HeapMemoryUsage#used",
-        "tags": {"messagingComponent": "broker", "messagingMetricType": "heapUsage"},
-        "type": "gauge"}, {"description": "Queue depth for ${address}", "id": "${address}.${queue}.${broker}.queueDepth",
-        "name": "org.apache.activemq.artemis:address=*,broker=*,component=addresses,queue=*,routing-type=*,subcomponent=queues#MessageCount",
-        "tags": {"messagingAddress": "${address}", "messagingBroker": "{broker}",
-        "messagingMetricType": "queueDepth", "messagingQueue": "${queue}"}, "type":
-        "gauge"}, {"description": "Number of consumers for ${address}", "id": "${address}.${queue}.${broker}.numConsumers",
-        "name": "org.apache.activemq.artemis:address=*,broker=*,component=addresses,queue=*,routing-type=*,subcomponent=queues#ConsumerCount",
-        "tags": {"messagingAddress": "${address}", "messagingBroker": "{broker}",
-        "messagingMetricType": "numConsumers", "messagingQueue": "${queue}"}, "type":
-        "gauge"}], "path": "/jolokia/", "port": 8161, "protocol": "http", "type":
-        "jolokia"}]}'
-    kind: ConfigMap
-    metadata:
-      name: hawkular-broker-config
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-        name: admin
-      name: admin
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            instance: "${INSTANCE}"
-            name: admin
-        spec:
-          containers:
-          - env:
-            - name: CONFIGURATION_SERVICE_HOST
-              value: localhost
-            - name: CONFIGURATION_SERVICE_PORT
-              value: '5672'
-            image: "${RAGENT_REPO}:latest"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: ragent
-            ports:
-            - containerPort: 55672
-              name: amqp
-              protocol: TCP
-            resources:
-              limits:
-                memory: 64Mi
-              requests:
-                memory: 64Mi
-          - env:
-            - name: CONFIGURATION_SERVICE_HOST
-              value: localhost
-            - name: CONFIGURATION_SERVICE_PORT
-              value: '5672'
-            image: "${QUEUE_SCHEDULER_REPO}:latest"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: queue-scheduler
-            ports:
-            - containerPort: 55667
-              name: amqp
-              protocol: TCP
-            resources:
-              limits:
-                memory: 128Mi
-              requests:
-                memory: 128Mi
-          - env:
-            - name: CONFIGURATION_SERVICE_HOST
-              value: localhost
-            - name: CONFIGURATION_SERVICE_PORT
-              value: '5672'
-            image: "${CONSOLE_REPO}:latest"
-            livenessProbe:
-              tcpSocket:
-                port: http
-            name: console
-            ports:
-            - containerPort: 8080
-              name: http
-              protocol: TCP
-            - containerPort: 56720
-              name: amqp-ws
-              protocol: TCP
-            resources:
-              limits:
-                memory: 64Mi
-              requests:
-                memory: 64Mi
-          - env: []
-            image: "${CONFIGSERV_REPO}:latest"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: configserv
-            ports:
-            - containerPort: 5672
-              name: amqp
-              protocol: TCP
-            resources:
-              limits:
-                memory: 256Mi
-              requests:
-                memory: 256Mi
-  - apiVersion: v1
-    kind: Service
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-      name: admin
-    spec:
-      ports:
-      - name: ragent
-        port: 55672
-      - name: configuration
-        port: 5672
-      - name: queue-scheduler
-        port: 55667
-      - name: console-ws
-        port: 56720
-      - name: console-http
-        port: 8080
-      selector:
-        instance: "${INSTANCE}"
-        name: admin
-  parameters:
-  - description: The image to use for the router
-    name: ROUTER_REPO
-    value: enmasseproject/qdrouterd
-  - description: The link capacity setting for router
-    name: ROUTER_LINK_CAPACITY
-    value: '50'
-  - description: The image to use for the configuration service
-    name: CONFIGSERV_REPO
-    value: enmasseproject/configserv
-  - description: The docker image to use for the queue scheduler
-    name: QUEUE_SCHEDULER_REPO
-    value: enmasseproject/queue-scheduler
-  - description: The image to use for the router agent
-    name: RAGENT_REPO
-    value: enmasseproject/ragent
-  - description: The image to use for the subscription services
-    name: SUBSERV_REPO
-    value: enmasseproject/subserv
-  - description: The image to use for the console
-    name: CONSOLE_REPO
-    value: enmasseproject/console
-  - description: The hostname to use for the exposed route for messaging (TLS only)
-    name: MESSAGING_HOSTNAME
-  - description: The image to use for the MQTT gateway
-    name: MQTT_GATEWAY_REPO
-    value: enmasseproject/mqtt-gateway
-  - description: The hostname to use for the exposed route for MQTT (TLS only)
-    name: MQTT_GATEWAY_HOSTNAME
-  - description: The hostname to use for the exposed route for the messaging console
-    name: CONSOLE_HOSTNAME
-  - description: The image to use for the MQTT LWT
-    name: MQTT_LWT_REPO
-    value: enmasseproject/mqtt-lwt
-  - description: The image to use for the AMQP Kafka Bridge
-    name: AMQP_KAFKA_BRIDGE_REPO
-    value: enmasseproject/amqp-kafka-bridge
-  - description: A list of host/port pairs to use for establishing the initial connection
-      to the Kafka cluster
-    name: KAFKA_BOOTSTRAP_SERVERS
-  - description: The instance this infrastructure is deployed for
-    name: INSTANCE
-    required: true
+    name: enmasse-template-config
 - apiVersion: extensions/v1beta1
   kind: Deployment
   metadata:
@@ -870,7 +583,14 @@ objects:
               memory: 256Mi
             requests:
               memory: 256Mi
+          volumeMounts:
+          - mountPath: "/templates"
+            name: templates
         serviceAccount: enmasse-service-account
+        volumes:
+        - configMap:
+            name: enmasse-template-config
+          name: templates
 - apiVersion: v1
   kind: Service
   metadata:

--- a/generated/tls-enmasse-template-with-kafka.yaml
+++ b/generated/tls-enmasse-template-with-kafka.yaml
@@ -7,973 +7,566 @@ metadata:
   name: tls-enmasse-infra
 objects:
 - apiVersion: v1
-  kind: Template
+  data:
+    enmasse-instance-infra.json: '{"apiVersion": "v1", "kind": "Template", "metadata":
+      {"labels": {"app": "enmasse"}, "name": "tls-enmasse-instance-infra"}, "objects":
+      [{"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels":
+      {"app": "enmasse", "instance": "${INSTANCE}", "name": "qdrouterd"}, "name":
+      "qdrouterd"}, "spec": {"replicas": 1, "template": {"metadata": {"labels": {"app":
+      "enmasse", "capability": "router", "instance": "${INSTANCE}", "name": "qdrouterd"}},
+      "spec": {"containers": [{"env": [{"name": "LINK_CAPACITY", "value": "${ROUTER_LINK_CAPACITY}"}],
+      "image": "${ROUTER_REPO}:latest", "livenessProbe": {"tcpSocket": {"port": "amqp"}},
+      "name": "router", "ports": [{"containerPort": 5672, "name": "amqp", "protocol":
+      "TCP"}, {"containerPort": 55673, "name": "internal", "protocol": "TCP"}, {"containerPort":
+      5671, "name": "amqps", "protocol": "TCP"}], "volumeMounts": [{"mountPath": "/etc/qpid-dispatch/ssl",
+      "name": "ssl-certs", "readOnly": true}]}], "volumes": [{"name": "ssl-certs",
+      "secret": {"secretName": "qdrouterd-certs"}}]}}}}, {"apiVersion": "v1", "kind":
+      "Service", "metadata": {"annotations": {"service.alpha.openshift.io/dependencies":
+      "[{\"kind\": \"Service\", \"name\": \"admin\", \"namespace\": \"\"}, {\"kind\":
+      \"Service\", \"name\": \"subscription\", \"namespace\": \"\"}, {\"kind\": \"Service\",
+      \"name\": \"mqtt\", \"namespace\": \"\"}]", "service.alpha.openshift.io/infrastructure":
+      "true"}, "labels": {"app": "enmasse", "instance": "${INSTANCE}"}, "name": "messaging"},
+      "spec": {"ports": [{"name": "amqp", "port": 5672, "protocol": "TCP", "targetPort":
+      5672}, {"name": "amqps", "port": 5671, "protocol": "TCP", "targetPort": 5671},
+      {"name": "internal", "port": 55673, "protocol": "TCP", "targetPort": 55673}],
+      "selector": {"capability": "router", "instance": "${INSTANCE}"}}}, {"apiVersion":
+      "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels": {"app": "enmasse",
+      "instance": "${INSTANCE}", "name": "subserv"}, "name": "subserv"}, "spec": {"replicas":
+      1, "template": {"metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}",
+      "name": "subserv"}}, "spec": {"containers": [{"env": [ ], "image": "${SUBSERV_REPO}:latest",
+      "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name": "subserv", "ports":
+      [{"containerPort": 5672, "name": "amqp", "protocol": "TCP"}], "resources": {"limits":
+      {"memory": "64Mi"}, "requests": {"memory": "64Mi"}}}]}}}}, {"apiVersion": "v1",
+      "kind": "Service", "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"},
+      "name": "subscription"}, "spec": {"ports": [{"name": "amqp", "port": 5672, "protocol":
+      "TCP", "targetPort": 5672}], "selector": {"instance": "${INSTANCE}", "name":
+      "subserv"}}}, {"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata":
+      {"labels": {"app": "enmasse", "instance": "${INSTANCE}", "name": "mqtt-gateway"},
+      "name": "mqtt-gateway"}, "spec": {"replicas": 1, "template": {"metadata": {"labels":
+      {"app": "enmasse", "instance": "${INSTANCE}", "name": "mqtt-gateway"}}, "spec":
+      {"containers": [{"image": "${MQTT_GATEWAY_REPO}:latest", "livenessProbe": {"initialDelaySeconds":
+      60, "tcpSocket": {"port": "secure-mqtt"}}, "name": "mqtt-gateway-tls", "ports":
+      [{"containerPort": 8883, "name": "secure-mqtt", "protocol": "TCP"}], "volumeMounts":
+      [{"mountPath": "/etc/mqtt-gateway/ssl", "name": "ssl-certs", "readOnly": true}]},
+      {"image": "${MQTT_GATEWAY_REPO}:latest", "livenessProbe": {"initialDelaySeconds":
+      60, "tcpSocket": {"port": "mqtt"}}, "name": "mqtt-gateway", "ports": [{"containerPort":
+      1883, "name": "mqtt", "protocol": "TCP"}]}], "volumes": [{"name": "ssl-certs",
+      "secret": {"secretName": "mqtt-certs"}}]}}}}, {"apiVersion": "v1", "kind": "Service",
+      "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"}, "name":
+      "mqtt"}, "spec": {"ports": [{"name": "mqtt", "port": 1883, "protocol": "TCP",
+      "targetPort": 1883}, {"name": "secure-mqtt", "port": 8883, "protocol": "TCP",
+      "targetPort": 8883}], "selector": {"instance": "${INSTANCE}", "name": "mqtt-gateway"}}},
+      {"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels":
+      {"app": "enmasse", "instance": "${INSTANCE}", "name": "mqtt-lwt"}, "name": "mqtt-lwt"},
+      "spec": {"replicas": 1, "template": {"metadata": {"labels": {"app": "enmasse",
+      "instance": "${INSTANCE}", "name": "mqtt-lwt"}}, "spec": {"containers": [{"image":
+      "${MQTT_LWT_REPO}:latest", "name": "mqtt-lwt"}]}}}}, {"apiVersion": "v1", "kind":
+      "Route", "metadata": {"labels": {"app": "enmasse"}, "name": "console"}, "spec":
+      {"host": "${CONSOLE_HOSTNAME}", "port": {"targetPort": "console-http"}, "to":
+      {"kind": "Service", "name": "admin"}}}, {"apiVersion": "v1", "data": {"hawkular-openshift-agent":
+      "{\"endpoints\": [{\"collection_interval\": \"60s\", \"metrics\": [{\"id\":
+      \"broker.threadCount\", \"name\": \"java.lang:type=Threading#ThreadCount\",
+      \"tags\": {\"messagingComponent\": \"broker\", \"messagingMetricType\": \"threadCount\"},
+      \"type\": \"counter\"}, {\"id\": \"broker.memoryHeapUsage\", \"name\": \"java.lang:type=Memory#HeapMemoryUsage#used\",
+      \"tags\": {\"messagingComponent\": \"broker\", \"messagingMetricType\": \"heapUsage\"},
+      \"type\": \"gauge\"}, {\"description\": \"Queue depth for ${address}\", \"id\":
+      \"${address}.${queue}.${broker}.queueDepth\", \"name\": \"org.apache.activemq.artemis:address=*,broker=*,component=addresses,queue=*,routing-type=*,subcomponent=queues#MessageCount\",
+      \"tags\": {\"messagingAddress\": \"${address}\", \"messagingBroker\": \"{broker}\",
+      \"messagingMetricType\": \"queueDepth\", \"messagingQueue\": \"${queue}\"},
+      \"type\": \"gauge\"}, {\"description\": \"Number of consumers for ${address}\",
+      \"id\": \"${address}.${queue}.${broker}.numConsumers\", \"name\": \"org.apache.activemq.artemis:address=*,broker=*,component=addresses,queue=*,routing-type=*,subcomponent=queues#ConsumerCount\",
+      \"tags\": {\"messagingAddress\": \"${address}\", \"messagingBroker\": \"{broker}\",
+      \"messagingMetricType\": \"numConsumers\", \"messagingQueue\": \"${queue}\"},
+      \"type\": \"gauge\"}], \"path\": \"/jolokia/\", \"port\": 8161, \"protocol\":
+      \"http\", \"type\": \"jolokia\"}]}"}, "kind": "ConfigMap", "metadata": {"name":
+      "hawkular-broker-config"}}, {"apiVersion": "extensions/v1beta1", "kind": "Deployment",
+      "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}", "name":
+      "admin"}, "name": "admin"}, "spec": {"replicas": 1, "template": {"metadata":
+      {"labels": {"app": "enmasse", "instance": "${INSTANCE}", "name": "admin"}},
+      "spec": {"containers": [{"env": [{"name": "CONFIGURATION_SERVICE_HOST", "value":
+      "localhost"}, {"name": "CONFIGURATION_SERVICE_PORT", "value": "5672"}], "image":
+      "${RAGENT_REPO}:latest", "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name":
+      "ragent", "ports": [{"containerPort": 55672, "name": "amqp", "protocol": "TCP"}],
+      "resources": {"limits": {"memory": "64Mi"}, "requests": {"memory": "64Mi"}}},
+      {"env": [{"name": "CONFIGURATION_SERVICE_HOST", "value": "localhost"}, {"name":
+      "CONFIGURATION_SERVICE_PORT", "value": "5672"}], "image": "${QUEUE_SCHEDULER_REPO}:latest",
+      "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name": "queue-scheduler",
+      "ports": [{"containerPort": 55667, "name": "amqp", "protocol": "TCP"}], "resources":
+      {"limits": {"memory": "128Mi"}, "requests": {"memory": "128Mi"}}}, {"env": [{"name":
+      "CONFIGURATION_SERVICE_HOST", "value": "localhost"}, {"name": "CONFIGURATION_SERVICE_PORT",
+      "value": "5672"}], "image": "${CONSOLE_REPO}:latest", "livenessProbe": {"tcpSocket":
+      {"port": "http"}}, "name": "console", "ports": [{"containerPort": 8080, "name":
+      "http", "protocol": "TCP"}, {"containerPort": 56720, "name": "amqp-ws", "protocol":
+      "TCP"}], "resources": {"limits": {"memory": "64Mi"}, "requests": {"memory":
+      "64Mi"}}}, {"env": [ ], "image": "${CONFIGSERV_REPO}:latest", "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "configserv", "ports": [{"containerPort":
+      5672, "name": "amqp", "protocol": "TCP"}], "resources": {"limits": {"memory":
+      "256Mi"}, "requests": {"memory": "256Mi"}}}]}}}}, {"apiVersion": "v1", "kind":
+      "Service", "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"},
+      "name": "admin"}, "spec": {"ports": [{"name": "ragent", "port": 55672}, {"name":
+      "configuration", "port": 5672}, {"name": "queue-scheduler", "port": 55667},
+      {"name": "console-ws", "port": 56720}, {"name": "console-http", "port": 8080}],
+      "selector": {"instance": "${INSTANCE}", "name": "admin"}}}, {"apiVersion": "v1",
+      "kind": "Service", "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"},
+      "name": "amqp-kafka-bridge"}, "spec": {"ports": [{"name": "amqp", "port": 5672,
+      "protocol": "TCP", "targetPort": 5672}], "selector": {"capability": "bridge",
+      "instance": "${INSTANCE}"}}}, {"apiVersion": "extensions/v1beta1", "kind": "Deployment",
+      "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}", "name":
+      "amqp-kafka-bridge"}, "name": "amqp-kafka-bridge"}, "spec": {"replicas": 1,
+      "template": {"metadata": {"labels": {"app": "enmasse", "capability": "bridge",
+      "instance": "${INSTANCE}", "name": "amqp-kafka-bridge"}}, "spec": {"containers":
+      [{"env": [{"name": "KAFKA_BOOTSTRAP_SERVERS", "value": "${KAFKA_BOOTSTRAP_SERVERS}"}],
+      "image": "${AMQP_KAFKA_BRIDGE_REPO}:latest", "name": "amqp-kafka-bridge", "resources":
+      {"limits": {"memory": "512Mi"}, "requests": {"memory": "512Mi"}}}]}}}}, {"apiVersion":
+      "v1", "kind": "Route", "metadata": {"labels": {"app": "enmasse", "instance":
+      "${INSTANCE}"}, "name": "messaging"}, "spec": {"host": "${MESSAGING_HOSTNAME}",
+      "port": {"targetPort": "amqps"}, "tls": {"termination": "passthrough"}, "to":
+      {"kind": "Service", "name": "messaging", "weight": 100}}}, {"apiVersion": "v1",
+      "kind": "Route", "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"},
+      "name": "mqtt"}, "spec": {"host": "${MQTT_GATEWAY_HOSTNAME}", "port": {"targetPort":
+      "secure-mqtt"}, "tls": {"termination": "passthrough"}, "to": {"kind": "Service",
+      "name": "mqtt", "weight": 100}}}], "parameters": [{"description": "The image
+      to use for the router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"},
+      {"description": "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY",
+      "value": "50"}, {"description": "The image to use for the configuration service",
+      "name": "CONFIGSERV_REPO", "value": "enmasseproject/configserv"}, {"description":
+      "The docker image to use for the queue scheduler", "name": "QUEUE_SCHEDULER_REPO",
+      "value": "enmasseproject/queue-scheduler"}, {"description": "The image to use
+      for the router agent", "name": "RAGENT_REPO", "value": "enmasseproject/ragent"},
+      {"description": "The image to use for the subscription services", "name": "SUBSERV_REPO",
+      "value": "enmasseproject/subserv"}, {"description": "The image to use for the
+      console", "name": "CONSOLE_REPO", "value": "enmasseproject/console"}, {"description":
+      "The hostname to use for the exposed route for messaging (TLS only)", "name":
+      "MESSAGING_HOSTNAME"}, {"description": "The image to use for the MQTT gateway",
+      "name": "MQTT_GATEWAY_REPO", "value": "enmasseproject/mqtt-gateway"}, {"description":
+      "The hostname to use for the exposed route for MQTT (TLS only)", "name": "MQTT_GATEWAY_HOSTNAME"},
+      {"description": "The hostname to use for the exposed route for the messaging
+      console", "name": "CONSOLE_HOSTNAME"}, {"description": "The image to use for
+      the MQTT LWT", "name": "MQTT_LWT_REPO", "value": "enmasseproject/mqtt-lwt"},
+      {"description": "The image to use for the AMQP Kafka Bridge", "name": "AMQP_KAFKA_BRIDGE_REPO",
+      "value": "enmasseproject/amqp-kafka-bridge"}, {"description": "A list of host/port
+      pairs to use for establishing the initial connection to the Kafka cluster",
+      "name": "KAFKA_BOOTSTRAP_SERVERS"}, {"description": "The instance this infrastructure
+      is deployed for", "name": "INSTANCE", "required": true}]}'
+    queue-inmemory.json: '{"apiVersion": "v1", "kind": "Template", "metadata": {"labels":
+      {"app": "enmasse"}, "name": "queue-inmemory"}, "objects": [{"apiVersion": "extensions/v1beta1",
+      "kind": "Deployment", "metadata": {"labels": {"address_config": "address-config-${INSTANCE}-${NAME}",
+      "app": "enmasse", "group_id": "${NAME}", "instance": "${INSTANCE}"}, "name":
+      "${NAME}"}, "spec": {"replicas": 1, "template": {"metadata": {"labels": {"app":
+      "enmasse", "group_id": "${NAME}", "instance": "${INSTANCE}", "role": "broker"}},
+      "spec": {"containers": [{"env": [{"name": "QUEUE_NAME", "value": "${ADDRESS}"},
+      {"name": "GROUP_ID", "value": "${NAME}"}], "image": "${BROKER_REPO}:latest",
+      "lifecycle": {"preStop": {"exec": {"command": ["/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"]}}},
+      "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name": "broker", "ports":
+      [{"containerPort": 5673, "name": "amqp"}, {"containerPort": 61616, "name": "core"},
+      {"containerPort": 8161, "name": "jolokia"}], "readinessProbe": {"tcpSocket":
+      {"port": "amqp"}}, "volumeMounts": [{"mountPath": "/var/run/artemis", "name":
+      "vol-${NAME}"}]}], "volumes": [{"emptyDir": { }, "name": "vol-${NAME}"}, {"configMap":
+      {"name": "hawkular-broker-config"}, "name": "hawkular-openshift-agent"}]}}}}],
+      "parameters": [{"description": "Storage capacity required for volume claims",
+      "name": "STORAGE_CAPACITY", "value": "2Gi"}, {"description": "The docker image
+      to use for the message broker", "name": "BROKER_REPO", "value": "enmasseproject/artemis"},
+      {"description": "The default image to use as topic forwarder", "name": "TOPIC_FORWARDER_REPO",
+      "value": "enmasseproject/topic-forwarder"}, {"description": "The image to use
+      for the router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"},
+      {"description": "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY",
+      "value": "50"}, {"description": "A valid instance name for the instance", "name":
+      "INSTANCE", "required": true}, {"description": "A valid name for the instance",
+      "name": "NAME", "required": true}, {"description": "The address to use for the
+      queue", "name": "ADDRESS", "required": true}]}'
+    queue-persisted.json: '{"apiVersion": "v1", "kind": "Template", "metadata": {"labels":
+      {"app": "enmasse"}, "name": "queue-persisted"}, "objects": [{"apiVersion": "v1",
+      "kind": "PersistentVolumeClaim", "metadata": {"labels": {"app": "enmasse", "group_id":
+      "${NAME}", "instance": "${INSTANCE}"}, "name": "pvc-${NAME}"}, "spec": {"accessModes":
+      ["ReadWriteMany"], "resources": {"requests": {"storage": "${STORAGE_CAPACITY}"}}}},
+      {"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels":
+      {"address_config": "address-config-${INSTANCE}-${NAME}", "app": "enmasse", "group_id":
+      "${NAME}", "instance": "${INSTANCE}"}, "name": "${NAME}"}, "spec": {"replicas":
+      1, "template": {"metadata": {"labels": {"app": "enmasse", "group_id": "${NAME}",
+      "instance": "${INSTANCE}", "role": "broker"}}, "spec": {"containers": [{"env":
+      [{"name": "QUEUE_NAME", "value": "${ADDRESS}"}, {"name": "GROUP_ID", "value":
+      "${NAME}"}], "image": "${BROKER_REPO}:latest", "lifecycle": {"preStop": {"exec":
+      {"command": ["/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"]}}}, "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "broker", "ports": [{"containerPort":
+      5673, "name": "amqp"}, {"containerPort": 61616, "name": "core"}, {"containerPort":
+      8161, "name": "jolokia"}], "readinessProbe": {"tcpSocket": {"port": "amqp"}},
+      "volumeMounts": [{"mountPath": "/var/run/artemis", "name": "vol-${NAME}"}]}],
+      "volumes": [{"name": "vol-${NAME}", "persistentVolumeClaim": {"claimName": "pvc-${NAME}"}},
+      {"configMap": {"name": "hawkular-broker-config"}, "name": "hawkular-openshift-agent"}]}}}}],
+      "parameters": [{"description": "Storage capacity required for volume claims",
+      "name": "STORAGE_CAPACITY", "value": "2Gi"}, {"description": "The docker image
+      to use for the message broker", "name": "BROKER_REPO", "value": "enmasseproject/artemis"},
+      {"description": "The default image to use as topic forwarder", "name": "TOPIC_FORWARDER_REPO",
+      "value": "enmasseproject/topic-forwarder"}, {"description": "The image to use
+      for the router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"},
+      {"description": "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY",
+      "value": "50"}, {"description": "A valid instance name for the instance", "name":
+      "INSTANCE", "required": true}, {"description": "A valid name for the instance",
+      "name": "NAME", "required": true}, {"description": "The address to use for the
+      queue", "name": "ADDRESS", "required": true}]}'
+    tls-enmasse-instance-infra.json: '{"apiVersion": "v1", "kind": "Template", "metadata":
+      {"labels": {"app": "enmasse"}, "name": "tls-enmasse-instance-infra"}, "objects":
+      [{"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels":
+      {"app": "enmasse", "instance": "${INSTANCE}", "name": "qdrouterd"}, "name":
+      "qdrouterd"}, "spec": {"replicas": 1, "template": {"metadata": {"labels": {"app":
+      "enmasse", "capability": "router", "instance": "${INSTANCE}", "name": "qdrouterd"}},
+      "spec": {"containers": [{"env": [{"name": "LINK_CAPACITY", "value": "${ROUTER_LINK_CAPACITY}"}],
+      "image": "${ROUTER_REPO}:latest", "livenessProbe": {"tcpSocket": {"port": "amqp"}},
+      "name": "router", "ports": [{"containerPort": 5672, "name": "amqp", "protocol":
+      "TCP"}, {"containerPort": 55673, "name": "internal", "protocol": "TCP"}, {"containerPort":
+      5671, "name": "amqps", "protocol": "TCP"}], "volumeMounts": [{"mountPath": "/etc/qpid-dispatch/ssl",
+      "name": "ssl-certs", "readOnly": true}]}], "volumes": [{"name": "ssl-certs",
+      "secret": {"secretName": "qdrouterd-certs"}}]}}}}, {"apiVersion": "v1", "kind":
+      "Service", "metadata": {"annotations": {"service.alpha.openshift.io/dependencies":
+      "[{\"kind\": \"Service\", \"name\": \"admin\", \"namespace\": \"\"}, {\"kind\":
+      \"Service\", \"name\": \"subscription\", \"namespace\": \"\"}, {\"kind\": \"Service\",
+      \"name\": \"mqtt\", \"namespace\": \"\"}]", "service.alpha.openshift.io/infrastructure":
+      "true"}, "labels": {"app": "enmasse", "instance": "${INSTANCE}"}, "name": "messaging"},
+      "spec": {"ports": [{"name": "amqp", "port": 5672, "protocol": "TCP", "targetPort":
+      5672}, {"name": "amqps", "port": 5671, "protocol": "TCP", "targetPort": 5671},
+      {"name": "internal", "port": 55673, "protocol": "TCP", "targetPort": 55673}],
+      "selector": {"capability": "router", "instance": "${INSTANCE}"}}}, {"apiVersion":
+      "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels": {"app": "enmasse",
+      "instance": "${INSTANCE}", "name": "subserv"}, "name": "subserv"}, "spec": {"replicas":
+      1, "template": {"metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}",
+      "name": "subserv"}}, "spec": {"containers": [{"env": [ ], "image": "${SUBSERV_REPO}:latest",
+      "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name": "subserv", "ports":
+      [{"containerPort": 5672, "name": "amqp", "protocol": "TCP"}], "resources": {"limits":
+      {"memory": "64Mi"}, "requests": {"memory": "64Mi"}}}]}}}}, {"apiVersion": "v1",
+      "kind": "Service", "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"},
+      "name": "subscription"}, "spec": {"ports": [{"name": "amqp", "port": 5672, "protocol":
+      "TCP", "targetPort": 5672}], "selector": {"instance": "${INSTANCE}", "name":
+      "subserv"}}}, {"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata":
+      {"labels": {"app": "enmasse", "instance": "${INSTANCE}", "name": "mqtt-gateway"},
+      "name": "mqtt-gateway"}, "spec": {"replicas": 1, "template": {"metadata": {"labels":
+      {"app": "enmasse", "instance": "${INSTANCE}", "name": "mqtt-gateway"}}, "spec":
+      {"containers": [{"image": "${MQTT_GATEWAY_REPO}:latest", "livenessProbe": {"initialDelaySeconds":
+      60, "tcpSocket": {"port": "secure-mqtt"}}, "name": "mqtt-gateway-tls", "ports":
+      [{"containerPort": 8883, "name": "secure-mqtt", "protocol": "TCP"}], "volumeMounts":
+      [{"mountPath": "/etc/mqtt-gateway/ssl", "name": "ssl-certs", "readOnly": true}]},
+      {"image": "${MQTT_GATEWAY_REPO}:latest", "livenessProbe": {"initialDelaySeconds":
+      60, "tcpSocket": {"port": "mqtt"}}, "name": "mqtt-gateway", "ports": [{"containerPort":
+      1883, "name": "mqtt", "protocol": "TCP"}]}], "volumes": [{"name": "ssl-certs",
+      "secret": {"secretName": "mqtt-certs"}}]}}}}, {"apiVersion": "v1", "kind": "Service",
+      "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"}, "name":
+      "mqtt"}, "spec": {"ports": [{"name": "mqtt", "port": 1883, "protocol": "TCP",
+      "targetPort": 1883}, {"name": "secure-mqtt", "port": 8883, "protocol": "TCP",
+      "targetPort": 8883}], "selector": {"instance": "${INSTANCE}", "name": "mqtt-gateway"}}},
+      {"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels":
+      {"app": "enmasse", "instance": "${INSTANCE}", "name": "mqtt-lwt"}, "name": "mqtt-lwt"},
+      "spec": {"replicas": 1, "template": {"metadata": {"labels": {"app": "enmasse",
+      "instance": "${INSTANCE}", "name": "mqtt-lwt"}}, "spec": {"containers": [{"image":
+      "${MQTT_LWT_REPO}:latest", "name": "mqtt-lwt"}]}}}}, {"apiVersion": "v1", "kind":
+      "Route", "metadata": {"labels": {"app": "enmasse"}, "name": "console"}, "spec":
+      {"host": "${CONSOLE_HOSTNAME}", "port": {"targetPort": "console-http"}, "to":
+      {"kind": "Service", "name": "admin"}}}, {"apiVersion": "v1", "data": {"hawkular-openshift-agent":
+      "{\"endpoints\": [{\"collection_interval\": \"60s\", \"metrics\": [{\"id\":
+      \"broker.threadCount\", \"name\": \"java.lang:type=Threading#ThreadCount\",
+      \"tags\": {\"messagingComponent\": \"broker\", \"messagingMetricType\": \"threadCount\"},
+      \"type\": \"counter\"}, {\"id\": \"broker.memoryHeapUsage\", \"name\": \"java.lang:type=Memory#HeapMemoryUsage#used\",
+      \"tags\": {\"messagingComponent\": \"broker\", \"messagingMetricType\": \"heapUsage\"},
+      \"type\": \"gauge\"}, {\"description\": \"Queue depth for ${address}\", \"id\":
+      \"${address}.${queue}.${broker}.queueDepth\", \"name\": \"org.apache.activemq.artemis:address=*,broker=*,component=addresses,queue=*,routing-type=*,subcomponent=queues#MessageCount\",
+      \"tags\": {\"messagingAddress\": \"${address}\", \"messagingBroker\": \"{broker}\",
+      \"messagingMetricType\": \"queueDepth\", \"messagingQueue\": \"${queue}\"},
+      \"type\": \"gauge\"}, {\"description\": \"Number of consumers for ${address}\",
+      \"id\": \"${address}.${queue}.${broker}.numConsumers\", \"name\": \"org.apache.activemq.artemis:address=*,broker=*,component=addresses,queue=*,routing-type=*,subcomponent=queues#ConsumerCount\",
+      \"tags\": {\"messagingAddress\": \"${address}\", \"messagingBroker\": \"{broker}\",
+      \"messagingMetricType\": \"numConsumers\", \"messagingQueue\": \"${queue}\"},
+      \"type\": \"gauge\"}], \"path\": \"/jolokia/\", \"port\": 8161, \"protocol\":
+      \"http\", \"type\": \"jolokia\"}]}"}, "kind": "ConfigMap", "metadata": {"name":
+      "hawkular-broker-config"}}, {"apiVersion": "extensions/v1beta1", "kind": "Deployment",
+      "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}", "name":
+      "admin"}, "name": "admin"}, "spec": {"replicas": 1, "template": {"metadata":
+      {"labels": {"app": "enmasse", "instance": "${INSTANCE}", "name": "admin"}},
+      "spec": {"containers": [{"env": [{"name": "CONFIGURATION_SERVICE_HOST", "value":
+      "localhost"}, {"name": "CONFIGURATION_SERVICE_PORT", "value": "5672"}], "image":
+      "${RAGENT_REPO}:latest", "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name":
+      "ragent", "ports": [{"containerPort": 55672, "name": "amqp", "protocol": "TCP"}],
+      "resources": {"limits": {"memory": "64Mi"}, "requests": {"memory": "64Mi"}}},
+      {"env": [{"name": "CONFIGURATION_SERVICE_HOST", "value": "localhost"}, {"name":
+      "CONFIGURATION_SERVICE_PORT", "value": "5672"}], "image": "${QUEUE_SCHEDULER_REPO}:latest",
+      "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name": "queue-scheduler",
+      "ports": [{"containerPort": 55667, "name": "amqp", "protocol": "TCP"}], "resources":
+      {"limits": {"memory": "128Mi"}, "requests": {"memory": "128Mi"}}}, {"env": [{"name":
+      "CONFIGURATION_SERVICE_HOST", "value": "localhost"}, {"name": "CONFIGURATION_SERVICE_PORT",
+      "value": "5672"}], "image": "${CONSOLE_REPO}:latest", "livenessProbe": {"tcpSocket":
+      {"port": "http"}}, "name": "console", "ports": [{"containerPort": 8080, "name":
+      "http", "protocol": "TCP"}, {"containerPort": 56720, "name": "amqp-ws", "protocol":
+      "TCP"}], "resources": {"limits": {"memory": "64Mi"}, "requests": {"memory":
+      "64Mi"}}}, {"env": [ ], "image": "${CONFIGSERV_REPO}:latest", "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "configserv", "ports": [{"containerPort":
+      5672, "name": "amqp", "protocol": "TCP"}], "resources": {"limits": {"memory":
+      "256Mi"}, "requests": {"memory": "256Mi"}}}]}}}}, {"apiVersion": "v1", "kind":
+      "Service", "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"},
+      "name": "admin"}, "spec": {"ports": [{"name": "ragent", "port": 55672}, {"name":
+      "configuration", "port": 5672}, {"name": "queue-scheduler", "port": 55667},
+      {"name": "console-ws", "port": 56720}, {"name": "console-http", "port": 8080}],
+      "selector": {"instance": "${INSTANCE}", "name": "admin"}}}, {"apiVersion": "v1",
+      "kind": "Service", "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"},
+      "name": "amqp-kafka-bridge"}, "spec": {"ports": [{"name": "amqp", "port": 5672,
+      "protocol": "TCP", "targetPort": 5672}], "selector": {"capability": "bridge",
+      "instance": "${INSTANCE}"}}}, {"apiVersion": "extensions/v1beta1", "kind": "Deployment",
+      "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}", "name":
+      "amqp-kafka-bridge"}, "name": "amqp-kafka-bridge"}, "spec": {"replicas": 1,
+      "template": {"metadata": {"labels": {"app": "enmasse", "capability": "bridge",
+      "instance": "${INSTANCE}", "name": "amqp-kafka-bridge"}}, "spec": {"containers":
+      [{"env": [{"name": "KAFKA_BOOTSTRAP_SERVERS", "value": "${KAFKA_BOOTSTRAP_SERVERS}"}],
+      "image": "${AMQP_KAFKA_BRIDGE_REPO}:latest", "name": "amqp-kafka-bridge", "resources":
+      {"limits": {"memory": "512Mi"}, "requests": {"memory": "512Mi"}}}]}}}}, {"apiVersion":
+      "v1", "kind": "Route", "metadata": {"labels": {"app": "enmasse", "instance":
+      "${INSTANCE}"}, "name": "messaging"}, "spec": {"host": "${MESSAGING_HOSTNAME}",
+      "port": {"targetPort": "amqps"}, "tls": {"termination": "passthrough"}, "to":
+      {"kind": "Service", "name": "messaging", "weight": 100}}}, {"apiVersion": "v1",
+      "kind": "Route", "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"},
+      "name": "mqtt"}, "spec": {"host": "${MQTT_GATEWAY_HOSTNAME}", "port": {"targetPort":
+      "secure-mqtt"}, "tls": {"termination": "passthrough"}, "to": {"kind": "Service",
+      "name": "mqtt", "weight": 100}}}], "parameters": [{"description": "The image
+      to use for the router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"},
+      {"description": "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY",
+      "value": "50"}, {"description": "The image to use for the configuration service",
+      "name": "CONFIGSERV_REPO", "value": "enmasseproject/configserv"}, {"description":
+      "The docker image to use for the queue scheduler", "name": "QUEUE_SCHEDULER_REPO",
+      "value": "enmasseproject/queue-scheduler"}, {"description": "The image to use
+      for the router agent", "name": "RAGENT_REPO", "value": "enmasseproject/ragent"},
+      {"description": "The image to use for the subscription services", "name": "SUBSERV_REPO",
+      "value": "enmasseproject/subserv"}, {"description": "The image to use for the
+      console", "name": "CONSOLE_REPO", "value": "enmasseproject/console"}, {"description":
+      "The hostname to use for the exposed route for messaging (TLS only)", "name":
+      "MESSAGING_HOSTNAME"}, {"description": "The image to use for the MQTT gateway",
+      "name": "MQTT_GATEWAY_REPO", "value": "enmasseproject/mqtt-gateway"}, {"description":
+      "The hostname to use for the exposed route for MQTT (TLS only)", "name": "MQTT_GATEWAY_HOSTNAME"},
+      {"description": "The hostname to use for the exposed route for the messaging
+      console", "name": "CONSOLE_HOSTNAME"}, {"description": "The image to use for
+      the MQTT LWT", "name": "MQTT_LWT_REPO", "value": "enmasseproject/mqtt-lwt"},
+      {"description": "The image to use for the AMQP Kafka Bridge", "name": "AMQP_KAFKA_BRIDGE_REPO",
+      "value": "enmasseproject/amqp-kafka-bridge"}, {"description": "A list of host/port
+      pairs to use for establishing the initial connection to the Kafka cluster",
+      "name": "KAFKA_BOOTSTRAP_SERVERS"}, {"description": "The instance this infrastructure
+      is deployed for", "name": "INSTANCE", "required": true}]}'
+    tls-queue-inmemory.json: '{"apiVersion": "v1", "kind": "Template", "metadata":
+      {"labels": {"app": "enmasse"}, "name": "tls-queue-inmemory"}, "objects": [{"apiVersion":
+      "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels": {"address_config":
+      "address-config-${INSTANCE}-${NAME}", "app": "enmasse", "group_id": "${NAME}",
+      "instance": "${INSTANCE}"}, "name": "${NAME}"}, "spec": {"replicas": 1, "template":
+      {"metadata": {"labels": {"app": "enmasse", "group_id": "${NAME}", "instance":
+      "${INSTANCE}", "role": "broker"}}, "spec": {"containers": [{"env": [{"name":
+      "QUEUE_NAME", "value": "${ADDRESS}"}, {"name": "GROUP_ID", "value": "${NAME}"}],
+      "image": "${BROKER_REPO}:latest", "lifecycle": {"preStop": {"exec": {"command":
+      ["/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"]}}}, "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "broker", "ports": [{"containerPort":
+      5673, "name": "amqp"}, {"containerPort": 61616, "name": "core"}, {"containerPort":
+      8161, "name": "jolokia"}], "readinessProbe": {"tcpSocket": {"port": "amqp"}},
+      "volumeMounts": [{"mountPath": "/var/run/artemis", "name": "vol-${NAME}"}]}],
+      "volumes": [{"emptyDir": { }, "name": "vol-${NAME}"}, {"name": "ssl-certs",
+      "secret": {"secretName": "qdrouterd-certs"}}, {"configMap": {"name": "hawkular-broker-config"},
+      "name": "hawkular-openshift-agent"}]}}}}], "parameters": [{"description": "Storage
+      capacity required for volume claims", "name": "STORAGE_CAPACITY", "value": "2Gi"},
+      {"description": "The docker image to use for the message broker", "name": "BROKER_REPO",
+      "value": "enmasseproject/artemis"}, {"description": "The default image to use
+      as topic forwarder", "name": "TOPIC_FORWARDER_REPO", "value": "enmasseproject/topic-forwarder"},
+      {"description": "The image to use for the router", "name": "ROUTER_REPO", "value":
+      "enmasseproject/qdrouterd"}, {"description": "The link capacity setting for
+      router", "name": "ROUTER_LINK_CAPACITY", "value": "50"}, {"description": "A
+      valid instance name for the instance", "name": "INSTANCE", "required": true},
+      {"description": "A valid name for the instance", "name": "NAME", "required":
+      true}, {"description": "The address to use for the queue", "name": "ADDRESS",
+      "required": true}]}'
+    tls-queue-persisted.json: '{"apiVersion": "v1", "kind": "Template", "metadata":
+      {"labels": {"app": "enmasse"}, "name": "tls-queue-persisted"}, "objects": [{"apiVersion":
+      "v1", "kind": "PersistentVolumeClaim", "metadata": {"labels": {"app": "enmasse",
+      "group_id": "${NAME}", "instance": "${INSTANCE}"}, "name": "pvc-${NAME}"}, "spec":
+      {"accessModes": ["ReadWriteMany"], "resources": {"requests": {"storage": "${STORAGE_CAPACITY}"}}}},
+      {"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels":
+      {"address_config": "address-config-${INSTANCE}-${NAME}", "app": "enmasse", "group_id":
+      "${NAME}", "instance": "${INSTANCE}"}, "name": "${NAME}"}, "spec": {"replicas":
+      1, "template": {"metadata": {"labels": {"app": "enmasse", "group_id": "${NAME}",
+      "instance": "${INSTANCE}", "role": "broker"}}, "spec": {"containers": [{"env":
+      [{"name": "QUEUE_NAME", "value": "${ADDRESS}"}, {"name": "GROUP_ID", "value":
+      "${NAME}"}], "image": "${BROKER_REPO}:latest", "lifecycle": {"preStop": {"exec":
+      {"command": ["/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"]}}}, "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "broker", "ports": [{"containerPort":
+      5673, "name": "amqp"}, {"containerPort": 61616, "name": "core"}, {"containerPort":
+      8161, "name": "jolokia"}], "readinessProbe": {"tcpSocket": {"port": "amqp"}},
+      "volumeMounts": [{"mountPath": "/var/run/artemis", "name": "vol-${NAME}"}]}],
+      "volumes": [{"name": "vol-${NAME}", "persistentVolumeClaim": {"claimName": "pvc-${NAME}"}},
+      {"name": "ssl-certs", "secret": {"secretName": "qdrouterd-certs"}}, {"configMap":
+      {"name": "hawkular-broker-config"}, "name": "hawkular-openshift-agent"}]}}}}],
+      "parameters": [{"description": "Storage capacity required for volume claims",
+      "name": "STORAGE_CAPACITY", "value": "2Gi"}, {"description": "The docker image
+      to use for the message broker", "name": "BROKER_REPO", "value": "enmasseproject/artemis"},
+      {"description": "The default image to use as topic forwarder", "name": "TOPIC_FORWARDER_REPO",
+      "value": "enmasseproject/topic-forwarder"}, {"description": "The image to use
+      for the router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"},
+      {"description": "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY",
+      "value": "50"}, {"description": "A valid instance name for the instance", "name":
+      "INSTANCE", "required": true}, {"description": "A valid name for the instance",
+      "name": "NAME", "required": true}, {"description": "The address to use for the
+      queue", "name": "ADDRESS", "required": true}]}'
+    tls-topic-inmemory.json: '{"apiVersion": "v1", "kind": "Template", "metadata":
+      {"labels": {"app": "enmasse"}, "name": "tls-topic-inmemory"}, "objects": [{"apiVersion":
+      "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels": {"address_config":
+      "address-config-${INSTANCE}-${NAME}", "app": "enmasse", "group_id": "${NAME}",
+      "instance": "${INSTANCE}"}, "name": "${NAME}"}, "spec": {"replicas": 1, "template":
+      {"metadata": {"labels": {"app": "enmasse", "group_id": "${NAME}", "instance":
+      "${INSTANCE}", "role": "broker"}}, "spec": {"containers": [{"env": [{"name":
+      "TOPIC_NAME", "value": "${ADDRESS}"}, {"name": "GROUP_ID", "value": "${NAME}"}],
+      "image": "${BROKER_REPO}:latest", "lifecycle": {"preStop": {"exec": {"command":
+      ["/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"]}}}, "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "broker", "ports": [{"containerPort":
+      5673, "name": "amqp"}, {"containerPort": 61616, "name": "core"}, {"containerPort":
+      8161, "name": "jolokia"}], "readinessProbe": {"tcpSocket": {"port": "amqp"}},
+      "volumeMounts": [{"mountPath": "/var/run/artemis", "name": "vol-${NAME}"}]},
+      {"env": [{"name": "LINK_CAPACITY", "value": "${ROUTER_LINK_CAPACITY}"}, {"name":
+      "TOPIC_NAME", "value": "${ADDRESS}"}], "image": "${ROUTER_REPO}:latest", "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "router", "ports": [{"containerPort":
+      5672, "name": "amqp", "protocol": "TCP"}, {"containerPort": 55673, "name": "internal",
+      "protocol": "TCP"}, {"containerPort": 5671, "name": "amqps", "protocol": "TCP"}],
+      "resources": {"limits": {"memory": "256Mi"}, "requests": {"memory": "256Mi"}},
+      "volumeMounts": [{"mountPath": "/etc/qpid-dispatch/ssl", "name": "ssl-certs",
+      "readOnly": true}]}, {"env": [{"name": "TOPIC_NAME", "value": "${ADDRESS}"},
+      {"name": "GROUP_ID", "value": "${NAME}"}], "image": "${TOPIC_FORWARDER_REPO}:latest",
+      "livenessProbe": {"httpGet": {"path": "/health", "port": "health"}}, "name":
+      "forwarder", "ports": [{"containerPort": 8080, "name": "health"}], "resources":
+      {"limits": {"memory": "128Mi"}, "requests": {"memory": "128Mi"}}}], "volumes":
+      [{"emptyDir": { }, "name": "vol-${NAME}"}, {"name": "ssl-certs", "secret": {"secretName":
+      "qdrouterd-certs"}}, {"configMap": {"name": "hawkular-broker-config"}, "name":
+      "hawkular-openshift-agent"}]}}}}], "parameters": [{"description": "Storage capacity
+      required for volume claims", "name": "STORAGE_CAPACITY", "value": "2Gi"}, {"description":
+      "The docker image to use for the message broker", "name": "BROKER_REPO", "value":
+      "enmasseproject/artemis"}, {"description": "The default image to use as topic
+      forwarder", "name": "TOPIC_FORWARDER_REPO", "value": "enmasseproject/topic-forwarder"},
+      {"description": "The image to use for the router", "name": "ROUTER_REPO", "value":
+      "enmasseproject/qdrouterd"}, {"description": "The link capacity setting for
+      router", "name": "ROUTER_LINK_CAPACITY", "value": "50"}, {"description": "A
+      valid instance name for the instance", "name": "INSTANCE", "required": true},
+      {"description": "A valid name for the instance", "name": "NAME", "required":
+      true}, {"description": "The address to use for the topic", "name": "ADDRESS",
+      "required": true}]}'
+    tls-topic-persisted.json: '{"apiVersion": "v1", "kind": "Template", "metadata":
+      {"labels": {"app": "enmasse"}, "name": "tls-topic-persisted"}, "objects": [{"apiVersion":
+      "v1", "kind": "PersistentVolumeClaim", "metadata": {"labels": {"app": "enmasse",
+      "group_id": "${NAME}", "instance": "${INSTANCE}"}, "name": "pvc-${NAME}"}, "spec":
+      {"accessModes": ["ReadWriteMany"], "resources": {"requests": {"storage": "${STORAGE_CAPACITY}"}}}},
+      {"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels":
+      {"address_config": "address-config-${INSTANCE}-${NAME}", "app": "enmasse", "group_id":
+      "${NAME}", "instance": "${INSTANCE}"}, "name": "${NAME}"}, "spec": {"replicas":
+      1, "template": {"metadata": {"labels": {"app": "enmasse", "group_id": "${NAME}",
+      "instance": "${INSTANCE}", "role": "broker"}}, "spec": {"containers": [{"env":
+      [{"name": "TOPIC_NAME", "value": "${ADDRESS}"}, {"name": "GROUP_ID", "value":
+      "${NAME}"}], "image": "${BROKER_REPO}:latest", "lifecycle": {"preStop": {"exec":
+      {"command": ["/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"]}}}, "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "broker", "ports": [{"containerPort":
+      5673, "name": "amqp"}, {"containerPort": 61616, "name": "core"}, {"containerPort":
+      8161, "name": "jolokia"}], "readinessProbe": {"tcpSocket": {"port": "amqp"}},
+      "volumeMounts": [{"mountPath": "/var/run/artemis", "name": "vol-${NAME}"}]},
+      {"env": [{"name": "LINK_CAPACITY", "value": "${ROUTER_LINK_CAPACITY}"}, {"name":
+      "TOPIC_NAME", "value": "${ADDRESS}"}], "image": "${ROUTER_REPO}:latest", "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "router", "ports": [{"containerPort":
+      5672, "name": "amqp", "protocol": "TCP"}, {"containerPort": 55673, "name": "internal",
+      "protocol": "TCP"}, {"containerPort": 5671, "name": "amqps", "protocol": "TCP"}],
+      "resources": {"limits": {"memory": "256Mi"}, "requests": {"memory": "256Mi"}},
+      "volumeMounts": [{"mountPath": "/etc/qpid-dispatch/ssl", "name": "ssl-certs",
+      "readOnly": true}]}, {"env": [{"name": "TOPIC_NAME", "value": "${ADDRESS}"},
+      {"name": "GROUP_ID", "value": "${NAME}"}], "image": "${TOPIC_FORWARDER_REPO}:latest",
+      "livenessProbe": {"httpGet": {"path": "/health", "port": "health"}}, "name":
+      "forwarder", "ports": [{"containerPort": 8080, "name": "health"}], "resources":
+      {"limits": {"memory": "128Mi"}, "requests": {"memory": "128Mi"}}}], "volumes":
+      [{"name": "vol-${NAME}", "persistentVolumeClaim": {"claimName": "pvc-${NAME}"}},
+      {"name": "ssl-certs", "secret": {"secretName": "qdrouterd-certs"}}, {"configMap":
+      {"name": "hawkular-broker-config"}, "name": "hawkular-openshift-agent"}]}}}}],
+      "parameters": [{"description": "Storage capacity required for volume claims",
+      "name": "STORAGE_CAPACITY", "value": "2Gi"}, {"description": "The docker image
+      to use for the message broker", "name": "BROKER_REPO", "value": "enmasseproject/artemis"},
+      {"description": "The default image to use as topic forwarder", "name": "TOPIC_FORWARDER_REPO",
+      "value": "enmasseproject/topic-forwarder"}, {"description": "The image to use
+      for the router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"},
+      {"description": "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY",
+      "value": "50"}, {"description": "A valid instance name for the instance", "name":
+      "INSTANCE", "required": true}, {"description": "A valid name for the instance",
+      "name": "NAME", "required": true}, {"description": "The address to use for the
+      topic", "name": "ADDRESS", "required": true}]}'
+    topic-inmemory.json: '{"apiVersion": "v1", "kind": "Template", "metadata": {"labels":
+      {"app": "enmasse"}, "name": "topic-inmemory"}, "objects": [{"apiVersion": "extensions/v1beta1",
+      "kind": "Deployment", "metadata": {"labels": {"address_config": "address-config-${INSTANCE}-${NAME}",
+      "app": "enmasse", "group_id": "${NAME}", "instance": "${INSTANCE}"}, "name":
+      "${NAME}"}, "spec": {"replicas": 1, "template": {"metadata": {"labels": {"app":
+      "enmasse", "group_id": "${NAME}", "instance": "${INSTANCE}", "role": "broker"}},
+      "spec": {"containers": [{"env": [{"name": "TOPIC_NAME", "value": "${ADDRESS}"},
+      {"name": "GROUP_ID", "value": "${NAME}"}], "image": "${BROKER_REPO}:latest",
+      "lifecycle": {"preStop": {"exec": {"command": ["/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"]}}},
+      "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name": "broker", "ports":
+      [{"containerPort": 5673, "name": "amqp"}, {"containerPort": 61616, "name": "core"},
+      {"containerPort": 8161, "name": "jolokia"}], "readinessProbe": {"tcpSocket":
+      {"port": "amqp"}}, "volumeMounts": [{"mountPath": "/var/run/artemis", "name":
+      "vol-${NAME}"}]}, {"env": [{"name": "LINK_CAPACITY", "value": "${ROUTER_LINK_CAPACITY}"},
+      {"name": "TOPIC_NAME", "value": "${ADDRESS}"}], "image": "${ROUTER_REPO}:latest",
+      "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name": "router", "ports":
+      [{"containerPort": 5672, "name": "amqp", "protocol": "TCP"}, {"containerPort":
+      55673, "name": "internal", "protocol": "TCP"}], "resources": {"limits": {"memory":
+      "256Mi"}, "requests": {"memory": "256Mi"}}}, {"env": [{"name": "TOPIC_NAME",
+      "value": "${ADDRESS}"}, {"name": "GROUP_ID", "value": "${NAME}"}], "image":
+      "${TOPIC_FORWARDER_REPO}:latest", "livenessProbe": {"httpGet": {"path": "/health",
+      "port": "health"}}, "name": "forwarder", "ports": [{"containerPort": 8080, "name":
+      "health"}], "resources": {"limits": {"memory": "128Mi"}, "requests": {"memory":
+      "128Mi"}}}], "volumes": [{"emptyDir": { }, "name": "vol-${NAME}"}, {"configMap":
+      {"name": "hawkular-broker-config"}, "name": "hawkular-openshift-agent"}]}}}}],
+      "parameters": [{"description": "Storage capacity required for volume claims",
+      "name": "STORAGE_CAPACITY", "value": "2Gi"}, {"description": "The docker image
+      to use for the message broker", "name": "BROKER_REPO", "value": "enmasseproject/artemis"},
+      {"description": "The default image to use as topic forwarder", "name": "TOPIC_FORWARDER_REPO",
+      "value": "enmasseproject/topic-forwarder"}, {"description": "The image to use
+      for the router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"},
+      {"description": "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY",
+      "value": "50"}, {"description": "A valid instance name for the instance", "name":
+      "INSTANCE", "required": true}, {"description": "A valid name for the instance",
+      "name": "NAME", "required": true}, {"description": "The address to use for the
+      topic", "name": "ADDRESS", "required": true}]}'
+    topic-persisted.json: '{"apiVersion": "v1", "kind": "Template", "metadata": {"labels":
+      {"app": "enmasse"}, "name": "topic-persisted"}, "objects": [{"apiVersion": "v1",
+      "kind": "PersistentVolumeClaim", "metadata": {"labels": {"app": "enmasse", "group_id":
+      "${NAME}", "instance": "${INSTANCE}"}, "name": "pvc-${NAME}"}, "spec": {"accessModes":
+      ["ReadWriteMany"], "resources": {"requests": {"storage": "${STORAGE_CAPACITY}"}}}},
+      {"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels":
+      {"address_config": "address-config-${INSTANCE}-${NAME}", "app": "enmasse", "group_id":
+      "${NAME}", "instance": "${INSTANCE}"}, "name": "${NAME}"}, "spec": {"replicas":
+      1, "template": {"metadata": {"labels": {"app": "enmasse", "group_id": "${NAME}",
+      "instance": "${INSTANCE}", "role": "broker"}}, "spec": {"containers": [{"env":
+      [{"name": "TOPIC_NAME", "value": "${ADDRESS}"}, {"name": "GROUP_ID", "value":
+      "${NAME}"}], "image": "${BROKER_REPO}:latest", "lifecycle": {"preStop": {"exec":
+      {"command": ["/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"]}}}, "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "broker", "ports": [{"containerPort":
+      5673, "name": "amqp"}, {"containerPort": 61616, "name": "core"}, {"containerPort":
+      8161, "name": "jolokia"}], "readinessProbe": {"tcpSocket": {"port": "amqp"}},
+      "volumeMounts": [{"mountPath": "/var/run/artemis", "name": "vol-${NAME}"}]},
+      {"env": [{"name": "LINK_CAPACITY", "value": "${ROUTER_LINK_CAPACITY}"}, {"name":
+      "TOPIC_NAME", "value": "${ADDRESS}"}], "image": "${ROUTER_REPO}:latest", "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "router", "ports": [{"containerPort":
+      5672, "name": "amqp", "protocol": "TCP"}, {"containerPort": 55673, "name": "internal",
+      "protocol": "TCP"}], "resources": {"limits": {"memory": "256Mi"}, "requests":
+      {"memory": "256Mi"}}}, {"env": [{"name": "TOPIC_NAME", "value": "${ADDRESS}"},
+      {"name": "GROUP_ID", "value": "${NAME}"}], "image": "${TOPIC_FORWARDER_REPO}:latest",
+      "livenessProbe": {"httpGet": {"path": "/health", "port": "health"}}, "name":
+      "forwarder", "ports": [{"containerPort": 8080, "name": "health"}], "resources":
+      {"limits": {"memory": "128Mi"}, "requests": {"memory": "128Mi"}}}], "volumes":
+      [{"name": "vol-${NAME}", "persistentVolumeClaim": {"claimName": "pvc-${NAME}"}},
+      {"configMap": {"name": "hawkular-broker-config"}, "name": "hawkular-openshift-agent"}]}}}}],
+      "parameters": [{"description": "Storage capacity required for volume claims",
+      "name": "STORAGE_CAPACITY", "value": "2Gi"}, {"description": "The docker image
+      to use for the message broker", "name": "BROKER_REPO", "value": "enmasseproject/artemis"},
+      {"description": "The default image to use as topic forwarder", "name": "TOPIC_FORWARDER_REPO",
+      "value": "enmasseproject/topic-forwarder"}, {"description": "The image to use
+      for the router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"},
+      {"description": "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY",
+      "value": "50"}, {"description": "A valid instance name for the instance", "name":
+      "INSTANCE", "required": true}, {"description": "A valid name for the instance",
+      "name": "NAME", "required": true}, {"description": "The address to use for the
+      topic", "name": "ADDRESS", "required": true}]}'
+  kind: ConfigMap
   metadata:
     labels:
       app: enmasse
-    name: tls-queue-inmemory
-  objects:
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        address_config: address-config-${INSTANCE}-${NAME}
-        app: enmasse
-        group_id: "${NAME}"
-        instance: "${INSTANCE}"
-      name: "${NAME}"
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            group_id: "${NAME}"
-            instance: "${INSTANCE}"
-            role: broker
-        spec:
-          containers:
-          - env:
-            - name: QUEUE_NAME
-              value: "${ADDRESS}"
-            - name: GROUP_ID
-              value: "${NAME}"
-            image: "${BROKER_REPO}:latest"
-            lifecycle:
-              preStop:
-                exec:
-                  command:
-                  - "/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: broker
-            ports:
-            - containerPort: 5673
-              name: amqp
-            - containerPort: 61616
-              name: core
-            - containerPort: 8161
-              name: jolokia
-            readinessProbe:
-              tcpSocket:
-                port: amqp
-            volumeMounts:
-            - mountPath: "/var/run/artemis"
-              name: vol-${NAME}
-          volumes:
-          - emptyDir: {}
-            name: vol-${NAME}
-          - name: ssl-certs
-            secret:
-              secretName: qdrouterd-certs
-          - configMap:
-              name: hawkular-broker-config
-            name: hawkular-openshift-agent
-  parameters:
-  - description: Storage capacity required for volume claims
-    name: STORAGE_CAPACITY
-    value: 2Gi
-  - description: The docker image to use for the message broker
-    name: BROKER_REPO
-    value: enmasseproject/artemis
-  - description: The default image to use as topic forwarder
-    name: TOPIC_FORWARDER_REPO
-    value: enmasseproject/topic-forwarder
-  - description: The image to use for the router
-    name: ROUTER_REPO
-    value: enmasseproject/qdrouterd
-  - description: The link capacity setting for router
-    name: ROUTER_LINK_CAPACITY
-    value: '50'
-  - description: A valid instance name for the instance
-    name: INSTANCE
-    required: true
-  - description: A valid name for the instance
-    name: NAME
-    required: true
-  - description: The address to use for the queue
-    name: ADDRESS
-    required: true
-- apiVersion: v1
-  kind: Template
-  metadata:
-    labels:
-      app: enmasse
-    name: tls-queue-persisted
-  objects:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
-    metadata:
-      labels:
-        app: enmasse
-        group_id: "${NAME}"
-        instance: "${INSTANCE}"
-      name: pvc-${NAME}
-    spec:
-      accessModes:
-      - ReadWriteMany
-      resources:
-        requests:
-          storage: "${STORAGE_CAPACITY}"
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        address_config: address-config-${INSTANCE}-${NAME}
-        app: enmasse
-        group_id: "${NAME}"
-        instance: "${INSTANCE}"
-      name: "${NAME}"
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            group_id: "${NAME}"
-            instance: "${INSTANCE}"
-            role: broker
-        spec:
-          containers:
-          - env:
-            - name: QUEUE_NAME
-              value: "${ADDRESS}"
-            - name: GROUP_ID
-              value: "${NAME}"
-            image: "${BROKER_REPO}:latest"
-            lifecycle:
-              preStop:
-                exec:
-                  command:
-                  - "/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: broker
-            ports:
-            - containerPort: 5673
-              name: amqp
-            - containerPort: 61616
-              name: core
-            - containerPort: 8161
-              name: jolokia
-            readinessProbe:
-              tcpSocket:
-                port: amqp
-            volumeMounts:
-            - mountPath: "/var/run/artemis"
-              name: vol-${NAME}
-          volumes:
-          - name: vol-${NAME}
-            persistentVolumeClaim:
-              claimName: pvc-${NAME}
-          - name: ssl-certs
-            secret:
-              secretName: qdrouterd-certs
-          - configMap:
-              name: hawkular-broker-config
-            name: hawkular-openshift-agent
-  parameters:
-  - description: Storage capacity required for volume claims
-    name: STORAGE_CAPACITY
-    value: 2Gi
-  - description: The docker image to use for the message broker
-    name: BROKER_REPO
-    value: enmasseproject/artemis
-  - description: The default image to use as topic forwarder
-    name: TOPIC_FORWARDER_REPO
-    value: enmasseproject/topic-forwarder
-  - description: The image to use for the router
-    name: ROUTER_REPO
-    value: enmasseproject/qdrouterd
-  - description: The link capacity setting for router
-    name: ROUTER_LINK_CAPACITY
-    value: '50'
-  - description: A valid instance name for the instance
-    name: INSTANCE
-    required: true
-  - description: A valid name for the instance
-    name: NAME
-    required: true
-  - description: The address to use for the queue
-    name: ADDRESS
-    required: true
-- apiVersion: v1
-  kind: Template
-  metadata:
-    labels:
-      app: enmasse
-    name: tls-topic-inmemory
-  objects:
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        address_config: address-config-${INSTANCE}-${NAME}
-        app: enmasse
-        group_id: "${NAME}"
-        instance: "${INSTANCE}"
-      name: "${NAME}"
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            group_id: "${NAME}"
-            instance: "${INSTANCE}"
-            role: broker
-        spec:
-          containers:
-          - env:
-            - name: TOPIC_NAME
-              value: "${ADDRESS}"
-            - name: GROUP_ID
-              value: "${NAME}"
-            image: "${BROKER_REPO}:latest"
-            lifecycle:
-              preStop:
-                exec:
-                  command:
-                  - "/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: broker
-            ports:
-            - containerPort: 5673
-              name: amqp
-            - containerPort: 61616
-              name: core
-            - containerPort: 8161
-              name: jolokia
-            readinessProbe:
-              tcpSocket:
-                port: amqp
-            volumeMounts:
-            - mountPath: "/var/run/artemis"
-              name: vol-${NAME}
-          - env:
-            - name: LINK_CAPACITY
-              value: "${ROUTER_LINK_CAPACITY}"
-            - name: TOPIC_NAME
-              value: "${ADDRESS}"
-            image: "${ROUTER_REPO}:latest"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: router
-            ports:
-            - containerPort: 5672
-              name: amqp
-              protocol: TCP
-            - containerPort: 55673
-              name: internal
-              protocol: TCP
-            - containerPort: 5671
-              name: amqps
-              protocol: TCP
-            resources:
-              limits:
-                memory: 256Mi
-              requests:
-                memory: 256Mi
-            volumeMounts:
-            - mountPath: "/etc/qpid-dispatch/ssl"
-              name: ssl-certs
-              readOnly: true
-          - env:
-            - name: TOPIC_NAME
-              value: "${ADDRESS}"
-            - name: GROUP_ID
-              value: "${NAME}"
-            image: "${TOPIC_FORWARDER_REPO}:latest"
-            livenessProbe:
-              httpGet:
-                path: "/health"
-                port: health
-            name: forwarder
-            ports:
-            - containerPort: 8080
-              name: health
-            resources:
-              limits:
-                memory: 128Mi
-              requests:
-                memory: 128Mi
-          volumes:
-          - emptyDir: {}
-            name: vol-${NAME}
-          - name: ssl-certs
-            secret:
-              secretName: qdrouterd-certs
-          - configMap:
-              name: hawkular-broker-config
-            name: hawkular-openshift-agent
-  parameters:
-  - description: Storage capacity required for volume claims
-    name: STORAGE_CAPACITY
-    value: 2Gi
-  - description: The docker image to use for the message broker
-    name: BROKER_REPO
-    value: enmasseproject/artemis
-  - description: The default image to use as topic forwarder
-    name: TOPIC_FORWARDER_REPO
-    value: enmasseproject/topic-forwarder
-  - description: The image to use for the router
-    name: ROUTER_REPO
-    value: enmasseproject/qdrouterd
-  - description: The link capacity setting for router
-    name: ROUTER_LINK_CAPACITY
-    value: '50'
-  - description: A valid instance name for the instance
-    name: INSTANCE
-    required: true
-  - description: A valid name for the instance
-    name: NAME
-    required: true
-  - description: The address to use for the topic
-    name: ADDRESS
-    required: true
-- apiVersion: v1
-  kind: Template
-  metadata:
-    labels:
-      app: enmasse
-    name: tls-topic-persisted
-  objects:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
-    metadata:
-      labels:
-        app: enmasse
-        group_id: "${NAME}"
-        instance: "${INSTANCE}"
-      name: pvc-${NAME}
-    spec:
-      accessModes:
-      - ReadWriteMany
-      resources:
-        requests:
-          storage: "${STORAGE_CAPACITY}"
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        address_config: address-config-${INSTANCE}-${NAME}
-        app: enmasse
-        group_id: "${NAME}"
-        instance: "${INSTANCE}"
-      name: "${NAME}"
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            group_id: "${NAME}"
-            instance: "${INSTANCE}"
-            role: broker
-        spec:
-          containers:
-          - env:
-            - name: TOPIC_NAME
-              value: "${ADDRESS}"
-            - name: GROUP_ID
-              value: "${NAME}"
-            image: "${BROKER_REPO}:latest"
-            lifecycle:
-              preStop:
-                exec:
-                  command:
-                  - "/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: broker
-            ports:
-            - containerPort: 5673
-              name: amqp
-            - containerPort: 61616
-              name: core
-            - containerPort: 8161
-              name: jolokia
-            readinessProbe:
-              tcpSocket:
-                port: amqp
-            volumeMounts:
-            - mountPath: "/var/run/artemis"
-              name: vol-${NAME}
-          - env:
-            - name: LINK_CAPACITY
-              value: "${ROUTER_LINK_CAPACITY}"
-            - name: TOPIC_NAME
-              value: "${ADDRESS}"
-            image: "${ROUTER_REPO}:latest"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: router
-            ports:
-            - containerPort: 5672
-              name: amqp
-              protocol: TCP
-            - containerPort: 55673
-              name: internal
-              protocol: TCP
-            - containerPort: 5671
-              name: amqps
-              protocol: TCP
-            resources:
-              limits:
-                memory: 256Mi
-              requests:
-                memory: 256Mi
-            volumeMounts:
-            - mountPath: "/etc/qpid-dispatch/ssl"
-              name: ssl-certs
-              readOnly: true
-          - env:
-            - name: TOPIC_NAME
-              value: "${ADDRESS}"
-            - name: GROUP_ID
-              value: "${NAME}"
-            image: "${TOPIC_FORWARDER_REPO}:latest"
-            livenessProbe:
-              httpGet:
-                path: "/health"
-                port: health
-            name: forwarder
-            ports:
-            - containerPort: 8080
-              name: health
-            resources:
-              limits:
-                memory: 128Mi
-              requests:
-                memory: 128Mi
-          volumes:
-          - name: vol-${NAME}
-            persistentVolumeClaim:
-              claimName: pvc-${NAME}
-          - name: ssl-certs
-            secret:
-              secretName: qdrouterd-certs
-          - configMap:
-              name: hawkular-broker-config
-            name: hawkular-openshift-agent
-  parameters:
-  - description: Storage capacity required for volume claims
-    name: STORAGE_CAPACITY
-    value: 2Gi
-  - description: The docker image to use for the message broker
-    name: BROKER_REPO
-    value: enmasseproject/artemis
-  - description: The default image to use as topic forwarder
-    name: TOPIC_FORWARDER_REPO
-    value: enmasseproject/topic-forwarder
-  - description: The image to use for the router
-    name: ROUTER_REPO
-    value: enmasseproject/qdrouterd
-  - description: The link capacity setting for router
-    name: ROUTER_LINK_CAPACITY
-    value: '50'
-  - description: A valid instance name for the instance
-    name: INSTANCE
-    required: true
-  - description: A valid name for the instance
-    name: NAME
-    required: true
-  - description: The address to use for the topic
-    name: ADDRESS
-    required: true
-- apiVersion: v1
-  kind: Template
-  metadata:
-    labels:
-      app: enmasse
-    name: tls-enmasse-instance-infra
-  objects:
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-        name: qdrouterd
-      name: qdrouterd
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            capability: router
-            instance: "${INSTANCE}"
-            name: qdrouterd
-        spec:
-          containers:
-          - env:
-            - name: LINK_CAPACITY
-              value: "${ROUTER_LINK_CAPACITY}"
-            image: "${ROUTER_REPO}:latest"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: router
-            ports:
-            - containerPort: 5672
-              name: amqp
-              protocol: TCP
-            - containerPort: 55673
-              name: internal
-              protocol: TCP
-            - containerPort: 5671
-              name: amqps
-              protocol: TCP
-            volumeMounts:
-            - mountPath: "/etc/qpid-dispatch/ssl"
-              name: ssl-certs
-              readOnly: true
-          volumes:
-          - name: ssl-certs
-            secret:
-              secretName: qdrouterd-certs
-  - apiVersion: v1
-    kind: Service
-    metadata:
-      annotations:
-        service.alpha.openshift.io/dependencies: '[{"kind": "Service", "name": "admin",
-          "namespace": ""}, {"kind": "Service", "name": "subscription", "namespace":
-          ""}, {"kind": "Service", "name": "mqtt", "namespace": ""}]'
-        service.alpha.openshift.io/infrastructure: 'true'
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-      name: messaging
-    spec:
-      ports:
-      - name: amqp
-        port: 5672
-        protocol: TCP
-        targetPort: 5672
-      - name: amqps
-        port: 5671
-        protocol: TCP
-        targetPort: 5671
-      - name: internal
-        port: 55673
-        protocol: TCP
-        targetPort: 55673
-      selector:
-        capability: router
-        instance: "${INSTANCE}"
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-        name: subserv
-      name: subserv
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            instance: "${INSTANCE}"
-            name: subserv
-        spec:
-          containers:
-          - env: []
-            image: "${SUBSERV_REPO}:latest"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: subserv
-            ports:
-            - containerPort: 5672
-              name: amqp
-              protocol: TCP
-            resources:
-              limits:
-                memory: 64Mi
-              requests:
-                memory: 64Mi
-  - apiVersion: v1
-    kind: Service
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-      name: subscription
-    spec:
-      ports:
-      - name: amqp
-        port: 5672
-        protocol: TCP
-        targetPort: 5672
-      selector:
-        instance: "${INSTANCE}"
-        name: subserv
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-        name: mqtt-gateway
-      name: mqtt-gateway
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            instance: "${INSTANCE}"
-            name: mqtt-gateway
-        spec:
-          containers:
-          - image: "${MQTT_GATEWAY_REPO}:latest"
-            livenessProbe:
-              initialDelaySeconds: 60
-              tcpSocket:
-                port: secure-mqtt
-            name: mqtt-gateway-tls
-            ports:
-            - containerPort: 8883
-              name: secure-mqtt
-              protocol: TCP
-            volumeMounts:
-            - mountPath: "/etc/mqtt-gateway/ssl"
-              name: ssl-certs
-              readOnly: true
-          - image: "${MQTT_GATEWAY_REPO}:latest"
-            livenessProbe:
-              initialDelaySeconds: 60
-              tcpSocket:
-                port: mqtt
-            name: mqtt-gateway
-            ports:
-            - containerPort: 1883
-              name: mqtt
-              protocol: TCP
-          volumes:
-          - name: ssl-certs
-            secret:
-              secretName: mqtt-certs
-  - apiVersion: v1
-    kind: Service
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-      name: mqtt
-    spec:
-      ports:
-      - name: mqtt
-        port: 1883
-        protocol: TCP
-        targetPort: 1883
-      - name: secure-mqtt
-        port: 8883
-        protocol: TCP
-        targetPort: 8883
-      selector:
-        instance: "${INSTANCE}"
-        name: mqtt-gateway
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-        name: mqtt-lwt
-      name: mqtt-lwt
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            instance: "${INSTANCE}"
-            name: mqtt-lwt
-        spec:
-          containers:
-          - image: "${MQTT_LWT_REPO}:latest"
-            name: mqtt-lwt
-  - apiVersion: v1
-    kind: Route
-    metadata:
-      labels:
-        app: enmasse
-      name: console
-    spec:
-      host: "${CONSOLE_HOSTNAME}"
-      port:
-        targetPort: console-http
-      to:
-        kind: Service
-        name: admin
-  - apiVersion: v1
-    data:
-      hawkular-openshift-agent: '{"endpoints": [{"collection_interval": "60s", "metrics":
-        [{"id": "broker.threadCount", "name": "java.lang:type=Threading#ThreadCount",
-        "tags": {"messagingComponent": "broker", "messagingMetricType": "threadCount"},
-        "type": "counter"}, {"id": "broker.memoryHeapUsage", "name": "java.lang:type=Memory#HeapMemoryUsage#used",
-        "tags": {"messagingComponent": "broker", "messagingMetricType": "heapUsage"},
-        "type": "gauge"}, {"description": "Queue depth for ${address}", "id": "${address}.${queue}.${broker}.queueDepth",
-        "name": "org.apache.activemq.artemis:address=*,broker=*,component=addresses,queue=*,routing-type=*,subcomponent=queues#MessageCount",
-        "tags": {"messagingAddress": "${address}", "messagingBroker": "{broker}",
-        "messagingMetricType": "queueDepth", "messagingQueue": "${queue}"}, "type":
-        "gauge"}, {"description": "Number of consumers for ${address}", "id": "${address}.${queue}.${broker}.numConsumers",
-        "name": "org.apache.activemq.artemis:address=*,broker=*,component=addresses,queue=*,routing-type=*,subcomponent=queues#ConsumerCount",
-        "tags": {"messagingAddress": "${address}", "messagingBroker": "{broker}",
-        "messagingMetricType": "numConsumers", "messagingQueue": "${queue}"}, "type":
-        "gauge"}], "path": "/jolokia/", "port": 8161, "protocol": "http", "type":
-        "jolokia"}]}'
-    kind: ConfigMap
-    metadata:
-      name: hawkular-broker-config
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-        name: admin
-      name: admin
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            instance: "${INSTANCE}"
-            name: admin
-        spec:
-          containers:
-          - env:
-            - name: CONFIGURATION_SERVICE_HOST
-              value: localhost
-            - name: CONFIGURATION_SERVICE_PORT
-              value: '5672'
-            image: "${RAGENT_REPO}:latest"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: ragent
-            ports:
-            - containerPort: 55672
-              name: amqp
-              protocol: TCP
-            resources:
-              limits:
-                memory: 64Mi
-              requests:
-                memory: 64Mi
-          - env:
-            - name: CONFIGURATION_SERVICE_HOST
-              value: localhost
-            - name: CONFIGURATION_SERVICE_PORT
-              value: '5672'
-            image: "${QUEUE_SCHEDULER_REPO}:latest"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: queue-scheduler
-            ports:
-            - containerPort: 55667
-              name: amqp
-              protocol: TCP
-            resources:
-              limits:
-                memory: 128Mi
-              requests:
-                memory: 128Mi
-          - env:
-            - name: CONFIGURATION_SERVICE_HOST
-              value: localhost
-            - name: CONFIGURATION_SERVICE_PORT
-              value: '5672'
-            image: "${CONSOLE_REPO}:latest"
-            livenessProbe:
-              tcpSocket:
-                port: http
-            name: console
-            ports:
-            - containerPort: 8080
-              name: http
-              protocol: TCP
-            - containerPort: 56720
-              name: amqp-ws
-              protocol: TCP
-            resources:
-              limits:
-                memory: 64Mi
-              requests:
-                memory: 64Mi
-          - env: []
-            image: "${CONFIGSERV_REPO}:latest"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: configserv
-            ports:
-            - containerPort: 5672
-              name: amqp
-              protocol: TCP
-            resources:
-              limits:
-                memory: 256Mi
-              requests:
-                memory: 256Mi
-  - apiVersion: v1
-    kind: Service
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-      name: admin
-    spec:
-      ports:
-      - name: ragent
-        port: 55672
-      - name: configuration
-        port: 5672
-      - name: queue-scheduler
-        port: 55667
-      - name: console-ws
-        port: 56720
-      - name: console-http
-        port: 8080
-      selector:
-        instance: "${INSTANCE}"
-        name: admin
-  - apiVersion: v1
-    kind: Service
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-      name: amqp-kafka-bridge
-    spec:
-      ports:
-      - name: amqp
-        port: 5672
-        protocol: TCP
-        targetPort: 5672
-      selector:
-        capability: bridge
-        instance: "${INSTANCE}"
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-        name: amqp-kafka-bridge
-      name: amqp-kafka-bridge
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            capability: bridge
-            instance: "${INSTANCE}"
-            name: amqp-kafka-bridge
-        spec:
-          containers:
-          - env:
-            - name: KAFKA_BOOTSTRAP_SERVERS
-              value: "${KAFKA_BOOTSTRAP_SERVERS}"
-            image: "${AMQP_KAFKA_BRIDGE_REPO}:latest"
-            name: amqp-kafka-bridge
-            resources:
-              limits:
-                memory: 512Mi
-              requests:
-                memory: 512Mi
-  - apiVersion: v1
-    kind: Route
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-      name: messaging
-    spec:
-      host: "${MESSAGING_HOSTNAME}"
-      port:
-        targetPort: amqps
-      tls:
-        termination: passthrough
-      to:
-        kind: Service
-        name: messaging
-        weight: 100
-  - apiVersion: v1
-    kind: Route
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-      name: mqtt
-    spec:
-      host: "${MQTT_GATEWAY_HOSTNAME}"
-      port:
-        targetPort: secure-mqtt
-      tls:
-        termination: passthrough
-      to:
-        kind: Service
-        name: mqtt
-        weight: 100
-  parameters:
-  - description: The image to use for the router
-    name: ROUTER_REPO
-    value: enmasseproject/qdrouterd
-  - description: The link capacity setting for router
-    name: ROUTER_LINK_CAPACITY
-    value: '50'
-  - description: The image to use for the configuration service
-    name: CONFIGSERV_REPO
-    value: enmasseproject/configserv
-  - description: The docker image to use for the queue scheduler
-    name: QUEUE_SCHEDULER_REPO
-    value: enmasseproject/queue-scheduler
-  - description: The image to use for the router agent
-    name: RAGENT_REPO
-    value: enmasseproject/ragent
-  - description: The image to use for the subscription services
-    name: SUBSERV_REPO
-    value: enmasseproject/subserv
-  - description: The image to use for the console
-    name: CONSOLE_REPO
-    value: enmasseproject/console
-  - description: The hostname to use for the exposed route for messaging (TLS only)
-    name: MESSAGING_HOSTNAME
-  - description: The image to use for the MQTT gateway
-    name: MQTT_GATEWAY_REPO
-    value: enmasseproject/mqtt-gateway
-  - description: The hostname to use for the exposed route for MQTT (TLS only)
-    name: MQTT_GATEWAY_HOSTNAME
-  - description: The hostname to use for the exposed route for the messaging console
-    name: CONSOLE_HOSTNAME
-  - description: The image to use for the MQTT LWT
-    name: MQTT_LWT_REPO
-    value: enmasseproject/mqtt-lwt
-  - description: The image to use for the AMQP Kafka Bridge
-    name: AMQP_KAFKA_BRIDGE_REPO
-    value: enmasseproject/amqp-kafka-bridge
-  - description: A list of host/port pairs to use for establishing the initial connection
-      to the Kafka cluster
-    name: KAFKA_BOOTSTRAP_SERVERS
-  - description: The instance this infrastructure is deployed for
-    name: INSTANCE
-    required: true
+    name: enmasse-template-config
 - apiVersion: extensions/v1beta1
   kind: Deployment
   metadata:
@@ -1012,7 +605,14 @@ objects:
               memory: 256Mi
             requests:
               memory: 256Mi
+          volumeMounts:
+          - mountPath: "/templates"
+            name: templates
         serviceAccount: enmasse-service-account
+        volumes:
+        - configMap:
+            name: enmasse-template-config
+          name: templates
 - apiVersion: v1
   kind: Service
   metadata:

--- a/generated/tls-enmasse-template-with-kafka.yaml
+++ b/generated/tls-enmasse-template-with-kafka.yaml
@@ -60,12 +60,9 @@ objects:
       {"app": "enmasse", "instance": "${INSTANCE}", "name": "mqtt-lwt"}, "name": "mqtt-lwt"},
       "spec": {"replicas": 1, "template": {"metadata": {"labels": {"app": "enmasse",
       "instance": "${INSTANCE}", "name": "mqtt-lwt"}}, "spec": {"containers": [{"image":
-      "${MQTT_LWT_REPO}:latest", "name": "mqtt-lwt"}]}}}}, {"apiVersion": "v1", "kind":
-      "Route", "metadata": {"labels": {"app": "enmasse"}, "name": "console"}, "spec":
-      {"host": "${CONSOLE_HOSTNAME}", "port": {"targetPort": "console-http"}, "to":
-      {"kind": "Service", "name": "admin"}}}, {"apiVersion": "v1", "data": {"hawkular-openshift-agent":
-      "{\"endpoints\": [{\"collection_interval\": \"60s\", \"metrics\": [{\"id\":
-      \"broker.threadCount\", \"name\": \"java.lang:type=Threading#ThreadCount\",
+      "${MQTT_LWT_REPO}:latest", "name": "mqtt-lwt"}]}}}}, {"apiVersion": "v1", "data":
+      {"hawkular-openshift-agent": "{\"endpoints\": [{\"collection_interval\": \"60s\",
+      \"metrics\": [{\"id\": \"broker.threadCount\", \"name\": \"java.lang:type=Threading#ThreadCount\",
       \"tags\": {\"messagingComponent\": \"broker\", \"messagingMetricType\": \"threadCount\"},
       \"type\": \"counter\"}, {\"id\": \"broker.memoryHeapUsage\", \"name\": \"java.lang:type=Memory#HeapMemoryUsage#used\",
       \"tags\": {\"messagingComponent\": \"broker\", \"messagingMetricType\": \"heapUsage\"},
@@ -125,21 +122,24 @@ objects:
       "kind": "Route", "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"},
       "name": "mqtt"}, "spec": {"host": "${MQTT_GATEWAY_HOSTNAME}", "port": {"targetPort":
       "secure-mqtt"}, "tls": {"termination": "passthrough"}, "to": {"kind": "Service",
-      "name": "mqtt", "weight": 100}}}], "parameters": [{"description": "The image
-      to use for the router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"},
-      {"description": "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY",
-      "value": "50"}, {"description": "The image to use for the configuration service",
-      "name": "CONFIGSERV_REPO", "value": "enmasseproject/configserv"}, {"description":
-      "The docker image to use for the queue scheduler", "name": "QUEUE_SCHEDULER_REPO",
-      "value": "enmasseproject/queue-scheduler"}, {"description": "The image to use
-      for the router agent", "name": "RAGENT_REPO", "value": "enmasseproject/ragent"},
-      {"description": "The image to use for the subscription services", "name": "SUBSERV_REPO",
-      "value": "enmasseproject/subserv"}, {"description": "The image to use for the
-      console", "name": "CONSOLE_REPO", "value": "enmasseproject/console"}, {"description":
-      "The hostname to use for the exposed route for messaging (TLS only)", "name":
-      "MESSAGING_HOSTNAME"}, {"description": "The image to use for the MQTT gateway",
-      "name": "MQTT_GATEWAY_REPO", "value": "enmasseproject/mqtt-gateway"}, {"description":
-      "The hostname to use for the exposed route for MQTT (TLS only)", "name": "MQTT_GATEWAY_HOSTNAME"},
+      "name": "mqtt", "weight": 100}}}, {"apiVersion": "v1", "kind": "Route", "metadata":
+      {"labels": {"app": "enmasse"}, "name": "console"}, "spec": {"host": "${CONSOLE_HOSTNAME}",
+      "port": {"targetPort": "console-http"}, "to": {"kind": "Service", "name": "admin"}}}],
+      "parameters": [{"description": "The image to use for the router", "name": "ROUTER_REPO",
+      "value": "enmasseproject/qdrouterd"}, {"description": "The link capacity setting
+      for router", "name": "ROUTER_LINK_CAPACITY", "value": "50"}, {"description":
+      "The image to use for the configuration service", "name": "CONFIGSERV_REPO",
+      "value": "enmasseproject/configserv"}, {"description": "The docker image to
+      use for the queue scheduler", "name": "QUEUE_SCHEDULER_REPO", "value": "enmasseproject/queue-scheduler"},
+      {"description": "The image to use for the router agent", "name": "RAGENT_REPO",
+      "value": "enmasseproject/ragent"}, {"description": "The image to use for the
+      subscription services", "name": "SUBSERV_REPO", "value": "enmasseproject/subserv"},
+      {"description": "The image to use for the console", "name": "CONSOLE_REPO",
+      "value": "enmasseproject/console"}, {"description": "The hostname to use for
+      the exposed route for messaging (TLS only)", "name": "MESSAGING_HOSTNAME"},
+      {"description": "The image to use for the MQTT gateway", "name": "MQTT_GATEWAY_REPO",
+      "value": "enmasseproject/mqtt-gateway"}, {"description": "The hostname to use
+      for the exposed route for MQTT (TLS only)", "name": "MQTT_GATEWAY_HOSTNAME"},
       {"description": "The hostname to use for the exposed route for the messaging
       console", "name": "CONSOLE_HOSTNAME"}, {"description": "The image to use for
       the MQTT LWT", "name": "MQTT_LWT_REPO", "value": "enmasseproject/mqtt-lwt"},
@@ -256,12 +256,9 @@ objects:
       {"app": "enmasse", "instance": "${INSTANCE}", "name": "mqtt-lwt"}, "name": "mqtt-lwt"},
       "spec": {"replicas": 1, "template": {"metadata": {"labels": {"app": "enmasse",
       "instance": "${INSTANCE}", "name": "mqtt-lwt"}}, "spec": {"containers": [{"image":
-      "${MQTT_LWT_REPO}:latest", "name": "mqtt-lwt"}]}}}}, {"apiVersion": "v1", "kind":
-      "Route", "metadata": {"labels": {"app": "enmasse"}, "name": "console"}, "spec":
-      {"host": "${CONSOLE_HOSTNAME}", "port": {"targetPort": "console-http"}, "to":
-      {"kind": "Service", "name": "admin"}}}, {"apiVersion": "v1", "data": {"hawkular-openshift-agent":
-      "{\"endpoints\": [{\"collection_interval\": \"60s\", \"metrics\": [{\"id\":
-      \"broker.threadCount\", \"name\": \"java.lang:type=Threading#ThreadCount\",
+      "${MQTT_LWT_REPO}:latest", "name": "mqtt-lwt"}]}}}}, {"apiVersion": "v1", "data":
+      {"hawkular-openshift-agent": "{\"endpoints\": [{\"collection_interval\": \"60s\",
+      \"metrics\": [{\"id\": \"broker.threadCount\", \"name\": \"java.lang:type=Threading#ThreadCount\",
       \"tags\": {\"messagingComponent\": \"broker\", \"messagingMetricType\": \"threadCount\"},
       \"type\": \"counter\"}, {\"id\": \"broker.memoryHeapUsage\", \"name\": \"java.lang:type=Memory#HeapMemoryUsage#used\",
       \"tags\": {\"messagingComponent\": \"broker\", \"messagingMetricType\": \"heapUsage\"},
@@ -321,21 +318,24 @@ objects:
       "kind": "Route", "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"},
       "name": "mqtt"}, "spec": {"host": "${MQTT_GATEWAY_HOSTNAME}", "port": {"targetPort":
       "secure-mqtt"}, "tls": {"termination": "passthrough"}, "to": {"kind": "Service",
-      "name": "mqtt", "weight": 100}}}], "parameters": [{"description": "The image
-      to use for the router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"},
-      {"description": "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY",
-      "value": "50"}, {"description": "The image to use for the configuration service",
-      "name": "CONFIGSERV_REPO", "value": "enmasseproject/configserv"}, {"description":
-      "The docker image to use for the queue scheduler", "name": "QUEUE_SCHEDULER_REPO",
-      "value": "enmasseproject/queue-scheduler"}, {"description": "The image to use
-      for the router agent", "name": "RAGENT_REPO", "value": "enmasseproject/ragent"},
-      {"description": "The image to use for the subscription services", "name": "SUBSERV_REPO",
-      "value": "enmasseproject/subserv"}, {"description": "The image to use for the
-      console", "name": "CONSOLE_REPO", "value": "enmasseproject/console"}, {"description":
-      "The hostname to use for the exposed route for messaging (TLS only)", "name":
-      "MESSAGING_HOSTNAME"}, {"description": "The image to use for the MQTT gateway",
-      "name": "MQTT_GATEWAY_REPO", "value": "enmasseproject/mqtt-gateway"}, {"description":
-      "The hostname to use for the exposed route for MQTT (TLS only)", "name": "MQTT_GATEWAY_HOSTNAME"},
+      "name": "mqtt", "weight": 100}}}, {"apiVersion": "v1", "kind": "Route", "metadata":
+      {"labels": {"app": "enmasse"}, "name": "console"}, "spec": {"host": "${CONSOLE_HOSTNAME}",
+      "port": {"targetPort": "console-http"}, "to": {"kind": "Service", "name": "admin"}}}],
+      "parameters": [{"description": "The image to use for the router", "name": "ROUTER_REPO",
+      "value": "enmasseproject/qdrouterd"}, {"description": "The link capacity setting
+      for router", "name": "ROUTER_LINK_CAPACITY", "value": "50"}, {"description":
+      "The image to use for the configuration service", "name": "CONFIGSERV_REPO",
+      "value": "enmasseproject/configserv"}, {"description": "The docker image to
+      use for the queue scheduler", "name": "QUEUE_SCHEDULER_REPO", "value": "enmasseproject/queue-scheduler"},
+      {"description": "The image to use for the router agent", "name": "RAGENT_REPO",
+      "value": "enmasseproject/ragent"}, {"description": "The image to use for the
+      subscription services", "name": "SUBSERV_REPO", "value": "enmasseproject/subserv"},
+      {"description": "The image to use for the console", "name": "CONSOLE_REPO",
+      "value": "enmasseproject/console"}, {"description": "The hostname to use for
+      the exposed route for messaging (TLS only)", "name": "MESSAGING_HOSTNAME"},
+      {"description": "The image to use for the MQTT gateway", "name": "MQTT_GATEWAY_REPO",
+      "value": "enmasseproject/mqtt-gateway"}, {"description": "The hostname to use
+      for the exposed route for MQTT (TLS only)", "name": "MQTT_GATEWAY_HOSTNAME"},
       {"description": "The hostname to use for the exposed route for the messaging
       console", "name": "CONSOLE_HOSTNAME"}, {"description": "The image to use for
       the MQTT LWT", "name": "MQTT_LWT_REPO", "value": "enmasseproject/mqtt-lwt"},

--- a/generated/tls-enmasse-template.yaml
+++ b/generated/tls-enmasse-template.yaml
@@ -7,928 +7,544 @@ metadata:
   name: tls-enmasse-infra
 objects:
 - apiVersion: v1
-  kind: Template
+  data:
+    enmasse-instance-infra.json: '{"apiVersion": "v1", "kind": "Template", "metadata":
+      {"labels": {"app": "enmasse"}, "name": "tls-enmasse-instance-infra"}, "objects":
+      [{"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels":
+      {"app": "enmasse", "instance": "${INSTANCE}", "name": "qdrouterd"}, "name":
+      "qdrouterd"}, "spec": {"replicas": 1, "template": {"metadata": {"labels": {"app":
+      "enmasse", "capability": "router", "instance": "${INSTANCE}", "name": "qdrouterd"}},
+      "spec": {"containers": [{"env": [{"name": "LINK_CAPACITY", "value": "${ROUTER_LINK_CAPACITY}"}],
+      "image": "${ROUTER_REPO}:latest", "livenessProbe": {"tcpSocket": {"port": "amqp"}},
+      "name": "router", "ports": [{"containerPort": 5672, "name": "amqp", "protocol":
+      "TCP"}, {"containerPort": 55673, "name": "internal", "protocol": "TCP"}, {"containerPort":
+      5671, "name": "amqps", "protocol": "TCP"}], "volumeMounts": [{"mountPath": "/etc/qpid-dispatch/ssl",
+      "name": "ssl-certs", "readOnly": true}]}], "volumes": [{"name": "ssl-certs",
+      "secret": {"secretName": "qdrouterd-certs"}}]}}}}, {"apiVersion": "v1", "kind":
+      "Service", "metadata": {"annotations": {"service.alpha.openshift.io/dependencies":
+      "[{\"kind\": \"Service\", \"name\": \"admin\", \"namespace\": \"\"}, {\"kind\":
+      \"Service\", \"name\": \"subscription\", \"namespace\": \"\"}, {\"kind\": \"Service\",
+      \"name\": \"mqtt\", \"namespace\": \"\"}]", "service.alpha.openshift.io/infrastructure":
+      "true"}, "labels": {"app": "enmasse", "instance": "${INSTANCE}"}, "name": "messaging"},
+      "spec": {"ports": [{"name": "amqp", "port": 5672, "protocol": "TCP", "targetPort":
+      5672}, {"name": "amqps", "port": 5671, "protocol": "TCP", "targetPort": 5671},
+      {"name": "internal", "port": 55673, "protocol": "TCP", "targetPort": 55673}],
+      "selector": {"capability": "router", "instance": "${INSTANCE}"}}}, {"apiVersion":
+      "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels": {"app": "enmasse",
+      "instance": "${INSTANCE}", "name": "subserv"}, "name": "subserv"}, "spec": {"replicas":
+      1, "template": {"metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}",
+      "name": "subserv"}}, "spec": {"containers": [{"env": [ ], "image": "${SUBSERV_REPO}:latest",
+      "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name": "subserv", "ports":
+      [{"containerPort": 5672, "name": "amqp", "protocol": "TCP"}], "resources": {"limits":
+      {"memory": "64Mi"}, "requests": {"memory": "64Mi"}}}]}}}}, {"apiVersion": "v1",
+      "kind": "Service", "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"},
+      "name": "subscription"}, "spec": {"ports": [{"name": "amqp", "port": 5672, "protocol":
+      "TCP", "targetPort": 5672}], "selector": {"instance": "${INSTANCE}", "name":
+      "subserv"}}}, {"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata":
+      {"labels": {"app": "enmasse", "instance": "${INSTANCE}", "name": "mqtt-gateway"},
+      "name": "mqtt-gateway"}, "spec": {"replicas": 1, "template": {"metadata": {"labels":
+      {"app": "enmasse", "instance": "${INSTANCE}", "name": "mqtt-gateway"}}, "spec":
+      {"containers": [{"image": "${MQTT_GATEWAY_REPO}:latest", "livenessProbe": {"initialDelaySeconds":
+      60, "tcpSocket": {"port": "secure-mqtt"}}, "name": "mqtt-gateway-tls", "ports":
+      [{"containerPort": 8883, "name": "secure-mqtt", "protocol": "TCP"}], "volumeMounts":
+      [{"mountPath": "/etc/mqtt-gateway/ssl", "name": "ssl-certs", "readOnly": true}]},
+      {"image": "${MQTT_GATEWAY_REPO}:latest", "livenessProbe": {"initialDelaySeconds":
+      60, "tcpSocket": {"port": "mqtt"}}, "name": "mqtt-gateway", "ports": [{"containerPort":
+      1883, "name": "mqtt", "protocol": "TCP"}]}], "volumes": [{"name": "ssl-certs",
+      "secret": {"secretName": "mqtt-certs"}}]}}}}, {"apiVersion": "v1", "kind": "Service",
+      "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"}, "name":
+      "mqtt"}, "spec": {"ports": [{"name": "mqtt", "port": 1883, "protocol": "TCP",
+      "targetPort": 1883}, {"name": "secure-mqtt", "port": 8883, "protocol": "TCP",
+      "targetPort": 8883}], "selector": {"instance": "${INSTANCE}", "name": "mqtt-gateway"}}},
+      {"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels":
+      {"app": "enmasse", "instance": "${INSTANCE}", "name": "mqtt-lwt"}, "name": "mqtt-lwt"},
+      "spec": {"replicas": 1, "template": {"metadata": {"labels": {"app": "enmasse",
+      "instance": "${INSTANCE}", "name": "mqtt-lwt"}}, "spec": {"containers": [{"image":
+      "${MQTT_LWT_REPO}:latest", "name": "mqtt-lwt"}]}}}}, {"apiVersion": "v1", "kind":
+      "Route", "metadata": {"labels": {"app": "enmasse"}, "name": "console"}, "spec":
+      {"host": "${CONSOLE_HOSTNAME}", "port": {"targetPort": "console-http"}, "to":
+      {"kind": "Service", "name": "admin"}}}, {"apiVersion": "v1", "data": {"hawkular-openshift-agent":
+      "{\"endpoints\": [{\"collection_interval\": \"60s\", \"metrics\": [{\"id\":
+      \"broker.threadCount\", \"name\": \"java.lang:type=Threading#ThreadCount\",
+      \"tags\": {\"messagingComponent\": \"broker\", \"messagingMetricType\": \"threadCount\"},
+      \"type\": \"counter\"}, {\"id\": \"broker.memoryHeapUsage\", \"name\": \"java.lang:type=Memory#HeapMemoryUsage#used\",
+      \"tags\": {\"messagingComponent\": \"broker\", \"messagingMetricType\": \"heapUsage\"},
+      \"type\": \"gauge\"}, {\"description\": \"Queue depth for ${address}\", \"id\":
+      \"${address}.${queue}.${broker}.queueDepth\", \"name\": \"org.apache.activemq.artemis:address=*,broker=*,component=addresses,queue=*,routing-type=*,subcomponent=queues#MessageCount\",
+      \"tags\": {\"messagingAddress\": \"${address}\", \"messagingBroker\": \"{broker}\",
+      \"messagingMetricType\": \"queueDepth\", \"messagingQueue\": \"${queue}\"},
+      \"type\": \"gauge\"}, {\"description\": \"Number of consumers for ${address}\",
+      \"id\": \"${address}.${queue}.${broker}.numConsumers\", \"name\": \"org.apache.activemq.artemis:address=*,broker=*,component=addresses,queue=*,routing-type=*,subcomponent=queues#ConsumerCount\",
+      \"tags\": {\"messagingAddress\": \"${address}\", \"messagingBroker\": \"{broker}\",
+      \"messagingMetricType\": \"numConsumers\", \"messagingQueue\": \"${queue}\"},
+      \"type\": \"gauge\"}], \"path\": \"/jolokia/\", \"port\": 8161, \"protocol\":
+      \"http\", \"type\": \"jolokia\"}]}"}, "kind": "ConfigMap", "metadata": {"name":
+      "hawkular-broker-config"}}, {"apiVersion": "extensions/v1beta1", "kind": "Deployment",
+      "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}", "name":
+      "admin"}, "name": "admin"}, "spec": {"replicas": 1, "template": {"metadata":
+      {"labels": {"app": "enmasse", "instance": "${INSTANCE}", "name": "admin"}},
+      "spec": {"containers": [{"env": [{"name": "CONFIGURATION_SERVICE_HOST", "value":
+      "localhost"}, {"name": "CONFIGURATION_SERVICE_PORT", "value": "5672"}], "image":
+      "${RAGENT_REPO}:latest", "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name":
+      "ragent", "ports": [{"containerPort": 55672, "name": "amqp", "protocol": "TCP"}],
+      "resources": {"limits": {"memory": "64Mi"}, "requests": {"memory": "64Mi"}}},
+      {"env": [{"name": "CONFIGURATION_SERVICE_HOST", "value": "localhost"}, {"name":
+      "CONFIGURATION_SERVICE_PORT", "value": "5672"}], "image": "${QUEUE_SCHEDULER_REPO}:latest",
+      "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name": "queue-scheduler",
+      "ports": [{"containerPort": 55667, "name": "amqp", "protocol": "TCP"}], "resources":
+      {"limits": {"memory": "128Mi"}, "requests": {"memory": "128Mi"}}}, {"env": [{"name":
+      "CONFIGURATION_SERVICE_HOST", "value": "localhost"}, {"name": "CONFIGURATION_SERVICE_PORT",
+      "value": "5672"}], "image": "${CONSOLE_REPO}:latest", "livenessProbe": {"tcpSocket":
+      {"port": "http"}}, "name": "console", "ports": [{"containerPort": 8080, "name":
+      "http", "protocol": "TCP"}, {"containerPort": 56720, "name": "amqp-ws", "protocol":
+      "TCP"}], "resources": {"limits": {"memory": "64Mi"}, "requests": {"memory":
+      "64Mi"}}}, {"env": [ ], "image": "${CONFIGSERV_REPO}:latest", "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "configserv", "ports": [{"containerPort":
+      5672, "name": "amqp", "protocol": "TCP"}], "resources": {"limits": {"memory":
+      "256Mi"}, "requests": {"memory": "256Mi"}}}]}}}}, {"apiVersion": "v1", "kind":
+      "Service", "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"},
+      "name": "admin"}, "spec": {"ports": [{"name": "ragent", "port": 55672}, {"name":
+      "configuration", "port": 5672}, {"name": "queue-scheduler", "port": 55667},
+      {"name": "console-ws", "port": 56720}, {"name": "console-http", "port": 8080}],
+      "selector": {"instance": "${INSTANCE}", "name": "admin"}}}, {"apiVersion": "v1",
+      "kind": "Route", "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"},
+      "name": "messaging"}, "spec": {"host": "${MESSAGING_HOSTNAME}", "port": {"targetPort":
+      "amqps"}, "tls": {"termination": "passthrough"}, "to": {"kind": "Service", "name":
+      "messaging", "weight": 100}}}, {"apiVersion": "v1", "kind": "Route", "metadata":
+      {"labels": {"app": "enmasse", "instance": "${INSTANCE}"}, "name": "mqtt"}, "spec":
+      {"host": "${MQTT_GATEWAY_HOSTNAME}", "port": {"targetPort": "secure-mqtt"},
+      "tls": {"termination": "passthrough"}, "to": {"kind": "Service", "name": "mqtt",
+      "weight": 100}}}], "parameters": [{"description": "The image to use for the
+      router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"}, {"description":
+      "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY", "value":
+      "50"}, {"description": "The image to use for the configuration service", "name":
+      "CONFIGSERV_REPO", "value": "enmasseproject/configserv"}, {"description": "The
+      docker image to use for the queue scheduler", "name": "QUEUE_SCHEDULER_REPO",
+      "value": "enmasseproject/queue-scheduler"}, {"description": "The image to use
+      for the router agent", "name": "RAGENT_REPO", "value": "enmasseproject/ragent"},
+      {"description": "The image to use for the subscription services", "name": "SUBSERV_REPO",
+      "value": "enmasseproject/subserv"}, {"description": "The image to use for the
+      console", "name": "CONSOLE_REPO", "value": "enmasseproject/console"}, {"description":
+      "The hostname to use for the exposed route for messaging (TLS only)", "name":
+      "MESSAGING_HOSTNAME"}, {"description": "The image to use for the MQTT gateway",
+      "name": "MQTT_GATEWAY_REPO", "value": "enmasseproject/mqtt-gateway"}, {"description":
+      "The hostname to use for the exposed route for MQTT (TLS only)", "name": "MQTT_GATEWAY_HOSTNAME"},
+      {"description": "The hostname to use for the exposed route for the messaging
+      console", "name": "CONSOLE_HOSTNAME"}, {"description": "The image to use for
+      the MQTT LWT", "name": "MQTT_LWT_REPO", "value": "enmasseproject/mqtt-lwt"},
+      {"description": "The image to use for the AMQP Kafka Bridge", "name": "AMQP_KAFKA_BRIDGE_REPO",
+      "value": "enmasseproject/amqp-kafka-bridge"}, {"description": "A list of host/port
+      pairs to use for establishing the initial connection to the Kafka cluster",
+      "name": "KAFKA_BOOTSTRAP_SERVERS"}, {"description": "The instance this infrastructure
+      is deployed for", "name": "INSTANCE", "required": true}]}'
+    queue-inmemory.json: '{"apiVersion": "v1", "kind": "Template", "metadata": {"labels":
+      {"app": "enmasse"}, "name": "queue-inmemory"}, "objects": [{"apiVersion": "extensions/v1beta1",
+      "kind": "Deployment", "metadata": {"labels": {"address_config": "address-config-${INSTANCE}-${NAME}",
+      "app": "enmasse", "group_id": "${NAME}", "instance": "${INSTANCE}"}, "name":
+      "${NAME}"}, "spec": {"replicas": 1, "template": {"metadata": {"labels": {"app":
+      "enmasse", "group_id": "${NAME}", "instance": "${INSTANCE}", "role": "broker"}},
+      "spec": {"containers": [{"env": [{"name": "QUEUE_NAME", "value": "${ADDRESS}"},
+      {"name": "GROUP_ID", "value": "${NAME}"}], "image": "${BROKER_REPO}:latest",
+      "lifecycle": {"preStop": {"exec": {"command": ["/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"]}}},
+      "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name": "broker", "ports":
+      [{"containerPort": 5673, "name": "amqp"}, {"containerPort": 61616, "name": "core"},
+      {"containerPort": 8161, "name": "jolokia"}], "readinessProbe": {"tcpSocket":
+      {"port": "amqp"}}, "volumeMounts": [{"mountPath": "/var/run/artemis", "name":
+      "vol-${NAME}"}]}], "volumes": [{"emptyDir": { }, "name": "vol-${NAME}"}, {"configMap":
+      {"name": "hawkular-broker-config"}, "name": "hawkular-openshift-agent"}]}}}}],
+      "parameters": [{"description": "Storage capacity required for volume claims",
+      "name": "STORAGE_CAPACITY", "value": "2Gi"}, {"description": "The docker image
+      to use for the message broker", "name": "BROKER_REPO", "value": "enmasseproject/artemis"},
+      {"description": "The default image to use as topic forwarder", "name": "TOPIC_FORWARDER_REPO",
+      "value": "enmasseproject/topic-forwarder"}, {"description": "The image to use
+      for the router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"},
+      {"description": "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY",
+      "value": "50"}, {"description": "A valid instance name for the instance", "name":
+      "INSTANCE", "required": true}, {"description": "A valid name for the instance",
+      "name": "NAME", "required": true}, {"description": "The address to use for the
+      queue", "name": "ADDRESS", "required": true}]}'
+    queue-persisted.json: '{"apiVersion": "v1", "kind": "Template", "metadata": {"labels":
+      {"app": "enmasse"}, "name": "queue-persisted"}, "objects": [{"apiVersion": "v1",
+      "kind": "PersistentVolumeClaim", "metadata": {"labels": {"app": "enmasse", "group_id":
+      "${NAME}", "instance": "${INSTANCE}"}, "name": "pvc-${NAME}"}, "spec": {"accessModes":
+      ["ReadWriteMany"], "resources": {"requests": {"storage": "${STORAGE_CAPACITY}"}}}},
+      {"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels":
+      {"address_config": "address-config-${INSTANCE}-${NAME}", "app": "enmasse", "group_id":
+      "${NAME}", "instance": "${INSTANCE}"}, "name": "${NAME}"}, "spec": {"replicas":
+      1, "template": {"metadata": {"labels": {"app": "enmasse", "group_id": "${NAME}",
+      "instance": "${INSTANCE}", "role": "broker"}}, "spec": {"containers": [{"env":
+      [{"name": "QUEUE_NAME", "value": "${ADDRESS}"}, {"name": "GROUP_ID", "value":
+      "${NAME}"}], "image": "${BROKER_REPO}:latest", "lifecycle": {"preStop": {"exec":
+      {"command": ["/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"]}}}, "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "broker", "ports": [{"containerPort":
+      5673, "name": "amqp"}, {"containerPort": 61616, "name": "core"}, {"containerPort":
+      8161, "name": "jolokia"}], "readinessProbe": {"tcpSocket": {"port": "amqp"}},
+      "volumeMounts": [{"mountPath": "/var/run/artemis", "name": "vol-${NAME}"}]}],
+      "volumes": [{"name": "vol-${NAME}", "persistentVolumeClaim": {"claimName": "pvc-${NAME}"}},
+      {"configMap": {"name": "hawkular-broker-config"}, "name": "hawkular-openshift-agent"}]}}}}],
+      "parameters": [{"description": "Storage capacity required for volume claims",
+      "name": "STORAGE_CAPACITY", "value": "2Gi"}, {"description": "The docker image
+      to use for the message broker", "name": "BROKER_REPO", "value": "enmasseproject/artemis"},
+      {"description": "The default image to use as topic forwarder", "name": "TOPIC_FORWARDER_REPO",
+      "value": "enmasseproject/topic-forwarder"}, {"description": "The image to use
+      for the router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"},
+      {"description": "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY",
+      "value": "50"}, {"description": "A valid instance name for the instance", "name":
+      "INSTANCE", "required": true}, {"description": "A valid name for the instance",
+      "name": "NAME", "required": true}, {"description": "The address to use for the
+      queue", "name": "ADDRESS", "required": true}]}'
+    tls-enmasse-instance-infra.json: '{"apiVersion": "v1", "kind": "Template", "metadata":
+      {"labels": {"app": "enmasse"}, "name": "tls-enmasse-instance-infra"}, "objects":
+      [{"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels":
+      {"app": "enmasse", "instance": "${INSTANCE}", "name": "qdrouterd"}, "name":
+      "qdrouterd"}, "spec": {"replicas": 1, "template": {"metadata": {"labels": {"app":
+      "enmasse", "capability": "router", "instance": "${INSTANCE}", "name": "qdrouterd"}},
+      "spec": {"containers": [{"env": [{"name": "LINK_CAPACITY", "value": "${ROUTER_LINK_CAPACITY}"}],
+      "image": "${ROUTER_REPO}:latest", "livenessProbe": {"tcpSocket": {"port": "amqp"}},
+      "name": "router", "ports": [{"containerPort": 5672, "name": "amqp", "protocol":
+      "TCP"}, {"containerPort": 55673, "name": "internal", "protocol": "TCP"}, {"containerPort":
+      5671, "name": "amqps", "protocol": "TCP"}], "volumeMounts": [{"mountPath": "/etc/qpid-dispatch/ssl",
+      "name": "ssl-certs", "readOnly": true}]}], "volumes": [{"name": "ssl-certs",
+      "secret": {"secretName": "qdrouterd-certs"}}]}}}}, {"apiVersion": "v1", "kind":
+      "Service", "metadata": {"annotations": {"service.alpha.openshift.io/dependencies":
+      "[{\"kind\": \"Service\", \"name\": \"admin\", \"namespace\": \"\"}, {\"kind\":
+      \"Service\", \"name\": \"subscription\", \"namespace\": \"\"}, {\"kind\": \"Service\",
+      \"name\": \"mqtt\", \"namespace\": \"\"}]", "service.alpha.openshift.io/infrastructure":
+      "true"}, "labels": {"app": "enmasse", "instance": "${INSTANCE}"}, "name": "messaging"},
+      "spec": {"ports": [{"name": "amqp", "port": 5672, "protocol": "TCP", "targetPort":
+      5672}, {"name": "amqps", "port": 5671, "protocol": "TCP", "targetPort": 5671},
+      {"name": "internal", "port": 55673, "protocol": "TCP", "targetPort": 55673}],
+      "selector": {"capability": "router", "instance": "${INSTANCE}"}}}, {"apiVersion":
+      "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels": {"app": "enmasse",
+      "instance": "${INSTANCE}", "name": "subserv"}, "name": "subserv"}, "spec": {"replicas":
+      1, "template": {"metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}",
+      "name": "subserv"}}, "spec": {"containers": [{"env": [ ], "image": "${SUBSERV_REPO}:latest",
+      "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name": "subserv", "ports":
+      [{"containerPort": 5672, "name": "amqp", "protocol": "TCP"}], "resources": {"limits":
+      {"memory": "64Mi"}, "requests": {"memory": "64Mi"}}}]}}}}, {"apiVersion": "v1",
+      "kind": "Service", "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"},
+      "name": "subscription"}, "spec": {"ports": [{"name": "amqp", "port": 5672, "protocol":
+      "TCP", "targetPort": 5672}], "selector": {"instance": "${INSTANCE}", "name":
+      "subserv"}}}, {"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata":
+      {"labels": {"app": "enmasse", "instance": "${INSTANCE}", "name": "mqtt-gateway"},
+      "name": "mqtt-gateway"}, "spec": {"replicas": 1, "template": {"metadata": {"labels":
+      {"app": "enmasse", "instance": "${INSTANCE}", "name": "mqtt-gateway"}}, "spec":
+      {"containers": [{"image": "${MQTT_GATEWAY_REPO}:latest", "livenessProbe": {"initialDelaySeconds":
+      60, "tcpSocket": {"port": "secure-mqtt"}}, "name": "mqtt-gateway-tls", "ports":
+      [{"containerPort": 8883, "name": "secure-mqtt", "protocol": "TCP"}], "volumeMounts":
+      [{"mountPath": "/etc/mqtt-gateway/ssl", "name": "ssl-certs", "readOnly": true}]},
+      {"image": "${MQTT_GATEWAY_REPO}:latest", "livenessProbe": {"initialDelaySeconds":
+      60, "tcpSocket": {"port": "mqtt"}}, "name": "mqtt-gateway", "ports": [{"containerPort":
+      1883, "name": "mqtt", "protocol": "TCP"}]}], "volumes": [{"name": "ssl-certs",
+      "secret": {"secretName": "mqtt-certs"}}]}}}}, {"apiVersion": "v1", "kind": "Service",
+      "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"}, "name":
+      "mqtt"}, "spec": {"ports": [{"name": "mqtt", "port": 1883, "protocol": "TCP",
+      "targetPort": 1883}, {"name": "secure-mqtt", "port": 8883, "protocol": "TCP",
+      "targetPort": 8883}], "selector": {"instance": "${INSTANCE}", "name": "mqtt-gateway"}}},
+      {"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels":
+      {"app": "enmasse", "instance": "${INSTANCE}", "name": "mqtt-lwt"}, "name": "mqtt-lwt"},
+      "spec": {"replicas": 1, "template": {"metadata": {"labels": {"app": "enmasse",
+      "instance": "${INSTANCE}", "name": "mqtt-lwt"}}, "spec": {"containers": [{"image":
+      "${MQTT_LWT_REPO}:latest", "name": "mqtt-lwt"}]}}}}, {"apiVersion": "v1", "kind":
+      "Route", "metadata": {"labels": {"app": "enmasse"}, "name": "console"}, "spec":
+      {"host": "${CONSOLE_HOSTNAME}", "port": {"targetPort": "console-http"}, "to":
+      {"kind": "Service", "name": "admin"}}}, {"apiVersion": "v1", "data": {"hawkular-openshift-agent":
+      "{\"endpoints\": [{\"collection_interval\": \"60s\", \"metrics\": [{\"id\":
+      \"broker.threadCount\", \"name\": \"java.lang:type=Threading#ThreadCount\",
+      \"tags\": {\"messagingComponent\": \"broker\", \"messagingMetricType\": \"threadCount\"},
+      \"type\": \"counter\"}, {\"id\": \"broker.memoryHeapUsage\", \"name\": \"java.lang:type=Memory#HeapMemoryUsage#used\",
+      \"tags\": {\"messagingComponent\": \"broker\", \"messagingMetricType\": \"heapUsage\"},
+      \"type\": \"gauge\"}, {\"description\": \"Queue depth for ${address}\", \"id\":
+      \"${address}.${queue}.${broker}.queueDepth\", \"name\": \"org.apache.activemq.artemis:address=*,broker=*,component=addresses,queue=*,routing-type=*,subcomponent=queues#MessageCount\",
+      \"tags\": {\"messagingAddress\": \"${address}\", \"messagingBroker\": \"{broker}\",
+      \"messagingMetricType\": \"queueDepth\", \"messagingQueue\": \"${queue}\"},
+      \"type\": \"gauge\"}, {\"description\": \"Number of consumers for ${address}\",
+      \"id\": \"${address}.${queue}.${broker}.numConsumers\", \"name\": \"org.apache.activemq.artemis:address=*,broker=*,component=addresses,queue=*,routing-type=*,subcomponent=queues#ConsumerCount\",
+      \"tags\": {\"messagingAddress\": \"${address}\", \"messagingBroker\": \"{broker}\",
+      \"messagingMetricType\": \"numConsumers\", \"messagingQueue\": \"${queue}\"},
+      \"type\": \"gauge\"}], \"path\": \"/jolokia/\", \"port\": 8161, \"protocol\":
+      \"http\", \"type\": \"jolokia\"}]}"}, "kind": "ConfigMap", "metadata": {"name":
+      "hawkular-broker-config"}}, {"apiVersion": "extensions/v1beta1", "kind": "Deployment",
+      "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}", "name":
+      "admin"}, "name": "admin"}, "spec": {"replicas": 1, "template": {"metadata":
+      {"labels": {"app": "enmasse", "instance": "${INSTANCE}", "name": "admin"}},
+      "spec": {"containers": [{"env": [{"name": "CONFIGURATION_SERVICE_HOST", "value":
+      "localhost"}, {"name": "CONFIGURATION_SERVICE_PORT", "value": "5672"}], "image":
+      "${RAGENT_REPO}:latest", "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name":
+      "ragent", "ports": [{"containerPort": 55672, "name": "amqp", "protocol": "TCP"}],
+      "resources": {"limits": {"memory": "64Mi"}, "requests": {"memory": "64Mi"}}},
+      {"env": [{"name": "CONFIGURATION_SERVICE_HOST", "value": "localhost"}, {"name":
+      "CONFIGURATION_SERVICE_PORT", "value": "5672"}], "image": "${QUEUE_SCHEDULER_REPO}:latest",
+      "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name": "queue-scheduler",
+      "ports": [{"containerPort": 55667, "name": "amqp", "protocol": "TCP"}], "resources":
+      {"limits": {"memory": "128Mi"}, "requests": {"memory": "128Mi"}}}, {"env": [{"name":
+      "CONFIGURATION_SERVICE_HOST", "value": "localhost"}, {"name": "CONFIGURATION_SERVICE_PORT",
+      "value": "5672"}], "image": "${CONSOLE_REPO}:latest", "livenessProbe": {"tcpSocket":
+      {"port": "http"}}, "name": "console", "ports": [{"containerPort": 8080, "name":
+      "http", "protocol": "TCP"}, {"containerPort": 56720, "name": "amqp-ws", "protocol":
+      "TCP"}], "resources": {"limits": {"memory": "64Mi"}, "requests": {"memory":
+      "64Mi"}}}, {"env": [ ], "image": "${CONFIGSERV_REPO}:latest", "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "configserv", "ports": [{"containerPort":
+      5672, "name": "amqp", "protocol": "TCP"}], "resources": {"limits": {"memory":
+      "256Mi"}, "requests": {"memory": "256Mi"}}}]}}}}, {"apiVersion": "v1", "kind":
+      "Service", "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"},
+      "name": "admin"}, "spec": {"ports": [{"name": "ragent", "port": 55672}, {"name":
+      "configuration", "port": 5672}, {"name": "queue-scheduler", "port": 55667},
+      {"name": "console-ws", "port": 56720}, {"name": "console-http", "port": 8080}],
+      "selector": {"instance": "${INSTANCE}", "name": "admin"}}}, {"apiVersion": "v1",
+      "kind": "Route", "metadata": {"labels": {"app": "enmasse", "instance": "${INSTANCE}"},
+      "name": "messaging"}, "spec": {"host": "${MESSAGING_HOSTNAME}", "port": {"targetPort":
+      "amqps"}, "tls": {"termination": "passthrough"}, "to": {"kind": "Service", "name":
+      "messaging", "weight": 100}}}, {"apiVersion": "v1", "kind": "Route", "metadata":
+      {"labels": {"app": "enmasse", "instance": "${INSTANCE}"}, "name": "mqtt"}, "spec":
+      {"host": "${MQTT_GATEWAY_HOSTNAME}", "port": {"targetPort": "secure-mqtt"},
+      "tls": {"termination": "passthrough"}, "to": {"kind": "Service", "name": "mqtt",
+      "weight": 100}}}], "parameters": [{"description": "The image to use for the
+      router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"}, {"description":
+      "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY", "value":
+      "50"}, {"description": "The image to use for the configuration service", "name":
+      "CONFIGSERV_REPO", "value": "enmasseproject/configserv"}, {"description": "The
+      docker image to use for the queue scheduler", "name": "QUEUE_SCHEDULER_REPO",
+      "value": "enmasseproject/queue-scheduler"}, {"description": "The image to use
+      for the router agent", "name": "RAGENT_REPO", "value": "enmasseproject/ragent"},
+      {"description": "The image to use for the subscription services", "name": "SUBSERV_REPO",
+      "value": "enmasseproject/subserv"}, {"description": "The image to use for the
+      console", "name": "CONSOLE_REPO", "value": "enmasseproject/console"}, {"description":
+      "The hostname to use for the exposed route for messaging (TLS only)", "name":
+      "MESSAGING_HOSTNAME"}, {"description": "The image to use for the MQTT gateway",
+      "name": "MQTT_GATEWAY_REPO", "value": "enmasseproject/mqtt-gateway"}, {"description":
+      "The hostname to use for the exposed route for MQTT (TLS only)", "name": "MQTT_GATEWAY_HOSTNAME"},
+      {"description": "The hostname to use for the exposed route for the messaging
+      console", "name": "CONSOLE_HOSTNAME"}, {"description": "The image to use for
+      the MQTT LWT", "name": "MQTT_LWT_REPO", "value": "enmasseproject/mqtt-lwt"},
+      {"description": "The image to use for the AMQP Kafka Bridge", "name": "AMQP_KAFKA_BRIDGE_REPO",
+      "value": "enmasseproject/amqp-kafka-bridge"}, {"description": "A list of host/port
+      pairs to use for establishing the initial connection to the Kafka cluster",
+      "name": "KAFKA_BOOTSTRAP_SERVERS"}, {"description": "The instance this infrastructure
+      is deployed for", "name": "INSTANCE", "required": true}]}'
+    tls-queue-inmemory.json: '{"apiVersion": "v1", "kind": "Template", "metadata":
+      {"labels": {"app": "enmasse"}, "name": "tls-queue-inmemory"}, "objects": [{"apiVersion":
+      "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels": {"address_config":
+      "address-config-${INSTANCE}-${NAME}", "app": "enmasse", "group_id": "${NAME}",
+      "instance": "${INSTANCE}"}, "name": "${NAME}"}, "spec": {"replicas": 1, "template":
+      {"metadata": {"labels": {"app": "enmasse", "group_id": "${NAME}", "instance":
+      "${INSTANCE}", "role": "broker"}}, "spec": {"containers": [{"env": [{"name":
+      "QUEUE_NAME", "value": "${ADDRESS}"}, {"name": "GROUP_ID", "value": "${NAME}"}],
+      "image": "${BROKER_REPO}:latest", "lifecycle": {"preStop": {"exec": {"command":
+      ["/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"]}}}, "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "broker", "ports": [{"containerPort":
+      5673, "name": "amqp"}, {"containerPort": 61616, "name": "core"}, {"containerPort":
+      8161, "name": "jolokia"}], "readinessProbe": {"tcpSocket": {"port": "amqp"}},
+      "volumeMounts": [{"mountPath": "/var/run/artemis", "name": "vol-${NAME}"}]}],
+      "volumes": [{"emptyDir": { }, "name": "vol-${NAME}"}, {"name": "ssl-certs",
+      "secret": {"secretName": "qdrouterd-certs"}}, {"configMap": {"name": "hawkular-broker-config"},
+      "name": "hawkular-openshift-agent"}]}}}}], "parameters": [{"description": "Storage
+      capacity required for volume claims", "name": "STORAGE_CAPACITY", "value": "2Gi"},
+      {"description": "The docker image to use for the message broker", "name": "BROKER_REPO",
+      "value": "enmasseproject/artemis"}, {"description": "The default image to use
+      as topic forwarder", "name": "TOPIC_FORWARDER_REPO", "value": "enmasseproject/topic-forwarder"},
+      {"description": "The image to use for the router", "name": "ROUTER_REPO", "value":
+      "enmasseproject/qdrouterd"}, {"description": "The link capacity setting for
+      router", "name": "ROUTER_LINK_CAPACITY", "value": "50"}, {"description": "A
+      valid instance name for the instance", "name": "INSTANCE", "required": true},
+      {"description": "A valid name for the instance", "name": "NAME", "required":
+      true}, {"description": "The address to use for the queue", "name": "ADDRESS",
+      "required": true}]}'
+    tls-queue-persisted.json: '{"apiVersion": "v1", "kind": "Template", "metadata":
+      {"labels": {"app": "enmasse"}, "name": "tls-queue-persisted"}, "objects": [{"apiVersion":
+      "v1", "kind": "PersistentVolumeClaim", "metadata": {"labels": {"app": "enmasse",
+      "group_id": "${NAME}", "instance": "${INSTANCE}"}, "name": "pvc-${NAME}"}, "spec":
+      {"accessModes": ["ReadWriteMany"], "resources": {"requests": {"storage": "${STORAGE_CAPACITY}"}}}},
+      {"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels":
+      {"address_config": "address-config-${INSTANCE}-${NAME}", "app": "enmasse", "group_id":
+      "${NAME}", "instance": "${INSTANCE}"}, "name": "${NAME}"}, "spec": {"replicas":
+      1, "template": {"metadata": {"labels": {"app": "enmasse", "group_id": "${NAME}",
+      "instance": "${INSTANCE}", "role": "broker"}}, "spec": {"containers": [{"env":
+      [{"name": "QUEUE_NAME", "value": "${ADDRESS}"}, {"name": "GROUP_ID", "value":
+      "${NAME}"}], "image": "${BROKER_REPO}:latest", "lifecycle": {"preStop": {"exec":
+      {"command": ["/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"]}}}, "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "broker", "ports": [{"containerPort":
+      5673, "name": "amqp"}, {"containerPort": 61616, "name": "core"}, {"containerPort":
+      8161, "name": "jolokia"}], "readinessProbe": {"tcpSocket": {"port": "amqp"}},
+      "volumeMounts": [{"mountPath": "/var/run/artemis", "name": "vol-${NAME}"}]}],
+      "volumes": [{"name": "vol-${NAME}", "persistentVolumeClaim": {"claimName": "pvc-${NAME}"}},
+      {"name": "ssl-certs", "secret": {"secretName": "qdrouterd-certs"}}, {"configMap":
+      {"name": "hawkular-broker-config"}, "name": "hawkular-openshift-agent"}]}}}}],
+      "parameters": [{"description": "Storage capacity required for volume claims",
+      "name": "STORAGE_CAPACITY", "value": "2Gi"}, {"description": "The docker image
+      to use for the message broker", "name": "BROKER_REPO", "value": "enmasseproject/artemis"},
+      {"description": "The default image to use as topic forwarder", "name": "TOPIC_FORWARDER_REPO",
+      "value": "enmasseproject/topic-forwarder"}, {"description": "The image to use
+      for the router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"},
+      {"description": "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY",
+      "value": "50"}, {"description": "A valid instance name for the instance", "name":
+      "INSTANCE", "required": true}, {"description": "A valid name for the instance",
+      "name": "NAME", "required": true}, {"description": "The address to use for the
+      queue", "name": "ADDRESS", "required": true}]}'
+    tls-topic-inmemory.json: '{"apiVersion": "v1", "kind": "Template", "metadata":
+      {"labels": {"app": "enmasse"}, "name": "tls-topic-inmemory"}, "objects": [{"apiVersion":
+      "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels": {"address_config":
+      "address-config-${INSTANCE}-${NAME}", "app": "enmasse", "group_id": "${NAME}",
+      "instance": "${INSTANCE}"}, "name": "${NAME}"}, "spec": {"replicas": 1, "template":
+      {"metadata": {"labels": {"app": "enmasse", "group_id": "${NAME}", "instance":
+      "${INSTANCE}", "role": "broker"}}, "spec": {"containers": [{"env": [{"name":
+      "TOPIC_NAME", "value": "${ADDRESS}"}, {"name": "GROUP_ID", "value": "${NAME}"}],
+      "image": "${BROKER_REPO}:latest", "lifecycle": {"preStop": {"exec": {"command":
+      ["/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"]}}}, "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "broker", "ports": [{"containerPort":
+      5673, "name": "amqp"}, {"containerPort": 61616, "name": "core"}, {"containerPort":
+      8161, "name": "jolokia"}], "readinessProbe": {"tcpSocket": {"port": "amqp"}},
+      "volumeMounts": [{"mountPath": "/var/run/artemis", "name": "vol-${NAME}"}]},
+      {"env": [{"name": "LINK_CAPACITY", "value": "${ROUTER_LINK_CAPACITY}"}, {"name":
+      "TOPIC_NAME", "value": "${ADDRESS}"}], "image": "${ROUTER_REPO}:latest", "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "router", "ports": [{"containerPort":
+      5672, "name": "amqp", "protocol": "TCP"}, {"containerPort": 55673, "name": "internal",
+      "protocol": "TCP"}, {"containerPort": 5671, "name": "amqps", "protocol": "TCP"}],
+      "resources": {"limits": {"memory": "256Mi"}, "requests": {"memory": "256Mi"}},
+      "volumeMounts": [{"mountPath": "/etc/qpid-dispatch/ssl", "name": "ssl-certs",
+      "readOnly": true}]}, {"env": [{"name": "TOPIC_NAME", "value": "${ADDRESS}"},
+      {"name": "GROUP_ID", "value": "${NAME}"}], "image": "${TOPIC_FORWARDER_REPO}:latest",
+      "livenessProbe": {"httpGet": {"path": "/health", "port": "health"}}, "name":
+      "forwarder", "ports": [{"containerPort": 8080, "name": "health"}], "resources":
+      {"limits": {"memory": "128Mi"}, "requests": {"memory": "128Mi"}}}], "volumes":
+      [{"emptyDir": { }, "name": "vol-${NAME}"}, {"name": "ssl-certs", "secret": {"secretName":
+      "qdrouterd-certs"}}, {"configMap": {"name": "hawkular-broker-config"}, "name":
+      "hawkular-openshift-agent"}]}}}}], "parameters": [{"description": "Storage capacity
+      required for volume claims", "name": "STORAGE_CAPACITY", "value": "2Gi"}, {"description":
+      "The docker image to use for the message broker", "name": "BROKER_REPO", "value":
+      "enmasseproject/artemis"}, {"description": "The default image to use as topic
+      forwarder", "name": "TOPIC_FORWARDER_REPO", "value": "enmasseproject/topic-forwarder"},
+      {"description": "The image to use for the router", "name": "ROUTER_REPO", "value":
+      "enmasseproject/qdrouterd"}, {"description": "The link capacity setting for
+      router", "name": "ROUTER_LINK_CAPACITY", "value": "50"}, {"description": "A
+      valid instance name for the instance", "name": "INSTANCE", "required": true},
+      {"description": "A valid name for the instance", "name": "NAME", "required":
+      true}, {"description": "The address to use for the topic", "name": "ADDRESS",
+      "required": true}]}'
+    tls-topic-persisted.json: '{"apiVersion": "v1", "kind": "Template", "metadata":
+      {"labels": {"app": "enmasse"}, "name": "tls-topic-persisted"}, "objects": [{"apiVersion":
+      "v1", "kind": "PersistentVolumeClaim", "metadata": {"labels": {"app": "enmasse",
+      "group_id": "${NAME}", "instance": "${INSTANCE}"}, "name": "pvc-${NAME}"}, "spec":
+      {"accessModes": ["ReadWriteMany"], "resources": {"requests": {"storage": "${STORAGE_CAPACITY}"}}}},
+      {"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels":
+      {"address_config": "address-config-${INSTANCE}-${NAME}", "app": "enmasse", "group_id":
+      "${NAME}", "instance": "${INSTANCE}"}, "name": "${NAME}"}, "spec": {"replicas":
+      1, "template": {"metadata": {"labels": {"app": "enmasse", "group_id": "${NAME}",
+      "instance": "${INSTANCE}", "role": "broker"}}, "spec": {"containers": [{"env":
+      [{"name": "TOPIC_NAME", "value": "${ADDRESS}"}, {"name": "GROUP_ID", "value":
+      "${NAME}"}], "image": "${BROKER_REPO}:latest", "lifecycle": {"preStop": {"exec":
+      {"command": ["/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"]}}}, "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "broker", "ports": [{"containerPort":
+      5673, "name": "amqp"}, {"containerPort": 61616, "name": "core"}, {"containerPort":
+      8161, "name": "jolokia"}], "readinessProbe": {"tcpSocket": {"port": "amqp"}},
+      "volumeMounts": [{"mountPath": "/var/run/artemis", "name": "vol-${NAME}"}]},
+      {"env": [{"name": "LINK_CAPACITY", "value": "${ROUTER_LINK_CAPACITY}"}, {"name":
+      "TOPIC_NAME", "value": "${ADDRESS}"}], "image": "${ROUTER_REPO}:latest", "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "router", "ports": [{"containerPort":
+      5672, "name": "amqp", "protocol": "TCP"}, {"containerPort": 55673, "name": "internal",
+      "protocol": "TCP"}, {"containerPort": 5671, "name": "amqps", "protocol": "TCP"}],
+      "resources": {"limits": {"memory": "256Mi"}, "requests": {"memory": "256Mi"}},
+      "volumeMounts": [{"mountPath": "/etc/qpid-dispatch/ssl", "name": "ssl-certs",
+      "readOnly": true}]}, {"env": [{"name": "TOPIC_NAME", "value": "${ADDRESS}"},
+      {"name": "GROUP_ID", "value": "${NAME}"}], "image": "${TOPIC_FORWARDER_REPO}:latest",
+      "livenessProbe": {"httpGet": {"path": "/health", "port": "health"}}, "name":
+      "forwarder", "ports": [{"containerPort": 8080, "name": "health"}], "resources":
+      {"limits": {"memory": "128Mi"}, "requests": {"memory": "128Mi"}}}], "volumes":
+      [{"name": "vol-${NAME}", "persistentVolumeClaim": {"claimName": "pvc-${NAME}"}},
+      {"name": "ssl-certs", "secret": {"secretName": "qdrouterd-certs"}}, {"configMap":
+      {"name": "hawkular-broker-config"}, "name": "hawkular-openshift-agent"}]}}}}],
+      "parameters": [{"description": "Storage capacity required for volume claims",
+      "name": "STORAGE_CAPACITY", "value": "2Gi"}, {"description": "The docker image
+      to use for the message broker", "name": "BROKER_REPO", "value": "enmasseproject/artemis"},
+      {"description": "The default image to use as topic forwarder", "name": "TOPIC_FORWARDER_REPO",
+      "value": "enmasseproject/topic-forwarder"}, {"description": "The image to use
+      for the router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"},
+      {"description": "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY",
+      "value": "50"}, {"description": "A valid instance name for the instance", "name":
+      "INSTANCE", "required": true}, {"description": "A valid name for the instance",
+      "name": "NAME", "required": true}, {"description": "The address to use for the
+      topic", "name": "ADDRESS", "required": true}]}'
+    topic-inmemory.json: '{"apiVersion": "v1", "kind": "Template", "metadata": {"labels":
+      {"app": "enmasse"}, "name": "topic-inmemory"}, "objects": [{"apiVersion": "extensions/v1beta1",
+      "kind": "Deployment", "metadata": {"labels": {"address_config": "address-config-${INSTANCE}-${NAME}",
+      "app": "enmasse", "group_id": "${NAME}", "instance": "${INSTANCE}"}, "name":
+      "${NAME}"}, "spec": {"replicas": 1, "template": {"metadata": {"labels": {"app":
+      "enmasse", "group_id": "${NAME}", "instance": "${INSTANCE}", "role": "broker"}},
+      "spec": {"containers": [{"env": [{"name": "TOPIC_NAME", "value": "${ADDRESS}"},
+      {"name": "GROUP_ID", "value": "${NAME}"}], "image": "${BROKER_REPO}:latest",
+      "lifecycle": {"preStop": {"exec": {"command": ["/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"]}}},
+      "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name": "broker", "ports":
+      [{"containerPort": 5673, "name": "amqp"}, {"containerPort": 61616, "name": "core"},
+      {"containerPort": 8161, "name": "jolokia"}], "readinessProbe": {"tcpSocket":
+      {"port": "amqp"}}, "volumeMounts": [{"mountPath": "/var/run/artemis", "name":
+      "vol-${NAME}"}]}, {"env": [{"name": "LINK_CAPACITY", "value": "${ROUTER_LINK_CAPACITY}"},
+      {"name": "TOPIC_NAME", "value": "${ADDRESS}"}], "image": "${ROUTER_REPO}:latest",
+      "livenessProbe": {"tcpSocket": {"port": "amqp"}}, "name": "router", "ports":
+      [{"containerPort": 5672, "name": "amqp", "protocol": "TCP"}, {"containerPort":
+      55673, "name": "internal", "protocol": "TCP"}], "resources": {"limits": {"memory":
+      "256Mi"}, "requests": {"memory": "256Mi"}}}, {"env": [{"name": "TOPIC_NAME",
+      "value": "${ADDRESS}"}, {"name": "GROUP_ID", "value": "${NAME}"}], "image":
+      "${TOPIC_FORWARDER_REPO}:latest", "livenessProbe": {"httpGet": {"path": "/health",
+      "port": "health"}}, "name": "forwarder", "ports": [{"containerPort": 8080, "name":
+      "health"}], "resources": {"limits": {"memory": "128Mi"}, "requests": {"memory":
+      "128Mi"}}}], "volumes": [{"emptyDir": { }, "name": "vol-${NAME}"}, {"configMap":
+      {"name": "hawkular-broker-config"}, "name": "hawkular-openshift-agent"}]}}}}],
+      "parameters": [{"description": "Storage capacity required for volume claims",
+      "name": "STORAGE_CAPACITY", "value": "2Gi"}, {"description": "The docker image
+      to use for the message broker", "name": "BROKER_REPO", "value": "enmasseproject/artemis"},
+      {"description": "The default image to use as topic forwarder", "name": "TOPIC_FORWARDER_REPO",
+      "value": "enmasseproject/topic-forwarder"}, {"description": "The image to use
+      for the router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"},
+      {"description": "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY",
+      "value": "50"}, {"description": "A valid instance name for the instance", "name":
+      "INSTANCE", "required": true}, {"description": "A valid name for the instance",
+      "name": "NAME", "required": true}, {"description": "The address to use for the
+      topic", "name": "ADDRESS", "required": true}]}'
+    topic-persisted.json: '{"apiVersion": "v1", "kind": "Template", "metadata": {"labels":
+      {"app": "enmasse"}, "name": "topic-persisted"}, "objects": [{"apiVersion": "v1",
+      "kind": "PersistentVolumeClaim", "metadata": {"labels": {"app": "enmasse", "group_id":
+      "${NAME}", "instance": "${INSTANCE}"}, "name": "pvc-${NAME}"}, "spec": {"accessModes":
+      ["ReadWriteMany"], "resources": {"requests": {"storage": "${STORAGE_CAPACITY}"}}}},
+      {"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata": {"labels":
+      {"address_config": "address-config-${INSTANCE}-${NAME}", "app": "enmasse", "group_id":
+      "${NAME}", "instance": "${INSTANCE}"}, "name": "${NAME}"}, "spec": {"replicas":
+      1, "template": {"metadata": {"labels": {"app": "enmasse", "group_id": "${NAME}",
+      "instance": "${INSTANCE}", "role": "broker"}}, "spec": {"containers": [{"env":
+      [{"name": "TOPIC_NAME", "value": "${ADDRESS}"}, {"name": "GROUP_ID", "value":
+      "${NAME}"}], "image": "${BROKER_REPO}:latest", "lifecycle": {"preStop": {"exec":
+      {"command": ["/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"]}}}, "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "broker", "ports": [{"containerPort":
+      5673, "name": "amqp"}, {"containerPort": 61616, "name": "core"}, {"containerPort":
+      8161, "name": "jolokia"}], "readinessProbe": {"tcpSocket": {"port": "amqp"}},
+      "volumeMounts": [{"mountPath": "/var/run/artemis", "name": "vol-${NAME}"}]},
+      {"env": [{"name": "LINK_CAPACITY", "value": "${ROUTER_LINK_CAPACITY}"}, {"name":
+      "TOPIC_NAME", "value": "${ADDRESS}"}], "image": "${ROUTER_REPO}:latest", "livenessProbe":
+      {"tcpSocket": {"port": "amqp"}}, "name": "router", "ports": [{"containerPort":
+      5672, "name": "amqp", "protocol": "TCP"}, {"containerPort": 55673, "name": "internal",
+      "protocol": "TCP"}], "resources": {"limits": {"memory": "256Mi"}, "requests":
+      {"memory": "256Mi"}}}, {"env": [{"name": "TOPIC_NAME", "value": "${ADDRESS}"},
+      {"name": "GROUP_ID", "value": "${NAME}"}], "image": "${TOPIC_FORWARDER_REPO}:latest",
+      "livenessProbe": {"httpGet": {"path": "/health", "port": "health"}}, "name":
+      "forwarder", "ports": [{"containerPort": 8080, "name": "health"}], "resources":
+      {"limits": {"memory": "128Mi"}, "requests": {"memory": "128Mi"}}}], "volumes":
+      [{"name": "vol-${NAME}", "persistentVolumeClaim": {"claimName": "pvc-${NAME}"}},
+      {"configMap": {"name": "hawkular-broker-config"}, "name": "hawkular-openshift-agent"}]}}}}],
+      "parameters": [{"description": "Storage capacity required for volume claims",
+      "name": "STORAGE_CAPACITY", "value": "2Gi"}, {"description": "The docker image
+      to use for the message broker", "name": "BROKER_REPO", "value": "enmasseproject/artemis"},
+      {"description": "The default image to use as topic forwarder", "name": "TOPIC_FORWARDER_REPO",
+      "value": "enmasseproject/topic-forwarder"}, {"description": "The image to use
+      for the router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"},
+      {"description": "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY",
+      "value": "50"}, {"description": "A valid instance name for the instance", "name":
+      "INSTANCE", "required": true}, {"description": "A valid name for the instance",
+      "name": "NAME", "required": true}, {"description": "The address to use for the
+      topic", "name": "ADDRESS", "required": true}]}'
+  kind: ConfigMap
   metadata:
     labels:
       app: enmasse
-    name: tls-queue-inmemory
-  objects:
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        address_config: address-config-${INSTANCE}-${NAME}
-        app: enmasse
-        group_id: "${NAME}"
-        instance: "${INSTANCE}"
-      name: "${NAME}"
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            group_id: "${NAME}"
-            instance: "${INSTANCE}"
-            role: broker
-        spec:
-          containers:
-          - env:
-            - name: QUEUE_NAME
-              value: "${ADDRESS}"
-            - name: GROUP_ID
-              value: "${NAME}"
-            image: "${BROKER_REPO}:latest"
-            lifecycle:
-              preStop:
-                exec:
-                  command:
-                  - "/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: broker
-            ports:
-            - containerPort: 5673
-              name: amqp
-            - containerPort: 61616
-              name: core
-            - containerPort: 8161
-              name: jolokia
-            readinessProbe:
-              tcpSocket:
-                port: amqp
-            volumeMounts:
-            - mountPath: "/var/run/artemis"
-              name: vol-${NAME}
-          volumes:
-          - emptyDir: {}
-            name: vol-${NAME}
-          - name: ssl-certs
-            secret:
-              secretName: qdrouterd-certs
-          - configMap:
-              name: hawkular-broker-config
-            name: hawkular-openshift-agent
-  parameters:
-  - description: Storage capacity required for volume claims
-    name: STORAGE_CAPACITY
-    value: 2Gi
-  - description: The docker image to use for the message broker
-    name: BROKER_REPO
-    value: enmasseproject/artemis
-  - description: The default image to use as topic forwarder
-    name: TOPIC_FORWARDER_REPO
-    value: enmasseproject/topic-forwarder
-  - description: The image to use for the router
-    name: ROUTER_REPO
-    value: enmasseproject/qdrouterd
-  - description: The link capacity setting for router
-    name: ROUTER_LINK_CAPACITY
-    value: '50'
-  - description: A valid instance name for the instance
-    name: INSTANCE
-    required: true
-  - description: A valid name for the instance
-    name: NAME
-    required: true
-  - description: The address to use for the queue
-    name: ADDRESS
-    required: true
-- apiVersion: v1
-  kind: Template
-  metadata:
-    labels:
-      app: enmasse
-    name: tls-queue-persisted
-  objects:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
-    metadata:
-      labels:
-        app: enmasse
-        group_id: "${NAME}"
-        instance: "${INSTANCE}"
-      name: pvc-${NAME}
-    spec:
-      accessModes:
-      - ReadWriteMany
-      resources:
-        requests:
-          storage: "${STORAGE_CAPACITY}"
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        address_config: address-config-${INSTANCE}-${NAME}
-        app: enmasse
-        group_id: "${NAME}"
-        instance: "${INSTANCE}"
-      name: "${NAME}"
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            group_id: "${NAME}"
-            instance: "${INSTANCE}"
-            role: broker
-        spec:
-          containers:
-          - env:
-            - name: QUEUE_NAME
-              value: "${ADDRESS}"
-            - name: GROUP_ID
-              value: "${NAME}"
-            image: "${BROKER_REPO}:latest"
-            lifecycle:
-              preStop:
-                exec:
-                  command:
-                  - "/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: broker
-            ports:
-            - containerPort: 5673
-              name: amqp
-            - containerPort: 61616
-              name: core
-            - containerPort: 8161
-              name: jolokia
-            readinessProbe:
-              tcpSocket:
-                port: amqp
-            volumeMounts:
-            - mountPath: "/var/run/artemis"
-              name: vol-${NAME}
-          volumes:
-          - name: vol-${NAME}
-            persistentVolumeClaim:
-              claimName: pvc-${NAME}
-          - name: ssl-certs
-            secret:
-              secretName: qdrouterd-certs
-          - configMap:
-              name: hawkular-broker-config
-            name: hawkular-openshift-agent
-  parameters:
-  - description: Storage capacity required for volume claims
-    name: STORAGE_CAPACITY
-    value: 2Gi
-  - description: The docker image to use for the message broker
-    name: BROKER_REPO
-    value: enmasseproject/artemis
-  - description: The default image to use as topic forwarder
-    name: TOPIC_FORWARDER_REPO
-    value: enmasseproject/topic-forwarder
-  - description: The image to use for the router
-    name: ROUTER_REPO
-    value: enmasseproject/qdrouterd
-  - description: The link capacity setting for router
-    name: ROUTER_LINK_CAPACITY
-    value: '50'
-  - description: A valid instance name for the instance
-    name: INSTANCE
-    required: true
-  - description: A valid name for the instance
-    name: NAME
-    required: true
-  - description: The address to use for the queue
-    name: ADDRESS
-    required: true
-- apiVersion: v1
-  kind: Template
-  metadata:
-    labels:
-      app: enmasse
-    name: tls-topic-inmemory
-  objects:
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        address_config: address-config-${INSTANCE}-${NAME}
-        app: enmasse
-        group_id: "${NAME}"
-        instance: "${INSTANCE}"
-      name: "${NAME}"
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            group_id: "${NAME}"
-            instance: "${INSTANCE}"
-            role: broker
-        spec:
-          containers:
-          - env:
-            - name: TOPIC_NAME
-              value: "${ADDRESS}"
-            - name: GROUP_ID
-              value: "${NAME}"
-            image: "${BROKER_REPO}:latest"
-            lifecycle:
-              preStop:
-                exec:
-                  command:
-                  - "/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: broker
-            ports:
-            - containerPort: 5673
-              name: amqp
-            - containerPort: 61616
-              name: core
-            - containerPort: 8161
-              name: jolokia
-            readinessProbe:
-              tcpSocket:
-                port: amqp
-            volumeMounts:
-            - mountPath: "/var/run/artemis"
-              name: vol-${NAME}
-          - env:
-            - name: LINK_CAPACITY
-              value: "${ROUTER_LINK_CAPACITY}"
-            - name: TOPIC_NAME
-              value: "${ADDRESS}"
-            image: "${ROUTER_REPO}:latest"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: router
-            ports:
-            - containerPort: 5672
-              name: amqp
-              protocol: TCP
-            - containerPort: 55673
-              name: internal
-              protocol: TCP
-            - containerPort: 5671
-              name: amqps
-              protocol: TCP
-            resources:
-              limits:
-                memory: 256Mi
-              requests:
-                memory: 256Mi
-            volumeMounts:
-            - mountPath: "/etc/qpid-dispatch/ssl"
-              name: ssl-certs
-              readOnly: true
-          - env:
-            - name: TOPIC_NAME
-              value: "${ADDRESS}"
-            - name: GROUP_ID
-              value: "${NAME}"
-            image: "${TOPIC_FORWARDER_REPO}:latest"
-            livenessProbe:
-              httpGet:
-                path: "/health"
-                port: health
-            name: forwarder
-            ports:
-            - containerPort: 8080
-              name: health
-            resources:
-              limits:
-                memory: 128Mi
-              requests:
-                memory: 128Mi
-          volumes:
-          - emptyDir: {}
-            name: vol-${NAME}
-          - name: ssl-certs
-            secret:
-              secretName: qdrouterd-certs
-          - configMap:
-              name: hawkular-broker-config
-            name: hawkular-openshift-agent
-  parameters:
-  - description: Storage capacity required for volume claims
-    name: STORAGE_CAPACITY
-    value: 2Gi
-  - description: The docker image to use for the message broker
-    name: BROKER_REPO
-    value: enmasseproject/artemis
-  - description: The default image to use as topic forwarder
-    name: TOPIC_FORWARDER_REPO
-    value: enmasseproject/topic-forwarder
-  - description: The image to use for the router
-    name: ROUTER_REPO
-    value: enmasseproject/qdrouterd
-  - description: The link capacity setting for router
-    name: ROUTER_LINK_CAPACITY
-    value: '50'
-  - description: A valid instance name for the instance
-    name: INSTANCE
-    required: true
-  - description: A valid name for the instance
-    name: NAME
-    required: true
-  - description: The address to use for the topic
-    name: ADDRESS
-    required: true
-- apiVersion: v1
-  kind: Template
-  metadata:
-    labels:
-      app: enmasse
-    name: tls-topic-persisted
-  objects:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
-    metadata:
-      labels:
-        app: enmasse
-        group_id: "${NAME}"
-        instance: "${INSTANCE}"
-      name: pvc-${NAME}
-    spec:
-      accessModes:
-      - ReadWriteMany
-      resources:
-        requests:
-          storage: "${STORAGE_CAPACITY}"
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        address_config: address-config-${INSTANCE}-${NAME}
-        app: enmasse
-        group_id: "${NAME}"
-        instance: "${INSTANCE}"
-      name: "${NAME}"
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            group_id: "${NAME}"
-            instance: "${INSTANCE}"
-            role: broker
-        spec:
-          containers:
-          - env:
-            - name: TOPIC_NAME
-              value: "${ADDRESS}"
-            - name: GROUP_ID
-              value: "${NAME}"
-            image: "${BROKER_REPO}:latest"
-            lifecycle:
-              preStop:
-                exec:
-                  command:
-                  - "/opt/artemis-shutdown-hook/bin/artemis-shutdown-hook"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: broker
-            ports:
-            - containerPort: 5673
-              name: amqp
-            - containerPort: 61616
-              name: core
-            - containerPort: 8161
-              name: jolokia
-            readinessProbe:
-              tcpSocket:
-                port: amqp
-            volumeMounts:
-            - mountPath: "/var/run/artemis"
-              name: vol-${NAME}
-          - env:
-            - name: LINK_CAPACITY
-              value: "${ROUTER_LINK_CAPACITY}"
-            - name: TOPIC_NAME
-              value: "${ADDRESS}"
-            image: "${ROUTER_REPO}:latest"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: router
-            ports:
-            - containerPort: 5672
-              name: amqp
-              protocol: TCP
-            - containerPort: 55673
-              name: internal
-              protocol: TCP
-            - containerPort: 5671
-              name: amqps
-              protocol: TCP
-            resources:
-              limits:
-                memory: 256Mi
-              requests:
-                memory: 256Mi
-            volumeMounts:
-            - mountPath: "/etc/qpid-dispatch/ssl"
-              name: ssl-certs
-              readOnly: true
-          - env:
-            - name: TOPIC_NAME
-              value: "${ADDRESS}"
-            - name: GROUP_ID
-              value: "${NAME}"
-            image: "${TOPIC_FORWARDER_REPO}:latest"
-            livenessProbe:
-              httpGet:
-                path: "/health"
-                port: health
-            name: forwarder
-            ports:
-            - containerPort: 8080
-              name: health
-            resources:
-              limits:
-                memory: 128Mi
-              requests:
-                memory: 128Mi
-          volumes:
-          - name: vol-${NAME}
-            persistentVolumeClaim:
-              claimName: pvc-${NAME}
-          - name: ssl-certs
-            secret:
-              secretName: qdrouterd-certs
-          - configMap:
-              name: hawkular-broker-config
-            name: hawkular-openshift-agent
-  parameters:
-  - description: Storage capacity required for volume claims
-    name: STORAGE_CAPACITY
-    value: 2Gi
-  - description: The docker image to use for the message broker
-    name: BROKER_REPO
-    value: enmasseproject/artemis
-  - description: The default image to use as topic forwarder
-    name: TOPIC_FORWARDER_REPO
-    value: enmasseproject/topic-forwarder
-  - description: The image to use for the router
-    name: ROUTER_REPO
-    value: enmasseproject/qdrouterd
-  - description: The link capacity setting for router
-    name: ROUTER_LINK_CAPACITY
-    value: '50'
-  - description: A valid instance name for the instance
-    name: INSTANCE
-    required: true
-  - description: A valid name for the instance
-    name: NAME
-    required: true
-  - description: The address to use for the topic
-    name: ADDRESS
-    required: true
-- apiVersion: v1
-  kind: Template
-  metadata:
-    labels:
-      app: enmasse
-    name: tls-enmasse-instance-infra
-  objects:
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-        name: qdrouterd
-      name: qdrouterd
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            capability: router
-            instance: "${INSTANCE}"
-            name: qdrouterd
-        spec:
-          containers:
-          - env:
-            - name: LINK_CAPACITY
-              value: "${ROUTER_LINK_CAPACITY}"
-            image: "${ROUTER_REPO}:latest"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: router
-            ports:
-            - containerPort: 5672
-              name: amqp
-              protocol: TCP
-            - containerPort: 55673
-              name: internal
-              protocol: TCP
-            - containerPort: 5671
-              name: amqps
-              protocol: TCP
-            volumeMounts:
-            - mountPath: "/etc/qpid-dispatch/ssl"
-              name: ssl-certs
-              readOnly: true
-          volumes:
-          - name: ssl-certs
-            secret:
-              secretName: qdrouterd-certs
-  - apiVersion: v1
-    kind: Service
-    metadata:
-      annotations:
-        service.alpha.openshift.io/dependencies: '[{"kind": "Service", "name": "admin",
-          "namespace": ""}, {"kind": "Service", "name": "subscription", "namespace":
-          ""}, {"kind": "Service", "name": "mqtt", "namespace": ""}]'
-        service.alpha.openshift.io/infrastructure: 'true'
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-      name: messaging
-    spec:
-      ports:
-      - name: amqp
-        port: 5672
-        protocol: TCP
-        targetPort: 5672
-      - name: amqps
-        port: 5671
-        protocol: TCP
-        targetPort: 5671
-      - name: internal
-        port: 55673
-        protocol: TCP
-        targetPort: 55673
-      selector:
-        capability: router
-        instance: "${INSTANCE}"
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-        name: subserv
-      name: subserv
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            instance: "${INSTANCE}"
-            name: subserv
-        spec:
-          containers:
-          - env: []
-            image: "${SUBSERV_REPO}:latest"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: subserv
-            ports:
-            - containerPort: 5672
-              name: amqp
-              protocol: TCP
-            resources:
-              limits:
-                memory: 64Mi
-              requests:
-                memory: 64Mi
-  - apiVersion: v1
-    kind: Service
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-      name: subscription
-    spec:
-      ports:
-      - name: amqp
-        port: 5672
-        protocol: TCP
-        targetPort: 5672
-      selector:
-        instance: "${INSTANCE}"
-        name: subserv
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-        name: mqtt-gateway
-      name: mqtt-gateway
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            instance: "${INSTANCE}"
-            name: mqtt-gateway
-        spec:
-          containers:
-          - image: "${MQTT_GATEWAY_REPO}:latest"
-            livenessProbe:
-              initialDelaySeconds: 60
-              tcpSocket:
-                port: secure-mqtt
-            name: mqtt-gateway-tls
-            ports:
-            - containerPort: 8883
-              name: secure-mqtt
-              protocol: TCP
-            volumeMounts:
-            - mountPath: "/etc/mqtt-gateway/ssl"
-              name: ssl-certs
-              readOnly: true
-          - image: "${MQTT_GATEWAY_REPO}:latest"
-            livenessProbe:
-              initialDelaySeconds: 60
-              tcpSocket:
-                port: mqtt
-            name: mqtt-gateway
-            ports:
-            - containerPort: 1883
-              name: mqtt
-              protocol: TCP
-          volumes:
-          - name: ssl-certs
-            secret:
-              secretName: mqtt-certs
-  - apiVersion: v1
-    kind: Service
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-      name: mqtt
-    spec:
-      ports:
-      - name: mqtt
-        port: 1883
-        protocol: TCP
-        targetPort: 1883
-      - name: secure-mqtt
-        port: 8883
-        protocol: TCP
-        targetPort: 8883
-      selector:
-        instance: "${INSTANCE}"
-        name: mqtt-gateway
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-        name: mqtt-lwt
-      name: mqtt-lwt
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            instance: "${INSTANCE}"
-            name: mqtt-lwt
-        spec:
-          containers:
-          - image: "${MQTT_LWT_REPO}:latest"
-            name: mqtt-lwt
-  - apiVersion: v1
-    kind: Route
-    metadata:
-      labels:
-        app: enmasse
-      name: console
-    spec:
-      host: "${CONSOLE_HOSTNAME}"
-      port:
-        targetPort: console-http
-      to:
-        kind: Service
-        name: admin
-  - apiVersion: v1
-    data:
-      hawkular-openshift-agent: '{"endpoints": [{"collection_interval": "60s", "metrics":
-        [{"id": "broker.threadCount", "name": "java.lang:type=Threading#ThreadCount",
-        "tags": {"messagingComponent": "broker", "messagingMetricType": "threadCount"},
-        "type": "counter"}, {"id": "broker.memoryHeapUsage", "name": "java.lang:type=Memory#HeapMemoryUsage#used",
-        "tags": {"messagingComponent": "broker", "messagingMetricType": "heapUsage"},
-        "type": "gauge"}, {"description": "Queue depth for ${address}", "id": "${address}.${queue}.${broker}.queueDepth",
-        "name": "org.apache.activemq.artemis:address=*,broker=*,component=addresses,queue=*,routing-type=*,subcomponent=queues#MessageCount",
-        "tags": {"messagingAddress": "${address}", "messagingBroker": "{broker}",
-        "messagingMetricType": "queueDepth", "messagingQueue": "${queue}"}, "type":
-        "gauge"}, {"description": "Number of consumers for ${address}", "id": "${address}.${queue}.${broker}.numConsumers",
-        "name": "org.apache.activemq.artemis:address=*,broker=*,component=addresses,queue=*,routing-type=*,subcomponent=queues#ConsumerCount",
-        "tags": {"messagingAddress": "${address}", "messagingBroker": "{broker}",
-        "messagingMetricType": "numConsumers", "messagingQueue": "${queue}"}, "type":
-        "gauge"}], "path": "/jolokia/", "port": 8161, "protocol": "http", "type":
-        "jolokia"}]}'
-    kind: ConfigMap
-    metadata:
-      name: hawkular-broker-config
-  - apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-        name: admin
-      name: admin
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: enmasse
-            instance: "${INSTANCE}"
-            name: admin
-        spec:
-          containers:
-          - env:
-            - name: CONFIGURATION_SERVICE_HOST
-              value: localhost
-            - name: CONFIGURATION_SERVICE_PORT
-              value: '5672'
-            image: "${RAGENT_REPO}:latest"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: ragent
-            ports:
-            - containerPort: 55672
-              name: amqp
-              protocol: TCP
-            resources:
-              limits:
-                memory: 64Mi
-              requests:
-                memory: 64Mi
-          - env:
-            - name: CONFIGURATION_SERVICE_HOST
-              value: localhost
-            - name: CONFIGURATION_SERVICE_PORT
-              value: '5672'
-            image: "${QUEUE_SCHEDULER_REPO}:latest"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: queue-scheduler
-            ports:
-            - containerPort: 55667
-              name: amqp
-              protocol: TCP
-            resources:
-              limits:
-                memory: 128Mi
-              requests:
-                memory: 128Mi
-          - env:
-            - name: CONFIGURATION_SERVICE_HOST
-              value: localhost
-            - name: CONFIGURATION_SERVICE_PORT
-              value: '5672'
-            image: "${CONSOLE_REPO}:latest"
-            livenessProbe:
-              tcpSocket:
-                port: http
-            name: console
-            ports:
-            - containerPort: 8080
-              name: http
-              protocol: TCP
-            - containerPort: 56720
-              name: amqp-ws
-              protocol: TCP
-            resources:
-              limits:
-                memory: 64Mi
-              requests:
-                memory: 64Mi
-          - env: []
-            image: "${CONFIGSERV_REPO}:latest"
-            livenessProbe:
-              tcpSocket:
-                port: amqp
-            name: configserv
-            ports:
-            - containerPort: 5672
-              name: amqp
-              protocol: TCP
-            resources:
-              limits:
-                memory: 256Mi
-              requests:
-                memory: 256Mi
-  - apiVersion: v1
-    kind: Service
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-      name: admin
-    spec:
-      ports:
-      - name: ragent
-        port: 55672
-      - name: configuration
-        port: 5672
-      - name: queue-scheduler
-        port: 55667
-      - name: console-ws
-        port: 56720
-      - name: console-http
-        port: 8080
-      selector:
-        instance: "${INSTANCE}"
-        name: admin
-  - apiVersion: v1
-    kind: Route
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-      name: messaging
-    spec:
-      host: "${MESSAGING_HOSTNAME}"
-      port:
-        targetPort: amqps
-      tls:
-        termination: passthrough
-      to:
-        kind: Service
-        name: messaging
-        weight: 100
-  - apiVersion: v1
-    kind: Route
-    metadata:
-      labels:
-        app: enmasse
-        instance: "${INSTANCE}"
-      name: mqtt
-    spec:
-      host: "${MQTT_GATEWAY_HOSTNAME}"
-      port:
-        targetPort: secure-mqtt
-      tls:
-        termination: passthrough
-      to:
-        kind: Service
-        name: mqtt
-        weight: 100
-  parameters:
-  - description: The image to use for the router
-    name: ROUTER_REPO
-    value: enmasseproject/qdrouterd
-  - description: The link capacity setting for router
-    name: ROUTER_LINK_CAPACITY
-    value: '50'
-  - description: The image to use for the configuration service
-    name: CONFIGSERV_REPO
-    value: enmasseproject/configserv
-  - description: The docker image to use for the queue scheduler
-    name: QUEUE_SCHEDULER_REPO
-    value: enmasseproject/queue-scheduler
-  - description: The image to use for the router agent
-    name: RAGENT_REPO
-    value: enmasseproject/ragent
-  - description: The image to use for the subscription services
-    name: SUBSERV_REPO
-    value: enmasseproject/subserv
-  - description: The image to use for the console
-    name: CONSOLE_REPO
-    value: enmasseproject/console
-  - description: The hostname to use for the exposed route for messaging (TLS only)
-    name: MESSAGING_HOSTNAME
-  - description: The image to use for the MQTT gateway
-    name: MQTT_GATEWAY_REPO
-    value: enmasseproject/mqtt-gateway
-  - description: The hostname to use for the exposed route for MQTT (TLS only)
-    name: MQTT_GATEWAY_HOSTNAME
-  - description: The hostname to use for the exposed route for the messaging console
-    name: CONSOLE_HOSTNAME
-  - description: The image to use for the MQTT LWT
-    name: MQTT_LWT_REPO
-    value: enmasseproject/mqtt-lwt
-  - description: The image to use for the AMQP Kafka Bridge
-    name: AMQP_KAFKA_BRIDGE_REPO
-    value: enmasseproject/amqp-kafka-bridge
-  - description: A list of host/port pairs to use for establishing the initial connection
-      to the Kafka cluster
-    name: KAFKA_BOOTSTRAP_SERVERS
-  - description: The instance this infrastructure is deployed for
-    name: INSTANCE
-    required: true
+    name: enmasse-template-config
 - apiVersion: extensions/v1beta1
   kind: Deployment
   metadata:
@@ -967,7 +583,14 @@ objects:
               memory: 256Mi
             requests:
               memory: 256Mi
+          volumeMounts:
+          - mountPath: "/templates"
+            name: templates
         serviceAccount: enmasse-service-account
+        volumes:
+        - configMap:
+            name: enmasse-template-config
+          name: templates
 - apiVersion: v1
   kind: Service
   metadata:

--- a/generated/tls-enmasse-template.yaml
+++ b/generated/tls-enmasse-template.yaml
@@ -60,12 +60,9 @@ objects:
       {"app": "enmasse", "instance": "${INSTANCE}", "name": "mqtt-lwt"}, "name": "mqtt-lwt"},
       "spec": {"replicas": 1, "template": {"metadata": {"labels": {"app": "enmasse",
       "instance": "${INSTANCE}", "name": "mqtt-lwt"}}, "spec": {"containers": [{"image":
-      "${MQTT_LWT_REPO}:latest", "name": "mqtt-lwt"}]}}}}, {"apiVersion": "v1", "kind":
-      "Route", "metadata": {"labels": {"app": "enmasse"}, "name": "console"}, "spec":
-      {"host": "${CONSOLE_HOSTNAME}", "port": {"targetPort": "console-http"}, "to":
-      {"kind": "Service", "name": "admin"}}}, {"apiVersion": "v1", "data": {"hawkular-openshift-agent":
-      "{\"endpoints\": [{\"collection_interval\": \"60s\", \"metrics\": [{\"id\":
-      \"broker.threadCount\", \"name\": \"java.lang:type=Threading#ThreadCount\",
+      "${MQTT_LWT_REPO}:latest", "name": "mqtt-lwt"}]}}}}, {"apiVersion": "v1", "data":
+      {"hawkular-openshift-agent": "{\"endpoints\": [{\"collection_interval\": \"60s\",
+      \"metrics\": [{\"id\": \"broker.threadCount\", \"name\": \"java.lang:type=Threading#ThreadCount\",
       \"tags\": {\"messagingComponent\": \"broker\", \"messagingMetricType\": \"threadCount\"},
       \"type\": \"counter\"}, {\"id\": \"broker.memoryHeapUsage\", \"name\": \"java.lang:type=Memory#HeapMemoryUsage#used\",
       \"tags\": {\"messagingComponent\": \"broker\", \"messagingMetricType\": \"heapUsage\"},
@@ -114,21 +111,24 @@ objects:
       {"labels": {"app": "enmasse", "instance": "${INSTANCE}"}, "name": "mqtt"}, "spec":
       {"host": "${MQTT_GATEWAY_HOSTNAME}", "port": {"targetPort": "secure-mqtt"},
       "tls": {"termination": "passthrough"}, "to": {"kind": "Service", "name": "mqtt",
-      "weight": 100}}}], "parameters": [{"description": "The image to use for the
-      router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"}, {"description":
-      "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY", "value":
-      "50"}, {"description": "The image to use for the configuration service", "name":
-      "CONFIGSERV_REPO", "value": "enmasseproject/configserv"}, {"description": "The
-      docker image to use for the queue scheduler", "name": "QUEUE_SCHEDULER_REPO",
-      "value": "enmasseproject/queue-scheduler"}, {"description": "The image to use
-      for the router agent", "name": "RAGENT_REPO", "value": "enmasseproject/ragent"},
-      {"description": "The image to use for the subscription services", "name": "SUBSERV_REPO",
-      "value": "enmasseproject/subserv"}, {"description": "The image to use for the
-      console", "name": "CONSOLE_REPO", "value": "enmasseproject/console"}, {"description":
-      "The hostname to use for the exposed route for messaging (TLS only)", "name":
-      "MESSAGING_HOSTNAME"}, {"description": "The image to use for the MQTT gateway",
-      "name": "MQTT_GATEWAY_REPO", "value": "enmasseproject/mqtt-gateway"}, {"description":
-      "The hostname to use for the exposed route for MQTT (TLS only)", "name": "MQTT_GATEWAY_HOSTNAME"},
+      "weight": 100}}}, {"apiVersion": "v1", "kind": "Route", "metadata": {"labels":
+      {"app": "enmasse"}, "name": "console"}, "spec": {"host": "${CONSOLE_HOSTNAME}",
+      "port": {"targetPort": "console-http"}, "to": {"kind": "Service", "name": "admin"}}}],
+      "parameters": [{"description": "The image to use for the router", "name": "ROUTER_REPO",
+      "value": "enmasseproject/qdrouterd"}, {"description": "The link capacity setting
+      for router", "name": "ROUTER_LINK_CAPACITY", "value": "50"}, {"description":
+      "The image to use for the configuration service", "name": "CONFIGSERV_REPO",
+      "value": "enmasseproject/configserv"}, {"description": "The docker image to
+      use for the queue scheduler", "name": "QUEUE_SCHEDULER_REPO", "value": "enmasseproject/queue-scheduler"},
+      {"description": "The image to use for the router agent", "name": "RAGENT_REPO",
+      "value": "enmasseproject/ragent"}, {"description": "The image to use for the
+      subscription services", "name": "SUBSERV_REPO", "value": "enmasseproject/subserv"},
+      {"description": "The image to use for the console", "name": "CONSOLE_REPO",
+      "value": "enmasseproject/console"}, {"description": "The hostname to use for
+      the exposed route for messaging (TLS only)", "name": "MESSAGING_HOSTNAME"},
+      {"description": "The image to use for the MQTT gateway", "name": "MQTT_GATEWAY_REPO",
+      "value": "enmasseproject/mqtt-gateway"}, {"description": "The hostname to use
+      for the exposed route for MQTT (TLS only)", "name": "MQTT_GATEWAY_HOSTNAME"},
       {"description": "The hostname to use for the exposed route for the messaging
       console", "name": "CONSOLE_HOSTNAME"}, {"description": "The image to use for
       the MQTT LWT", "name": "MQTT_LWT_REPO", "value": "enmasseproject/mqtt-lwt"},
@@ -245,12 +245,9 @@ objects:
       {"app": "enmasse", "instance": "${INSTANCE}", "name": "mqtt-lwt"}, "name": "mqtt-lwt"},
       "spec": {"replicas": 1, "template": {"metadata": {"labels": {"app": "enmasse",
       "instance": "${INSTANCE}", "name": "mqtt-lwt"}}, "spec": {"containers": [{"image":
-      "${MQTT_LWT_REPO}:latest", "name": "mqtt-lwt"}]}}}}, {"apiVersion": "v1", "kind":
-      "Route", "metadata": {"labels": {"app": "enmasse"}, "name": "console"}, "spec":
-      {"host": "${CONSOLE_HOSTNAME}", "port": {"targetPort": "console-http"}, "to":
-      {"kind": "Service", "name": "admin"}}}, {"apiVersion": "v1", "data": {"hawkular-openshift-agent":
-      "{\"endpoints\": [{\"collection_interval\": \"60s\", \"metrics\": [{\"id\":
-      \"broker.threadCount\", \"name\": \"java.lang:type=Threading#ThreadCount\",
+      "${MQTT_LWT_REPO}:latest", "name": "mqtt-lwt"}]}}}}, {"apiVersion": "v1", "data":
+      {"hawkular-openshift-agent": "{\"endpoints\": [{\"collection_interval\": \"60s\",
+      \"metrics\": [{\"id\": \"broker.threadCount\", \"name\": \"java.lang:type=Threading#ThreadCount\",
       \"tags\": {\"messagingComponent\": \"broker\", \"messagingMetricType\": \"threadCount\"},
       \"type\": \"counter\"}, {\"id\": \"broker.memoryHeapUsage\", \"name\": \"java.lang:type=Memory#HeapMemoryUsage#used\",
       \"tags\": {\"messagingComponent\": \"broker\", \"messagingMetricType\": \"heapUsage\"},
@@ -299,21 +296,24 @@ objects:
       {"labels": {"app": "enmasse", "instance": "${INSTANCE}"}, "name": "mqtt"}, "spec":
       {"host": "${MQTT_GATEWAY_HOSTNAME}", "port": {"targetPort": "secure-mqtt"},
       "tls": {"termination": "passthrough"}, "to": {"kind": "Service", "name": "mqtt",
-      "weight": 100}}}], "parameters": [{"description": "The image to use for the
-      router", "name": "ROUTER_REPO", "value": "enmasseproject/qdrouterd"}, {"description":
-      "The link capacity setting for router", "name": "ROUTER_LINK_CAPACITY", "value":
-      "50"}, {"description": "The image to use for the configuration service", "name":
-      "CONFIGSERV_REPO", "value": "enmasseproject/configserv"}, {"description": "The
-      docker image to use for the queue scheduler", "name": "QUEUE_SCHEDULER_REPO",
-      "value": "enmasseproject/queue-scheduler"}, {"description": "The image to use
-      for the router agent", "name": "RAGENT_REPO", "value": "enmasseproject/ragent"},
-      {"description": "The image to use for the subscription services", "name": "SUBSERV_REPO",
-      "value": "enmasseproject/subserv"}, {"description": "The image to use for the
-      console", "name": "CONSOLE_REPO", "value": "enmasseproject/console"}, {"description":
-      "The hostname to use for the exposed route for messaging (TLS only)", "name":
-      "MESSAGING_HOSTNAME"}, {"description": "The image to use for the MQTT gateway",
-      "name": "MQTT_GATEWAY_REPO", "value": "enmasseproject/mqtt-gateway"}, {"description":
-      "The hostname to use for the exposed route for MQTT (TLS only)", "name": "MQTT_GATEWAY_HOSTNAME"},
+      "weight": 100}}}, {"apiVersion": "v1", "kind": "Route", "metadata": {"labels":
+      {"app": "enmasse"}, "name": "console"}, "spec": {"host": "${CONSOLE_HOSTNAME}",
+      "port": {"targetPort": "console-http"}, "to": {"kind": "Service", "name": "admin"}}}],
+      "parameters": [{"description": "The image to use for the router", "name": "ROUTER_REPO",
+      "value": "enmasseproject/qdrouterd"}, {"description": "The link capacity setting
+      for router", "name": "ROUTER_LINK_CAPACITY", "value": "50"}, {"description":
+      "The image to use for the configuration service", "name": "CONFIGSERV_REPO",
+      "value": "enmasseproject/configserv"}, {"description": "The docker image to
+      use for the queue scheduler", "name": "QUEUE_SCHEDULER_REPO", "value": "enmasseproject/queue-scheduler"},
+      {"description": "The image to use for the router agent", "name": "RAGENT_REPO",
+      "value": "enmasseproject/ragent"}, {"description": "The image to use for the
+      subscription services", "name": "SUBSERV_REPO", "value": "enmasseproject/subserv"},
+      {"description": "The image to use for the console", "name": "CONSOLE_REPO",
+      "value": "enmasseproject/console"}, {"description": "The hostname to use for
+      the exposed route for messaging (TLS only)", "name": "MESSAGING_HOSTNAME"},
+      {"description": "The image to use for the MQTT gateway", "name": "MQTT_GATEWAY_REPO",
+      "value": "enmasseproject/mqtt-gateway"}, {"description": "The hostname to use
+      for the exposed route for MQTT (TLS only)", "name": "MQTT_GATEWAY_HOSTNAME"},
       {"description": "The hostname to use for the exposed route for the messaging
       console", "name": "CONSOLE_HOSTNAME"}, {"description": "The image to use for
       the MQTT LWT", "name": "MQTT_LWT_REPO", "value": "enmasseproject/mqtt-lwt"},

--- a/include/address-controller.jsonnet
+++ b/include/address-controller.jsonnet
@@ -60,7 +60,20 @@ local common = import "common.jsonnet";
               }, {
                 "name": "TLS",
                 "value": secure
-              }])
+              }], [
+                {
+                  "name": "templates",
+                  "mountPath": "/templates"
+                }
+              ])
+            ],
+            "volumes": [
+              {
+                "name": "templates",
+                "configMap": {
+                  "name": "enmasse-template-config"
+                }
+              }
             ]
           }
         }

--- a/include/common.jsonnet
+++ b/include/common.jsonnet
@@ -27,11 +27,12 @@ local version = std.extVar("VERSION");
     }
   },
 
-  container2(name, image, port_name, port, port2_name, port2_port, mem_request, env)::
+  container2(name, image, port_name, port, port2_name, port2_port, mem_request, env, volumeMounts)::
   {
     "image": image + ":" + version,
     "name": name,
     "env": env,
+    "volumeMounts": volumeMounts,
     "resources": {
         "requests": {
             "memory": mem_request,

--- a/include/enmasse-kubernetes.jsonnet
+++ b/include/enmasse-kubernetes.jsonnet
@@ -1,0 +1,16 @@
+local templateConfig = import "template-config.jsonnet";
+local addressController = import "address-controller.jsonnet";
+local restapiRoute = import "restapi-route.jsonnet";
+local flavorConfig = import "flavor.jsonnet";
+{
+  generate(use_tls, use_sasl, compact, with_kafka)::
+  {
+    local templateName = (if use_tls then "tls-enmasse-infra" else "enmasse-infra"),
+    "apiVersion": "v1",
+    "kind": "List",
+    "items": [ templateConfig.generate(use_tls, use_sasl, compact, with_kafka, false),
+               addressController.deployment(std.toString(use_tls), "enmasseproject/address-controller", "false"),
+               addressController.service,
+               flavorConfig.generate(use_tls) ]
+  }
+}

--- a/include/enmasse-template.jsonnet
+++ b/include/enmasse-template.jsonnet
@@ -14,7 +14,7 @@ local flavorConfig = import "flavor.jsonnet";
       },
       "name": templateName
     },
-    "objects": [ templateConfig.generate(use_tls, use_sasl, compact, with_kafka),
+    "objects": [ templateConfig.generate(use_tls, use_sasl, compact, with_kafka, true),
                  addressController.deployment(std.toString(use_tls), "${ADDRESS_CONTROLLER_REPO}", "${MULTIINSTANCE}"),
                  addressController.service,
                  restapiRoute.generate("${RESTAPI_HOSTNAME}"),

--- a/include/enmasse-template.jsonnet
+++ b/include/enmasse-template.jsonnet
@@ -1,8 +1,7 @@
-local storage = import "storage-template.jsonnet";
+local templateConfig = import "template-config.jsonnet";
 local addressController = import "address-controller.jsonnet";
 local restapiRoute = import "restapi-route.jsonnet";
 local flavorConfig = import "flavor.jsonnet";
-local enmasseInfra = import "enmasse-instance-infra.jsonnet";
 {
   generate(use_tls, use_sasl, compact, with_kafka)::
   {
@@ -15,11 +14,7 @@ local enmasseInfra = import "enmasse-instance-infra.jsonnet";
       },
       "name": templateName
     },
-    "objects": [ storage.template(false, false, use_tls),
-                 storage.template(false, true, use_tls),
-                 storage.template(true, false, use_tls),
-                 storage.template(true, true, use_tls),
-                 enmasseInfra.generate(use_tls, use_sasl, compact, with_kafka),
+    "objects": [ templateConfig.generate(use_tls, use_sasl, compact, with_kafka),
                  addressController.deployment(std.toString(use_tls), "${ADDRESS_CONTROLLER_REPO}", "${MULTIINSTANCE}"),
                  addressController.service,
                  restapiRoute.generate("${RESTAPI_HOSTNAME}"),

--- a/include/template-config.jsonnet
+++ b/include/template-config.jsonnet
@@ -1,7 +1,7 @@
 local storage = import "storage-template.jsonnet";
 local enmasseInfra = import "enmasse-instance-infra.jsonnet";
 {
-  generate(use_tls, use_sasl, compact, with_kafka)::
+  generate(use_tls, use_sasl, compact, with_kafka, use_routes)::
   {
     "apiVersion": "v1",
     "kind": "ConfigMap",
@@ -20,8 +20,8 @@ local enmasseInfra = import "enmasse-instance-infra.jsonnet";
       "tls-topic-inmemory.json": std.toString(storage.template(true, false, true)),
       "topic-persisted.json": std.toString(storage.template(true, true, false)),
       "tls-topic-persisted.json": std.toString(storage.template(true, true, true)),
-      "enmasse-instance-infra.json": std.toString(enmasseInfra.generate(true, use_sasl, compact, with_kafka)),
-      "tls-enmasse-instance-infra.json": std.toString(enmasseInfra.generate(true, use_sasl, compact, with_kafka))
+      "enmasse-instance-infra.json": std.toString(enmasseInfra.generate(true, use_sasl, compact, with_kafka, use_routes)),
+      "tls-enmasse-instance-infra.json": std.toString(enmasseInfra.generate(true, use_sasl, compact, with_kafka, use_routes))
     }
   }
 }

--- a/include/template-config.jsonnet
+++ b/include/template-config.jsonnet
@@ -1,0 +1,27 @@
+local storage = import "storage-template.jsonnet";
+local enmasseInfra = import "enmasse-instance-infra.jsonnet";
+{
+  generate(use_tls, use_sasl, compact, with_kafka)::
+  {
+    "apiVersion": "v1",
+    "kind": "ConfigMap",
+    "metadata": {
+      "name": "enmasse-template-config",
+      "labels": {
+        "app": "enmasse"
+      }
+    },
+    "data": {
+      "queue-inmemory.json": std.toString(storage.template(false, false, false)),
+      "tls-queue-inmemory.json": std.toString(storage.template(false, false, true)),
+      "queue-persisted.json": std.toString(storage.template(false, true, false)),
+      "tls-queue-persisted.json": std.toString(storage.template(false, true, true)),
+      "topic-inmemory.json": std.toString(storage.template(true, false, false)),
+      "tls-topic-inmemory.json": std.toString(storage.template(true, false, true)),
+      "topic-persisted.json": std.toString(storage.template(true, true, false)),
+      "tls-topic-persisted.json": std.toString(storage.template(true, true, true)),
+      "enmasse-instance-infra.json": std.toString(enmasseInfra.generate(true, use_sasl, compact, with_kafka)),
+      "tls-enmasse-instance-infra.json": std.toString(enmasseInfra.generate(true, use_sasl, compact, with_kafka))
+    }
+  }
+}


### PR DESCRIPTION
* All templates are part of a enmasse-template-config configMap, and is
mounted inside the address controller for it to process them when
requested.

This is a first step in making the configs useful on kubernetes as in #17