### PR TITLE
Use common base image with node runtime

### DIFF
--- a/console/Dockerfile
+++ b/console/Dockerfile
@@ -1,9 +1,4 @@
-FROM centos:7
-
-RUN yum -y update  \
-    && yum -y install epel-release cyrus-sasl-lib \
-    && yum -y install nodejs npm \
-    && yum clean all
+FROM enmasseproject/nodejs-base:6
 
 RUN mkdir -p /opt/app-root/src/
 WORKDIR /opt/app-root/src/

--- a/ragent/Dockerfile
+++ b/ragent/Dockerfile
@@ -1,10 +1,4 @@
-FROM centos:7
-
-RUN yum -y update  \
-    && yum -y install epel-release \
-    && yum -y install nodejs \
-    npm \
-    && yum clean all
+FROM enmasseproject/nodejs-base:6
 
 RUN mkdir -p /opt/app-root/src/
 RUN cd /opt/app-root/src/

--- a/subserv/Dockerfile
+++ b/subserv/Dockerfile
@@ -1,10 +1,4 @@
-FROM centos:7
-
-RUN yum -y update  \
-    && yum -y install epel-release \
-    && yum -y install nodejs \
-    npm \
-    && yum clean all
+FROM enmasseproject/nodejs-base:6
 
 RUN mkdir -p /opt/app-root/src/
 RUN cd /opt/app-root/src/


### PR DESCRIPTION
This saves some time and space for building docker images that all
install the same RPMs.

@grs Wdyt? Some travis builds hang on RPM install, and I was hoping this would fix that as well.