### PR TITLE
Added a way to add readiness probe to a "client" mode container

### DIFF
--- a/templates/include/amqp-kafka-bridge.jsonnet
+++ b/templates/include/amqp-kafka-bridge.jsonnet
@@ -33,7 +33,7 @@ local common = import "common.jsonnet";
                         {
                           "name": "KAFKA_BOOTSTRAP_SERVERS",
                           "value": "${KAFKA_BOOTSTRAP_SERVERS}"
-                        }], true),
+                        }], true, true),
             ]
           }
         }

--- a/templates/install/openshift/enmasse-with-kafka.yaml
+++ b/templates/install/openshift/enmasse-with-kafka.yaml
@@ -1017,6 +1017,12 @@ objects:
             ports:
             - containerPort: 8080
               name: health
+            - containerPort: 8080
+              name: ready
+            readinessProbe:
+              httpGet:
+                path: "/ready"
+                port: ready
             resources:
               limits:
                 memory: 512Mi


### PR DESCRIPTION
Modified clientContainer function to allow HTTP readiness probe creation
Updated AMQP - Kafka bridge definition with HTTP readiness probe