### PR TITLE
Add jenkinsfile to support building on jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,40 @@
+node('enmasse') {
+    stage ('checkout') {
+        git 'https://github.com/EnMasseProject/enmasse.git'
+        sh 'git checkout add-jenkins-file'
+        sh 'git submodule update --init --recursive'
+        sh 'rm -rf artifacts && mkdir -p artifacts'
+    }
+    stage ('build') {
+        try {
+            sh './gradlew build -q --rerun-tasks'
+        } finally {
+            junit '**/TEST-*.xml'
+            junit '**/test-results.xml'
+        }
+    }
+    stage ('build docker image') {
+        withCredentials([string(credentialsId: 'docker-registry-host', variable: 'DOCKER_REGISTRY')]) {
+            sh './gradlew pack buildImage -q --rerun-tasks'
+        }
+        sh 'cat templates/install/openshift/enmasse.yaml'
+    }
+    stage ('push docker image') {
+        withCredentials([string(credentialsId: 'docker-registry-host', variable: 'DOCKER_REGISTRY'), usernamePassword(credentialsId: 'docker-registry-credentials', passwordVariable: 'DOCKER_PASS', usernameVariable: 'DOCKER_USER')]) {
+            sh './gradlew tagImage pushImage -q'
+        }
+    }
+    stage('system tests') {
+        withCredentials([string(credentialsId: 'openshift-host', variable: 'OPENSHIFT_URL'), usernamePassword(credentialsId: 'openshift-credentials', passwordVariable: 'OPENSHIFT_PASSWD', usernameVariable: 'OPENSHIFT_USER')]) {
+            try {
+                sh 'ARTIFACTS_DIR=artifacts OPENSHIFT_PROJECT=$BUILD_TAG ./systemtests/scripts/run_test_component.sh templates/install /tmp/openshift systemtests'
+            } finally {
+                junit '**/TEST-*.xml'
+            }
+        }
+    }
+    stage('archive artifacts') {
+        sh 'ls artifacts'
+        archive 'artifacts/*'
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,40 +1,48 @@
 node('enmasse') {
-    stage ('checkout') {
-        git 'https://github.com/EnMasseProject/enmasse.git'
-        sh 'git checkout add-jenkins-file'
-        sh 'git submodule update --init --recursive'
-        sh 'rm -rf artifacts && mkdir -p artifacts'
-    }
-    stage ('build') {
-        try {
-            sh './gradlew build -q --rerun-tasks'
-        } finally {
-            junit '**/TEST-*.xml'
-            junit '**/test-results.xml'
+    result = 'failure'
+    catchError {
+        stage ('checkout') {
+            git 'https://github.com/EnMasseProject/enmasse.git'
+            sh 'git checkout add-jenkins-file'
+            sh 'git submodule update --init --recursive'
+            sh 'rm -rf artifacts && mkdir -p artifacts'
         }
-    }
-    stage ('build docker image') {
-        withCredentials([string(credentialsId: 'docker-registry-host', variable: 'DOCKER_REGISTRY')]) {
-            sh './gradlew pack buildImage -q --rerun-tasks'
-        }
-        sh 'cat templates/install/openshift/enmasse.yaml'
-    }
-    stage ('push docker image') {
-        withCredentials([string(credentialsId: 'docker-registry-host', variable: 'DOCKER_REGISTRY'), usernamePassword(credentialsId: 'docker-registry-credentials', passwordVariable: 'DOCKER_PASS', usernameVariable: 'DOCKER_USER')]) {
-            sh './gradlew tagImage pushImage -q'
-        }
-    }
-    stage('system tests') {
-        withCredentials([string(credentialsId: 'openshift-host', variable: 'OPENSHIFT_URL'), usernamePassword(credentialsId: 'openshift-credentials', passwordVariable: 'OPENSHIFT_PASSWD', usernameVariable: 'OPENSHIFT_USER')]) {
+        stage ('build') {
             try {
-                sh 'ARTIFACTS_DIR=artifacts OPENSHIFT_PROJECT=$BUILD_TAG ./systemtests/scripts/run_test_component.sh templates/install /tmp/openshift systemtests'
+                sh './gradlew build -q --rerun-tasks'
             } finally {
                 junit '**/TEST-*.xml'
             }
         }
+        stage ('build docker image') {
+            withCredentials([string(credentialsId: 'docker-registry-host', variable: 'DOCKER_REGISTRY')]) {
+                sh './gradlew pack buildImage -q --rerun-tasks'
+            }
+            sh 'cat templates/install/openshift/enmasse.yaml'
+        }
+        stage ('push docker image') {
+            withCredentials([string(credentialsId: 'docker-registry-host', variable: 'DOCKER_REGISTRY'), usernamePassword(credentialsId: 'docker-registry-credentials', passwordVariable: 'DOCKER_PASS', usernameVariable: 'DOCKER_USER')]) {
+                sh './gradlew tagImage pushImage -q'
+            }
+        }
+        stage('system tests') {
+            withCredentials([string(credentialsId: 'openshift-host', variable: 'OPENSHIFT_URL'), usernamePassword(credentialsId: 'openshift-credentials', passwordVariable: 'OPENSHIFT_PASSWD', usernameVariable: 'OPENSHIFT_USER')]) {
+                try {
+                    sh 'ARTIFACTS_DIR=artifacts OPENSHIFT_PROJECT=$BUILD_TAG ./systemtests/scripts/run_test_component.sh templates/install /tmp/openshift systemtests'
+                } finally {
+                    junit '**/TEST-*.xml'
+                }
+            }
+        }
+        stage('archive artifacts') {
+            sh 'ls artifacts'
+            archive 'artifacts/*'
+        }
+        result = 'success'
     }
-    stage('archive artifacts') {
-        sh 'ls artifacts'
-        archive 'artifacts/*'
+    stage('notify mailing list') {
+        if (result.equals("failure") || !hudson.model.Result.SUCCESS.equals(currentBuild.rawBuild.getPreviousBuild()?.getResult())) {
+            mail to: "$MAILING_LIST", subject: "EnMasse build has finished with ${result}", body: "See ${env.BUILD_URL}"
+        }
     }
 }

--- a/ragent/build.gradle
+++ b/ragent/build.gradle
@@ -11,6 +11,7 @@ task runMocha(type: Exec) {
         result.exitValue == 0
     }
     executable = "mocha"
+    args "--reporter=mocha-junit-reporter"
 }
 test.dependsOn(runMocha)
 

--- a/ragent/build.gradle
+++ b/ragent/build.gradle
@@ -11,6 +11,7 @@ task runMocha(type: Exec) {
         result.exitValue == 0
     }
     executable = "mocha"
+    environment("MOCHA_FILE", "build/test-results/test/TEST-ragent.xml")
     args "--reporter=mocha-junit-reporter"
 }
 test.dependsOn(runMocha)

--- a/systemtests/scripts/collect_logs.sh
+++ b/systemtests/scripts/collect_logs.sh
@@ -12,20 +12,22 @@ function runcmd {
     echo '#######################################################################'
 }
 
+mkdir -p $ARTIFACTS_DIR/logs
+
 for pod in `oc get pods -o jsonpath='{.items[*].metadata.name}'`
 do
     for container in `oc get pod $pod -o jsonpath='{.spec.containers[*].name}'`
     do
-        runcmd "oc logs -c $container $pod > ${ARTIFACTS_DIR}/${pod}_${container}.log"
+        runcmd "oc logs -c $container $pod > ${ARTIFACTS_DIR}/logs/${pod}_${container}.log"
         if [ "$container" == "router" ]; then
-            runcmd "oc rsh -c $container $pod qdmanage query --type=address > ${ARTIFACTS_DIR}/${pod}_${container}_router_address.txt"
-            runcmd "oc rsh -c $container $pod qdmanage query --type=connection > ${ARTIFACTS_DIR}/${pod}_${container}_router_connection.txt"
-            runcmd "oc rsh -c $container $pod qdmanage query --type=connector > ${ARTIFACTS_DIR}/${pod}_${container}_router_connector.txt"
+            runcmd "oc rsh -c $container $pod qdmanage query --type=address > ${ARTIFACTS_DIR}/logs/${pod}_${container}_router_address.txt"
+            runcmd "oc rsh -c $container $pod qdmanage query --type=connection > ${ARTIFACTS_DIR}/logs/${pod}_${container}_router_connection.txt"
+            runcmd "oc rsh -c $container $pod qdmanage query --type=connector > ${ARTIFACTS_DIR}/logs/${pod}_${container}_router_connector.txt"
         fi
     done
 done
 
 for log in `find /tmp/testlogs`
 do
-    runcmd "cp $log $ARTIFACTS_DIR/"
+    runcmd "cp $log $ARTIFACTS_DIR/logs/"
 done

--- a/systemtests/scripts/common.sh
+++ b/systemtests/scripts/common.sh
@@ -52,7 +52,7 @@ function run_test() {
     export OPENSHIFT_MULTITENANT=$MULTITENANT
     export OPENSHIFT_TOKEN=`oc whoami -t`
     export OPENSHIFT_MASTER_URL=$OPENSHIFT_URL
-    ../gradlew :systemtests:test -Psystemtests -i --rerun-tasks -Djava.net.preferIPv4Stack=true
+    ../gradlew :systemtests:test -Psystemtests -q --rerun-tasks -Djava.net.preferIPv4Stack=true
 }
 
 function teardown_test() {


### PR DESCRIPTION
Docker registry and OpenShift instance settings are provided using
jenkins credentials that must be setup on the jenkins master.

This fixes #92