### PR TITLE
Updated to use host in favour of the deprecated addr.

### DIFF
--- a/router/colocated-topic.snippet
+++ b/router/colocated-topic.snippet
@@ -18,7 +18,7 @@
 ##
 
 connector {
-    addr: 127.0.0.1
+    host: 127.0.0.1
     port: 5673
     name: localbroker
     role: route-container

--- a/router/qdrouterd.conf.template
+++ b/router/qdrouterd.conf.template
@@ -27,28 +27,28 @@ router {
 }
 
 listener {
-    addr: 0.0.0.0
+    host: 0.0.0.0
     port: 5672
     authenticatePeer: no
     linkCapacity: ${LINK_CAPACITY}
 }
 
 listener {
-    addr: 0.0.0.0
+    host: 0.0.0.0
     port: 55673
     authenticatePeer: no
     role: route-container
 }
 
 listener {
-    addr: ${MY_IP_ADDR}
+    host: ${MY_IP_ADDR}
     port: 55672
     role: inter-router
     authenticatePeer: no
 }
 
 connector {
-    addr: ${RAGENT_SERVICE_HOST}
+    host: ${RAGENT_SERVICE_HOST}
     port: ${RAGENT_SERVICE_PORT}
 }
 

--- a/router/ssl.snippet
+++ b/router/ssl.snippet
@@ -24,7 +24,7 @@ sslProfile {
 }
 
 listener {
-    addr: 0.0.0.0
+    host: 0.0.0.0
     port: 5671
     authenticatePeer: no
     sslProfile: ssl_details

--- a/router/subscriptions.snippet
+++ b/router/subscriptions.snippet
@@ -18,7 +18,7 @@
 ##
 
 connector {
-    addr: ${SUBSCRIPTION_SERVICE_HOST}
+    host: ${SUBSCRIPTION_SERVICE_HOST}
     port: ${SUBSCRIPTION_SERVICE_PORT}
     name: subscription-service
     role: route-container


### PR DESCRIPTION
This avoids https://issues.apache.org/jira/browse/DISPATCH-804 (though that is now resolved).