### PR TITLE
Modify deployment scripts to work on OS X

### DIFF
--- a/templates/install/common.sh
+++ b/templates/install/common.sh
@@ -32,6 +32,17 @@ function create_csr() {
   local CN=$3
 
   runcmd "openssl req -new -batch -nodes -keyout ${KEYFILE} -subj \"/O=io.enmasse/CN=${CN}\" -out ${CSRFILE}" "Create certificate signing request for ${CN}"
+  fix_key_file_format ${KEYFILE}
+}
+
+function fix_key_file_format() {
+  local KEYFILE=$1
+
+  if grep -q 'BEGIN RSA PRIVATE KEY' ${KEYFILE}; then
+      runcmd "mv ${KEYFILE} ${KEYFILE}.tmp" "Rename ${KEYFILE} so we can convert from PKCS#1 to PKCS#8"
+      runcmd "openssl pkcs8 -topk8 -inform pem -in ${KEYFILE}.tmp -outform pem -nocrypt -out ${KEYFILE}" "Convert from PKCS#1 to PKCS#8"
+      runcmd "rm ${KEYFILE}.tmp" "Delete the PKCS#1 format file" 
+  fi
 }
 
 function sign_csr() {
@@ -48,6 +59,11 @@ function create_tls_secret() {
   local SECRET_NAME=$2
   local KEYFILE=$3
   local CERTFILE=$4
+  if [ $(uname) = 'Darwin' ]; then
+      local WRAPOPTION="-b"
+  else
+      local WRAPOPTION="-w"
+  fi
 
   runcmd "cat <<EOF | $CMD create -n ${NAMESPACE} -f -
 {
@@ -58,8 +74,8 @@ function create_tls_secret() {
     },
     \"type\": \"kubernetes.io/tls\",
     \"data\": {
-        \"tls.key\": \"\$(base64 -w 0 ${KEYFILE})\",
-        \"tls.crt\": \"\$(base64 -w 0 ${CERTFILE})\"
+        \"tls.key\": \"\$(base64 ${WRAPOPTION} 0 ${KEYFILE})\",
+        \"tls.crt\": \"\$(base64 ${WRAPOPTION} 0 ${CERTFILE})\"
     }
 }
 EOF" "Create $SECRET_NAME TLS secret"
@@ -90,5 +106,6 @@ function create_self_signed_cert() {
     CERT=${TEMPDIR}/${CN}.crt
 
     runcmd "openssl req -new -x509 -batch -nodes -days 11000 -out ${CERT} -keyout ${KEY} -subj \"/O=io.enmasse/CN=${CN}\"" "Create self-signed certificate for ${CN}"
+    fix_key_file_format ${KEY}
     create_tls_secret $CMD $SECRET_NAME $KEY $CERT
 }

--- a/templates/install/deploy-kubernetes.sh
+++ b/templates/install/deploy-kubernetes.sh
@@ -26,7 +26,7 @@ TEMPLATE_PARAMS=""
 ENMASSE_TEMPLATE=$SCRIPTDIR/kubernetes/enmasse.yaml
 KEYCLOAK_TEMPLATE=$SCRIPTDIR/kubernetes/addons/keycloak.yaml
 KEYCLOAK_TEMPLATE_PARAMS=""
-KEYCLOAK_PASSWORD=`head /dev/urandom | tr -dc A-Za-z0-9 | head -c 128`
+KEYCLOAK_PASSWORD=`head /dev/urandom | LC_CTYPE=C tr -dc A-Za-z0-9 | head -c 128`
 DEFAULT_NAMESPACE=enmasse
 GUIDE=false
 
@@ -109,7 +109,7 @@ runcmd "kubectl create sa enmasse-service-account -n $NAMESPACE" "Create service
 CA_KEY=${TEMPDIR}/ca.key
 CA_CERT=${TEMPDIR}/ca.crt
 runcmd "openssl req -new -x509 -batch -nodes -days 11000 -subj \"/O=io.enmasse/CN=enmasse\" -out ${CA_CERT} -keyout ${CA_KEY}" "Create self-signed certificate"
-
+fix_key_file_format ${CA_KEY}
 create_tls_secret "kubectl" "enmasse-ca" $CA_KEY $CA_CERT
 
 create_and_sign_cert "kubectl " $CA_KEY $CA_CERT "address-controller.${NAMESPACE}.svc.cluster.local" "address-controller-cert"

--- a/templates/install/deploy-openshift.sh
+++ b/templates/install/deploy-openshift.sh
@@ -29,7 +29,7 @@ KEYCLOAK_TEMPLATE=$SCRIPTDIR/openshift/addons/keycloak.yaml
 KEYCLOAK_TEMPLATE_PARAMS=""
 TEMPLATE_NAME=enmasse
 TEMPLATE_PARAMS=""
-KEYCLOAK_PASSWORD=`head /dev/urandom | tr -dc A-Za-z0-9 | head -c 128`
+KEYCLOAK_PASSWORD=`head /dev/urandom | LC_CTYPE=C tr -dc A-Za-z0-9 | head -c 128`
 
 DEFAULT_USER=developer
 DEFAULT_NAMESPACE=myproject
@@ -160,6 +160,7 @@ CA_CERT=${TEMPDIR}/ca.crt
 if [ -z $CA_SECRET ]; then
     CA_SECRET=enmasse-ca
     runcmd "openssl req -new -x509 -batch -nodes -days 11000 -subj \"/O=io.enmasse/CN=enmasse\" -out ${CA_CERT} -keyout ${CA_KEY}" "Create self-signed certificate"
+    fix_key_file_format ${CA_KEY}
     create_tls_secret "oc" "enmasse-ca" $CA_KEY $CA_CERT
 else
     runcmd "oc get secret -o jsonpath='{.data.tls\.key}' ${CA_SECRET} > ${CA_KEY}" "Retrieve CA key"


### PR DESCRIPTION
OS X uses openssl 0.9.8 rather than something more modern (which uses PKCS#1 rather than PKCS#8 format for keys by default)
Also, for tr to work from /dev/urandom we must set LC_CTYPE=C (this would also likely cause problems with linux users with non-default LC_CTYPE also)
Finally the command line options for base64 are different