### PR TITLE
Deploy external loadbalancers and keycloak credentials into the correct namespace

### DIFF
--- a/templates/install/deploy-kubernetes.sh
+++ b/templates/install/deploy-kubernetes.sh
@@ -116,7 +116,7 @@ create_self_signed_cert "kubectl" "none-authservice.${NAMESPACE}.svc.cluster.loc
 
 if [ -n "$KEYCLOAK_PASSWORD" ]; then
     create_self_signed_cert "kubectl" "standard-authservice.${NAMESPACE}.svc.cluster.local" "standard-authservice-cert"
-    runcmd "kubectl create secret generic keycloak-credentials --from-literal=admin.username=admin --from-literal=admin.password=$KEYCLOAK_PASSWORD" "Create secret with keycloak admin credentials"
+    runcmd "kubectl create secret generic keycloak-credentials --from-literal=admin.username=admin --from-literal=admin.password=$KEYCLOAK_PASSWORD -n $NAMESPACE" "Create secret with keycloak admin credentials"
     runcmd "kubectl apply -f $KEYCLOAK_TEMPLATE -n $NAMESPACE" "Deploy Keycloak to $NAMESPACE"
 fi
 
@@ -129,5 +129,5 @@ runcmd "kubectl apply -f $ENMASSE_TEMPLATE -n $NAMESPACE" "Deploy EnMasse to $NA
 
 if [ "$EXTERNAL_LB" == "true" ]
 then
-    runcmd "kubectl apply -f kubernetes/addons/external-lb.yaml"
+    runcmd "kubectl apply -f kubernetes/addons/external-lb.yaml -n $NAMESPACE"
 fi


### PR DESCRIPTION
When deploying on Kubernetes, the external load balancers and keycloak credentials are deployed without namespace. As a result they end up in the default namespace and that causes problems.