### PR TITLE
Stop address controller incorrectly deleting existing queues

### DIFF
--- a/admin/address-controller/lib/src/main/java/io/enmasse/controller/api/v1/AddressApiHelper.java
+++ b/admin/address-controller/lib/src/main/java/io/enmasse/controller/api/v1/AddressApiHelper.java
@@ -1,15 +1,17 @@
 package io.enmasse.controller.api.v1;
 
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.ws.rs.NotFoundException;
+
 import io.enmasse.address.model.Address;
 import io.enmasse.address.model.AddressList;
 import io.enmasse.address.model.AddressSpace;
 import io.enmasse.k8s.api.AddressApi;
 import io.enmasse.k8s.api.AddressSpaceApi;
-
-import javax.ws.rs.NotFoundException;
-import java.io.IOException;
-import java.util.Optional;
-import java.util.Set;
 
 /**
  * This is a handler for doing operations on the addressing manager that works independent of AMQP and HTTP.
@@ -33,7 +35,7 @@ public class AddressApiHelper {
         AddressSpace addressSpace = getOrCreateAddressSpace(addressSpaceId);
         AddressApi addressApi = addressSpaceApi.withAddressSpace(addressSpace);
 
-        Set<Address> toRemove = addressApi.listAddresses();
+        Set<Address> toRemove = new HashSet<>(addressApi.listAddresses());
         toRemove.removeAll(addressList);
         toRemove.forEach(addressApi::deleteAddress);
         addressList.forEach(addressApi::createAddress);

--- a/admin/address-controller/lib/src/test/java/io/enmasse/controller/api/v1/AddressApiHelperTest.java
+++ b/admin/address-controller/lib/src/test/java/io/enmasse/controller/api/v1/AddressApiHelperTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.enmasse.controller.api.v1;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import io.enmasse.address.model.Address;
+import io.enmasse.address.model.AddressList;
+import io.enmasse.address.model.AddressSpace;
+import io.enmasse.address.model.types.standard.StandardType;
+import io.enmasse.k8s.api.AddressApi;
+import io.enmasse.k8s.api.AddressSpaceApi;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AddressApiHelperTest {
+
+    private AddressApiHelper helper;
+    private AddressApi addressApi;
+
+    @Before
+    public void setup() {
+        AddressSpace addressSpace = mock(AddressSpace.class);
+        AddressSpaceApi addressSpaceApi = mock(AddressSpaceApi.class);
+        addressApi = mock(AddressApi.class);
+        when(addressSpaceApi.getAddressSpaceWithName(eq("test"))).thenReturn(Optional.of(addressSpace));
+        when(addressSpaceApi.withAddressSpace(eq(addressSpace))).thenReturn(addressApi);
+        helper = new AddressApiHelper(addressSpaceApi);
+    }
+
+    @Test
+    public void testPutAddresses() throws Exception {
+        final Set<Address> addresses = new HashSet<>();
+        when(addressApi.listAddresses()).thenReturn(Collections.singleton(createAddress("q1")));
+        addresses.add(createAddress("q1"));
+        addresses.add(createAddress("q2"));
+        helper.putAddresses("test", new AddressList(addresses));
+        verify(addressApi, never()).deleteAddress(any());
+        verify(addressApi).createAddress(eq(createAddress("q2")));
+    }
+
+    private Address createAddress(final String name)
+    {
+        return new Address.Builder().setName(name).setAddressSpace("test").setType(StandardType.QUEUE).setPlan(StandardType.QUEUE.getDefaultPlan()).build();
+    }
+}

--- a/admin/common-lib/config/src/main/java/io/enmasse/address/model/Address.java
+++ b/admin/common-lib/config/src/main/java/io/enmasse/address/model/Address.java
@@ -15,11 +15,12 @@
  */
 package io.enmasse.address.model;
 
-import io.enmasse.address.model.types.AddressType;
-import io.enmasse.address.model.types.Plan;
-
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.UUID;
+
+import io.enmasse.address.model.types.AddressType;
+import io.enmasse.address.model.types.Plan;
 
 /**
  * An EnMasse Address addressspace.
@@ -95,8 +96,8 @@ public class Address {
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("{address=").append(address).append(",");
-        sb.append("name=").append(address).append(",");
-        sb.append("uuid=").append(address).append(",");
+        sb.append("name=").append(name).append(",");
+        sb.append("uuid=").append(uuid).append(",");
         sb.append("type=").append(type).append(",");
         sb.append("plan=").append(plan).append(",");
         sb.append("status=").append(status).append("}");
@@ -105,7 +106,7 @@ public class Address {
 
     public static class Builder {
         private String name;
-        private String uuid = UUID.randomUUID().toString();
+        private String uuid;
         private String address;
         private String addressSpace = "default";
         private AddressType type;
@@ -173,7 +174,9 @@ public class Address {
             Objects.requireNonNull(type, "type not set");
             Objects.requireNonNull(plan, "plan not set");
             Objects.requireNonNull(status, "status not set");
-
+            if(uuid == null) {
+                uuid = UUID.nameUUIDFromBytes(address.getBytes(StandardCharsets.UTF_8)).toString();
+            }
             return new Address(name, uuid, address, addressSpace, type, plan, status);
         }
     }


### PR DESCRIPTION
Address objects are compared including their uuid, however where a request is made without specifying a uuid then a random value is generated.
Instead a stable uuid value should be generated based on the address string if no uuid is supplied.