### PR TITLE
Add TLS support for AMQP-Kafka bridge

### DIFF
--- a/templates/include/amqp-kafka-bridge.jsonnet
+++ b/templates/include/amqp-kafka-bridge.jsonnet
@@ -31,57 +31,18 @@ local common = import "common.jsonnet";
           },
           "spec": {
             "containers": [
-              {
-                "image": image_repo,
-                "name": "amqp-kafka-bridge",
-                "env": [
-                  {
-                    "name": "AMQP_CERT_DIR",
-                    "value": "/etc/enmasse-certs"
-                  },
-                  {
-                    "name": "KAFKA_BOOTSTRAP_SERVERS",
-                    "value": "${KAFKA_BOOTSTRAP_SERVERS}"
-                  }
-                ],
-                "resources": {
-                    "requests": {
-                        "memory": "512Mi"
-                    },
-                    "limits": {
-                        "memory": "512Mi"
-                    }
-                },
-                "volumeMounts": [
-                  {
-                    "name": certSecretName,
-                    "mountPath": "/etc/enmasse-certs",
-                    "readOnly": true
-                  }
-                ],
-                "ports": [
-                  {
-                    "name": "health",
-                    "containerPort": "8080"
-                  },
-                  {
-                    "name": "ready",
-                    "containerPort": "8080"
-                  }
-                ],
-                "livenessProbe": {
-                  "httpGet": {
-                    "path": "/health",
-                    "port": "health"
-                  }
-                },
-                "readinessProbe": {
-                  "httpGet": {
-                    "path": "/ready",
-                    "port": "ready"
-                  }
-                },
-              }
+              common.clientContainer("amqp-kafka-bridge", image_repo, "512Mi", [{
+                          "name": "AMQP_CERT_DIR",
+                          "value": "/etc/enmasse-certs"
+                        }, {
+                          "name": "KAFKA_BOOTSTRAP_SERVERS",
+                          "value": "${KAFKA_BOOTSTRAP_SERVERS}"
+                        }], [{
+                          "name": certSecretName,
+                          "mountPath": "/etc/enmasse-certs",
+                          "readOnly": true
+                        }],
+                        true, true),
             ],
             "volumes": [
               {

--- a/templates/include/common.jsonnet
+++ b/templates/include/common.jsonnet
@@ -26,7 +26,7 @@
     }
   },
 
-  clientContainer(name, image, mem_request, env, http_health, http_ready)::
+  clientContainer(name, image, mem_request, env, volumeMounts, http_health, http_ready)::
   {
     local health_port =
     {
@@ -55,6 +55,7 @@
     "image": image,
     "name": name,
     "env": env,
+    "volumeMounts": volumeMounts,
     "resources": {
         "requests": {
             "memory": mem_request,

--- a/templates/install/openshift/enmasse-with-kafka.yaml
+++ b/templates/install/openshift/enmasse-with-kafka.yaml
@@ -1248,6 +1248,7 @@ objects:
     metadata:
       annotations:
         addressSpace: "${ADDRESS_SPACE}"
+        io.enmasse.certSecretName: amqp-kafka-bridge-internal-cert
       labels:
         app: enmasse
         name: amqp-kafka-bridge
@@ -1265,6 +1266,8 @@ objects:
         spec:
           containers:
           - env:
+            - name: AMQP_CERT_DIR
+              value: /etc/enmasse-certs
             - name: KAFKA_BOOTSTRAP_SERVERS
               value: "${KAFKA_BOOTSTRAP_SERVERS}"
             image: "${AMQP_KAFKA_BRIDGE_REPO}"
@@ -1287,6 +1290,14 @@ objects:
                 memory: 512Mi
               requests:
                 memory: 512Mi
+            volumeMounts:
+            - mountPath: /etc/enmasse-certs
+              name: amqp-kafka-bridge-internal-cert
+              readOnly: true
+          volumes:
+          - name: amqp-kafka-bridge-internal-cert
+            secret:
+              secretName: amqp-kafka-bridge-internal-cert
   parameters:
   - description: Hostname where API server can be reached
     name: ADDRESS_SPACE_SERVICE_HOST


### PR DESCRIPTION
In master the AMQP-Kafka bridge doesn't work because the bridge doesn't use TLS and the right port when connecting to the router. 

This PR adds the annotation to the bridge deployment to generate the secret with TLS certificates and maps this secret as a volume. A second PR  EnMasseProject/amqp-kafka-bridge#75 adds TLS support for the bridge it self.