### PR TITLE
Downgrade gradle wrapper version

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jun 29 21:10:52 CEST 2017
+#Tue Sep 12 13:43:07 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.5.1-all.zip


### PR DESCRIPTION
Gradle 4.x can cause issues with older (2016) versions of IntelliJ