### PR TITLE
Always provide list of items in JSON serialisation of an AddressList

### DIFF
--- a/admin/common-lib/config/src/main/java/io/enmasse/address/model/v1/AddressListV1Serializer.java
+++ b/admin/common-lib/config/src/main/java/io/enmasse/address/model/v1/AddressListV1Serializer.java
@@ -36,12 +36,10 @@ class AddressListV1Serializer extends JsonSerializer<AddressList> {
         ObjectNode root = (ObjectNode) jsonGenerator.getCodec().createObjectNode();
         root.put(Fields.API_VERSION, "enmasse.io/v1");
         root.put(Fields.KIND, "AddressList");
-        if (!addressList.isEmpty()) {
-            ArrayNode items = root.putArray(Fields.ITEMS);
-            for (Address address : addressList) {
-                ObjectNode entry = items.addObject();
-                AddressV1Serializer.serialize(address, entry);
-            }
+        ArrayNode items = root.putArray(Fields.ITEMS);
+        for (Address address : addressList) {
+            ObjectNode entry = items.addObject();
+            AddressV1Serializer.serialize(address, entry);
         }
         root.serialize(jsonGenerator, serializerProvider);
     }

--- a/admin/common-lib/config/src/main/java/io/enmasse/address/model/v1/AddressSpaceListV1Serializer.java
+++ b/admin/common-lib/config/src/main/java/io/enmasse/address/model/v1/AddressSpaceListV1Serializer.java
@@ -35,12 +35,10 @@ class AddressSpaceListV1Serializer extends JsonSerializer<AddressSpaceList> {
         ObjectNode root = (ObjectNode) jsonGenerator.getCodec().createObjectNode();
         root.put(Fields.API_VERSION, "enmasse.io/v1");
         root.put(Fields.KIND, "AddressSpaceList");
-        if (!addressSpaceList.isEmpty()) {
-            ArrayNode items = root.putArray(Fields.ITEMS);
-            for (AddressSpace addressSpace : addressSpaceList) {
-                ObjectNode entry = items.addObject();
-                AddressSpaceV1Serializer.serialize(addressSpace, entry);
-            }
+        ArrayNode items = root.putArray(Fields.ITEMS);
+        for (AddressSpace addressSpace : addressSpaceList) {
+            ObjectNode entry = items.addObject();
+            AddressSpaceV1Serializer.serialize(addressSpace, entry);
         }
         root.serialize(jsonGenerator, serializerProvider);
     }

--- a/admin/common-lib/config/src/main/java/io/enmasse/address/model/v1/AddressSpaceV1Serializer.java
+++ b/admin/common-lib/config/src/main/java/io/enmasse/address/model/v1/AddressSpaceV1Serializer.java
@@ -53,19 +53,17 @@ class AddressSpaceV1Serializer extends JsonSerializer<AddressSpace> {
         spec.put(Fields.TYPE, addressSpace.getType().getName());
         spec.put(Fields.PLAN, addressSpace.getPlan().getName());
 
-        if (!addressSpace.getEndpoints().isEmpty()) {
-            ArrayNode endpoints = spec.putArray(Fields.ENDPOINTS);
-            for (io.enmasse.address.model.Endpoint endpoint : addressSpace.getEndpoints()) {
-                ObjectNode e = endpoints.addObject();
-                e.put(Fields.NAME, endpoint.getName());
-                e.put(Fields.SERVICE, endpoint.getService());
-                endpoint.getHost().ifPresent(h -> e.put(Fields.HOST, h));
-                endpoint.getCertProvider().ifPresent(provider -> {
-                    ObjectNode p = e.putObject(Fields.CERT_PROVIDER);
-                    p.put(Fields.NAME, provider.getName());
-                    p.put(Fields.SECRET_NAME, provider.getSecretName());
-                });
-            }
+        ArrayNode endpoints = spec.putArray(Fields.ENDPOINTS);
+        for (io.enmasse.address.model.Endpoint endpoint : addressSpace.getEndpoints()) {
+            ObjectNode e = endpoints.addObject();
+            e.put(Fields.NAME, endpoint.getName());
+            e.put(Fields.SERVICE, endpoint.getService());
+            endpoint.getHost().ifPresent(h -> e.put(Fields.HOST, h));
+            endpoint.getCertProvider().ifPresent(provider -> {
+                ObjectNode p = e.putObject(Fields.CERT_PROVIDER);
+                p.put(Fields.NAME, provider.getName());
+                p.put(Fields.SECRET_NAME, provider.getSecretName());
+            });
         }
 
         ObjectNode authenticationService = spec.putObject(Fields.AUTHENTICATION_SERVICE);

--- a/admin/common-lib/config/src/test/java/io/enmasse/address/model/v1/address/SerializationTest.java
+++ b/admin/common-lib/config/src/test/java/io/enmasse/address/model/v1/address/SerializationTest.java
@@ -30,6 +30,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 // TODO: Add more tests of invalid input to deserialization
 public class SerializationTest {
@@ -100,6 +101,21 @@ public class SerializationTest {
 
         assertThat(deserialized, is(list));
     }
+
+
+    @Test
+    public void testSerializeEmptyAddressList() throws IOException {
+
+        AddressList list = new AddressList(Collections.emptySet());
+
+        String serialized = CodecV1.getMapper().writeValueAsString(list);
+        assertTrue("Serialized form '"+serialized+"' does not include empty items list",
+                   serialized.matches(".*\"items\"\\s*:\\s*\\[\\s*\\].*"));
+        List<Address> deserialized = CodecV1.getMapper().readValue(serialized, AddressList.class);
+
+        assertThat(deserialized, is(list));
+    }
+
 
     @Test
     public void testSerializeAddressSpace() throws IOException {


### PR DESCRIPTION
When serializing address lists always provide a (possibly empty) list of items.

This closes #216