### PR TITLE
Disable automatic ingress for endpoints

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -6,10 +6,8 @@ if [ "$VERSION" != "latest" ]; then
     export TAG=$VERSION
 fi
 
-IS_PR=false
 if [ "$TRAVIS_BRANCH" != "master" ] && [ "$TRAVIS_BRANCH" != "$TRAVIS_TAG" ] || [ "$TRAVIS_PULL_REQUEST" != "false" ]
 then
-    export IS_PR=true
     export DOCKER_REGISTRY="172.30.1.1:5000"
     export DOCKER_ORG=enmasseci
 fi
@@ -20,7 +18,7 @@ MOCHA_ARGS="--reporter=mocha-junit-reporter" make
 echo "Tagging Docker Images"
 make docker_tag
 #
-if [ "$IS_PR" == "true" ]
+if [ "$TRAVIS_BRANCH" != "master" ] && [ "$TRAVIS_BRANCH" != "$TRAVIS_TAG" ] || [ "$TRAVIS_PULL_REQUEST" != "false" ]
 then
     echo "Logging into to local docker registry"
     oc login -u test -p test --insecure-skip-tls-verify=true https://localhost:8443

--- a/admin/address-controller/lib/src/main/java/io/enmasse/controller/common/KubernetesHelper.java
+++ b/admin/address-controller/lib/src/main/java/io/enmasse/controller/common/KubernetesHelper.java
@@ -258,34 +258,6 @@ public class KubernetesHelper implements Kubernetes {
                         .endSpec();
             }
             route.done();
-        } else {
-            DoneableIngress ingress = client.extensions().ingresses().inNamespace(namespace).createNew()
-                    .editOrNewMetadata()
-                    .withName(endpoint.getName())
-                    .addToAnnotations(AnnotationKeys.ADDRESS_SPACE, addressSpaceName)
-                    .endMetadata()
-                    .editOrNewSpec()
-                    .editOrNewBackend()
-                    .withServiceName(endpoint.getService())
-                    .withServicePort(new IntOrString(servicePortMap.get(endpoint.getService())))
-                    .endBackend()
-                    .endSpec();
-
-            if (endpoint.getCertProvider().isPresent()) {
-                ingress.editOrNewMetadata()
-                        .addToAnnotations(AnnotationKeys.CERT_SECRET_NAME, endpoint.getCertProvider().get().getSecretName())
-                        .endMetadata()
-                        .editOrNewSpec();
-
-                if (endpoint.getHost().isPresent()) {
-                    ingress.editOrNewSpec()
-                            .addNewTl()
-                            .addToHosts(endpoint.getHost().get())
-                            .withSecretName(endpoint.getCertProvider().get().getSecretName())
-                            .endTl();
-                }
-            }
-            ingress.done();
         }
     }
 

--- a/documentation/getting-started/kubernetes.adoc
+++ b/documentation/getting-started/kubernetes.adoc
@@ -123,6 +123,15 @@ kubectl apply -f kubernetes/addons/external-lb.yaml -n enmasse
 The EnMasse console should be available at `http://$(minikube ip)/`. You
 can create and monitor queues and topics using the UI.
 
+[[exposing-console]]
+=== Exposing console througn Ingress
+
+To expose the EnMasse console, you can deploy this ingress resource:
+
+....
+kubectl apply -f kubernetes/addons/console-ingress.yaml -n enmasse
+....
+
 [[exposing-messaging-through-ingress-resource]]
 === Exposing messaging through Ingress resource
 

--- a/templates/install/kubernetes/addons/console-ingress.yaml
+++ b/templates/install/kubernetes/addons/console-ingress.yaml
@@ -1,0 +1,12 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: console
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /
+        backend:
+          serviceName: console
+          servicePort: 8080


### PR DESCRIPTION
This feature is only half-working due to limited capability in
ingress resources. Instead, add instructions on how to add
ingress manually to console.