### PR TITLE
Use TLS when connecting to router for address health check

### DIFF
--- a/admin/address-controller/lib/src/main/java/io/enmasse/controller/auth/AuthController.java
+++ b/admin/address-controller/lib/src/main/java/io/enmasse/controller/auth/AuthController.java
@@ -15,6 +15,7 @@
  */
 package io.enmasse.controller.auth;
 
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -121,7 +122,7 @@ public class AuthController extends AbstractVerticle implements Watcher<AddressS
     }
 
     private void issueComponentCertificates(AddressSpace addressSpace) {
-        vertx.executeBlocking(promise -> {
+        vertx.executeBlocking((Future<List<Cert>> promise) -> {
             try {
                 final String caSecretName = KubeUtil.getAddressSpaceCaSecretName(addressSpace.getNamespace());
                 promise.complete(certManager.listComponents(addressSpace.getNamespace()).stream()
@@ -138,7 +139,10 @@ public class AuthController extends AbstractVerticle implements Watcher<AddressS
             }
         }, result -> {
             if (result.succeeded()) {
-                log.info("Issued component certificates: {}", result.result());
+                List<Cert> components = result.result();
+                if (!components.isEmpty()) {
+                    log.info("Issued component certificates: {}", result.result());
+                }
             } else {
                 log.warn("Error issuing component certificates", result.cause());
             }

--- a/admin/address-controller/lib/src/main/java/io/enmasse/controller/auth/AuthController.java
+++ b/admin/address-controller/lib/src/main/java/io/enmasse/controller/auth/AuthController.java
@@ -102,7 +102,7 @@ public class AuthController extends AbstractVerticle implements Watcher<AddressS
     {
         vertx.executeBlocking(promise -> {
             try {
-                final String addressSpaceCaSecretName = getAddressSpaceCaSecretName(addressSpace);
+                final String addressSpaceCaSecretName = KubeUtil.getAddressSpaceCaSecretName(addressSpace.getNamespace());
                 if(!certManager.certExists(addressSpaceCaSecretName)) {
                     certManager.createSelfSignedCertSecret(addressSpaceCaSecretName);
                     //put crt into address space
@@ -123,7 +123,7 @@ public class AuthController extends AbstractVerticle implements Watcher<AddressS
     private void issueComponentCertificates(AddressSpace addressSpace) {
         vertx.executeBlocking(promise -> {
             try {
-                final String caSecretName = getAddressSpaceCaSecretName(addressSpace);
+                final String caSecretName = KubeUtil.getAddressSpaceCaSecretName(addressSpace.getNamespace());
                 promise.complete(certManager.listComponents(addressSpace.getNamespace()).stream()
                         .filter(component -> !certManager.certExists(component))
                         .map(certManager::createCsr)
@@ -143,10 +143,5 @@ public class AuthController extends AbstractVerticle implements Watcher<AddressS
                 log.warn("Error issuing component certificates", result.cause());
             }
         });
-    }
-
-    private static String getAddressSpaceCaSecretName(final AddressSpace addressSpace)
-    {
-        return KubeUtil.sanitizeName("addressspace-" + addressSpace.getNamespace() + "-ca");
     }
 }

--- a/admin/address-controller/lib/src/main/java/io/enmasse/controller/standard/AddressController.java
+++ b/admin/address-controller/lib/src/main/java/io/enmasse/controller/standard/AddressController.java
@@ -220,7 +220,7 @@ public class AddressController extends AbstractVerticle implements Watcher<Addre
         // running inside the address space instead.
         Optional<Secret> addressSpaceCaSecret = kubernetes.getSecret(KubeUtil.getAddressSpaceCaSecretName(kubernetes.getNamespace()));
         if (port != 0 && addressSpaceCaSecret.isPresent() && addressSpaceCaSecret.get().getData() != null) {
-            log.info("Checkieng router status of router " + router.getStatus().getPodIP());
+            log.debug("Checking router status of router " + router.getStatus().getPodIP());
             Buffer ca = Buffer.buffer(Base64.getDecoder().decode(addressSpaceCaSecret.get().getData().get("tls.crt")));
             ProtonClientOptions clientOptions = new ProtonClientOptions()
                     .setSsl(true)

--- a/admin/address-controller/lib/src/main/java/io/enmasse/controller/standard/StandardController.java
+++ b/admin/address-controller/lib/src/main/java/io/enmasse/controller/standard/StandardController.java
@@ -33,6 +33,7 @@ import io.vertx.core.Future;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -54,13 +55,15 @@ public class StandardController extends AbstractVerticle implements Watcher<Addr
     private final Map<AddressSpace, String> addressControllerMap = new HashMap<>();
     private final Kubernetes kubernetes;
     private final AuthenticationServiceResolverFactory authResolverFactory;
+    private final String certDir;
 
-    public StandardController(OpenShiftClient client, AddressSpaceApi addressSpaceApi, Kubernetes kubernetes, AuthenticationServiceResolverFactory authResolverFactory, boolean isMultitenant, UserDatabase userDatabase) {
+    public StandardController(OpenShiftClient client, AddressSpaceApi addressSpaceApi, Kubernetes kubernetes, AuthenticationServiceResolverFactory authResolverFactory, boolean isMultitenant, UserDatabase userDatabase, String certDir) {
         this.helper = new StandardHelper(kubernetes, isMultitenant, authResolverFactory, userDatabase);
         this.client = client;
         this.addressSpaceApi = addressSpaceApi;
         this.kubernetes = kubernetes;
         this.authResolverFactory = authResolverFactory;
+        this.certDir = certDir;
     }
 
     @Override
@@ -125,7 +128,8 @@ public class StandardController extends AbstractVerticle implements Watcher<Addr
                 AddressController addressController = new AddressController(
                         addressSpaceApi.withAddressSpace(addressSpace),
                         kubernetes.withNamespace(addressSpace.getNamespace()),
-                        clusterGenerator);
+                        clusterGenerator,
+                        certDir);
                 log.info("Deploying address space controller for " + addressSpace.getName());
                 vertx.deployVerticle(addressController, result -> {
                     if (result.succeeded()) {

--- a/admin/address-controller/lib/src/test/java/io/enmasse/controller/standard/AddressControllerTest.java
+++ b/admin/address-controller/lib/src/test/java/io/enmasse/controller/standard/AddressControllerTest.java
@@ -54,7 +54,7 @@ public class AddressControllerTest {
         mockClient = mock(OpenShiftClient.class);
 
         when(mockHelper.getNamespace()).thenReturn("myinstance");
-        controller = new AddressController(mockApi, mockHelper, mockGenerator);
+        controller = new AddressController(mockApi, mockHelper, mockGenerator, null);
     }
 
     private Address createAddress(String address, AddressType type) {

--- a/admin/address-controller/server/src/main/java/io/enmasse/controller/Controller.java
+++ b/admin/address-controller/server/src/main/java/io/enmasse/controller/Controller.java
@@ -97,7 +97,7 @@ public class Controller extends AbstractVerticle {
 
         deployVerticles(startPromise,
                 new Deployment(new AuthController(certManager, addressSpaceApi)),
-                new Deployment(new StandardController(controllerClient, addressSpaceApi, kubernetes, createResolverFactory(options), options.isMultiinstance(), userDb)),
+                new Deployment(new StandardController(controllerClient, addressSpaceApi, kubernetes, createResolverFactory(options), options.isMultiinstance(), userDb, options.certDir())),
 //                new Deployment(new AMQPServer(kubernetes.getNamespace(), addressSpaceApi, options.port())),
                 new Deployment(new HTTPServer(addressSpaceApi, options.certDir(), options.osbAuth().orElse(null), userDb), new DeploymentOptions().setWorker(true)));
     }

--- a/admin/address-controller/server/src/main/java/io/enmasse/controller/HTTPServer.java
+++ b/admin/address-controller/server/src/main/java/io/enmasse/controller/HTTPServer.java
@@ -126,15 +126,10 @@ public class HTTPServer extends AbstractVerticle {
         if (new File(certDir).exists()) {
             HttpServerOptions options = new HttpServerOptions();
             File keyFile = new File(certDir, "tls.key");
-            // TODO: Remove once Vert.x supports PKCS#1: https://github.com/eclipse/vert.x/issues/1851
-            // This also implies that _KEY ROTATION DOES NOT WORK_
-            File outputFile = new File("/tmp/pkcs8.key");
-            convertKey(keyFile, outputFile);
-
             File certFile = new File(certDir, "tls.crt");
             log.info("Loading key from " + keyFile.getAbsolutePath() + ", cert from " + certFile.getAbsolutePath());
             options.setKeyCertOptions(new PemKeyCertOptions()
-                    .setKeyPath(outputFile.getAbsolutePath())
+                    .setKeyPath(keyFile.getAbsolutePath())
                     .setCertPath(certFile.getAbsolutePath()));
             options.setSsl(true);
 
@@ -153,18 +148,6 @@ public class HTTPServer extends AbstractVerticle {
             startPromise.complete();
         }
     }
-
-    private void convertKey(File keyFile, File outputFile) {
-        try {
-            Process p = new ProcessBuilder("openssl", "pkcs8", "-topk8", "-inform", "PEM",
-                    "-outform", "PEM", "-nocrypt", "-in", keyFile.getAbsolutePath(), "-out", outputFile.getAbsolutePath())
-                    .start();
-            p.waitFor(1, TimeUnit.MINUTES);
-        } catch (Exception e) {
-            log.info("Error converting key from PKCS#1 to PKCS#8");
-        }
-    }
-
 
     private void createOpenServer(VertxRequestHandler requestHandler, Future<Void> startPromise) {
         httpServer = vertx.createHttpServer()

--- a/admin/common-lib/amqp/src/main/java/io/enmasse/amqp/SyncRequestClient.java
+++ b/admin/common-lib/amqp/src/main/java/io/enmasse/amqp/SyncRequestClient.java
@@ -17,13 +17,13 @@
 package io.enmasse.amqp;
 
 import io.vertx.core.Vertx;
-import io.vertx.proton.ProtonClient;
-import io.vertx.proton.ProtonConnection;
-import io.vertx.proton.ProtonReceiver;
-import io.vertx.proton.ProtonSender;
+import io.vertx.core.net.PemKeyCertOptions;
+import io.vertx.core.net.PemTrustOptions;
+import io.vertx.proton.*;
 import org.apache.qpid.proton.amqp.messaging.Source;
 import org.apache.qpid.proton.message.Message;
 
+import java.io.File;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -36,15 +36,21 @@ public class SyncRequestClient implements AutoCloseable {
     private final String host;
     private final int port;
     private final Vertx vertx;
+    private final ProtonClientOptions clientOptions;
 
     public SyncRequestClient(String host, int port) {
         this(host, port, Vertx.vertx());
     }
 
     public SyncRequestClient(String host, int port, Vertx vertx) {
+        this(host, port, vertx, new ProtonClientOptions());
+    }
+
+    public SyncRequestClient(String host, int port, Vertx vertx, ProtonClientOptions clientOptions) {
         this.host = host;
         this.port = port;
         this.vertx = vertx;
+        this.clientOptions = clientOptions;
     }
 
     public Message request(Message message, long timeout, TimeUnit timeUnit) throws InterruptedException, TimeoutException, ExecutionException {
@@ -52,7 +58,7 @@ public class SyncRequestClient implements AutoCloseable {
         CompletableFuture<Message> response = new CompletableFuture<>();
 
         ProtonClient client = ProtonClient.create(vertx);
-        client.connect(host, port, connectEvent -> {
+        client.connect(clientOptions, host, port, connectEvent -> {
             if (connectEvent.succeeded()) {
                 ProtonConnection connection = connectEvent.result();
                 connection.open();

--- a/admin/k8s-api/src/main/java/io/enmasse/k8s/api/KubeUtil.java
+++ b/admin/k8s-api/src/main/java/io/enmasse/k8s/api/KubeUtil.java
@@ -29,4 +29,8 @@ public class KubeUtil {
         }
         return replaced;
     }
+
+    public static String getAddressSpaceCaSecretName(String namespace) {
+        return sanitizeName("addressspace-" + namespace + "-ca");
+    }
 }

--- a/router/qdrouterd.conf.template
+++ b/router/qdrouterd.conf.template
@@ -71,7 +71,7 @@ sslProfile {
    name: ssl_internal_details
    certFile: /etc/enmasse-certs/tls.crt
    keyFile: /etc/enmasse-certs/tls.key
-   certDb: /etc/enmasse-certs/ca.crt
+   certDb: /tmp/ca.crt
 }
 
 listener {

--- a/router/run_qdr.sh
+++ b/router/run_qdr.sh
@@ -32,4 +32,12 @@ fi
 if [ -n "$AMQP_KAFKA_BRIDGE_SERVICE_HOST" ]; then
     envsubst < /etc/qpid-dispatch/amqp-kafka-bridge.snippet >> /tmp/qdrouterd.conf
 fi
+
+# TODO: This is a hack for allowing 2 CAs (address space + address controller) to be accepted as
+# avalid clients. This is needed by the address controller to check the router status
+if [ -d "/etc/enmasse-certs" ] && [ -d "/etc/qpid-dispatch/address-controller-ca" ]; then
+    cat /etc/enmasse-certs/ca.crt > /tmp/ca.crt
+    cat /etc/qpid-dispatch/address-controller-ca/tls.crt >> /tmp/ca.crt
+fi
+
 exec /sbin/qdrouterd --conf /tmp/qdrouterd.conf

--- a/templates/include/enmasse-instance-infra.jsonnet
+++ b/templates/include/enmasse-instance-infra.jsonnet
@@ -37,7 +37,7 @@ local images = import "images.jsonnet";
       messagingService.internal("${ADDRESS_SPACE}"),
       subserv.service("${ADDRESS_SPACE}"),
       mqttService.internal("${ADDRESS_SPACE}"),
-      qdrouterd.deployment("${ADDRESS_SPACE}", "${ROUTER_REPO}", "${ROUTER_METRICS_REPO}", "${ROUTER_SECRET}", "authservice-ca"),
+      qdrouterd.deployment("${ADDRESS_SPACE}", "${ROUTER_REPO}", "${ROUTER_METRICS_REPO}", "${ROUTER_SECRET}", "authservice-ca", "address-controller-ca"),
       subserv.deployment("${ADDRESS_SPACE}", "${SUBSERV_REPO}"),
       mqttGateway.deployment("${ADDRESS_SPACE}", "${MQTT_GATEWAY_REPO}", "${MQTT_SECRET}"),
       mqttLwt.deployment("${ADDRESS_SPACE}", "${MQTT_LWT_REPO}"),

--- a/templates/include/qdrouterd.jsonnet
+++ b/templates/include/qdrouterd.jsonnet
@@ -1,7 +1,7 @@
 local router = import "router.jsonnet";
 local common = import "common.jsonnet";
 {
-  deployment(addressSpace, image_repo, metrics_image_repo, router_secret, auth_service_ca_secret)::
+  deployment(addressSpace, image_repo, metrics_image_repo, router_secret, auth_service_ca_secret, address_controller_ca_secret)::
     {
       "apiVersion": "extensions/v1beta1",
       "kind": "Deployment",
@@ -36,6 +36,7 @@ local common = import "common.jsonnet";
               router.hawkular_volume(),
               router.secret_volume("ssl-certs", router_secret),
               router.secret_volume("authservice-ca", auth_service_ca_secret),
+              router.secret_volume("address-controller-ca", address_controller_ca_secret),
               router.secret_volume("router-internal-cert", "router-internal-cert"),
             ]
           }

--- a/templates/include/router.jsonnet
+++ b/templates/include/router.jsonnet
@@ -104,6 +104,12 @@ local authService = import "auth-service.jsonnet";
         "readOnly": true
       }],
 
+      local address_controller_ca = [{
+        "name": "address-controller-ca",
+        "mountPath": "/etc/qpid-dispatch/address-controller-ca",
+        "readOnly": true
+      }],
+
       local router_internal_cert = [{
         "name": internal_cert_volume,
         "mountPath": "/etc/enmasse-certs",
@@ -111,7 +117,7 @@ local authService = import "auth-service.jsonnet";
       }],
 
       [if mem_request != "" then "resources"]: resources,
-      "volumeMounts": ssl_certs + authservice_ca + router_internal_cert
+      "volumeMounts": ssl_certs + authservice_ca + router_internal_cert + address_controller_ca
     },
 
   secret_volume(name, secret)::

--- a/templates/include/storage-template.jsonnet
+++ b/templates/include/storage-template.jsonnet
@@ -58,6 +58,7 @@ local forwarder = import "forwarder.jsonnet";
                 brokerVolume,
                 router.secret_volume("ssl-certs", "${COLOCATED_ROUTER_SECRET}"),
                 router.secret_volume("authservice-ca", "authservice-ca"),
+                router.secret_volume("address-controller-ca", "address-controller-ca"),
                 router.secret_volume("broker-internal-cert", "broker-internal-cert"),
                 broker.hawkularVolume()
               ],

--- a/templates/install/kubernetes/enmasse.yaml
+++ b/templates/install/kubernetes/enmasse.yaml
@@ -58,15 +58,17 @@ items:
       "/etc/qpid-dispatch/ssl", "name": "ssl-certs", "readOnly": true}, {"mountPath":
       "/etc/qpid-dispatch/authservice-ca", "name": "authservice-ca", "readOnly": true},
       {"mountPath": "/etc/enmasse-certs", "name": "router-internal-cert", "readOnly":
-      true}]}, {"env": [{"name": "ROUTER_HOST", "value": "127.0.0.1"}, {"name": "ROUTER_PORT",
-      "value": "55671"}, {"name": "CERT_DIR", "value": "/etc/enmasse-certs"}], "image":
-      "${ROUTER_METRICS_REPO}", "livenessProbe": {"tcpSocket": {"port": "metrics"}},
+      true}, {"mountPath": "/etc/qpid-dispatch/address-controller-ca", "name": "address-controller-ca",
+      "readOnly": true}]}, {"env": [{"name": "ROUTER_HOST", "value": "127.0.0.1"},
+      {"name": "ROUTER_PORT", "value": "55671"}, {"name": "CERT_DIR", "value": "/etc/enmasse-certs"}],
+      "image": "${ROUTER_METRICS_REPO}", "livenessProbe": {"tcpSocket": {"port": "metrics"}},
       "name": "metrics", "ports": [{"containerPort": 8080, "name": "metrics", "protocol":
       "TCP"}], "resources": {"limits": {"memory": "32Mi"}, "requests": {"memory":
       "32Mi"}}, "volumeMounts": [{"mountPath": "/etc/enmasse-certs", "name": "router-internal-cert",
       "readOnly": true}]}], "volumes": [{"configMap": {"name": "hawkular-router-config"},
       "name": "hawkular-openshift-agent"}, {"name": "ssl-certs", "secret": {"secretName":
       "${ROUTER_SECRET}"}}, {"name": "authservice-ca", "secret": {"secretName": "authservice-ca"}},
+      {"name": "address-controller-ca", "secret": {"secretName": "address-controller-ca"}},
       {"name": "router-internal-cert", "secret": {"secretName": "router-internal-cert"}}]}}}},
       {"apiVersion": "extensions/v1beta1", "kind": "Deployment", "metadata": {"annotations":
       {"addressSpace": "${ADDRESS_SPACE}", "io.enmasse.certSecretName": "subserv-internal-cert"},
@@ -237,7 +239,8 @@ items:
       "name": "broker-internal-cert", "readOnly": true}]}], "volumes": [{"emptyDir":
       { }, "name": "vol-${NAME}"}, {"name": "ssl-certs", "secret": {"secretName":
       "${COLOCATED_ROUTER_SECRET}"}}, {"name": "authservice-ca", "secret": {"secretName":
-      "authservice-ca"}}, {"name": "broker-internal-cert", "secret": {"secretName":
+      "authservice-ca"}}, {"name": "address-controller-ca", "secret": {"secretName":
+      "address-controller-ca"}}, {"name": "broker-internal-cert", "secret": {"secretName":
       "broker-internal-cert"}}, {"configMap": {"name": "hawkular-broker-config"},
       "name": "hawkular-openshift-agent"}]}}}}], "parameters": [{"description": "Storage
       capacity required for volume claims", "name": "STORAGE_CAPACITY", "value": "2Gi"},
@@ -280,7 +283,8 @@ items:
       "name": "broker-internal-cert", "readOnly": true}]}], "volumes": [{"name": "vol-${NAME}",
       "persistentVolumeClaim": {"claimName": "pvc-${NAME}"}}, {"name": "ssl-certs",
       "secret": {"secretName": "${COLOCATED_ROUTER_SECRET}"}}, {"name": "authservice-ca",
-      "secret": {"secretName": "authservice-ca"}}, {"name": "broker-internal-cert",
+      "secret": {"secretName": "authservice-ca"}}, {"name": "address-controller-ca",
+      "secret": {"secretName": "address-controller-ca"}}, {"name": "broker-internal-cert",
       "secret": {"secretName": "broker-internal-cert"}}, {"configMap": {"name": "hawkular-broker-config"},
       "name": "hawkular-openshift-agent"}]}}}}], "parameters": [{"description": "Storage
       capacity required for volume claims", "name": "STORAGE_CAPACITY", "value": "2Gi"},
@@ -330,7 +334,8 @@ items:
       "256Mi"}, "requests": {"memory": "256Mi"}}, "volumeMounts": [{"mountPath": "/etc/qpid-dispatch/ssl",
       "name": "ssl-certs", "readOnly": true}, {"mountPath": "/etc/qpid-dispatch/authservice-ca",
       "name": "authservice-ca", "readOnly": true}, {"mountPath": "/etc/enmasse-certs",
-      "name": "broker-internal-cert", "readOnly": true}]}, {"env": [{"name": "TOPIC_NAME",
+      "name": "broker-internal-cert", "readOnly": true}, {"mountPath": "/etc/qpid-dispatch/address-controller-ca",
+      "name": "address-controller-ca", "readOnly": true}]}, {"env": [{"name": "TOPIC_NAME",
       "value": "${ADDRESS}"}, {"name": "CLUSTER_ID", "value": "${NAME}"}, {"name":
       "CERT_DIR", "value": "/etc/enmasse-certs"}], "image": "${TOPIC_FORWARDER_REPO}",
       "livenessProbe": {"httpGet": {"path": "/health", "port": "health"}}, "name":
@@ -339,7 +344,8 @@ items:
       [{"mountPath": "/etc/enmasse-certs", "name": "broker-internal-cert", "readOnly":
       true}]}], "volumes": [{"emptyDir": { }, "name": "vol-${NAME}"}, {"name": "ssl-certs",
       "secret": {"secretName": "${COLOCATED_ROUTER_SECRET}"}}, {"name": "authservice-ca",
-      "secret": {"secretName": "authservice-ca"}}, {"name": "broker-internal-cert",
+      "secret": {"secretName": "authservice-ca"}}, {"name": "address-controller-ca",
+      "secret": {"secretName": "address-controller-ca"}}, {"name": "broker-internal-cert",
       "secret": {"secretName": "broker-internal-cert"}}, {"configMap": {"name": "hawkular-broker-config"},
       "name": "hawkular-openshift-agent"}]}}}}], "parameters": [{"description": "Storage
       capacity required for volume claims", "name": "STORAGE_CAPACITY", "value": "2Gi"},
@@ -393,7 +399,8 @@ items:
       "256Mi"}, "requests": {"memory": "256Mi"}}, "volumeMounts": [{"mountPath": "/etc/qpid-dispatch/ssl",
       "name": "ssl-certs", "readOnly": true}, {"mountPath": "/etc/qpid-dispatch/authservice-ca",
       "name": "authservice-ca", "readOnly": true}, {"mountPath": "/etc/enmasse-certs",
-      "name": "broker-internal-cert", "readOnly": true}]}, {"env": [{"name": "TOPIC_NAME",
+      "name": "broker-internal-cert", "readOnly": true}, {"mountPath": "/etc/qpid-dispatch/address-controller-ca",
+      "name": "address-controller-ca", "readOnly": true}]}, {"env": [{"name": "TOPIC_NAME",
       "value": "${ADDRESS}"}, {"name": "CLUSTER_ID", "value": "${NAME}"}, {"name":
       "CERT_DIR", "value": "/etc/enmasse-certs"}], "image": "${TOPIC_FORWARDER_REPO}",
       "livenessProbe": {"httpGet": {"path": "/health", "port": "health"}}, "name":
@@ -403,8 +410,9 @@ items:
       true}]}], "volumes": [{"name": "vol-${NAME}", "persistentVolumeClaim": {"claimName":
       "pvc-${NAME}"}}, {"name": "ssl-certs", "secret": {"secretName": "${COLOCATED_ROUTER_SECRET}"}},
       {"name": "authservice-ca", "secret": {"secretName": "authservice-ca"}}, {"name":
-      "broker-internal-cert", "secret": {"secretName": "broker-internal-cert"}}, {"configMap":
-      {"name": "hawkular-broker-config"}, "name": "hawkular-openshift-agent"}]}}}}],
+      "address-controller-ca", "secret": {"secretName": "address-controller-ca"}},
+      {"name": "broker-internal-cert", "secret": {"secretName": "broker-internal-cert"}},
+      {"configMap": {"name": "hawkular-broker-config"}, "name": "hawkular-openshift-agent"}]}}}}],
       "parameters": [{"description": "Storage capacity required for volume claims",
       "name": "STORAGE_CAPACITY", "value": "2Gi"}, {"description": "The docker image
       to use for the message broker", "name": "BROKER_REPO", "value": "docker.io/enmasseproject/artemis:latest"},

--- a/templates/install/openshift/enmasse.yaml
+++ b/templates/install/openshift/enmasse.yaml
@@ -73,6 +73,9 @@ objects:
           - name: authservice-ca
             secret:
               secretName: authservice-ca
+          - name: address-controller-ca
+            secret:
+              secretName: address-controller-ca
           - name: broker-internal-cert
             secret:
               secretName: broker-internal-cert
@@ -204,6 +207,9 @@ objects:
           - name: authservice-ca
             secret:
               secretName: authservice-ca
+          - name: address-controller-ca
+            secret:
+              secretName: address-controller-ca
           - name: broker-internal-cert
             secret:
               secretName: broker-internal-cert
@@ -356,6 +362,9 @@ objects:
             - mountPath: /etc/enmasse-certs
               name: broker-internal-cert
               readOnly: true
+            - mountPath: /etc/qpid-dispatch/address-controller-ca
+              name: address-controller-ca
+              readOnly: true
           - env:
             - name: TOPIC_NAME
               value: ${ADDRESS}
@@ -390,6 +399,9 @@ objects:
           - name: authservice-ca
             secret:
               secretName: authservice-ca
+          - name: address-controller-ca
+            secret:
+              secretName: address-controller-ca
           - name: broker-internal-cert
             secret:
               secretName: broker-internal-cert
@@ -557,6 +569,9 @@ objects:
             - mountPath: /etc/enmasse-certs
               name: broker-internal-cert
               readOnly: true
+            - mountPath: /etc/qpid-dispatch/address-controller-ca
+              name: address-controller-ca
+              readOnly: true
           - env:
             - name: TOPIC_NAME
               value: ${ADDRESS}
@@ -592,6 +607,9 @@ objects:
           - name: authservice-ca
             secret:
               secretName: authservice-ca
+          - name: address-controller-ca
+            secret:
+              secretName: address-controller-ca
           - name: broker-internal-cert
             secret:
               secretName: broker-internal-cert
@@ -843,6 +861,9 @@ objects:
             - mountPath: /etc/enmasse-certs
               name: router-internal-cert
               readOnly: true
+            - mountPath: /etc/qpid-dispatch/address-controller-ca
+              name: address-controller-ca
+              readOnly: true
           - env:
             - name: ROUTER_HOST
               value: 127.0.0.1
@@ -878,6 +899,9 @@ objects:
           - name: authservice-ca
             secret:
               secretName: authservice-ca
+          - name: address-controller-ca
+            secret:
+              secretName: address-controller-ca
           - name: router-internal-cert
             secret:
               secretName: router-internal-cert


### PR DESCRIPTION
This is a workaround for allowing the address controller to perform the health check against the router. Ideally this should be part of a component running inside the standard address space (standard-controller or whatever), but this 'hack' is needed for the health check to work with keycloak deployments.

I've added comments in some places that explains the 'hack' and reason for it. 

This fixes issue #242  though I'd like to do a manual run to verify that the issue has been fixed before merging.