### PR TITLE
Refactor framework to support creating both AMQP and MQTT clients in the same test

### DIFF
--- a/systemtests/src/main/java/enmasse/systemtest/KeycloakClient.java
+++ b/systemtests/src/main/java/enmasse/systemtest/KeycloakClient.java
@@ -34,6 +34,11 @@ public class KeycloakClient implements AutoCloseable {
                 "master", credentials.getUsername(), credentials.getPassword(), "admin-cli");
     }
 
+    public void createUser(String realm, String userName, String password) throws TimeoutException, InterruptedException {
+        createUser(realm, userName, password, 1, TimeUnit.MINUTES);
+    }
+
+
     public void createUser(String realm, String userName, String password, long timeout, TimeUnit timeUnit)
             throws InterruptedException, TimeoutException {
         RealmResource realmResource = waitForRealm(realm, timeout, timeUnit);

--- a/systemtests/src/main/java/enmasse/systemtest/amqp/AmqpClientFactory.java
+++ b/systemtests/src/main/java/enmasse/systemtest/amqp/AmqpClientFactory.java
@@ -13,45 +13,42 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package enmasse.systemtest;
+package enmasse.systemtest.amqp;
 
-import enmasse.systemtest.amqp.AmqpClient;
-import enmasse.systemtest.amqp.AmqpConnectOptions;
-import enmasse.systemtest.amqp.DurableTopicTerminusFactory;
-import enmasse.systemtest.amqp.QueueTerminusFactory;
-import enmasse.systemtest.amqp.TerminusFactory;
-import enmasse.systemtest.amqp.TopicTerminusFactory;
+import enmasse.systemtest.*;
 import io.vertx.proton.ProtonClientOptions;
 import io.vertx.proton.ProtonQoS;
-import org.junit.After;
-import org.junit.Before;
 
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 
-public abstract class AmqpTestBase extends TestBase {
-
+public class AmqpClientFactory {
+    private final OpenShift openShift;
+    private final Environment environment;
+    private final String defaultUsername;
+    private final String defaultPassword;
     private final List<AmqpClient> clients = new ArrayList<>();
 
-    @Before
-    public void setupAmqpTest() throws Exception {
-        clients.clear();
+    public AmqpClientFactory(OpenShift openShift, Environment environment, String defaultUsername, String defaultPassword) {
+        this.openShift = openShift;
+        this.environment = environment;
+        this.defaultUsername = defaultUsername;
+        this.defaultPassword = defaultPassword;
     }
 
-    @After
-    public void teardownAmqpTest() throws Exception {
+    public void close() throws Exception {
         for (AmqpClient client : clients) {
             client.close();
         }
         clients.clear();
     }
 
-    protected AmqpClient createQueueClient() throws UnknownHostException, InterruptedException {
+    public AmqpClient createQueueClient() throws UnknownHostException, InterruptedException {
         return createClient(new QueueTerminusFactory(), ProtonQoS.AT_LEAST_ONCE);
     }
 
-    protected AmqpClient createTopicClient() throws UnknownHostException, InterruptedException {
+    public AmqpClient createTopicClient() throws UnknownHostException, InterruptedException {
         return createClient(new TopicTerminusFactory(), ProtonQoS.AT_LEAST_ONCE);
     }
 
@@ -59,7 +56,7 @@ public abstract class AmqpTestBase extends TestBase {
         return createClient(new DurableTopicTerminusFactory(), ProtonQoS.AT_LEAST_ONCE);
     }
 
-    protected AmqpClient createBroadcastClient() throws UnknownHostException, InterruptedException {
+    public AmqpClient createBroadcastClient() throws UnknownHostException, InterruptedException {
         return createClient(new QueueTerminusFactory(), ProtonQoS.AT_MOST_ONCE);
     }
 
@@ -96,8 +93,8 @@ public abstract class AmqpTestBase extends TestBase {
                 .setEndpoint(endpoint)
                 .setProtonClientOptions(protonOptions)
                 .setQos(qos)
-                .setUsername(username)
-                .setPassword(password);
+                .setUsername(defaultUsername)
+                .setPassword(defaultPassword);
         return createClient(connectOptions);
     }
 

--- a/systemtests/src/main/java/enmasse/systemtest/mqtt/MqttClientFactory.java
+++ b/systemtests/src/main/java/enmasse/systemtest/mqtt/MqttClientFactory.java
@@ -16,12 +16,8 @@
 
 package enmasse.systemtest.mqtt;
 
-import enmasse.systemtest.Endpoint;
-import enmasse.systemtest.TestBase;
-import enmasse.systemtest.TestUtils;
+import enmasse.systemtest.*;
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
-import org.junit.After;
-import org.junit.Before;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -43,20 +39,22 @@ import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.X509TrustManager;
 
-/**
- * Base class for all MQTT related tests
- */
-public abstract class MqttTestBase extends TestBase {
+public class MqttClientFactory {
 
+    private final OpenShift openShift;
+    private final Environment environment;
+    private final String username;
+    private final String password;
     private final List<MqttClient> clients = new ArrayList<>();
 
-    @Before
-    public void setupMqttTest() throws Exception {
-        this.clients.clear();
+    public MqttClientFactory(OpenShift openShift, Environment environment, String username, String password) {
+        this.openShift = openShift;
+        this.environment = environment;
+        this.username = username;
+        this.password = password;
     }
 
-    @After
-    public void teardownMqttTest() throws Exception {
+    public void close() throws Exception {
 
         for (MqttClient client : this.clients) {
             client.close();

--- a/systemtests/src/test/java/enmasse/systemtest/AnycastTest.java
+++ b/systemtests/src/test/java/enmasse/systemtest/AnycastTest.java
@@ -17,7 +17,7 @@
 package enmasse.systemtest;
 
 import enmasse.systemtest.amqp.AmqpClient;
-import io.vertx.core.http.HttpMethod;
+import enmasse.systemtest.amqp.AmqpClientFactory;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -28,12 +28,13 @@ import java.util.concurrent.TimeUnit;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-public class AnycastTest extends AmqpTestBase {
+public class AnycastTest extends TestBase {
+
     @Test
     public void testMessagesDeliveredToReceiver() throws Exception {
         Destination dest = Destination.anycast("anycast");
         setAddresses(dest);
-        AmqpClient client = createQueueClient();
+        AmqpClient client = amqpClientFactory.createQueueClient();
 
         List<String> msgs = Arrays.asList("foo", "bar", "baz");
 

--- a/systemtests/src/test/java/enmasse/systemtest/BroadcastTest.java
+++ b/systemtests/src/test/java/enmasse/systemtest/BroadcastTest.java
@@ -17,7 +17,7 @@
 package enmasse.systemtest;
 
 import enmasse.systemtest.amqp.AmqpClient;
-import io.vertx.core.http.HttpMethod;
+import enmasse.systemtest.amqp.AmqpClientFactory;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -29,14 +29,14 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-public class BroadcastTest extends AmqpTestBase {
+public class BroadcastTest extends TestBase {
 
     @Test
     public void testMultipleRecievers() throws Exception {
         Destination dest = Destination.multicast("broadcast");
         setAddresses(dest);
         Thread.sleep(20_000);
-        AmqpClient client = createBroadcastClient();
+        AmqpClient client = amqpClientFactory.createBroadcastClient();
         List<String> msgs = Arrays.asList("foo");
 
         List<Future<List<String>>> recvResults = Arrays.asList(

--- a/systemtests/src/test/java/enmasse/systemtest/QueueTest.java
+++ b/systemtests/src/test/java/enmasse/systemtest/QueueTest.java
@@ -17,6 +17,7 @@
 package enmasse.systemtest;
 
 import enmasse.systemtest.amqp.AmqpClient;
+import enmasse.systemtest.amqp.AmqpClientFactory;
 import org.apache.qpid.proton.message.Message;
 import org.junit.Test;
 
@@ -32,12 +33,13 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
-public class QueueTest extends AmqpTestBase {
+public class QueueTest extends TestBase {
+
     @Test
     public void testQueue() throws Exception {
         Destination dest = Destination.queue("myqueue");
         setAddresses(dest);
-        AmqpClient client = createQueueClient();
+        AmqpClient client = amqpClientFactory.createQueueClient();
 
         runQueueTest(client, dest);
     }
@@ -49,7 +51,7 @@ public class QueueTest extends AmqpTestBase {
         Destination q3 = Destination.queue("queue3", Optional.of("pooled-inmemory"));
         setAddresses(q1, q2, q3);
 
-        AmqpClient client = createQueueClient();
+        AmqpClient client = amqpClientFactory.createQueueClient();
         runQueueTest(client, q1);
         runQueueTest(client, q2);
         runQueueTest(client, q3);
@@ -62,7 +64,7 @@ public class QueueTest extends AmqpTestBase {
 
         setAddresses(q1, q2);
 
-        AmqpClient client = createQueueClient();
+        AmqpClient client = amqpClientFactory.createQueueClient();
         runQueueTest(client, q1);
         runQueueTest(client, q2);
     }
@@ -74,7 +76,7 @@ public class QueueTest extends AmqpTestBase {
 
         setAddresses(q1, q2);
 
-        AmqpClient client = createQueueClient();
+        AmqpClient client = amqpClientFactory.createQueueClient();
         runQueueTest(client, q1);
         runQueueTest(client, q2);
     }
@@ -86,7 +88,7 @@ public class QueueTest extends AmqpTestBase {
 
         setAddresses(q1, q2);
 
-        AmqpClient client = createQueueClient();
+        AmqpClient client = amqpClientFactory.createQueueClient();
         runQueueTest(client, q1);
         runQueueTest(client, q2);
     }
@@ -124,7 +126,7 @@ public class QueueTest extends AmqpTestBase {
         Destination dest = Destination.queue("scalequeue");
         setAddresses(dest);
         scale(dest, 4);
-        AmqpClient client = createQueueClient();
+        AmqpClient client = amqpClientFactory.createQueueClient();
         List<Future<Integer>> sent = Arrays.asList(
                 client.sendMessages(dest.getAddress(), TestUtils.generateMessages("foo", 1000)),
                 client.sendMessages(dest.getAddress(), TestUtils.generateMessages("bar", 1000)),

--- a/systemtests/src/test/java/enmasse/systemtest/TestBase.java
+++ b/systemtests/src/test/java/enmasse/systemtest/TestBase.java
@@ -68,8 +68,8 @@ public abstract class TestBase {
             Logging.log.info("Address space " + addressSpace + "doesn't exist and will be created.");
             addressApiClient.createAddressSpace(addressSpace, authService);
             logCollector.collectLogs(addressSpace);
+            TestUtils.waitForAddressSpaceReady(addressApiClient, addressSpace);
         }
-        TestUtils.waitForAddressSpaceReady(addressApiClient, addressSpace);
     }
 
     protected KeycloakClient getKeycloakClient() throws InterruptedException {

--- a/systemtests/src/test/java/enmasse/systemtest/TopicTest.java
+++ b/systemtests/src/test/java/enmasse/systemtest/TopicTest.java
@@ -18,7 +18,6 @@ package enmasse.systemtest;
 
 import enmasse.systemtest.amqp.AmqpClient;
 import enmasse.systemtest.amqp.TopicTerminusFactory;
-import io.vertx.core.http.HttpMethod;
 import org.apache.qpid.proton.amqp.messaging.AmqpValue;
 import org.apache.qpid.proton.amqp.messaging.Source;
 import org.apache.qpid.proton.amqp.messaging.TerminusDurability;
@@ -34,7 +33,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-public class TopicTest extends AmqpTestBase {
+public class TopicTest extends TestBase {
 
     @Test
     public void testMultipleSubscribers() throws Exception {
@@ -42,7 +41,7 @@ public class TopicTest extends AmqpTestBase {
         setAddresses(dest);
         scale(dest, 1);
         Thread.sleep(60_000);
-        AmqpClient client = createTopicClient();
+        AmqpClient client = amqpClientFactory.createTopicClient();
         List<String> msgs = TestUtils.generateMessages(1000);
 
         List<Future<List<String>>> recvResults = Arrays.asList(
@@ -76,7 +75,7 @@ public class TopicTest extends AmqpTestBase {
         Source source = new TopicTerminusFactory().getSource("locate/" + dest.getAddress());
         source.setDurable(TerminusDurability.UNSETTLED_STATE);
 
-        AmqpClient client = createTopicClient();
+        AmqpClient client = amqpClientFactory.createTopicClient();
         List<String> batch1 = Arrays.asList("one", "two", "three");
 
         Logging.log.info("Receiving first batch");
@@ -118,9 +117,9 @@ public class TopicTest extends AmqpTestBase {
 
         Thread.sleep(120_000);
 
-        AmqpClient subClient = createQueueClient();
-        AmqpClient queueClient = createQueueClient();
-        AmqpClient topicClient = createTopicClient();
+        AmqpClient subClient = amqpClientFactory.createQueueClient();
+        AmqpClient queueClient = amqpClientFactory.createQueueClient();
+        AmqpClient topicClient = amqpClientFactory.createTopicClient();
 
         Message sub = Message.Factory.create();
         sub.setAddress("$subctrl");

--- a/systemtests/src/test/java/enmasse/systemtest/mqtt/PublishTest.java
+++ b/systemtests/src/test/java/enmasse/systemtest/mqtt/PublishTest.java
@@ -17,9 +17,8 @@
 package enmasse.systemtest.mqtt;
 
 import enmasse.systemtest.Destination;
-import io.vertx.core.http.HttpMethod;
+import enmasse.systemtest.TestBase;
 import org.junit.Test;
-import org.junit.Ignore;
 
 import java.util.Arrays;
 import java.util.List;
@@ -32,7 +31,7 @@ import static org.junit.Assert.assertThat;
 /**
  * Tests related to publish messages via MQTT
  */
-public class PublishTest extends MqttTestBase {
+public class PublishTest extends TestBase {
 
     @Test
     public void testPublishQoS0() throws Exception {
@@ -66,7 +65,7 @@ public class PublishTest extends MqttTestBase {
         setAddresses(dest);
         Thread.sleep(60_000);
 
-        MqttClient client = this.createClient();
+        MqttClient client = mqttClientFactory.createClient();
 
         Future<List<String>> recvResult = client.recvMessages(dest.getAddress(), messages.size(), subscriberQos);
         Future<Integer> sendResult = client.sendMessages(dest.getAddress(), messages, publisherQos);


### PR DESCRIPTION
For authentication tests, it  would be useful to be able to create clients for multiple protocols in the same test. Rather than inheriting the capability from the test case parent, expose client support as 2 alternative client factories that can be called by tests.