### PR TITLE
UPD added new version of mocha for ragent and console

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -19,7 +19,7 @@
     },
     "devDependencies": {
         "eslint":"",
-        "mocha":"^3.0.0",
+        "mocha":"^4 || ^3.0.0",
         "mocha-junit-reporter":"",
         "browserify":"",
         "istanbul": ""

--- a/ragent/package.json
+++ b/ragent/package.json
@@ -15,7 +15,7 @@
     },
     "devDependencies": {
         "mocha-junit-reporter":"",
-        "mocha":"^3.0.0",
+        "mocha":"^4 || ^3.0.0",
         "istanbul": ""
     },
     "scripts": {


### PR DESCRIPTION
mocha-junit-reporter version dependency issue was fixed, so we are able to use latest version of mocha