### PR TITLE
Update keycloak dependencies to 3.3.0.Final

### DIFF
--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -1,4 +1,4 @@
-FROM jboss/keycloak:3.2.1.Final
+FROM jboss/keycloak:3.3.0.Final
 
 ARG version=latest
 ENV VERSION ${version}

--- a/keycloak/src/main/sh/init-keycloak.sh
+++ b/keycloak/src/main/sh/init-keycloak.sh
@@ -5,7 +5,6 @@ KEYCLOAK_CONFIG=${KEYCLOAK_DIR}/standalone/configuration/standalone.xml
 java -jar /usr/share/java/saxon.jar -s:${KEYCLOAK_CONFIG} -xsl:${KEYCLOAK_DIR}/addSaslPlugin.xsl -o:${KEYCLOAK_CONFIG}
 java -jar /usr/share/java/saxon.jar -s:${KEYCLOAK_CONFIG} -xsl:${KEYCLOAK_DIR}/removeFileLogging.xsl -o:${KEYCLOAK_CONFIG}
 
-mkdir ${KEYCLOAK_DIR}/standalone/{data,log}
 chown -R jboss:root ${KEYCLOAK_DIR}
 find ${KEYCLOAK_DIR} -type d -exec chmod 770 {} \;
 find ${KEYCLOAK_DIR}/standalone/configuration -type f -exec chmod 660 {} \;

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <spring.version>1.5.4.RELEASE</spring.version>
     <logback.version>1.1.11</logback.version>
     <netty.version>4.1.15.Final</netty.version>
-    <keycloak.version>3.2.1.Final</keycloak.version>
+    <keycloak.version>3.3.0.Final</keycloak.version>
     <jboss.logging.version>3.3.0.Final</jboss.logging.version>
     <jboss.logging.annotations.version>2.1.0.Final</jboss.logging.annotations.version>
     <protonj.version>0.22.0</protonj.version>


### PR DESCRIPTION
Do not merge until the 3.3.0.Final libraries have reached maven

(3.3.0.Final was apparently released on Oct 26; the Docker image is on Docker hub, but as of 9:00am Oct 27 the dependencies were not found in maven repos)