### PR TITLE
Durable Subscribers in jms.TopicTest renamed to be unique for each test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 node('enmasse') {
     result = 'failure'
-    timeout(120) {
+    timeout(150) {
         catchError {
             stage ('checkout') {
                 checkout scm

--- a/systemtests/src/test/java/io/enmasse/systemtest/auth/AuthenticationTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/auth/AuthenticationTest.java
@@ -57,8 +57,8 @@ public class AuthenticationTest extends TestBase {
     @After
     public void teardownSpaces() throws Exception {
         for (AddressSpace addressSpace : addressSpaces) {
-            deleteAddressSpace(addressSpace);
             getKeycloakClient().deleteUser(addressSpace.getName(), "bob");
+            deleteAddressSpace(addressSpace);
         }
         addressSpaces.clear();
     }

--- a/systemtests/src/test/java/io/enmasse/systemtest/brokered/jms/TopicTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/brokered/jms/TopicTest.java
@@ -120,8 +120,8 @@ public class TopicTest extends JMSTestBase {
         session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
         Topic testTopic = (Topic) context.lookup(topic);
 
-        String sub1ID = "sub1";
-        String sub2ID = "sub2";
+        String sub1ID = "sub1DurSub";
+        String sub2ID = "sub2DurSub";
         MessageConsumer subscriber1 = session.createDurableSubscriber(testTopic, sub1ID);
         MessageConsumer subscriber2 = session.createDurableSubscriber(testTopic, sub2ID);
         MessageProducer messageProducer = session.createProducer(testTopic);
@@ -177,8 +177,8 @@ public class TopicTest extends JMSTestBase {
         session = connection.createSession(true, Session.SESSION_TRANSACTED);
         Topic testTopic = (Topic) context.lookup(topic);
 
-        String sub1ID = "sub1";
-        String sub2ID = "sub2";
+        String sub1ID = "sub1DurSubTrans";
+        String sub2ID = "sub2DurSubTrans";
         MessageConsumer subscriber1 = session.createDurableSubscriber(testTopic, sub1ID);
         MessageConsumer subscriber2 = session.createDurableSubscriber(testTopic, sub2ID);
         MessageProducer messageProducer = session.createProducer(testTopic);


### PR DESCRIPTION
- Jenkins timeout increased due to failing on 'timeout reached'