### PR TITLE
Add environment parameter to controller to support multiple controllers in a cluster

### DIFF
--- a/address-controller/src/main/java/io/enmasse/controller/ControllerHelper.java
+++ b/address-controller/src/main/java/io/enmasse/controller/ControllerHelper.java
@@ -16,7 +16,6 @@
 package io.enmasse.controller;
 
 import io.enmasse.config.AnnotationKeys;
-import io.enmasse.config.LabelKeys;
 import io.enmasse.controller.common.AuthenticationServiceResolverFactory;
 import io.enmasse.controller.common.Kubernetes;
 import io.enmasse.controller.common.KubernetesHelper;
@@ -194,17 +193,13 @@ public class ControllerHelper {
             return;
         }
         Set<String> addressSpaceIds = desiredAddressSpaces.stream().map(AddressSpace::getName).collect(Collectors.toSet());
-
-        Map<String, String> labels = new LinkedHashMap<>();
-        labels.put(LabelKeys.APP, "enmasse");
-        labels.put(LabelKeys.TYPE, "address-space");
-        for (Namespace namespace : kubernetes.listNamespaces(labels)) {
+        for (Namespace namespace : kubernetes.listNamespaces()) {
             String id = namespace.getMetadata().getAnnotations().get(AnnotationKeys.ADDRESS_SPACE);
             if (!addressSpaceIds.contains(id)) {
                 try {
                     log.info("Deleting address space {}", id);
                     kubernetes.deleteNamespace(namespace.getMetadata().getName());
-                } catch(KubernetesClientException e){
+                } catch (KubernetesClientException e) {
                     log.info("Exception when deleting namespace (may already be in progress): " + e.getMessage());
                 }
             }

--- a/address-controller/src/main/java/io/enmasse/controller/ControllerOptions.java
+++ b/address-controller/src/main/java/io/enmasse/controller/ControllerOptions.java
@@ -34,71 +34,48 @@ public final class ControllerOptions {
 
     private final String certDir;
     private final File templateDir;
-    private final String messagingHost;
-    private final String mqttHost;
-    private final String consoleHost;
-    private final String certSecret;
     private final AuthServiceInfo noneAuthService;
     private final AuthServiceInfo standardAuthService;
     private final boolean enableRbac;
 
+    private final String environment;
+
     private ControllerOptions(String masterUrl, String namespace, String token,
-                              File caDir, File templateDir, String messagingHost, String mqttHost,
-                              String consoleHost, String certSecret, String certDir,
-                              AuthServiceInfo noneAuthService, AuthServiceInfo standardAuthService, boolean enableRbac) {
+                              File caDir, File templateDir, String certDir,
+                              AuthServiceInfo noneAuthService, AuthServiceInfo standardAuthService, boolean enableRbac, String environment) {
         this.masterUrl = masterUrl;
         this.namespace = namespace;
         this.token = token;
         this.caDir = caDir;
         this.templateDir = templateDir;
-        this.messagingHost = messagingHost;
-        this.mqttHost = mqttHost;
-        this.consoleHost = consoleHost;
-        this.certSecret = certSecret;
         this.certDir = certDir;
         this.noneAuthService = noneAuthService;
         this.standardAuthService = standardAuthService;
         this.enableRbac = enableRbac;
+        this.environment = environment;
     }
 
-    public String masterUrl() {
+    public String getMasterUrl() {
         return masterUrl;
     }
 
-    public String namespace() {
+    public String getNamespace() {
         return namespace;
     }
 
-    public String token() {
+    public String getToken() {
         return token;
     }
 
-    public File caDir() {
+    public File getCaDir() {
         return caDir;
     }
 
-    public Optional<File> templateDir() {
+    public Optional<File> getTemplateDir() {
         return Optional.ofNullable(templateDir);
     }
 
-    public Optional<String> messagingHost() {
-        return Optional.ofNullable(messagingHost);
-    }
-
-    public Optional<String> mqttHost() {
-        return Optional.ofNullable(mqttHost);
-
-    }
-
-    public Optional<String> consoleHost() {
-        return Optional.ofNullable(consoleHost);
-    }
-
-    public Optional<String> certSecret() {
-        return Optional.ofNullable(certSecret);
-    }
-
-    public String certDir() {
+    public String getCertDir() {
         return certDir;
     }
 
@@ -112,6 +89,10 @@ public final class ControllerOptions {
 
     public boolean isEnableRbac() {
         return enableRbac;
+    }
+
+    public String getEnvironment() {
+        return environment;
     }
 
     public static ControllerOptions fromEnv(Map<String, String> env) throws IOException {
@@ -140,26 +121,20 @@ public final class ControllerOptions {
 
         String certDir = getEnv(env, "CERT_DIR").orElse("/address-controller-cert");
 
-        String messagingHost = getEnv(env, "MESSAGING_ENDPOINT_HOST").orElse(null);
-        String mqttHost = getEnv(env, "MQTT_ENDPOINT_HOST").orElse(null);
-        String consoleHost = getEnv(env, "CONSOLE_ENDPOINT_HOST").orElse(null);
-        String certSecret = getEnv(env, "MESSAGING_CERT_SECRET").orElse(null);
-
         boolean enableRbac = getEnv(env, "ENABLE_RBAC").map(Boolean::parseBoolean).orElse(false);
+
+        String environment = getEnv(env, "ENVIRONMENT").orElse("development");
 
         return new ControllerOptions(String.format("https://%s:%s", masterHost, masterPort),
                 namespace,
                 token,
                 caDir,
                 templateDir,
-                messagingHost,
-                mqttHost,
-                consoleHost,
-                certSecret,
                 certDir,
                 noneAuthService,
                 standardAuthService,
-                enableRbac);
+                enableRbac,
+                environment);
     }
 
 

--- a/address-controller/src/main/java/io/enmasse/controller/common/Kubernetes.java
+++ b/address-controller/src/main/java/io/enmasse/controller/common/Kubernetes.java
@@ -47,9 +47,11 @@ public interface Kubernetes {
 
     Namespace createNamespace(String name, String namespace);
 
-    void addSystemImagePullerPolicy(String namespace, String tenantNamespace);
+    List<Namespace> listNamespaces();
 
     void deleteNamespace(String namespace);
+
+    void addSystemImagePullerPolicy(String namespace, String tenantNamespace);
 
     boolean hasService(String service);
 
@@ -58,8 +60,6 @@ public interface Kubernetes {
     Set<Deployment> getReadyDeployments();
 
     boolean isDestinationClusterReady(String clusterId);
-
-    List<Namespace> listNamespaces(Map<String, String> labels);
 
     List<Pod> listRouters();
 

--- a/address-controller/src/main/java/io/enmasse/controller/common/KubernetesHelper.java
+++ b/address-controller/src/main/java/io/enmasse/controller/common/KubernetesHelper.java
@@ -47,12 +47,14 @@ public class KubernetesHelper implements Kubernetes {
     private final OpenShiftClient client;
     private final String namespace;
     private final String controllerToken;
+    private final String environment;
     private final Optional<File> templateDir;
 
-    public KubernetesHelper(String namespace, OpenShiftClient client, String token, Optional<File> templateDir) {
+    public KubernetesHelper(String namespace, OpenShiftClient client, String token, String environment, Optional<File> templateDir) {
         this.client = client;
         this.namespace = namespace;
         this.controllerToken = token;
+        this.environment = environment;
         this.templateDir = templateDir;
     }
 
@@ -133,6 +135,7 @@ public class KubernetesHelper implements Kubernetes {
                     .withName(namespace)
                     .addToLabels("app", "enmasse")
                     .addToLabels(LabelKeys.TYPE, "address-space")
+                    .addToLabels(LabelKeys.ENVIRONMENT, environment)
                     .addToAnnotations(AnnotationKeys.ADDRESS_SPACE, name)
                 .endMetadata()
                 .done();
@@ -140,7 +143,7 @@ public class KubernetesHelper implements Kubernetes {
 
     @Override
     public Kubernetes withNamespace(String namespace) {
-        return new KubernetesHelper(namespace, client, controllerToken, templateDir);
+        return new KubernetesHelper(namespace, client, controllerToken, environment, templateDir);
     }
 
     @Override
@@ -270,7 +273,11 @@ public class KubernetesHelper implements Kubernetes {
     }
 
     @Override
-    public List<Namespace> listNamespaces(Map<String, String> labels) {
+    public List<Namespace> listNamespaces() {
+        Map<String, String> labels = new LinkedHashMap<>();
+        labels.put(LabelKeys.APP, "enmasse");
+        labels.put(LabelKeys.TYPE, "address-space");
+        labels.put(LabelKeys.ENVIRONMENT, environment);
         return client.namespaces().withLabels(labels).list().getItems();
     }
 

--- a/address-controller/src/test/java/io/enmasse/controller/ControllerHelperTest.java
+++ b/address-controller/src/test/java/io/enmasse/controller/ControllerHelperTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2017 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.enmasse.controller;
+
+import io.enmasse.address.model.AddressSpace;
+import io.enmasse.address.model.types.AddressSpaceType;
+import io.enmasse.address.model.types.common.Plan;
+import io.enmasse.config.AnnotationKeys;
+import io.enmasse.config.LabelKeys;
+import io.enmasse.controller.common.Kubernetes;
+import io.enmasse.controller.common.NoneAuthenticationServiceResolver;
+import io.fabric8.kubernetes.api.model.Namespace;
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.internal.util.collections.Sets;
+
+import java.util.*;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+public class ControllerHelperTest {
+
+    @Test
+    public void testAddressSpaceCreate() {
+        Kubernetes kubernetes = mock(Kubernetes.class);
+        when(kubernetes.withNamespace(any())).thenReturn(kubernetes);
+        when(kubernetes.hasService(any())).thenReturn(false);
+        when(kubernetes.getNamespace()).thenReturn("otherspace");
+
+        AddressSpaceType mockType = mock(AddressSpaceType.class);
+
+        AddressSpace addressSpace = new AddressSpace.Builder()
+                .setName("myspace")
+                .setNamespace("mynamespace")
+                .setType(mockType)
+                .setPlan(new Plan("myplan", "myplan", "myplan", "myuuid", null))
+                .build();
+
+
+        ControllerHelper helper = new ControllerHelper(kubernetes, authenticationServiceType -> new NoneAuthenticationServiceResolver("localhost", 12345));
+        helper.create(addressSpace);
+        ArgumentCaptor<String> nameCapture = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> namespaceCapture = ArgumentCaptor.forClass(String.class);
+        verify(kubernetes).createNamespace(nameCapture.capture(), namespaceCapture.capture());
+        assertThat(nameCapture.getValue(), is("myspace"));
+        assertThat(namespaceCapture.getValue(), is("mynamespace"));
+    }
+
+    @Test
+    public void testAddressSpaceRetain() {
+        Kubernetes kubernetes = mock(Kubernetes.class);
+        when(kubernetes.withNamespace(any())).thenReturn(kubernetes);
+        when(kubernetes.hasService(any())).thenReturn(false);
+        when(kubernetes.getNamespace()).thenReturn("otherspace");
+
+        Map<String, String> devLabels = new HashMap<>();
+        devLabels.put(LabelKeys.TYPE, "address-space");
+        devLabels.put(LabelKeys.APP, "enmasse");
+        devLabels.put(LabelKeys.ENVIRONMENT, "development");
+
+        Map<String, String> prodLabels = new HashMap<>();
+        prodLabels.put(LabelKeys.TYPE, "address-space");
+        prodLabels.put(LabelKeys.APP, "enmasse");
+        prodLabels.put(LabelKeys.ENVIRONMENT, "production");
+
+        List<Namespace> namespaceList = Arrays.asList(new NamespaceBuilder()
+                .editOrNewMetadata()
+                    .withName("mynamespace")
+                    .withAnnotations(Collections.singletonMap(AnnotationKeys.ADDRESS_SPACE, "myspace"))
+                    .withLabels(devLabels)
+                .endMetadata()
+                .build(),
+                new NamespaceBuilder()
+                .editOrNewMetadata()
+                    .withName("todelete")
+                    .withAnnotations(Collections.singletonMap(AnnotationKeys.ADDRESS_SPACE, "myspace2"))
+                    .withLabels(devLabels)
+                .endMetadata()
+                .build(),
+                new NamespaceBuilder()
+                .editOrNewMetadata()
+                    .withName("toignore")
+                    .withAnnotations(Collections.singletonMap(AnnotationKeys.ADDRESS_SPACE, "myspace"))
+                    .withLabels(prodLabels)
+                .endMetadata()
+                .build()
+                );
+
+        when(kubernetes.listNamespaces()).thenReturn(namespaceList);
+
+        AddressSpaceType mockType = mock(AddressSpaceType.class);
+
+        AddressSpace addressSpace = new AddressSpace.Builder()
+                .setName("myspace")
+                .setNamespace("mynamespace")
+                .setType(mockType)
+                .setPlan(new Plan("myplan", "myplan", "myplan", "myuuid", null))
+                .build();
+
+
+        ControllerHelper helper = new ControllerHelper(kubernetes, authenticationServiceType -> new NoneAuthenticationServiceResolver("localhost", 12345));
+        helper.retainAddressSpaces(Sets.newSet(addressSpace));
+
+        verify(kubernetes).deleteNamespace(eq("todelete"));
+    }
+}

--- a/address-model-lib/src/main/java/io/enmasse/config/LabelKeys.java
+++ b/address-model-lib/src/main/java/io/enmasse/config/LabelKeys.java
@@ -26,4 +26,5 @@ public interface LabelKeys {
     String ADDRESS = "address";
     String APP = "app";
     String CAPABILITY = "capability";
+    String ENVIRONMENT = "environment";
 }

--- a/templates/include/address-controller.jsonnet
+++ b/templates/include/address-controller.jsonnet
@@ -33,14 +33,15 @@ local common = import "common.jsonnet";
   external_service::
     self.common_service("address-controller-external", "LoadBalancer", {}),
 
-  deployment(image, template_config, ca_secret, cert_secret, enable_rbac)::
+  deployment(image, template_config, ca_secret, cert_secret, environment, enable_rbac)::
     {
       "apiVersion": "extensions/v1beta1",
       "kind": "Deployment",
       "metadata": {
         "labels": {
           "name": "address-controller",
-          "app": "enmasse"
+          "app": "enmasse",
+          "environment": environment
         },
         "name": "address-controller"
       },
@@ -50,7 +51,8 @@ local common = import "common.jsonnet";
           "metadata": {
             "labels": {
               "name": "address-controller",
-              "app": "enmasse"
+              "app": "enmasse",
+              "environment": environment
             }
           },
 
@@ -62,7 +64,8 @@ local common = import "common.jsonnet";
                 "name": "address-controller",
                 "env": [
                   common.env("CA_DIR", "/ca-cert"),
-                  common.env("ENABLE_RBAC", enable_rbac)
+                  common.env("ENABLE_RBAC", enable_rbac),
+                  common.env("ENVIRONMENT", environment)
                 ],
                 "volumeMounts": [
                   common.volume_mount("ca-cert", "/ca-cert", true),

--- a/templates/include/enmasse-kubernetes.jsonnet
+++ b/templates/include/enmasse-kubernetes.jsonnet
@@ -12,7 +12,7 @@ local images = import "images.jsonnet";
     "apiVersion": "v1",
     "kind": "List",
     "items": [ templateConfig.generate(with_kafka),
-               addressController.deployment(images.address_controller, "enmasse-template-config", "enmasse-ca", "address-controller-cert", "false"),
+               addressController.deployment(images.address_controller, "enmasse-template-config", "enmasse-ca", "address-controller-cert", "development", "false"),
                restapiRoute.ingress(""),
                addressController.internal_service ]
   },

--- a/templates/include/enmasse-template.jsonnet
+++ b/templates/include/enmasse-template.jsonnet
@@ -50,7 +50,7 @@ local images = import "images.jsonnet";
                  standardInfra.generate(with_kafka),
                  me.enmasse_admin_role,
                  brokeredInfra.template,
-                 addressController.deployment("${ADDRESS_CONTROLLER_REPO}", "", "${ENMASSE_CA_SECRET}", "${ADDRESS_CONTROLLER_CERT_SECRET}", "${ENABLE_RBAC}"),
+                 addressController.deployment("${ADDRESS_CONTROLLER_REPO}", "", "${ENMASSE_CA_SECRET}", "${ADDRESS_CONTROLLER_CERT_SECRET}", "${ENVIRONMENT}", "${ENABLE_RBAC}"),
                  addressController.internal_service,
                  restapiRoute.route("${RESTAPI_HOSTNAME}") ],
     "parameters": [
@@ -77,6 +77,11 @@ local images = import "images.jsonnet";
         "name": "ENABLE_RBAC",
         "description": "Enable RBAC for REST API authentication and authorization",
         "value": "false"
+      },
+      {
+        "name": "ENVIRONMENT",
+        "description": "The environment for this EnMasse instance (for instance development, testing or production).",
+        "value": "development"
       }
     ]
   }

--- a/templates/install/deploy-openshift.sh
+++ b/templates/install/deploy-openshift.sh
@@ -37,7 +37,7 @@ OC_ARGS=""
 GUIDE=false
 MODE="singletenant"
 
-while getopts a:c:dgm:n:o:p:st:u:yvh opt; do
+while getopts a:c:de:gm:n:o:p:st:u:yvh opt; do
     case $opt in
         a)
             AUTH_SERVICES=$OPTARG
@@ -47,6 +47,9 @@ while getopts a:c:dgm:n:o:p:st:u:yvh opt; do
             ;;
         d)
             OS_ALLINONE=true
+            ;;
+        e)
+            ENVIRONMENT=$OPTARG
             ;;
         g)
             GUIDE=true
@@ -90,6 +93,7 @@ while getopts a:c:dgm:n:o:p:st:u:yvh opt; do
             echo "  -a \"none standard\" Deploy given authentication services (default: \"none\")"
             echo "  -c                   CA certificate to use in address controller"
             echo "  -d                   create an all-in-one docker OpenShift on localhost"
+            echo "  -e                   Environment label for this EnMasse deployment"
             echo "  -n NAMESPACE         OpenShift project name to install EnMasse into (default: $DEFAULT_NAMESPACE)"
             echo "  -m MASTER            OpenShift master URI to login against (default: https://localhost:8443)"
             echo "  -o mode              Deploy in given mode, 'singletenant' or 'multitenant'.  (default: \"singletenant\")"
@@ -188,6 +192,9 @@ do
     fi
 done
 
+if [ "$ENVIRONMENT" != "" ]; then
+    TEMPLATE_PARAMS="$TEMPLATE_PARAMS ENVIRONMENT=$ENVIRONMENT"
+fi
 
 if [ $MODE == "multitenant" ]; then
     TEMPLATE_PARAMS="$TEMPLATE_PARAMS ENABLE_RBAC=true"

--- a/templates/install/kubernetes/enmasse.yaml
+++ b/templates/install/kubernetes/enmasse.yaml
@@ -562,6 +562,7 @@ items:
   metadata:
     labels:
       app: enmasse
+      environment: development
       name: address-controller
     name: address-controller
   spec:
@@ -570,6 +571,7 @@ items:
       metadata:
         labels:
           app: enmasse
+          environment: development
           name: address-controller
       spec:
         containers:
@@ -578,6 +580,8 @@ items:
             value: /ca-cert
           - name: ENABLE_RBAC
             value: 'false'
+          - name: ENVIRONMENT
+            value: development
           image: docker.io/enmasseproject/address-controller:latest
           livenessProbe:
             httpGet:

--- a/templates/install/openshift/enmasse.yaml
+++ b/templates/install/openshift/enmasse.yaml
@@ -1683,6 +1683,7 @@ objects:
   metadata:
     labels:
       app: enmasse
+      environment: ${ENVIRONMENT}
       name: address-controller
     name: address-controller
   spec:
@@ -1691,6 +1692,7 @@ objects:
       metadata:
         labels:
           app: enmasse
+          environment: ${ENVIRONMENT}
           name: address-controller
       spec:
         containers:
@@ -1699,6 +1701,8 @@ objects:
             value: /ca-cert
           - name: ENABLE_RBAC
             value: ${ENABLE_RBAC}
+          - name: ENVIRONMENT
+            value: ${ENVIRONMENT}
           image: ${ADDRESS_CONTROLLER_REPO}
           livenessProbe:
             httpGet:
@@ -1784,3 +1788,7 @@ parameters:
 - description: Enable RBAC for REST API authentication and authorization
   name: ENABLE_RBAC
   value: 'false'
+- description: The environment for this EnMasse instance (for instance development,
+    testing or production).
+  name: ENVIRONMENT
+  value: development


### PR DESCRIPTION

An address controller may optionally be configured with an 'ENVIRONMENT'
environment variable (available through OpenShift templates). Each
namespace created by a controller is labeled with the same environment,
ensuring that a controller will only touch namespaces with for its own
environment.

This fixes #474