### PR TITLE
Move API paths from /v1 to /apis/enmasse.io/v1

### DIFF
--- a/.travis/upload-artifacts.sh
+++ b/.travis/upload-artifacts.sh
@@ -9,7 +9,7 @@ fi
 
 export PACKAGE=enmasse
 export REPOSITORY="snapshots"
-if [ -n "$TRAVIS_TAG" ]
+if [ "$VERSION" != "latest" ]
 then
     export REPOSITORY="releases"
     export TRAVIS_BUILD_NUMBER="."

--- a/address-controller/src/main/java/io/enmasse/controller/api/v1/http/HttpAddressRootService.java
+++ b/address-controller/src/main/java/io/enmasse/controller/api/v1/http/HttpAddressRootService.java
@@ -32,7 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-@Path("/v1/addresses")
+@Path("/apis/enmasse.io/v1/addresses")
 public class HttpAddressRootService {
     private static final Logger log = LoggerFactory.getLogger(HttpAddressRootService.class.getName());
     private final AddressSpaceApi addressSpaceApi;

--- a/address-controller/src/main/java/io/enmasse/controller/api/v1/http/HttpAddressService.java
+++ b/address-controller/src/main/java/io/enmasse/controller/api/v1/http/HttpAddressService.java
@@ -33,7 +33,7 @@ import java.util.concurrent.Callable;
 /**
  * HTTP API for operating on addresses within an address space
  */
-@Path("/v1/addresses/{addressSpace}")
+@Path("/apis/enmasse.io/v1/addresses/{addressSpace}")
 public class HttpAddressService {
     private static final Logger log = LoggerFactory.getLogger(HttpAddressService.class.getName());
     private final AddressApiHelper apiHelper;

--- a/address-controller/src/main/java/io/enmasse/controller/api/v1/http/HttpAddressSpaceService.java
+++ b/address-controller/src/main/java/io/enmasse/controller/api/v1/http/HttpAddressSpaceService.java
@@ -34,7 +34,7 @@ import java.util.concurrent.Callable;
 @Path(HttpAddressSpaceService.BASE_URI)
 public class HttpAddressSpaceService {
 
-    static final String BASE_URI = "/v1/addressspaces";
+    static final String BASE_URI = "/apis/enmasse.io/v1/addressspaces";
 
     private static final Logger log = LoggerFactory.getLogger(HttpAddressSpaceService.class.getName());
     private final String namespace;

--- a/address-controller/src/main/java/io/enmasse/controller/api/v1/http/HttpHealthService.java
+++ b/address-controller/src/main/java/io/enmasse/controller/api/v1/http/HttpHealthService.java
@@ -23,7 +23,7 @@ import javax.ws.rs.core.Response;
 
 @Path(HttpHealthService.BASE_URI)
 public class HttpHealthService {
-    public static final String BASE_URI = "/v1/health";
+    public static final String BASE_URI = "/apis/enmasse.io/v1/health";
     @GET
     @Produces({MediaType.APPLICATION_JSON})
     public Response getHealth() {

--- a/address-controller/src/main/java/io/enmasse/controller/api/v1/http/HttpRootService.java
+++ b/address-controller/src/main/java/io/enmasse/controller/api/v1/http/HttpRootService.java
@@ -33,7 +33,7 @@ public class HttpRootService {
     public Response getAll(@Context UriInfo uriInfo) {
         List<URI> uriList = new ArrayList<>();
         URI baseUri = uriInfo.getBaseUri();
-        uriList.add(baseUri.resolve("/v1"));
+        uriList.add(baseUri.resolve("/apis/enmasse.io/v1"));
         uriList.add(baseUri.resolve("/osbapi"));
         return Response.status(200).entity(uriList).build();
     }

--- a/address-controller/src/main/java/io/enmasse/controller/api/v1/http/HttpSchemaService.java
+++ b/address-controller/src/main/java/io/enmasse/controller/api/v1/http/HttpSchemaService.java
@@ -31,7 +31,7 @@ import java.util.Collections;
 /**
  * API for serving address model schema.
  */
-@Path("/v1/schema")
+@Path("/apis/enmasse.io/v1/schema")
 public class HttpSchemaService {
     private static final Logger log = LoggerFactory.getLogger(HttpSchemaService.class.getName());
 

--- a/address-controller/src/main/java/io/enmasse/controller/api/v1/http/HttpV1RootService.java
+++ b/address-controller/src/main/java/io/enmasse/controller/api/v1/http/HttpV1RootService.java
@@ -26,17 +26,17 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
-@Path("/v1")
+@Path("/apis/enmasse.io/v1")
 public class HttpV1RootService {
     @GET
     @Produces({MediaType.APPLICATION_JSON})
     public Response getV1(@Context UriInfo uriInfo) {
         List<URI> uriList = new ArrayList<>();
         URI baseUri = uriInfo.getBaseUri();
-        uriList.add(baseUri.resolve("/v1/addressspaces"));
-        uriList.add(baseUri.resolve("/v1/addresses"));
-        uriList.add(baseUri.resolve("/v1/health"));
-        uriList.add(baseUri.resolve("/v1/schema"));
+        uriList.add(baseUri.resolve("/apis/enmasse.io/v1/addressspaces"));
+        uriList.add(baseUri.resolve("/apis/enmasse.io/v1/addresses"));
+        uriList.add(baseUri.resolve("/apis/enmasse.io/v1/health"));
+        uriList.add(baseUri.resolve("/apis/enmasse.io/v1/schema"));
         return Response.status(200).entity(uriList).build();
     }
 }

--- a/address-controller/src/main/resources/swagger.json
+++ b/address-controller/src/main/resources/swagger.json
@@ -5,7 +5,7 @@
         "version": "1.0.0",
         "title": "EnMasse API"
     },
-    "basePath": "/v1",
+    "basePath": "/apis/enmasse.io/v1",
     "tags": [
         {
             "name": "addressspaces",

--- a/address-controller/src/test/java/io/enmasse/controller/HTTPServerTest.java
+++ b/address-controller/src/test/java/io/enmasse/controller/HTTPServerTest.java
@@ -105,7 +105,7 @@ public class HTTPServerTest {
         HttpClient client = vertx.createHttpClient();
         Async async = context.async(3);
         try {
-            HttpClientRequest r1 = client.get(8080, "localhost", "/v1/addresses/myinstance", response -> {
+            HttpClientRequest r1 = client.get(8080, "localhost", "/apis/enmasse.io/v1/addresses/myinstance", response -> {
                 context.assertEquals(200, response.statusCode());
                 response.bodyHandler(buffer -> {
                     JsonObject data = buffer.toJsonObject();
@@ -117,7 +117,7 @@ public class HTTPServerTest {
             putAuthzToken(r1);
             r1.end();
 
-            HttpClientRequest r2 = client.get(8080, "localhost", "/v1/addresses/myinstance/addr1", response -> {
+            HttpClientRequest r2 = client.get(8080, "localhost", "/apis/enmasse.io/v1/addresses/myinstance/addr1", response -> {
                 response.bodyHandler(buffer -> {
                     JsonObject data = buffer.toJsonObject();
                     context.assertTrue(data.containsKey("metadata"));
@@ -128,7 +128,7 @@ public class HTTPServerTest {
             putAuthzToken(r2);
             r2.end();
 
-            HttpClientRequest r3 = client.post(8080, "localhost", "/v1/addresses/myinstance", response -> {
+            HttpClientRequest r3 = client.post(8080, "localhost", "/apis/enmasse.io/v1/addresses/myinstance", response -> {
                 response.bodyHandler(buffer -> {
                     JsonObject data = buffer.toJsonObject();
                     context.assertTrue(data.containsKey("items"));
@@ -156,7 +156,7 @@ public class HTTPServerTest {
         try {
             {
                 Async async = context.async();
-                HttpClientRequest rootReq = client.get(8080, "localhost", "/v1", response -> {
+                HttpClientRequest rootReq = client.get(8080, "localhost", "/apis/enmasse.io/v1", response -> {
                     context.assertEquals(200, response.statusCode());
                     response.bodyHandler(buffer -> {
                         JsonArray data = buffer.toJsonArray();
@@ -193,7 +193,7 @@ public class HTTPServerTest {
         try {
             {
                 Async async = context.async();
-                HttpClientRequest request = client.get(8080, "localhost", "/v1/schema", response -> {
+                HttpClientRequest request = client.get(8080, "localhost", "/apis/enmasse.io/v1/schema", response -> {
                     context.assertEquals(200, response.statusCode());
                     response.bodyHandler(buffer -> {
                         JsonObject data = buffer.toJsonObject();

--- a/address-controller/src/test/java/io/enmasse/controller/auth/AuthInterceptorTest.java
+++ b/address-controller/src/test/java/io/enmasse/controller/auth/AuthInterceptorTest.java
@@ -48,8 +48,8 @@ public class AuthInterceptorTest {
         mockRequestContext = mock(ContainerRequestContext.class);
 
         mockUriInfo = mock(UriInfo.class);
-        when(mockUriInfo.getAbsolutePath()).thenReturn(URI.create("https://localhost:443/v1/addressspaces"));
-        when(mockUriInfo.getPath()).thenReturn("/v1/addressspaces");
+        when(mockUriInfo.getAbsolutePath()).thenReturn(URI.create("https://localhost:443/apis/enmasse.io/v1/addressspaces"));
+        when(mockUriInfo.getPath()).thenReturn("/apis/enmasse.io/v1/addressspaces");
         when(mockRequestContext.getUriInfo()).thenReturn(mockUriInfo);
     }
 

--- a/agent/lib/address_ctrl.js
+++ b/agent/lib/address_ctrl.js
@@ -25,7 +25,7 @@ var AddressCtrl = function (host, port, ca, auth_string) {
     this.ca = ca;
     this.auth_string = auth_string;
 
-    this.addr_path = "/v1/addresses/";
+    this.addr_path = "/apis/enmasse.io/v1/addresses/";
     if (this.address_space) {
         this.addr_path += this.address_space + "/";
     }
@@ -127,7 +127,7 @@ function address_types(text) {
 }
 
 AddressCtrl.prototype.get_address_types = function () {
-    return this.request('/v1/schema/', 'GET', undefined, undefined, address_types);
+    return this.request('/apis/enmasse.io/v1/schema/', 'GET', undefined, undefined, address_types);
 }
 
 module.exports.create = function (env) {

--- a/agent/test/address_ctrl.js
+++ b/agent/test/address_ctrl.js
@@ -79,13 +79,13 @@ MockAddressSource.prototype.clear = function () {
 MockAddressSource.prototype.listen = function (port, callback) {
     var self = this;
     this.server = http.createServer(function (request, response) {
-        if (request.method === 'GET' && request.url === '/v1/schema/') {
+        if (request.method === 'GET' && request.url === '/apis/enmasse.io/v1/schema/') {
             self.get_schema(request, response);
-        } else if (request.method === 'GET' && request.url === '/v1/addresses/') {
+        } else if (request.method === 'GET' && request.url === '/apis/enmasse.io/v1/addresses/') {
             self.get_addresses(request, response);
-        } else if (request.method === 'POST' && request.url === '/v1/addresses/') {
+        } else if (request.method === 'POST' && request.url === '/apis/enmasse.io/v1/addresses/') {
             self.post_addresses(request, response);
-        } else if (request.method === 'DELETE' && request.url.indexOf('/v1/addresses/') === 0) {
+        } else if (request.method === 'DELETE' && request.url.indexOf('/apis/enmasse.io/v1/addresses/') === 0) {
             self.delete_address(request, response);
         }
     });

--- a/agent/www/help.html
+++ b/agent/www/help.html
@@ -471,6 +471,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#apache_qpid_jms">Apache Qpid JMS</a></li>
 <li><a href="#rhea_javascript_client">Rhea JavaScript Client</a></li>
 <li><a href="#apache_qpid_proton_c">Apache Qpid Proton C++</a></li>
+<li><a href="#amqp_net_lite">AMQP.Net Lite</a></li>
 </ul>
 </li>
 </ul>
@@ -714,21 +715,8 @@ to decouple the producer and consumer. A queue in the brokered address spaces su
 message groups, transactions and other JMS features. If the queue is a high volume queue and these
 semantics are not needed, see the <a href="#standard-queue">standard address space <code>queue</code></a> type.</p>
 </div>
-<div class="sect5">
-<h6 id="brokered-queue-plans">Queue Plans</h6>
-<div class="ulist">
-<ul>
-<li>
-<p>standard</p>
-</li>
-</ul>
-</div>
-<div class="sect6">
-<h7 id="standard-queue-plan">Standard</h7>
 <div class="paragraph">
-<p>The standard queue plan deploys a queue in the broker for that address space.</p>
-</div>
-</div>
+<p>Only a standard plan is available for queues.</p>
 </div>
 </div>
 <div class="sect4">
@@ -736,21 +724,8 @@ semantics are not needed, see the <a href="#standard-queue">standard address spa
 <div class="paragraph">
 <p>The topic address type supports the publish-subscribe messaging pattern where you have 1..N producers and 1..M consumers. Each message published to a topic address is forwarded to all subscribers for that address. A subscriber can also be durable, in which case messages are kept until the subscriber has acknowledged them.</p>
 </div>
-<div class="sect5">
-<h6 id="brokered-topic-plans">Topic Plans</h6>
-<div class="ulist">
-<ul>
-<li>
-<p>standard</p>
-</li>
-</ul>
-</div>
-<div class="sect6">
-<h7 id="standard-topic-plan">Standard</h7>
 <div class="paragraph">
-<p>The standard topic plan deploys a topic in the broker for that address space.</p>
-</div>
-</div>
+<p>Only a standard plan is available for topics.</p>
 </div>
 </div>
 </div>
@@ -1006,12 +981,51 @@ int main(int argc, char **argv) {
 </div>
 </div>
 </div>
+<div class="sect4">
+<h5 id="amqp_net_lite">AMQP.Net Lite</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code>using System;
+using Amqp;
+
+namespace Test
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            String url = (args.Length &gt; 0) ? args[0] : "amqps://&lt;messaging-route-hostname&gt;:443";
+            String address = (args.Length &gt; 1) ? args[0] : "myqueue";
+
+            Connection.DisableServerCertValidation = true;
+            Connection connection = new Connection(new Address(url));
+            Session session = new Session(connection);
+            SenderLink sender = new SenderLink(session, "test-sender", address);
+
+            Message messageSent = new Message("Test Message");
+            sender.Send(messageSent);
+
+            ReceiverLink receiver = new ReceiverLink(session, "test-receiver", address);
+            Message messageReceived = receiver.Receive(TimeSpan.FromSeconds(2));
+            Console.WriteLine(messageReceived.GetBody&lt;String&gt;());
+            receiver.Accept(messageReceived);
+
+            sender.Close();
+            receiver.Close();
+            session.Close();
+            connection.Close();
+        }
+    }
+}</code></pre>
+</div>
+</div>
+</div>
 </div>
 </div>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-10-30 20:11:38 GMT
+Last updated 2017-10-30 14:52:22 CET
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css">

--- a/documentation/common/configuring-using-restapi.adoc
+++ b/documentation/common/configuring-using-restapi.adoc
@@ -42,7 +42,7 @@ various components.
 +
 [source,options="nowrap"]
 ----
-curl -k https://$(oc get route restapi -o jsonpath='{.spec.host}')/v1/addressspaces/myspace
+curl -k https://$(oc get route restapi -o jsonpath='{.spec.host}')/apis/enmasse.io/v1/addressspaces/myspace
 ----
 +
 You can consider the address space to be ready to use when `status.isReady` is `true` in the returned JSON
@@ -100,7 +100,7 @@ object.
 +
 [source,options="nowrap"]
 ----
-curl -X PUT -T addresses.json -H "content-type: application/json" -k https://$(oc get route restapi -o jsonpath='{.spec.host}')/v1/addresses/default
+curl -X PUT -T addresses.json -H "content-type: application/json" -k https://$(oc get route restapi -o jsonpath='{.spec.host}')/apis/enmasse.io/v1/addresses/default
 ----
 
 === Viewing Configured Addresses
@@ -111,7 +111,7 @@ curl -X PUT -T addresses.json -H "content-type: application/json" -k https://$(o
 +
 [source,options="nowrap"]
 ----
-curl -k https://$(oc get route restapi -o jsonpath='{.spec.host}')/v1/addresses/default
+curl -k https://$(oc get route restapi -o jsonpath='{.spec.host}')/apis/enmasse.io/v1/addresses/default
 ----
 +
 The addresses are ready to be used by messaging clients once the `status.isReady` field of each

--- a/documentation/service_admin/installing-kubernetes.adoc
+++ b/documentation/service_admin/installing-kubernetes.adoc
@@ -30,7 +30,7 @@ images for the various components.
 +
 [source,options="nowrap"]
 ----
-curl https://$(minikube ip)/v1/addressspaces/default
+curl -k https://$(minikube ip)/apis/enmasse.io/v1/addressspaces/default
 ----
 +
 The deployment is finished when `status.isReady` is `true` in the returned JSON object.

--- a/documentation/service_admin/installing-openshift.adoc
+++ b/documentation/service_admin/installing-openshift.adoc
@@ -31,7 +31,7 @@ images for the various components.
 +
 [source,options="nowrap"]
 ----
-curl -k https://$(oc get route restapi -o jsonpath='{.spec.host}')/v1/addressspaces/default
+curl -k https://$(oc get route restapi -o jsonpath='{.spec.host}')/apis/enmasse.io/v1/addressspaces/default
 ----
 +
 The deployment is finished when `status.isReady` is `true` in the returned JSON object.

--- a/systemtests/src/main/java/io/enmasse/systemtest/AddressApiClient.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/AddressApiClient.java
@@ -22,8 +22,8 @@ public class AddressApiClient {
     private Endpoint endpoint;
     private final Vertx vertx;
     private final int initRetry = 10;
-    private final String addressSpacesPath = "/v1/addressspaces";
-    private final String addressPath = "/v1/addresses";
+    private final String addressSpacesPath = "/apis/enmasse.io/v1/addressspaces";
+    private final String addressPath = "/apis/enmasse.io/v1/addresses";
     private final String authzString;
 
     public AddressApiClient(OpenShift openshift) throws InterruptedException {

--- a/templates/include/address-controller.jsonnet
+++ b/templates/include/address-controller.jsonnet
@@ -15,7 +15,7 @@ local common = import "common.jsonnet";
       "ports": [
         {
           "name": "https",
-          "port": 8081,
+          "port": 443,
           "protocol": "TCP",
           "targetPort": "https"
         }
@@ -83,8 +83,8 @@ local common = import "common.jsonnet";
                   common.container_port("https", 8081),
                   common.container_port("http", 8080)
                 ],
-               "livenessProbe": common.http_probe("https", "/v1/health", "HTTPS", 30),
-                "readinessProbe": common.http_probe("https", "/v1/health", "HTTPS", 30),
+               "livenessProbe": common.http_probe("https", "/apis/enmasse.io/v1/health", "HTTPS", 30),
+                "readinessProbe": common.http_probe("https", "/apis/enmasse.io/v1/health", "HTTPS", 30),
               }
             ],
             "volumes": [

--- a/templates/include/api-service.json
+++ b/templates/include/api-service.json
@@ -1,0 +1,32 @@
+
+{
+  "apiVersion": "v1",
+  "kind": "Template",
+  "objects": [
+    {
+      "apiVersion": "apiregistration.k8s.io/v1beta1",
+      "kind": "APIService",
+      "metadata": {
+        "name": "v1.enmasse.io"
+      },
+      "spec": {
+        "group": "enmasse.io",
+        "version": "v1",
+        "insecureSkipTLSVerify": true,
+        "groupPriorityMinimum": 1000,
+        "versionPriority": 15,
+        "service": {
+          "name": "address-controller",
+          "namespace": "${ENMASSE_NAMESPACE}"
+        }
+      }
+    }
+  ],
+  "parameters": [
+    {
+      "name": "ENMASSE_NAMESPACE",
+      "description": "Namespace where EnMasse is running",
+      "value": "enmasse"
+    }
+  ]
+}

--- a/templates/include/restapi-route.jsonnet
+++ b/templates/include/restapi-route.jsonnet
@@ -15,9 +15,6 @@
         "kind": "Service",
         "name": "address-controller"
       },
-      "port": {
-        "targetPort": "https"
-      },
       "tls": {
         "termination": "passthrough"
       }
@@ -41,10 +38,10 @@
           "http": {
             "paths": [
               {
-                "path": "/v1",
+                "path": "/apis/enmasse.io/v1",
                 "backend": {
                   "serviceName": "address-controller",
-                  "servicePort": 8081
+                  "servicePort": 443
                 }
               }
             ]

--- a/templates/install/kubernetes/addons/external-lb.yaml
+++ b/templates/install/kubernetes/addons/external-lb.yaml
@@ -10,7 +10,7 @@ items:
   spec:
     ports:
     - name: https
-      port: 8081
+      port: 443
       protocol: TCP
       targetPort: https
     selector:

--- a/templates/install/kubernetes/enmasse.yaml
+++ b/templates/install/kubernetes/enmasse.yaml
@@ -589,7 +589,7 @@ items:
           image: docker.io/enmasseproject/address-controller:latest
           livenessProbe:
             httpGet:
-              path: /v1/health
+              path: /apis/enmasse.io/v1/health
               port: https
               scheme: HTTPS
             initialDelaySeconds: 30
@@ -601,7 +601,7 @@ items:
             name: http
           readinessProbe:
             httpGet:
-              path: /v1/health
+              path: /apis/enmasse.io/v1/health
               port: https
               scheme: HTTPS
             initialDelaySeconds: 30
@@ -644,8 +644,8 @@ items:
         paths:
         - backend:
             serviceName: address-controller
-            servicePort: 8081
-          path: /v1
+            servicePort: 443
+          path: /apis/enmasse.io/v1
 - apiVersion: v1
   kind: Service
   metadata:
@@ -656,7 +656,7 @@ items:
   spec:
     ports:
     - name: https
-      port: 8081
+      port: 443
       protocol: TCP
       targetPort: https
     selector:

--- a/templates/install/openshift/enmasse.yaml
+++ b/templates/install/openshift/enmasse.yaml
@@ -1718,7 +1718,7 @@ objects:
           image: ${ADDRESS_CONTROLLER_REPO}
           livenessProbe:
             httpGet:
-              path: /v1/health
+              path: /apis/enmasse.io/v1/health
               port: https
               scheme: HTTPS
             initialDelaySeconds: 30
@@ -1730,7 +1730,7 @@ objects:
             name: http
           readinessProbe:
             httpGet:
-              path: /v1/health
+              path: /apis/enmasse.io/v1/health
               port: https
               scheme: HTTPS
             initialDelaySeconds: 30
@@ -1764,7 +1764,7 @@ objects:
   spec:
     ports:
     - name: https
-      port: 8081
+      port: 443
       protocol: TCP
       targetPort: https
     selector:
@@ -1778,8 +1778,6 @@ objects:
     name: restapi
   spec:
     host: ${RESTAPI_HOSTNAME}
-    port:
-      targetPort: https
     tls:
       termination: passthrough
     to:


### PR DESCRIPTION
This aligns the API with the format of other custom k8s apis and will make it easier to enable the API aggregator in 3.7