### PR TITLE
Replace use of Ingress with LoadBalancer for kubernetes

### DIFF
--- a/address-controller/src/main/java/io/enmasse/controller/Controller.java
+++ b/address-controller/src/main/java/io/enmasse/controller/Controller.java
@@ -19,6 +19,7 @@ import io.enmasse.address.model.AddressSpace;
 import io.enmasse.address.model.Endpoint;
 import io.enmasse.address.model.SecretCertProvider;
 import io.enmasse.config.AnnotationKeys;
+import io.enmasse.config.LabelKeys;
 import io.enmasse.controller.common.AddressSpaceController;
 import io.enmasse.controller.common.AuthenticationServiceResolverFactory;
 import io.enmasse.controller.common.Kubernetes;
@@ -26,7 +27,7 @@ import io.enmasse.k8s.api.AddressSpaceApi;
 import io.enmasse.k8s.api.Watch;
 import io.enmasse.k8s.api.Watcher;
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.extensions.Ingress;
+import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.vertx.core.AbstractVerticle;
@@ -137,16 +138,16 @@ public class Controller extends AbstractVerticle implements Watcher<AddressSpace
         annotations.put(AnnotationKeys.ADDRESS_SPACE, builder.getName());
 
         List<Endpoint> endpoints;
-        /* Watch for routes and ingress */
+        /* Watch for routes and lb services */
         if (client.isAdaptable(OpenShiftClient.class)) {
             endpoints = client.routes().inNamespace(builder.getNamespace()).list().getItems().stream()
                     .filter(route -> isPartOfAddressSpace(builder.getName(), route))
                     .map(this::routeToEndpoint)
                     .collect(Collectors.toList());
         } else {
-            endpoints = client.extensions().ingresses().inNamespace(builder.getNamespace()).list().getItems().stream()
-                    .filter(ingress -> isPartOfAddressSpace(builder.getName(), ingress))
-                    .map(this::ingressToEndpoint)
+            endpoints = client.services().inNamespace(builder.getNamespace()).withLabel(LabelKeys.TYPE, "loadbalancer").list().getItems().stream()
+                    .filter(service -> isPartOfAddressSpace(builder.getName(), service))
+                    .map(this::serviceToEndpoint)
                     .collect(Collectors.toList());
         }
 
@@ -163,6 +164,7 @@ public class Controller extends AbstractVerticle implements Watcher<AddressSpace
         Endpoint.Builder builder = new Endpoint.Builder()
                 .setName(route.getMetadata().getName())
                 .setHost(route.getSpec().getHost())
+                .setPort(443)
                 .setService(route.getSpec().getTo().getName());
 
         if (secretName != null) {
@@ -172,17 +174,25 @@ public class Controller extends AbstractVerticle implements Watcher<AddressSpace
         return builder.build();
     }
 
-    private Endpoint ingressToEndpoint(Ingress ingress) {
-        String secretName = ingress.getMetadata().getAnnotations().get(AnnotationKeys.CERT_SECRET_NAME);
+    private Endpoint serviceToEndpoint(Service service) {
+        String secretName = service.getMetadata().getAnnotations().get(AnnotationKeys.CERT_SECRET_NAME);
+        String serviceName = service.getMetadata().getAnnotations().get(AnnotationKeys.SERVICE_NAME);
         Endpoint.Builder builder = new Endpoint.Builder()
-                .setName(ingress.getMetadata().getName())
-                .setService(ingress.getSpec().getBackend().getServiceName());
+                .setName(service.getMetadata().getName())
+                .setService(serviceName);
 
         if (secretName != null) {
             builder.setCertProvider(new SecretCertProvider(secretName));
-            if (ingress.getSpec().getTls() != null && !ingress.getSpec().getTls().isEmpty() &&
-                    !ingress.getSpec().getTls().get(0).getHosts().isEmpty()) {
-                builder.setHost(ingress.getSpec().getTls().get(0).getHosts().get(0));
+        }
+
+        if (service.getSpec().getPorts().size() > 0) {
+            Integer nodePort = service.getSpec().getPorts().get(0).getNodePort();
+            Integer port = service.getSpec().getPorts().get(0).getPort();
+
+            if (nodePort != null) {
+                builder.setPort(nodePort);
+            } else if (port != null) {
+                builder.setPort(port);
             }
         }
 

--- a/address-model-lib/src/main/java/io/enmasse/address/model/Endpoint.java
+++ b/address-model-lib/src/main/java/io/enmasse/address/model/Endpoint.java
@@ -10,12 +10,14 @@ public class Endpoint {
     private final String name;
     private final String service;
     private final String host;
+    private final int port;
     private final CertProvider certProvider;
 
-    public Endpoint(String name, String service, String host, CertProvider certProvider) {
+    public Endpoint(String name, String service, String host, int port, CertProvider certProvider) {
         this.name = name;
         this.service = service;
         this.host = host;
+        this.port = port;
         this.certProvider = certProvider;
     }
 
@@ -25,6 +27,10 @@ public class Endpoint {
 
     public String getService() {
         return service;
+    }
+
+    public int getPort() {
+        return port;
     }
 
     public Optional<String> getHost() {
@@ -39,6 +45,7 @@ public class Endpoint {
         private String name;
         private String service;
         private String host;
+        private int port = 0;
         private CertProvider certProvider;
 
         public Builder() {}
@@ -65,6 +72,11 @@ public class Endpoint {
             return this;
         }
 
+        public Builder setPort(int port) {
+            this.port = port;
+            return this;
+        }
+
         public Builder setCertProvider(CertProvider certProvider) {
             this.certProvider = certProvider;
             return this;
@@ -73,7 +85,7 @@ public class Endpoint {
         public Endpoint build() {
             Objects.requireNonNull(name, "name not set");
             Objects.requireNonNull(service, "service not set");
-            return new Endpoint(name, service, host, certProvider);
+            return new Endpoint(name, service, host, port, certProvider);
         }
     }
 }

--- a/address-model-lib/src/main/java/io/enmasse/address/model/v1/AddressSpaceV1Deserializer.java
+++ b/address-model-lib/src/main/java/io/enmasse/address/model/v1/AddressSpaceV1Deserializer.java
@@ -79,6 +79,10 @@ class AddressSpaceV1Deserializer extends JsonDeserializer<AddressSpace> {
                     b.setHost(endpoint.get(Fields.HOST).asText());
                 }
 
+                if (endpoint.hasNonNull(Fields.PORT)) {
+                    b.setPort(endpoint.get(Fields.PORT).asInt());
+                }
+
                 if (endpoint.hasNonNull(Fields.CERT_PROVIDER)) {
                     ObjectNode certProvider = (ObjectNode) endpoint.get(Fields.CERT_PROVIDER);
                     b.setCertProvider(new CertProvider(

--- a/address-model-lib/src/main/java/io/enmasse/address/model/v1/AddressSpaceV1Serializer.java
+++ b/address-model-lib/src/main/java/io/enmasse/address/model/v1/AddressSpaceV1Serializer.java
@@ -59,6 +59,9 @@ class AddressSpaceV1Serializer extends JsonSerializer<AddressSpace> {
             e.put(Fields.NAME, endpoint.getName());
             e.put(Fields.SERVICE, endpoint.getService());
             endpoint.getHost().ifPresent(h -> e.put(Fields.HOST, h));
+            if (endpoint.getPort() != 0) {
+                e.put(Fields.PORT, endpoint.getPort());
+            }
             endpoint.getCertProvider().ifPresent(provider -> {
                 ObjectNode p = e.putObject(Fields.CERT_PROVIDER);
                 p.put(Fields.NAME, provider.getName());

--- a/address-model-lib/src/main/java/io/enmasse/address/model/v1/Fields.java
+++ b/address-model-lib/src/main/java/io/enmasse/address/model/v1/Fields.java
@@ -46,4 +46,5 @@ interface Fields {
     String DESCRIPTION = "description";
     String PLANS = "plans";
     String DETAILS = "details";
+    String PORT = "port";
 }

--- a/address-model-lib/src/main/java/io/enmasse/config/AnnotationKeys.java
+++ b/address-model-lib/src/main/java/io/enmasse/config/AnnotationKeys.java
@@ -20,4 +20,5 @@ public interface AnnotationKeys {
     String ADDRESS_SPACE = "addressSpace";
     String CERT_SECRET_NAME = "io.enmasse.certSecretName";
     String ENDPOINT_PORT = "io.enmasse.endpointPort";
+    String SERVICE_NAME = "io.enmasse.serviceName";
 }

--- a/agent/www/help.html
+++ b/agent/www/help.html
@@ -1025,7 +1025,7 @@ namespace Test
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-10-27 11:23:38 CEST
+Last updated 2017-11-01 23:15:24 CET
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css">

--- a/documentation/common/prerequisites-kubernetes.adoc
+++ b/documentation/common/prerequisites-kubernetes.adoc
@@ -5,10 +5,3 @@
 To install {ProductName}, you need to have Kubernetes installed. You can use
 https://github.com/kubernetes/minikube[minikube] if you want to install {ProductName} on your
 laptop.
-
-Since minikube runs in a virtual machine, you need to enable the ingress controller:
-
-[source,options="nowrap"]
-....
-minikube addons enable ingress
-....

--- a/documentation/getting_started/kubernetes.adoc
+++ b/documentation/getting_started/kubernetes.adoc
@@ -41,8 +41,7 @@ _Note: The `cluster-admin` role gives the `enmasse-service-account` service acco
 === Deploying external load balancers
 
 If you're running {ProductName} in your own Kubernetes instance on any of the
-cloud providers, and if you don't have or don't want to deploy an
-ingress controller, you can deploy the external load balancer services
+cloud providers, you can deploy the external load balancer services
 to expose {ProductName} ports:
 
 [options="nowrap"]
@@ -50,20 +49,17 @@ to expose {ProductName} ports:
 kubectl apply -f kubernetes/addons/external-lb.yaml -n enmasse
 ....
 
+If you are running in multitenant mode, exposing the restapi is sufficient:
+
+[options="nowrap"]
+....
+kubectl apply -f kubernetes/addons/external-lb-restapi.yaml -n enmasse
+....
+
 [[configuring-addresses-kubernetes]]
 === Configuring addresses
 
 include::configuring-addresses.adoc[leveloffset=+1]
-
-[[exposing-messaging-through-ingress-resource]]
-=== Exposing messaging through Ingress resource
-
-To open up for AMQP using minikube and the nginx ingress controller,
-follow
-https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx/examples/tcp[this]
-and
-https://github.com/kubernetes/ingress/tree/master/[this]
-guide, using the port `5672` and the service `default/messaging`.
 
 [[sending-and-receiving-messages-kubernetes]]
 === Sending and receiving messages

--- a/documentation/service_admin/installing-kubernetes.adoc
+++ b/documentation/service_admin/installing-kubernetes.adoc
@@ -15,9 +15,8 @@ not have cluster-admin privileges. Otherwise, choose multi-tenant mode.
 .Procedure 
 
 . To install {ProductName} in single-tenant mode run the following script:
-
 +
-[source,options="nowrap"]
+[options="nowrap"]
 ----
 ./deploy-kubernetes.sh -m "https://localhost:8443" -n enmasse -o singletenant
 ----
@@ -26,11 +25,18 @@ Running this script creates the deployments required for running {ProductName} i
 up {ProductName} will take a while, usually depending on how fast it is able to download the Docker
 images for the various components.
 
-. You can use the REST API to check the status of the deployment:
+. To access the REST API, enable the external service:
 +
-[source,options="nowrap"]
+[options="nowrap"]
 ----
-curl -k https://$(minikube ip)/apis/enmasse.io/v1/addressspaces/default
+kubectl create -f ./kubernetes/addons/external-lb.yaml
+----
+
+. You can then use the REST API to check the status of the deployment:
++
+[options="nowrap"]
+----
+curl -k $(minikube service --https --namespace enmasse restapi-external --url)/apis/enmasse.io/v1/addressspaces/default
 ----
 +
 The deployment is finished when `status.isReady` is `true` in the returned JSON object.
@@ -45,7 +51,7 @@ not have cluster-admin privileges. Otherwise, choose multi-tenant mode.
 
 . To install {ProductName} in multi-tenant mode, run the following script:
 +
-[source,options="nowrap"]
+[options="nowrap"]
 ----
 ./deploy-kubernetes.sh -m "https://localhost:8443" -n enmasse -o multitenant
 ----
@@ -57,16 +63,17 @@ to the `view` role and for the `enmasse-service-account` to the `cluster-admin` 
 
 . Grant cluster-admin privileges:
 +
-[source,options="nowrap"]
+[options="nowrap"]
 ----
 kubectl create clusterrolebinding enmasse-service-account-binding --clusterrole=cluster-admin --serviceaccount=enmasse:enmasse-service-account
 kubectl create rolebinding default-view-binding --clusterrole=view --serviceaccount=enmasse:default -n enmasse
 ----
 +
 The deployments required for running {ProductName} in multi-tenant mode are created.
+
 {ProductName} will be up and running once all pods in the 'enmasse' namespace are in the `Running` state:
 +
-[source,options="nowrap"]
+[options="nowrap"]
 ----
 kubectl get pods -n enmasse
 ----

--- a/templates/include/address-controller.jsonnet
+++ b/templates/include/address-controller.jsonnet
@@ -31,7 +31,7 @@ local common = import "common.jsonnet";
     self.common_service("address-controller", "ClusterIP", {}),
 
   external_service::
-    self.common_service("address-controller-external", "LoadBalancer", {}),
+    self.common_service("restapi-external", "LoadBalancer", {}),
 
   deployment(image, template_config, ca_secret, cert_secret, environment, enable_rbac)::
     {

--- a/templates/include/enmasse-kubernetes.jsonnet
+++ b/templates/include/enmasse-kubernetes.jsonnet
@@ -13,19 +13,9 @@ local images = import "images.jsonnet";
     "kind": "List",
     "items": [ templateConfig.generate(with_kafka),
                addressController.deployment(images.address_controller, "enmasse-template-config", "enmasse-ca", "address-controller-cert", "development", "false"),
-               restapiRoute.ingress(""),
                addressController.internal_service ]
   },
 
   external_lb::
-  {
-    "apiVersion": "v1",
-    "kind": "List",
-    "items": [ 
-      addressController.external_service,
-      messagingService.external,
-      mqttService.external,
-      consoleService.external
-    ]
-  }
+    addressController.external_service,
 }

--- a/templates/include/enmasse-template.jsonnet
+++ b/templates/include/enmasse-template.jsonnet
@@ -47,7 +47,6 @@ local images = import "images.jsonnet";
             "deployments",
             "replicasets",
             "routes",
-            "ingresses",
             "secrets",
             "services",
             "persistentvolumeclaims",

--- a/templates/install/kubernetes/addons/external-lb.yaml
+++ b/templates/install/kubernetes/addons/external-lb.yaml
@@ -1,73 +1,16 @@
 apiVersion: v1
-items:
-- apiVersion: v1
-  kind: Service
-  metadata:
-    annotations: {}
-    labels:
-      app: enmasse
-    name: address-controller-external
-  spec:
-    ports:
-    - name: https
-      port: 443
-      protocol: TCP
-      targetPort: https
-    selector:
-      name: address-controller
-    type: LoadBalancer
-- apiVersion: v1
-  kind: Service
-  metadata:
-    labels:
-      app: enmasse
-    name: messaging-external
-  spec:
-    ports:
-    - name: amqp
-      port: 5672
-      protocol: TCP
-      targetPort: 5672
-    - name: amqps
-      port: 5671
-      protocol: TCP
-      targetPort: 5671
-    selector:
-      capability: router
-    type: LoadBalancer
-- apiVersion: v1
-  kind: Service
-  metadata:
-    annotations: {}
-    labels:
-      app: enmasse
-    name: mqtt-external
-  spec:
-    ports:
-    - name: mqtt
-      port: 1883
-      protocol: TCP
-      targetPort: 1883
-    - name: secure-mqtt
-      port: 8883
-      protocol: TCP
-      targetPort: 8883
-    selector:
-      name: mqtt-gateway
-    type: LoadBalancer
-- apiVersion: v1
-  kind: Service
-  metadata:
-    labels:
-      app: enmasse
-    name: console-external
-  spec:
-    ports:
-    - name: console-ws
-      port: 56720
-    - name: console-http
-      port: 8080
-    selector:
-      name: admin
-    type: LoadBalancer
-kind: List
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app: enmasse
+  name: restapi-external
+spec:
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: https
+  selector:
+    name: address-controller
+  type: LoadBalancer

--- a/templates/install/kubernetes/enmasse.yaml
+++ b/templates/install/kubernetes/enmasse.yaml
@@ -639,21 +639,6 @@ items:
         - configMap:
             name: enmasse-template-config
           name: templates
-- apiVersion: extensions/v1beta1
-  kind: Ingress
-  metadata:
-    labels:
-      app: enmasse
-    name: restapi
-  spec:
-    rules:
-    - host: ''
-      http:
-        paths:
-        - backend:
-            serviceName: address-controller
-            servicePort: 443
-          path: /apis/enmasse.io/v1
 - apiVersion: v1
   kind: Service
   metadata:

--- a/templates/install/openshift/cluster-roles.yaml
+++ b/templates/install/openshift/cluster-roles.yaml
@@ -30,7 +30,6 @@ items:
     - deployments
     - replicasets
     - routes
-    - ingresses
     - secrets
     - services
     - persistentvolumeclaims


### PR DESCRIPTION
This attempts to fix the broken Ingress support, which has become more broken after moving to HTTPS for
our endpoints (Ingress doesnt support TLS passthrough).

Instead, on kubernetes, expose services using LoadBalancer, which works nicely with minikube as it will expose these using NodePort. For
production deployments, type=LoadBalancer is what you'd typically want so I think this makes the kubernetes use case much better.