### PR TITLE
simple authorization for console 

### DIFF
--- a/agent/lib/auth_service.js
+++ b/agent/lib/auth_service.js
@@ -18,6 +18,7 @@
 var path = require('path');
 var fs = require('fs');
 var rhea = require('rhea');
+var log = require("./log.js").logger();
 
 function authenticate(user, options) {
     return new Promise(function(resolve, reject) {
@@ -33,7 +34,7 @@ function authenticate(user, options) {
         authServer.on("connection_open", function (context) {
             handled = true;
             context.connection.close();
-            resolve();
+            resolve(context.connection.properties);
         });
         var handleFailure = function (context) {
             if (!handled) {
@@ -60,7 +61,7 @@ function default_options(env) {
         options.transport = 'tls';
         options.rejectUnauthorized = false;
     } catch (error) {
-        console.warn('CA cannot be loaded from ' + ca_path + ': ' + error);
+        log.warn('CA cannot be loaded from ' + ca_path + ': ' + error);
     }
     return options;
 }

--- a/agent/lib/authz.js
+++ b/agent/lib/authz.js
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2016 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+var myutils = require('./utils.js');
+
+function AuthorizationPolicy() {};
+
+AuthorizationPolicy.prototype.has_permission = function (required, actual) {
+    return actual && actual.indexOf(required) >= 0;
+};
+
+AuthorizationPolicy.prototype.set_authz_props = function (request, credentials, properties) {
+    if (credentials) {
+        request.authz_props = {groups:properties.groups, authid:credentials.name};
+    }
+};
+
+AuthorizationPolicy.prototype.get_authz_props = function (request) {
+    try {
+        var credentials = myutils.basic_auth(request);
+        if (credentials) {
+            return request.authz_props;
+        } else {
+            return undefined;
+        }
+    } catch (error) {
+        log.error('error retrieving authz properties for user: %s', error);
+        return undefined;
+    }
+};
+
+AuthorizationPolicy.prototype.address_filter = function (connection) {
+    var groups = connection.options.groups;
+    if (this.has_permission('address-space-admin', groups) || this.has_permission('address-space-monitor', groups)) {
+        return undefined;
+    } else {
+        var self = this;
+        return function (a) {
+            //TODO: handle wildcards
+            return self.has_permission('view_' + encodeURIComponent(a.address), groups);
+        };
+    }
+};
+
+AuthorizationPolicy.prototype.connection_filter = function (connection) {
+    var groups = connection.options.groups;
+    if (this.has_permission('address-space-admin', groups) || this.has_permission('address-space-monitor', groups)) {
+        return undefined;
+    } else {
+        return function (c) {
+            return connection.options.authid !== undefined && connection.options.authid === c.user;
+        };
+    }
+};
+
+AuthorizationPolicy.prototype.can_publish = function (sender, message) {
+    var groups = sender.connection.options.groups;
+    if (this.has_permission('address-space-admin', groups) || this.has_permission('address-space-monitor', groups)) {
+        return true;
+    } else if (message.subject === 'address' || message.subject === 'address_deleted') {
+        //TODO: handle wildcards
+        return this.has_permission('view_' + encodeURIComponent(message.body.address), groups);
+    } else if (message.subject === 'connection' || message.subject === 'connection_deleted') {
+        return sender.connection.options.authid === message.body.user;
+    }
+};
+
+function NullPolicy() {};
+
+NullPolicy.prototype.has_permission = function (required, actual) {
+    return true;
+};
+
+NullPolicy.prototype.set_authz_props = function (request, credentials, properties) {};
+
+NullPolicy.prototype.get_authz_props = function (request) {};
+
+NullPolicy.prototype.address_filter = function (connection) {
+    return undefined;
+};
+
+NullPolicy.prototype.connection_filter = function (connection) {
+    return undefined;
+};
+
+NullPolicy.prototype.can_publish = function (sender, message) {
+    return true;
+};
+
+module.exports.policy = function (env) {
+    if (env.KEYCLOAK_GROUP_PERMISSIONS) {
+        return new AuthorizationPolicy();
+    } else {
+        return new NullPolicy();
+    }
+}

--- a/agent/lib/registry.js
+++ b/agent/lib/registry.js
@@ -103,9 +103,11 @@ Registry.prototype.update_existing = function (updates) {
     }
 };
 
-Registry.prototype.for_each = function (f) {
+Registry.prototype.for_each = function (action, filter) {
     for (var key in this.objects) {
-        f(this.objects[key]);
+        if (filter === undefined || filter(this.objects[key])) {
+            action(this.objects[key]);
+        }
     }
 }
 

--- a/agent/lib/utils.js
+++ b/agent/lib/utils.js
@@ -45,3 +45,15 @@ module.exports.merge = function () {
         return a;
     });
 }
+
+module.exports.basic_auth = function (request) {
+    if (request.headers.authorization) {
+        var parts = request.headers.authorization.split(' ');
+        if (parts.length === 2 && parts[0].toLowerCase() === 'basic') {
+            parts = new Buffer(parts[1], 'base64').toString().split(':');
+            return { name: parts[0], pass: parts[1] };
+        } else {
+            throw new Error('Cannot handle authorization header ' + auth);
+        }
+    }
+}

--- a/agent/testlib/mock_authservice.js
+++ b/agent/testlib/mock_authservice.js
@@ -21,11 +21,18 @@ function is_valid_user(username, password) {
     return username === password.split().reverse().join('');
 }
 
-function MockAuthService(f) {
+function MockAuthService(f, groups) {
+    this.groups = groups;
+    var self = this;
     this.container = rhea.create_container({id:'mock-auth-service'});
     this.container.sasl_server_mechanisms.enable_plain(f || is_valid_user);
     this.container.sasl_server_mechanisms.enable_anonymous();
     this.container.on('connection_open', function (context) {
+        if (self.groups) {
+            var properties = context.connection.local.open.properties || {};
+            properties.groups = self.groups;
+            context.connection.local.open.properties = properties;
+        }
         context.connection.close();
     });
     this.container.on('disconnected', function (context) {});

--- a/agent/www/components/addresses/addresses.html
+++ b/agent/www/components/addresses/addresses.html
@@ -3,10 +3,10 @@
   <div class="row col-md-12">
     <div pf-toolbar id="exampleToolbar" config="toolbarConfig">
       <actions>
-        <button class="btn btn-default primary-action" type="button" ng-controller="WizardModalController" ng-click="openWizardModel()">
+        <button class="btn btn-default primary-action" type="button" ng-disabled=admin_disabled ng-controller="WizardModalController" ng-click="openWizardModel()">
           <span class="fa fa-plus"></span> Create
         </button>
-        <button class="btn btn-default primary-action" type="button" ng-click="delete_address()">
+        <button class="btn btn-default primary-action" ng-disabled=admin_disabled type="button" ng-click="delete_address()">
           Delete
         </button>
       </actions>

--- a/agent/www/components/addresses/addresses_ctrl.js
+++ b/agent/www/components/addresses/addresses_ctrl.js
@@ -1,5 +1,6 @@
 angular.module('patternfly.toolbars').controller('ViewCtrl', ['$scope', '$timeout', '$sce', '$templateCache', 'pfViewUtils', 'address_service',
     function ($scope, $timeout, $sce, $templateCache, pfViewUtils, address_service) {
+        $scope.admin_disabled = address_service.admin_disabled;
         $scope.get_stored_chart_config = function (address) {
             var chart = get_donut_chart(address, 'shard_depth_chart', 'Stored', get_tooltip_for_shard(address));
             if (address.shards) {
@@ -125,6 +126,7 @@ angular.module('patternfly.toolbars').controller('ViewCtrl', ['$scope', '$timeou
           if (reason.split('_')[0] !== 'address') {
             return
           }
+            $scope.admin_disabled = address_service.admin_disabled;
           $scope.items.forEach( function (item) {
             if (item.senders + item.receivers > 0) {
               if (!item.ingress_outcomes_link_table) {
@@ -279,8 +281,12 @@ angular.module('patternfly.toolbars').controller('ViewCtrl', ['$scope', '$timeou
           $scope.actionsText = action.name + "\n" + $scope.actionsText;
         };
 
-          $scope.delete_address = function (action) {
-              address_service.delete_selected();
+        $scope.delete_address = function (action) {
+            if ($scope.admin_disabled) {
+              window.alert('Delete disabled!');
+            } else {
+                address_service.delete_selected();
+            }
           };
           var suspend_address = function (action) {
               window.alert('Suspending not yet implemented!');
@@ -289,16 +295,18 @@ angular.module('patternfly.toolbars').controller('ViewCtrl', ['$scope', '$timeou
               window.alert('Purging not yet implemented!');
           };
 
-          $scope.actionsConfig = {
+        $scope.actionsConfig = {
           moreActions: [
               {
                   name: 'Suspend',
                   title: 'Suspend address',
+                  isDisabled: true,
                   actionFn: suspend_address
               },
               {
                   name: 'Purge',
                   title: 'Purge stored messages',
+                  isDisabled: true,
                   actionFn: purge_address
               }
           ],

--- a/agent/www/shared/address_service.js
+++ b/agent/www/shared/address_service.js
@@ -108,6 +108,7 @@ AddressDefinition.prototype.update_periodic_deltas = function () {
 
 function AddressService($http) {
     var self = this;  // 'this' is not available in the success funtion of $http.get
+    this.admin_disabled = true;
     this.addresses = [];
     this.address_types = [];
     this.address_space_type = '';
@@ -239,6 +240,7 @@ AddressService.prototype.on_message = function (context) {
     } else if (context.message.subject === 'address_types') {
         this.address_types = context.message.body;
         this.address_space_type = context.message.application_properties.address_space_type;
+        this.admin_disabled = context.message.application_properties.disable_admin;
         if (this.callback) this.callback('address_types');
     } else if (context.message.subject === 'connection') {
         this.update_connection(context.message.body);


### PR DESCRIPTION
Based on keycloak groups returned by auth service. Enabled through KEYCLOAK_GROUP_PERMISSIONS env var. Being a member of address-space-admin group provides full access. Being a member of address-space-monitor provides read only access to all data. Being a member of view_<address-name> provides read only access to the address in question (no wildcards yet). User not in either address-space-admin or address-space-monitor can only see their own connections.