### PR TITLE
replaced saxon with xsltproc

### DIFF
--- a/keycloak/src/main/sh/init-keycloak.sh
+++ b/keycloak/src/main/sh/init-keycloak.sh
@@ -2,9 +2,9 @@
 KEYCLOAK_DIR=$JBOSS_HOME
 KEYCLOAK_CONFIG=${KEYCLOAK_DIR}/standalone/configuration/standalone.xml
 
-java -jar /usr/share/java/saxon.jar -s:${KEYCLOAK_CONFIG} -xsl:${KEYCLOAK_DIR}/addSaslPlugin.xsl -o:${KEYCLOAK_CONFIG}
-java -jar /usr/share/java/saxon.jar -s:${KEYCLOAK_CONFIG} -xsl:${KEYCLOAK_DIR}/removeFileLogging.xsl -o:${KEYCLOAK_CONFIG}
-java -jar /usr/share/java/saxon.jar -s:${KEYCLOAK_CONFIG} -xsl:${KEYCLOAK_DIR}/addKeyStore.xsl -o:${KEYCLOAK_CONFIG}
+xsltproc ${KEYCLOAK_DIR}/addSaslPlugin.xsl ${KEYCLOAK_CONFIG} > ${KEYCLOAK_CONFIG}.new; mv ${KEYCLOAK_CONFIG}.new ${KEYCLOAK_CONFIG}
+xsltproc ${KEYCLOAK_DIR}/removeFileLogging.xsl ${KEYCLOAK_CONFIG} > ${KEYCLOAK_CONFIG}.new; mv ${KEYCLOAK_CONFIG}.new ${KEYCLOAK_CONFIG}
+xsltproc ${KEYCLOAK_DIR}/addKeyStore.xsl ${KEYCLOAK_CONFIG} > ${KEYCLOAK_CONFIG}.new; mv ${KEYCLOAK_CONFIG}.new ${KEYCLOAK_CONFIG}
 
 chown -R jboss:root ${KEYCLOAK_DIR}
 find ${KEYCLOAK_DIR} -type d -exec chmod 770 {} \;

--- a/keycloak/src/main/xsl/addKeyStore.xsl
+++ b/keycloak/src/main/xsl/addKeyStore.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="1.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:jboss="urn:jboss:domain:5.0">
 

--- a/keycloak/src/main/xsl/addSaslPlugin.xsl
+++ b/keycloak/src/main/xsl/addSaslPlugin.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="1.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:keycloak="urn:jboss:domain:keycloak-server:1.1">
 

--- a/keycloak/src/main/xsl/removeFileLogging.xsl
+++ b/keycloak/src/main/xsl/removeFileLogging.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="1.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:log="urn:jboss:domain:logging:3.0">
 


### PR DESCRIPTION
saxon is only available from the optional repository, which isn't available for productized images.
xsltproc is already available in the rhel image for modifying standalone.xml.  Using it, instead of having a productized build of saxon made available.