### PR TITLE
Common cert deploy directory.

### DIFF
--- a/keycloak/runlocal.sh
+++ b/keycloak/runlocal.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin -v $PWD/cert:/opt/jboss/keycloak/standalone/cert:z --net=host -ti enmasse-keycloak:latest
+docker run -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin -v $PWD/cert:/opt/enmasse/cert:z --net=host -ti enmasse-keycloak:latest

--- a/keycloak/src/main/sh/start-keycloak.sh
+++ b/keycloak/src/main/sh/start-keycloak.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 KEYSTORE_PATH=${JBOSS_HOME}/standalone/configuration/certificates.keystore
-CERT_PATH=${JBOSS_HOME}/standalone/cert
+CERT_PATH=/opt/enmasse/cert
 
 openssl pkcs12 -export -passout pass:enmasse -in ${CERT_PATH}/tls.crt -inkey ${CERT_PATH}/tls.key -name "server" -out /tmp/certificates-keystore.p12
 keytool -importkeystore -srcstorepass enmasse -deststorepass enmasse -destkeystore ${KEYSTORE_PATH} -srckeystore /tmp/certificates-keystore.p12 -srcstoretype PKCS12

--- a/keycloak/src/main/xsl/addSaslPlugin.xsl
+++ b/keycloak/src/main/xsl/addSaslPlugin.xsl
@@ -14,8 +14,8 @@
                     <properties>
                         <property name="enableTls" value="true"/>
                         <property name="enableNonTls" value="false"/>
-                        <property name="pemKeyPath" value="${{jboss.home.dir}}/standalone/cert/tls.key" />
-                        <property name="pemCertificatePath" value="${{jboss.home.dir}}/standalone/cert/tls.crt" />
+                        <property name="pemKeyPath" value="/opt/enmasse/cert/tls.key" />
+                        <property name="pemCertificatePath" value="/opt/enmasse/cert/tls.crt" />
                         <property name="tlsHost" value="0.0.0.0"/>
                         <property name="tlsPort" value="5671"/>
                         <property name="defaultDomain" value="enmasse"/>

--- a/templates/include/auth-service.jsonnet
+++ b/templates/include/auth-service.jsonnet
@@ -193,7 +193,7 @@ local images = import "images.jsonnet";
                 ],
                 "volumeMounts": [
                   common.volume_mount("keycloak-persistence", "/opt/jboss/keycloak/standalone/data"),
-                  common.volume_mount(cert_secret_name, "/opt/jboss/keycloak/standalone/cert")
+                  common.volume_mount(cert_secret_name, "/opt/enmasse/cert")
                 ],
                 "livenessProbe": common.http_probe("https", "/", "HTTPS", 120)
               }

--- a/templates/install/kubernetes/addons/standard-authservice.yaml
+++ b/templates/install/kubernetes/addons/standard-authservice.yaml
@@ -60,7 +60,7 @@ items:
           - mountPath: /opt/jboss/keycloak/standalone/data
             name: keycloak-persistence
             readOnly: false
-          - mountPath: /opt/jboss/keycloak/standalone/cert
+          - mountPath: /opt/enmasse/cert
             name: standard-authservice-cert
             readOnly: false
         volumes:

--- a/templates/install/openshift/addons/standard-authservice.yaml
+++ b/templates/install/openshift/addons/standard-authservice.yaml
@@ -61,7 +61,7 @@ objects:
           - mountPath: /opt/jboss/keycloak/standalone/data
             name: keycloak-persistence
             readOnly: false
-          - mountPath: /opt/jboss/keycloak/standalone/cert
+          - mountPath: /opt/enmasse/cert
             name: ${STANDARD_AUTHSERVICE_SECRET_NAME}
             readOnly: false
         volumes:


### PR DESCRIPTION
To keep mount points for the upstream and downstream templates consistent, created a certificate directory in /opt/enmasse.  Note: /opt/[product], is the recommended directory for ce images.