### PR TITLE
NEW functionality for storing logs of restarted pods

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/TestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/TestBase.java
@@ -70,10 +70,10 @@ public abstract class TestBase extends SystemTestRunListener {
     protected static void deleteAddressSpace(AddressSpace addressSpace) throws Exception {
         if (TestUtils.existAddressSpace(addressApiClient, addressSpace.getName())) {
             logCollector.collectEvents(addressSpace.getNamespace());
+            logCollector.collectLogsTerminatedPods(addressSpace.getNamespace());
             addressApiClient.deleteAddressSpace(addressSpace);
             TestUtils.waitForAddressSpaceDeleted(kubernetes, addressSpace);
             logCollector.stopCollecting(addressSpace.getNamespace());
-            logCollector.collectLogsTerminatedPods(addressSpace.getNamespace());
         } else {
             Logging.log.info("Address space '" + addressSpace + "' doesn't exists!");
         }

--- a/systemtests/src/test/java/io/enmasse/systemtest/TestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/TestBase.java
@@ -73,6 +73,7 @@ public abstract class TestBase extends SystemTestRunListener {
             addressApiClient.deleteAddressSpace(addressSpace);
             TestUtils.waitForAddressSpaceDeleted(kubernetes, addressSpace);
             logCollector.stopCollecting(addressSpace.getNamespace());
+            logCollector.collectLogsTerminatedPods(addressSpace.getNamespace());
         } else {
             Logging.log.info("Address space '" + addressSpace + "' doesn't exists!");
         }
@@ -83,7 +84,7 @@ public abstract class TestBase extends SystemTestRunListener {
     }
 
     @Before
-    public void setup() throws Exception {
+    public void setup() {
         addressSpaceList = new ArrayList<>();
         amqpClientFactory = new AmqpClientFactory(kubernetes, environment, null, username, password);
         mqttClientFactory = new MqttClientFactory(kubernetes, environment, null, username, password);


### PR DESCRIPTION
when name space is deleted then previous log from restarted pods is stored into log with following structure: ${NAMESPACE}.${POD-NAME}.terminated.log within ${NAMESCAPE} folder