### PR TITLE
Use correct routing type when creating queues

### DIFF
--- a/amqp-utils/src/main/java/io/enmasse/amqp/Artemis.java
+++ b/amqp-utils/src/main/java/io/enmasse/amqp/Artemis.java
@@ -200,6 +200,11 @@ public class Artemis implements AutoCloseable {
         doOperation("broker", "deployQueue", address, name, null, false);
     }
 
+    public void createQueue(String name, String address) throws TimeoutException {
+        log.info("Creating queue {} with address {}", name, address);
+        doOperation("broker", "createQueue", address, "ANYCAST", name, null, true, -1, false, true);
+    }
+
     public void createConnectorService(String name, Map<String, String> connParams) throws TimeoutException {
         log.info("Creating connector service {}", name);
         String factoryName = "org.apache.activemq.artemis.integration.amqp.AMQPConnectorServiceFactory";

--- a/artemis/shutdown-hook/src/main/java/enmasse/broker/prestop/TopicMigrator.java
+++ b/artemis/shutdown-hook/src/main/java/enmasse/broker/prestop/TopicMigrator.java
@@ -106,7 +106,7 @@ public class TopicMigrator implements DiscoveryListener {
             Host dest = destinations.next();
             QueueInfo queue = subscriptionInfo.getQueueInfo();
             try (Artemis manager = brokerFactory.createClient(vertx, protonClientOptions, dest.amqpEndpoint())) {
-                manager.deployQueue(queue.getQueueName(), queue.getAddress());
+                manager.createQueue(queue.getQueueName(), queue.getAddress());
                 manager.pauseQueue(queue.getQueueName());
                 if (subscriptionInfo.getDivertInfo().isPresent()) {
                     DivertInfo divert = subscriptionInfo.getDivertInfo().get();

--- a/queue-scheduler/src/main/java/io/enmasse/queue/scheduler/ArtemisAdapter.java
+++ b/queue-scheduler/src/main/java/io/enmasse/queue/scheduler/ArtemisAdapter.java
@@ -41,7 +41,7 @@ public class ArtemisAdapter implements Broker {
 
     @Override
     public void createQueue(String address) throws TimeoutException {
-        artemis.deployQueue(address, address);
+        artemis.createQueue(address, address);
         Map<String, String> connectorParams = new HashMap<>();
         connectorParams.put("host", messagingHost);
         connectorParams.put("port", messagingPort);


### PR DESCRIPTION
This bug caused colocated queues to get created as multicast addresses,
which in turn causes unexpected creation of temporary queues for
clients.

This fixes #720