### PR TITLE
Only copy address space plan and referred plans

### DIFF
--- a/address-controller/src/main/java/io/enmasse/controller/ControllerHelper.java
+++ b/address-controller/src/main/java/io/enmasse/controller/ControllerHelper.java
@@ -79,7 +79,7 @@ public class ControllerHelper {
             kubernetes.addSystemImagePullerPolicy(namespace, addressSpace);
             kubernetes.addAddressSpaceRoleBindings(addressSpace);
             kubernetes.createServiceAccount(addressSpace.getNamespace(), kubernetes.getAddressSpaceAdminSa());
-            schemaApi.copyIntoNamespace(addressSpace.getNamespace());
+            schemaApi.copyIntoNamespace(addressSpaceResolver.getPlan(addressSpaceResolver.getType(addressSpace), addressSpace), addressSpace.getNamespace());
         }
 
         StandardResources resourceList = createResourceList(addressSpace);

--- a/k8s-api-testutil/src/main/java/io/enmasse/k8s/api/TestSchemaApi.java
+++ b/k8s-api-testutil/src/main/java/io/enmasse/k8s/api/TestSchemaApi.java
@@ -15,7 +15,7 @@ public class TestSchemaApi implements SchemaApi {
     }
 
     @Override
-    public void copyIntoNamespace(String otherNamespace) {
+    public void copyIntoNamespace(AddressSpacePlan plan, String otherNamespace) {
         copiedTo.add(otherNamespace);
     }
 

--- a/k8s-api/src/main/java/io/enmasse/k8s/api/SchemaApi.java
+++ b/k8s-api/src/main/java/io/enmasse/k8s/api/SchemaApi.java
@@ -15,6 +15,7 @@
  */
 package io.enmasse.k8s.api;
 
+import io.enmasse.address.model.AddressSpacePlan;
 import io.enmasse.address.model.v1.SchemaProvider;
 
 /**
@@ -22,7 +23,7 @@ import io.enmasse.address.model.v1.SchemaProvider;
  */
 public interface SchemaApi extends SchemaProvider {
     /**
-     * Copy schema definitions into namespace;
+     * Copy address space plan and referenced address plans and resource definitions into namespace;
      */
-    void copyIntoNamespace(String otherNamespace);
+    void copyIntoNamespace(AddressSpacePlan addressSpacePlan, String otherNamespace);
 }


### PR DESCRIPTION
@grs It currently still copies all the resource definitions, but I think that is ok.