### PR TITLE
NEW TestBase - method for check count of subscribers via console

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/clients/MsgPatternsTestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/clients/MsgPatternsTestBase.java
@@ -102,7 +102,11 @@ public abstract class MsgPatternsTestBase extends ClientTestBase {
         Future<Boolean> recResult = subscriber.runAsync();
         Future<Boolean> recResult2 = subscriber2.runAsync();
 
-        waitForSubscribers(sharedAddressSpace, dest.getAddress(), 2);
+        if (isBrokered(sharedAddressSpace)) {
+            waitForSubscribers(sharedAddressSpace, dest.getAddress(), 2);
+        } else {
+            waitForSubscribersConsole(sharedAddressSpace, dest, 2);
+        }
 
         assertTrue("Producer failed, expected return code 0", sender.run());
         assertTrue("Subscriber failed, expected return code 0", recResult.get());
@@ -139,7 +143,7 @@ public abstract class MsgPatternsTestBase extends ClientTestBase {
 
         assertTrue("Sender failed, expected return code 0", sender.run());
         assertTrue("Browse receiver failed, expected return code 0", receiver_browse.run());
-        assertTrue("Receiver failed, expected return code 0",receiver_receive.run());
+        assertTrue("Receiver failed, expected return code 0", receiver_receive.run());
 
         assertEquals(String.format("Expected %d sent messages", expectedMsgCount),
                 expectedMsgCount, sender.getMessages().size());
@@ -271,7 +275,11 @@ public abstract class MsgPatternsTestBase extends ClientTestBase {
         Future<Boolean> result2 = subscriber2.runAsync();
         Future<Boolean> result3 = subscriber3.runAsync();
 
-        waitForSubscribers(sharedAddressSpace, topic.getAddress(), 3);
+        if (isBrokered(sharedAddressSpace)) {
+            waitForSubscribers(sharedAddressSpace, topic.getAddress(), 3);
+        } else {
+            waitForSubscribersConsole(sharedAddressSpace, topic, 3);
+        }
 
         assertTrue("Sender failed, expected return code 0", sender.run());
         assertTrue("Receiver 'colour = red' failed, expected return code 0", result1.get());

--- a/systemtests/src/test/java/io/enmasse/systemtest/brokered/web/ChromeWebConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/brokered/web/ChromeWebConsoleTest.java
@@ -3,8 +3,6 @@ package io.enmasse.systemtest.brokered.web;
 import io.enmasse.systemtest.AddressType;
 import io.enmasse.systemtest.Destination;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.chrome.ChromeOptions;
 
 public class ChromeWebConsoleTest extends BrokeredWebConsoleTest {
 
@@ -110,9 +108,6 @@ public class ChromeWebConsoleTest extends BrokeredWebConsoleTest {
 
     @Override
     public WebDriver buildDriver() {
-        ChromeOptions opts = new ChromeOptions();
-        opts.setHeadless(true);
-        opts.addArguments("--no-sandbox");
-        return new ChromeDriver(opts);
+        return getChromeDriver();
     }
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/brokered/web/FirefoxWebConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/brokered/web/FirefoxWebConsoleTest.java
@@ -4,8 +4,6 @@ import io.enmasse.systemtest.AddressType;
 import io.enmasse.systemtest.Destination;
 import org.junit.Test;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.firefox.FirefoxDriver;
-import org.openqa.selenium.firefox.FirefoxOptions;
 
 public class FirefoxWebConsoleTest extends BrokeredWebConsoleTest {
 
@@ -117,8 +115,6 @@ public class FirefoxWebConsoleTest extends BrokeredWebConsoleTest {
 
     @Override
     public WebDriver buildDriver() {
-        FirefoxOptions opts = new FirefoxOptions();
-        opts.setHeadless(true);
-        return new FirefoxDriver(opts);
+        return getFirefoxDriver();
     }
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/marathon/ChromeWebConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/marathon/ChromeWebConsoleTest.java
@@ -1,9 +1,6 @@
 package io.enmasse.systemtest.marathon;
 
-import org.junit.Test;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.chrome.ChromeOptions;
 
 public class ChromeWebConsoleTest extends WebConsoleTest {
 
@@ -14,9 +11,6 @@ public class ChromeWebConsoleTest extends WebConsoleTest {
 
     @Override
     public WebDriver buildDriver() {
-        ChromeOptions opts = new ChromeOptions();
-        opts.setHeadless(true);
-        opts.addArguments("--no-sandbox");
-        return new ChromeDriver(opts);
+        return getChromeDriver();
     }
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/marathon/FirefoxWebConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/marathon/FirefoxWebConsoleTest.java
@@ -2,8 +2,6 @@ package io.enmasse.systemtest.marathon;
 
 import org.junit.Test;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.firefox.FirefoxDriver;
-import org.openqa.selenium.firefox.FirefoxOptions;
 
 public class FirefoxWebConsoleTest extends WebConsoleTest {
 
@@ -14,8 +12,6 @@ public class FirefoxWebConsoleTest extends WebConsoleTest {
 
     @Override
     public WebDriver buildDriver() {
-        FirefoxOptions opts = new FirefoxOptions();
-        opts.setHeadless(true);
-        return new FirefoxDriver(opts);
+        return getFirefoxDriver();
     }
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/marathon/WebConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/marathon/WebConsoleTest.java
@@ -67,8 +67,4 @@ public abstract class WebConsoleTest extends MarathonTestBase implements ISeleni
         log.info("testCreateDeleteAddressesViaAgentLong finished");
     }
 
-    @Override
-    public WebDriver buildDriver() {
-        throw new NotImplementedException();
-    }
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/standard/clients/proton/java/MsgPatternsTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/standard/clients/proton/java/MsgPatternsTest.java
@@ -1,6 +1,5 @@
 package io.enmasse.systemtest.standard.clients.proton.java;
 
-import io.enmasse.systemtest.AddressSpaceType;
 import io.enmasse.systemtest.executor.client.proton.java.ProtonJMSClientReceiver;
 import io.enmasse.systemtest.executor.client.proton.java.ProtonJMSClientSender;
 import org.junit.Test;
@@ -17,7 +16,7 @@ public class MsgPatternsTest extends io.enmasse.systemtest.standard.clients.MsgP
         doRoundRobinReceiverTest(new ProtonJMSClientSender(), new ProtonJMSClientReceiver(), new ProtonJMSClientReceiver());
     }
 
-    //@Test
+    @Test
     public void testTopicSubscribe() throws Exception {
         doTopicSubscribeTest(new ProtonJMSClientSender(), new ProtonJMSClientReceiver(), new ProtonJMSClientReceiver(), true);
     }
@@ -37,7 +36,7 @@ public class MsgPatternsTest extends io.enmasse.systemtest.standard.clients.MsgP
         doMessageSelectorQueueTest(new ProtonJMSClientSender(), new ProtonJMSClientReceiver());
     }
 
-    //@Test
+    @Test
     public void testMessageSelectorTopic() throws Exception{
         doMessageSelectorTopicTest(new ProtonJMSClientSender(), new ProtonJMSClientReceiver(),
                 new ProtonJMSClientReceiver(), new ProtonJMSClientReceiver(), true);

--- a/systemtests/src/test/java/io/enmasse/systemtest/standard/clients/proton/python/MsgPatternsTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/standard/clients/proton/python/MsgPatternsTest.java
@@ -1,6 +1,5 @@
 package io.enmasse.systemtest.standard.clients.proton.python;
 
-import io.enmasse.systemtest.AddressSpaceType;
 import io.enmasse.systemtest.executor.client.proton.python.PythonClientReceiver;
 import io.enmasse.systemtest.executor.client.proton.python.PythonClientSender;
 import org.junit.Test;
@@ -17,7 +16,7 @@ public class MsgPatternsTest extends io.enmasse.systemtest.standard.clients.MsgP
         doRoundRobinReceiverTest(new PythonClientSender(), new PythonClientReceiver(), new PythonClientReceiver());
     }
 
-    //@Test
+    @Test
     public void testTopicSubscribe() throws Exception {
         doTopicSubscribeTest(new PythonClientSender(), new PythonClientReceiver(), new PythonClientReceiver(), false);
     }
@@ -37,7 +36,7 @@ public class MsgPatternsTest extends io.enmasse.systemtest.standard.clients.MsgP
         doMessageSelectorQueueTest(new PythonClientSender(), new PythonClientReceiver());
     }
 
-    //@Test
+    @Test
     public void testMessageSelectorTopic() throws Exception{
         doMessageSelectorTopicTest(new PythonClientSender(), new PythonClientReceiver(),
                 new PythonClientReceiver(), new PythonClientReceiver(), false);

--- a/systemtests/src/test/java/io/enmasse/systemtest/standard/clients/rhea/MsgPatternsTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/standard/clients/rhea/MsgPatternsTest.java
@@ -1,6 +1,5 @@
 package io.enmasse.systemtest.standard.clients.rhea;
 
-import io.enmasse.systemtest.AddressSpaceType;
 import io.enmasse.systemtest.executor.client.rhea.RheaClientReceiver;
 import io.enmasse.systemtest.executor.client.rhea.RheaClientSender;
 import org.junit.Test;
@@ -17,7 +16,7 @@ public class MsgPatternsTest extends io.enmasse.systemtest.standard.clients.MsgP
         doRoundRobinReceiverTest(new RheaClientSender(), new RheaClientReceiver(), new RheaClientReceiver());
     }
 
-    //@Test
+    @Test
     public void testTopicSubscribe() throws Exception {
         doTopicSubscribeTest(new RheaClientSender(), new RheaClientReceiver(), new RheaClientReceiver(), false);
     }
@@ -37,7 +36,7 @@ public class MsgPatternsTest extends io.enmasse.systemtest.standard.clients.MsgP
         doMessageSelectorQueueTest(new RheaClientSender(), new RheaClientReceiver());
     }
 
-    //@Test
+    @Test
     public void testMessageSelectorTopic() throws Exception{
         doMessageSelectorTopicTest(new RheaClientSender(), new RheaClientReceiver(),
                 new RheaClientReceiver(), new RheaClientReceiver(), false);

--- a/systemtests/src/test/java/io/enmasse/systemtest/standard/web/ChromeWebConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/standard/web/ChromeWebConsoleTest.java
@@ -3,8 +3,6 @@ package io.enmasse.systemtest.standard.web;
 import io.enmasse.systemtest.AddressType;
 import io.enmasse.systemtest.Destination;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.chrome.ChromeOptions;
 
 public class ChromeWebConsoleTest extends StandardWebConsoleTest {
 
@@ -120,9 +118,6 @@ public class ChromeWebConsoleTest extends StandardWebConsoleTest {
 
     @Override
     public WebDriver buildDriver() {
-        ChromeOptions opts = new ChromeOptions();
-        opts.setHeadless(true);
-        opts.addArguments("--no-sandbox");
-        return new ChromeDriver(opts);
+        return getChromeDriver();
     }
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/standard/web/FirefoxWebConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/standard/web/FirefoxWebConsoleTest.java
@@ -4,8 +4,6 @@ import io.enmasse.systemtest.AddressType;
 import io.enmasse.systemtest.Destination;
 import org.junit.Test;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.firefox.FirefoxDriver;
-import org.openqa.selenium.firefox.FirefoxOptions;
 
 public class FirefoxWebConsoleTest extends StandardWebConsoleTest {
 
@@ -127,8 +125,6 @@ public class FirefoxWebConsoleTest extends StandardWebConsoleTest {
 
     @Override
     public WebDriver buildDriver() {
-        FirefoxOptions opts = new FirefoxOptions();
-        opts.setHeadless(true);
-        return new FirefoxDriver(opts);
+        return getFirefoxDriver();
     }
 }


### PR DESCRIPTION
- 'get web browser drivers' moved into TestBase
- standard clients test(testMessageSelectorTopic, testTopicSubscribe) enabled for rhea, proton(java, python)