### PR TITLE
Configure connected brokers where indicated by broker-id annotation.

### DIFF
--- a/agent/bin/agent.js
+++ b/agent/bin/agent.js
@@ -35,8 +35,8 @@ function start(env) {
         console_server.listen(env);
 
         if (env.ADDRESS_SPACE_TYPE === 'brokered') {
-            var BrokerController = require('../lib/broker_controller.js');
-            var bc = new BrokerController(kubernetes.post_event);
+            address_source.filter_on_phase = false;
+            var bc = require('../lib/broker_controller.js').create_agent(kubernetes.post_event);
             bind_event(bc, 'address_stats_retrieved', console_server.addresses, 'update_existing');
             bind_event(bc, 'connection_stats_retrieved', console_server.connections, 'set');
             bind_event(address_source, 'addresses_defined', bc);

--- a/agent/lib/internal_address_source.js
+++ b/agent/lib/internal_address_source.js
@@ -30,25 +30,52 @@ function AddressSource(address_space, config) {
     this.watcher = kubernetes.watch('configmaps', options);
     this.watcher.on('updated', this.updated.bind(this));
     this.readiness = {};
+    this.filter_on_phase = true;
 }
 
 util.inherits(AddressSource, events.EventEmitter);
 
-function extract_address_spec(object) {
+function extract_address(object) {
     try {
-        var def = JSON.parse(object.data['config.json']);
-        if (def.spec === undefined) {
-            console.error('no spec found on %j', def);
-        }
-        return def.spec;
+        return JSON.parse(object.data['config.json']);
     } catch (e) {
         console.error('Failed to parse config.json for address: %s %j', e, object);
     }
 }
 
+function extract_spec(def) {
+    try {
+        if (def.spec === undefined) {
+            console.error('no spec found on %j', def);
+        }
+        if (def.metadata && def.metadata.annotations && def.metadata.annotations['enmasse.io/broker-id']) {
+            var o = Object.create(def.spec);
+            o.allocated_to = def.metadata.annotations['enmasse.io/broker-id'];
+            return o;
+        } else {
+            return def.spec;
+        }
+    } catch (e) {
+        console.error('Failed to parse config.json for address: %s %j', e, object);
+    }
+}
+
+function extract_address_spec(object) {
+    try {
+        return JSON.parse(object.data['config.json']).spec;
+    } catch (e) {
+        console.error('Failed to parse config.json for address: %s %j', e, object);
+    }
+}
+
+function ready (addr) {
+    return addr.status && addr.status.phase !== 'Terminating' && addr.status.phase !== 'Pending';
+}
+
 AddressSource.prototype.updated = function (objects) {
-    var addresses = objects.map(extract_address_spec);
+    var addresses = this.filter_on_phase ? objects.map(extract_address).filter(ready).map(extract_spec) : objects.map(extract_address_spec);
     log.debug('addresses updated: %j', addresses);
+    log.info('retrieved address definitions: %j -> %j', objects, addresses);
     var self = this;
     this.readiness = objects.reduce(function (map, configmap) {
         var address = extract_address_spec(configmap).address;

--- a/agent/lib/router.js
+++ b/agent/lib/router.js
@@ -142,7 +142,7 @@ function is_topic(address) {
 }
 
 function to_link_route(direction, address) {
-    return {name:address.name + '_' + direction, prefix:address.name, dir:direction};
+    return {name:address.name + '_' + direction, prefix:address.name, dir:direction, containerId:address.allocated_to};
 }
 
 function to_in_link_route(address) {
@@ -278,7 +278,8 @@ ConnectedRouter.prototype.define_autolink = function (address, direction) {
     var future = futurejs.future(created);
     var name = (direction == "in" ? "autoLinkIn" : "autoLinkOut") + address.name;
     log.info('defining autolink for ' + address.name + ' in direction ' + direction + ' on router ' + this.container_id);
-    this.create_entity('org.apache.qpid.dispatch.router.config.autoLink', name, {dir:direction, addr:address.name, containerId:address.name}, future.as_callback());
+    var brokerId = address.allocated_to || address.name;
+    this.create_entity('org.apache.qpid.dispatch.router.config.autoLink', name, {dir:direction, addr:address.name, containerId:brokerId}, future.as_callback());
     return future;
 }
 
@@ -303,7 +304,9 @@ ConnectedRouter.prototype.delete_address_and_autolinks = function (address) {
 ConnectedRouter.prototype.define_link_route = function (route) {
     var future = futurejs.future(created);
     log.info('defining ' + route.dir + ' link route ' + route.prefix + ' on router ' + this.container_id);
-    this.create_entity('org.apache.qpid.dispatch.router.config.linkRoute', route.name, {'prefix':route.prefix, dir:route.dir}, future.as_callback());
+    var props = {'prefix':route.prefix, dir:route.dir};
+    if (route.containerId) props.containerId = route.containerId;
+    this.create_entity('org.apache.qpid.dispatch.router.config.linkRoute', route.name, props, future.as_callback());
     return future;
 };
 

--- a/agent/lib/utils.js
+++ b/agent/lib/utils.js
@@ -127,3 +127,31 @@ module.exports.kubernetes_name = function (name) {
     }
     return clean;
 }
+
+module.exports.serialize = function (f) {
+    var in_progress = false;
+    var pending = 0;
+    function execute() {
+        f().then(function () {
+            if (pending) {
+                next();
+            } else {
+                in_progress = false;
+            }
+        }).catch(function() {
+            in_progress = false;
+        });
+    }
+    function next() {
+        pending--;
+        setImmediate(execute);
+    };
+    return function () {
+        if (in_progress) {
+            pending++;
+        } else {
+            in_progress = true;
+            execute();
+        }
+    };
+};

--- a/agent/test/internal_address_source.js
+++ b/agent/test/internal_address_source.js
@@ -51,6 +51,26 @@ describe('configmap backed address source', function() {
             done();
         });
     });
+    it('indicates allocation to broker', function(done) {
+        configmaps.add_address_definition({address:'foo', type:'queue'}, undefined, {'enmasse.io/broker-id':'broker-1'});
+        configmaps.add_address_definition({address:'bar', type:'topic'}, undefined, {'enmasse.io/broker-id':'broker-2'});
+        configmaps.add_address_definition({address:'baz', type:'anycast'});
+        var source = new AddressSource('foo', {port:configmaps.port, host:'localhost', token:'foo', namespace:'default'});
+        source.watcher.close();//prevents watching
+        source.on('addresses_defined', function (addresses) {
+            assert.equal(addresses.length, 3);
+            assert.equal(addresses[0].address, 'foo');
+            assert.equal(addresses[0].type, 'queue');
+            assert.equal(addresses[0].allocated_to, 'broker-1');
+            assert.equal(addresses[1].address, 'bar');
+            assert.equal(addresses[1].type, 'topic');
+            assert.equal(addresses[1].allocated_to, 'broker-2');
+            assert.equal(addresses[2].address, 'baz');
+            assert.equal(addresses[2].type, 'anycast');
+            assert.equal(addresses[2].allocated_to, undefined);
+            done();
+        });
+    });
     it('watches for changes', function(done) {
         var source = new AddressSource('foo', {port:configmaps.port, host:'localhost', token:'foo', namespace:'default'});
         source.once('addresses_defined', function () {
@@ -157,10 +177,10 @@ describe('configmap backed address source', function() {
     });
     it('creates an address', function(done) {
         var source = new AddressSource('foo', {port:configmaps.port, host:'localhost', token:'foo', namespace:'default'});
-        source.on('addresses_defined', function () {
+        source.once('addresses_defined', function () {
             source.create_address({address:'myqueue', type:'queue', plan:'clever'}).then(
                 function () {
-                    source.on('addresses_defined', function (addresses) {
+                    source.once('addresses_defined', function (addresses) {
                         assert.equal(addresses.length, 1);
                         assert.equal(addresses[0].address, 'myqueue');
                         assert.equal(addresses[0].type, 'queue');

--- a/agent/testlib/mock_broker.js
+++ b/agent/testlib/mock_broker.js
@@ -142,6 +142,10 @@ MockBroker.prototype.listen = function (port) {
     return this.server;
 };
 
+MockBroker.prototype.connect = function (port) {
+    return this.container.connect({port:port, properties:{product:'apache-activemq-artemis'}});
+};
+
 MockBroker.prototype.close = function (callback) {
     if (this.server) this.server.close(callback);
 };
@@ -328,5 +332,51 @@ MockBroker.prototype.get_pod_definition = function () {
         }
     };
 };
+
+function remove(list, predicate) {
+    var removed = [];
+    for (var i = 0; i < list.length; ) {
+        if (predicate(list[i])) {
+            removed.push(list.splice(i, 1)[0]);
+        } else {
+            i++;
+        }
+    }
+    return removed;
+}
+
+MockBroker.prototype.verify_queue = function (addresses, queues, name) {
+    var results = remove(queues, function (o) { return o.name === name; });
+    assert.equal(results.length, 1, util.format('queue %s not found', name));
+    assert.equal(results[0].name, name);
+    results = remove(addresses, function (o) { return o.name === name; });
+    assert.equal(results.length, 1, util.format('address %s not found', name));
+    assert.equal(results[0].name, name);
+    assert.equal(results[0].routingTypesAsJSON[0], 'ANYCAST');
+    assert.equal(results[0].queueNames[0], name);
+    return results[0];
+};
+
+MockBroker.prototype.verify_topic = function (addresses, name) {
+    var results = remove(addresses, function (o) { return o.name === name; });
+    assert.equal(results.length, 1, util.format('address %s not found', name));
+    assert.equal(results[0].name, name);
+    assert.equal(results[0].routingTypesAsJSON[0], 'MULTICAST');
+    return results[0];
+};
+
+MockBroker.prototype.verify_addresses = function (expected) {
+    var addresses = this.list_addresses();
+    var queues = this.list_queues();
+    for (var i = 0; i < expected.length; i++) {
+        if (expected[i].type === 'queue') {
+            this.verify_queue(addresses, queues, expected[i].address);
+        } else if (expected[i].type === 'topic') {
+            this.verify_topic(addresses, expected[i].address);
+        }
+    }
+    assert.equal(addresses.length, 0);
+    assert.equal(queues.length, 0);
+}
 
 module.exports = MockBroker;

--- a/artemis/config_templates/standard/broker_queue_colocated.xml
+++ b/artemis/config_templates/standard/broker_queue_colocated.xml
@@ -12,4 +12,11 @@
           <param key="containerId" value="$CONTAINER_ID" />
           <param key="clusterId" value="$CLUSTER_ID" />
         </connector-service>
+        <connector-service name="router-connector">
+          <factory-class>org.apache.activemq.artemis.integration.amqp.AMQPConnectorServiceFactory</factory-class>
+          <param key="host" value="$MESSAGING_SERVICE_HOST" />
+          <param key="port" value="$MESSAGING_SERVICE_PORT_AMQPS_BROKER" />
+          <param key="containerId" value="$CONTAINER_ID" />
+          <param key="clusterId" value="$CLUSTER_ID" />
+        </connector-service>
       </connector-services>

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/AddressController.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/AddressController.java
@@ -156,6 +156,7 @@ public class AddressController extends AbstractVerticle implements Watcher<Addre
         Map<Address, Integer> okMap = checkStatuses(addresses, addressResolver);
         for (Map.Entry<Address, Integer> entry : okMap.entrySet()) {
             if (entry.getValue() == 0) {
+                log.info("Garbage collecting {}", entry.getKey());
                 addressApi.deleteAddress(entry.getKey());
             }
         }

--- a/templates/include/admin.jsonnet
+++ b/templates/include/admin.jsonnet
@@ -25,7 +25,7 @@ local common = import "common.jsonnet";
   services(addressSpace)::
   [
     self.service("ragent", addressSpace, [{"name": "amqp", "port": 5671, "targetPort": 55671}]),
-    self.service("queue-scheduler", addressSpace, [{"name": "amqp", "port": 5672, "targetPort": 55667}]),
+    self.service("queue-scheduler", addressSpace, [{"name": "amqp", "port": 5672, "targetPort": 55671}]),
     self.service("console", addressSpace, [{"name": "https", "port": 8081, "targetPort": 8080}], "https")
   ],
 

--- a/templates/install/kubernetes/enmasse.yaml
+++ b/templates/install/kubernetes/enmasse.yaml
@@ -263,7 +263,7 @@ items:
       {"name": "admin"}}}, {"apiVersion": "v1", "kind": "Service", "metadata": {"annotations":
       {"addressSpace": "${ADDRESS_SPACE}"}, "labels": {"app": "enmasse"}, "name":
       "queue-scheduler"}, "spec": {"ports": [{"name": "amqp", "port": 5672, "targetPort":
-      55667}], "selector": {"name": "admin"}}}, {"apiVersion": "v1", "kind": "Service",
+      55671}], "selector": {"name": "admin"}}}, {"apiVersion": "v1", "kind": "Service",
       "metadata": {"annotations": {"addressSpace": "${ADDRESS_SPACE}", "io.enmasse.endpointPort":
       "https"}, "labels": {"app": "enmasse"}, "name": "console"}, "spec": {"ports":
       [{"name": "https", "port": 8081, "targetPort": 8080}], "selector": {"name":

--- a/templates/install/openshift/enmasse.yaml
+++ b/templates/install/openshift/enmasse.yaml
@@ -1442,13 +1442,13 @@ objects:
     value: docker.io/enmasseproject/configserv:latest
   - description: The docker image to use for the queue scheduler
     name: QUEUE_SCHEDULER_IMAGE
-    value: docker.io/gordons/queue-scheduler:latest
+    value: docker.io/enmasseproject/queue-scheduler:latest
   - description: The docker image to use for the standard controller
     name: STANDARD_CONTROLLER_IMAGE
     value: docker.io/enmasseproject/standard-controller:latest
   - description: The image to use for the enmasse agent
     name: AGENT_IMAGE
-    value: docker.io/gordons/agent:latest
+    value: docker.io/enmasseproject/agent:latest
   - description: The hostname to use for the exposed route for messaging
     name: MESSAGING_HOSTNAME
   - description: The image to use for the MQTT gateway

--- a/templates/install/openshift/enmasse.yaml
+++ b/templates/install/openshift/enmasse.yaml
@@ -523,7 +523,7 @@ objects:
       ports:
       - name: amqp
         port: 5672
-        targetPort: 55667
+        targetPort: 55671
       selector:
         name: admin
   - apiVersion: v1
@@ -1442,13 +1442,13 @@ objects:
     value: docker.io/enmasseproject/configserv:latest
   - description: The docker image to use for the queue scheduler
     name: QUEUE_SCHEDULER_IMAGE
-    value: docker.io/enmasseproject/queue-scheduler:latest
+    value: docker.io/gordons/queue-scheduler:latest
   - description: The docker image to use for the standard controller
     name: STANDARD_CONTROLLER_IMAGE
     value: docker.io/enmasseproject/standard-controller:latest
   - description: The image to use for the enmasse agent
     name: AGENT_IMAGE
-    value: docker.io/enmasseproject/agent:latest
+    value: docker.io/gordons/agent:latest
   - description: The hostname to use for the exposed route for messaging
     name: MESSAGING_HOSTNAME
   - description: The image to use for the MQTT gateway


### PR DESCRIPTION
Ignore addresses in the Pending and Terminating phases.
Have 'pool' brokers connect to agent rather than queue-scheduler.