### PR TITLE
Variable substition for generating the templates for keycloak-plugin and subserv

### DIFF
--- a/templates/Makefile
+++ b/templates/Makefile
@@ -18,6 +18,10 @@ KEYCLOAK_IMAGE ?= "jboss/keycloak-openshift:3.3.0.Final"
 KEYCLOAK_PLUGIN_IMAGE ?= "keycloak-plugin"
 KEYCLOAK_CONTROLLER_IMAGE ?= "keycloak-controller"
 
+KEYCLOAK_HOME ?= "/opt/jboss/keycloak"
+ADD_KEYCLOAK_USER ?= "false"
+NODE_CMD="node"
+
 SRCS=$(wildcard *.jsonnet)
 OBJS=$(patsubst %.jsonnet,%.json,$(SRCS))
 INSTALLDIR=enmasse-$(TAG)
@@ -43,6 +47,9 @@ INSTALLDIR=enmasse-$(TAG)
 		-V KEYCLOAK_IMAGE=$(KEYCLOAK_IMAGE) \
 		-V KEYCLOAK_PLUGIN_IMAGE=$(KEYCLOAK_PLUGIN_IMAGE) \
 		-V KEYCLOAK_CONTROLLER_IMAGE=$(KEYCLOAK_CONTROLLER_IMAGE) \
+		-V KEYCLOAK_HOME=$(KEYCLOAK_HOME) \
+		-V ADD_KEYCLOAK_USER=$(ADD_KEYCLOAK_USER) \
+		-V NODE_CMD=$(NODE_CMD) \
 		-m build $<
 
 yaml:

--- a/templates/include/subserv.jsonnet
+++ b/templates/include/subserv.jsonnet
@@ -33,7 +33,7 @@ local common = import "common.jsonnet";
           "containers": [
             {
               "image": container_image,
-              "command": ["node", "/opt/app-root/src/bin/subserv.js"],
+              "command": [std.extVar("NODE_CMD"), "/opt/app-root/src/bin/subserv.js"],
               "name": "subserv",
               "resources": {
                   "requests": {


### PR DESCRIPTION
When generating the templates:
- allow to specify the node command to use
- allow to specify the keycloak home dir
- allow to specify if you are adding extra script to keycloak-plugin