### PR TITLE
Fix wrong references from the index

### DIFF
--- a/documentation/service_admin/installing-kubernetes.adoc
+++ b/documentation/service_admin/installing-kubernetes.adoc
@@ -1,4 +1,4 @@
-[[installing-openshift]]
+[[installing-kubernetes]]
 
 == Installing {ProductName} on Kubernetes
 

--- a/documentation/service_admin/monitoring-kubernetes.adoc
+++ b/documentation/service_admin/monitoring-kubernetes.adoc
@@ -1,4 +1,4 @@
-[[monitoring]]
+[[monitoring-kubernetes]]
 
 == Monitoring {ProductName} on Kubernetes
 

--- a/documentation/service_admin/monitoring-openshift.adoc
+++ b/documentation/service_admin/monitoring-openshift.adoc
@@ -1,4 +1,4 @@
-[[monitoring]]
+[[monitoring-openshift]]
 
 == Monitoring {ProductName} on OpenShift
 


### PR DESCRIPTION
This PR fixes the links from the index for "installing on Kubernetes" and "monitoring" sections. Currently they always reference the OpenShift ones (even for Kubernetes).