### PR TITLE
Check keycloak realm existence every 30 seconds by default

### DIFF
--- a/keycloak-controller/src/main/java/io/enmasse/keycloak/controller/KeycloakManager.java
+++ b/keycloak-controller/src/main/java/io/enmasse/keycloak/controller/KeycloakManager.java
@@ -36,7 +36,9 @@ public class KeycloakManager implements Watcher<AddressSpace>
                              .filter(x -> x.getAuthenticationService().getType() == AuthenticationServiceType.STANDARD)
                              .collect(Collectors.toMap(AddressSpace::getName, Function.identity()));
 
-        for(String realmName : keycloak.getRealmNames()) {
+        Set<String> realmNames = keycloak.getRealmNames();
+        log.info("Actual: {}, Desired: {}", realmNames, standardAuthSvcSpaces.keySet());
+        for(String realmName : realmNames) {
             if(standardAuthSvcSpaces.remove(realmName) == null && !"master".equals(realmName)) {
                 log.info("Deleting realm {}", realmName);
                 keycloak.deleteRealm(realmName);


### PR DESCRIPTION
This fixes an issue where the controller would receive all address
space creation events before keycloak was fully running and accepting
connections. The update to keycloak would then get lost. Instead, introduce a more frequent interval in which keycloak is checked against the latest known set of address spaces.

@grs @kornys I believe this will the 'unable to find realm within timeout' failures we've seen in the systemtests.