### PR TITLE
Fix for mocha tests on release branch (not relevant for master)

### DIFF
--- a/agent/test/internal_address_source.js
+++ b/agent/test/internal_address_source.js
@@ -115,10 +115,10 @@ describe('configmap backed address source', function() {
                 setTimeout(function () {
                     assert.equal(addresses.length, 2);
                     //relies on sorted order (TODO: avoid relying on any order)
-                    assert.equal(addresses[0].address, 'bar');
-                    assert.equal(addresses[0].type, 'topic');
-                    assert.equal(addresses[1].address, 'foo');
-                    assert.equal(addresses[1].type, 'queue');
+                    assert.equal(addresses[1].address, 'bar');
+                    assert.equal(addresses[1].type, 'topic');
+                    assert.equal(addresses[0].address, 'foo');
+                    assert.equal(addresses[0].type, 'queue');
                     source.watcher.close().then(function () {
                         done();
                     });


### PR DESCRIPTION
On 0.17.2 release branch, address order in internal events is creation order (on master it is now ordered by address). This change fixes the order for the release branch which does not have the ordering change from master.