### PR TITLE
restapi tests modified to not delete all address in addr-space

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/TestBaseWithShared.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/TestBaseWithShared.java
@@ -249,9 +249,9 @@ public abstract class TestBaseWithShared extends TestBase {
         assertThat("Rest api returns addresses", response.get(1, TimeUnit.MINUTES), is(Collections.emptyList()));
         log.info("addresses {} successfully deleted", d2.getAddress());
 
-        //check if delete all works
         setAddresses(d1, d2);
-        deleteAddresses();
+        deleteAddresses(d1, d2);
+
         response = getAddresses(Optional.empty());
         assertThat("Rest api returns addresses", response.get(1, TimeUnit.MINUTES), is(Collections.emptyList()));
         log.info("addresses {} successfully deleted", Arrays.toString(destinationsNames.toArray()));

--- a/systemtests/src/test/java/io/enmasse/systemtest/common/api/AddressControllerApiTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/common/api/AddressControllerApiTest.java
@@ -114,11 +114,13 @@ public class AddressControllerApiTest extends TestBase {
         setAddresses(addressSpace, dest1);
         Address dest1AddressObj = getAddressesObjects(addressSpace, Optional.of(dest1.getAddress())).get(20, TimeUnit.SECONDS).get(0);
         assertEquals("Address uuid is not equal", uuid, dest1AddressObj.getUuid());
+        deleteAddresses(addressSpace);
 
         logWithSeparator(log, "Check if name is optional");
         Destination dest2 = new Destination(null, null, addressSpace.getName(),
                 "test-rest-api-queue2", AddressType.QUEUE.toString(), "brokered-queue");
         setAddresses(addressSpace, dest2);
+        deleteAddresses(addressSpace);
 
         Address dest2AddressObj = getAddressesObjects(addressSpace, Optional.empty()).get(20, TimeUnit.SECONDS).get(0);
         assertEquals("Address name is empty",
@@ -128,6 +130,7 @@ public class AddressControllerApiTest extends TestBase {
         Destination dest3 = new Destination(null, null, null,
                 "test-rest-api-queue3", AddressType.QUEUE.toString(), "brokered-queue");
         setAddresses(addressSpace, dest3);
+        deleteAddresses(addressSpace);
 
         Address dest3AddressObj = getAddressesObjects(addressSpace, Optional.empty()).get(20, TimeUnit.SECONDS).get(0);
         assertEquals("Addressspace name is empty",


### PR DESCRIPTION
- because we use dummy address for faster deploy of new destinations and
this test remove all addresses (include dummy-address)
- delete all addresse moved into common.api tests