### PR TITLE
Use reduced set of privileges for service account

### DIFF
--- a/address-controller/src/main/java/io/enmasse/controller/ControllerChain.java
+++ b/address-controller/src/main/java/io/enmasse/controller/ControllerChain.java
@@ -10,6 +10,7 @@ import io.enmasse.controller.common.Kubernetes;
 import io.enmasse.controller.common.NamespaceInfo;
 import io.enmasse.k8s.api.*;
 import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.utils.ImpersonatorInterceptor;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Future;
 import org.slf4j.Logger;

--- a/address-controller/src/main/java/io/enmasse/controller/ControllerOptions.java
+++ b/address-controller/src/main/java/io/enmasse/controller/ControllerOptions.java
@@ -117,6 +117,7 @@ public final class ControllerOptions {
         return recheckInterval;
     }
 
+
     public static ControllerOptions fromEnv(Map<String, String> env) throws IOException {
 
         String masterHost = getEnvOrThrow(env, "KUBERNETES_SERVICE_HOST");

--- a/address-controller/src/main/java/io/enmasse/controller/api/RbacSecurityContext.java
+++ b/address-controller/src/main/java/io/enmasse/controller/api/RbacSecurityContext.java
@@ -35,16 +35,14 @@ public class RbacSecurityContext implements SecurityContext {
 
         String namespace = data.getString("namespace");
         String verb = data.getString("verb");
-        String impersonateUser = data.getString("impersonateUser");
-        SubjectAccessReview accessReview = kubernetes.performSubjectAccessReview(tokenReview.getUserName(), namespace, verb, impersonateUser);
+        SubjectAccessReview accessReview = kubernetes.performSubjectAccessReview(tokenReview.getUserName(), namespace, verb);
         return accessReview.isAllowed();
     }
 
-    public static String rbacToRole(String namespace, ResourceVerb verb, String impersonateUser) {
+    public static String rbacToRole(String namespace, ResourceVerb verb) {
         JsonObject object = new JsonObject();
         object.put("namespace", namespace);
         object.put("verb", verb);
-        object.put("impersonateUser", impersonateUser);
         return object.toString();
     }
 

--- a/address-controller/src/main/java/io/enmasse/controller/api/osb/v2/OSBServiceBase.java
+++ b/address-controller/src/main/java/io/enmasse/controller/api/osb/v2/OSBServiceBase.java
@@ -42,7 +42,7 @@ public abstract class OSBServiceBase {
     }
 
     protected void verifyAuthorized(SecurityContext securityContext, ResourceVerb verb) {
-        if (!securityContext.isUserInRole(RbacSecurityContext.rbacToRole(namespace, verb, null))) {
+        if (!securityContext.isUserInRole(RbacSecurityContext.rbacToRole(namespace, verb))) {
             throw OSBExceptions.notAuthorizedException();
         }
     }

--- a/address-controller/src/main/java/io/enmasse/controller/api/v1/AddressApiHelper.java
+++ b/address-controller/src/main/java/io/enmasse/controller/api/v1/AddressApiHelper.java
@@ -38,7 +38,7 @@ public class AddressApiHelper {
     }
 
     private void verifyAuthorized(SecurityContext securityContext, AddressSpace addressSpace, ResourceVerb verb) {
-        if (!securityContext.isUserInRole(RbacSecurityContext.rbacToRole(addressSpace.getNamespace(), verb, addressSpace.getCreatedBy()))) {
+        if (!securityContext.isUserInRole(RbacSecurityContext.rbacToRole(addressSpace.getNamespace(), verb))) {
             throw OSBExceptions.notAuthorizedException();
         }
     }

--- a/address-controller/src/main/java/io/enmasse/controller/api/v1/http/HttpAddressSpaceService.java
+++ b/address-controller/src/main/java/io/enmasse/controller/api/v1/http/HttpAddressSpaceService.java
@@ -50,8 +50,7 @@ public class HttpAddressSpaceService {
     }
 
     private void verifyAuthorized(SecurityContext securityContext, ResourceVerb verb) {
-        String user = securityContext.getUserPrincipal() != null ? securityContext.getUserPrincipal().getName() : null;
-        if (!securityContext.isUserInRole(RbacSecurityContext.rbacToRole(namespace, verb, user))) {
+        if (!securityContext.isUserInRole(RbacSecurityContext.rbacToRole(namespace, verb))) {
             throw OSBExceptions.notAuthorizedException();
         }
     }

--- a/address-controller/src/main/java/io/enmasse/controller/common/Kubernetes.java
+++ b/address-controller/src/main/java/io/enmasse/controller/common/Kubernetes.java
@@ -22,11 +22,8 @@ public interface Kubernetes {
     String getNamespace();
     Kubernetes withNamespace(String namespace);
 
-    void create(HasMetadata ... resources);
-    void create(KubernetesList resources);
     void create(KubernetesList resources, String namespace);
     void delete(KubernetesList resources);
-    void delete(HasMetadata ... resources);
     KubernetesList processTemplate(String templateName, ParameterValue ... parameterValues);
 
     Set<NamespaceInfo> listAddressSpaces();
@@ -45,7 +42,7 @@ public interface Kubernetes {
 
     TokenReview performTokenReview(String token);
 
-    SubjectAccessReview performSubjectAccessReview(String user, String namespace, String verb, String impersonateUser);
+    SubjectAccessReview performSubjectAccessReview(String user, String namespace, String verb);
 
     boolean isRBACSupported();
     void addAddressSpaceRoleBindings(AddressSpace namespace);

--- a/address-controller/src/test/java/io/enmasse/controller/HTTPServerTest.java
+++ b/address-controller/src/test/java/io/enmasse/controller/HTTPServerTest.java
@@ -51,8 +51,8 @@ public class HTTPServerTest {
         Kubernetes kubernetes = mock(Kubernetes.class);
         when(kubernetes.getNamespace()).thenReturn("controller");
         when(kubernetes.performTokenReview(eq("mytoken"))).thenReturn(new TokenReview("foo", true));
-        when(kubernetes.performSubjectAccessReview(eq("foo"), any(), any(), any())).thenReturn(new SubjectAccessReview("foo", true));
-        when(kubernetes.performSubjectAccessReview(eq("foo"), any(), any(), any())).thenReturn(new SubjectAccessReview("foo", true));
+        when(kubernetes.performSubjectAccessReview(eq("foo"), any(), any())).thenReturn(new SubjectAccessReview("foo", true));
+        when(kubernetes.performSubjectAccessReview(eq("foo"), any(), any())).thenReturn(new SubjectAccessReview("foo", true));
         vertx.deployVerticle(new HTTPServer(instanceApi, new TestSchemaProvider(),"/doesnotexist", kubernetes, true), context.asyncAssertSuccess());
     }
 

--- a/address-controller/src/test/java/io/enmasse/controller/auth/AuthInterceptorTest.java
+++ b/address-controller/src/test/java/io/enmasse/controller/auth/AuthInterceptorTest.java
@@ -92,7 +92,7 @@ public class AuthInterceptorTest {
         TokenReview returnedTokenReview = new TokenReview("foo", true);
         when(mockKubernetes.performTokenReview("valid_token")).thenReturn(returnedTokenReview);
         SubjectAccessReview returnedSubjectAccessReview = new SubjectAccessReview("foo", false);
-        when(mockKubernetes.performSubjectAccessReview(eq("foo"), any(), eq("create"), any())).thenReturn(returnedSubjectAccessReview);
+        when(mockKubernetes.performSubjectAccessReview(eq("foo"), any(), eq("create"))).thenReturn(returnedSubjectAccessReview);
         when(mockRequestContext.getHeaderString(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer valid_token");
         when(mockRequestContext.getMethod()).thenReturn(HttpMethod.POST);
 
@@ -105,7 +105,7 @@ public class AuthInterceptorTest {
         assertThat(context.getAuthenticationScheme(), is("RBAC"));
         RbacSecurityContext rbacSecurityContext = (RbacSecurityContext) context;
         assertThat(rbacSecurityContext.getUserPrincipal().getName(), is("foo"));
-        assertFalse(rbacSecurityContext.isUserInRole(RbacSecurityContext.rbacToRole("myspace", ResourceVerb.create, null)));
+        assertFalse(rbacSecurityContext.isUserInRole(RbacSecurityContext.rbacToRole("myspace", ResourceVerb.create)));
     }
 
     @Test
@@ -119,7 +119,7 @@ public class AuthInterceptorTest {
         TokenReview returnedTokenReview = new TokenReview("foo", true);
         when(mockKubernetes.performTokenReview("valid_token")).thenReturn(returnedTokenReview);
         SubjectAccessReview returnedSubjectAccessReview = new SubjectAccessReview("foo", true);
-        when(mockKubernetes.performSubjectAccessReview(eq("foo"), any(), eq("create"), any())).thenReturn(returnedSubjectAccessReview);
+        when(mockKubernetes.performSubjectAccessReview(eq("foo"), any(), eq("create"))).thenReturn(returnedSubjectAccessReview);
         when(mockRequestContext.getHeaderString(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer valid_token");
         when(mockRequestContext.getMethod()).thenReturn(HttpMethod.POST);
 
@@ -132,6 +132,6 @@ public class AuthInterceptorTest {
         assertThat(context.getAuthenticationScheme(), is("RBAC"));
         RbacSecurityContext rbacSecurityContext = (RbacSecurityContext) context;
         assertThat(rbacSecurityContext.getUserPrincipal().getName(), is("foo"));
-        assertTrue(rbacSecurityContext.isUserInRole(RbacSecurityContext.rbacToRole("myspace", ResourceVerb.create, null)));
+        assertTrue(rbacSecurityContext.isUserInRole(RbacSecurityContext.rbacToRole("myspace", ResourceVerb.create)));
     }
 }

--- a/documentation/service_admin/installing-openshift.adoc
+++ b/documentation/service_admin/installing-openshift.adoc
@@ -122,7 +122,7 @@ oc create -f ./openshift/cluster-roles.yaml
 [options="nowrap"]
 ----
 oc login -u system:admin
-oc adm policy add-cluster-role-to-user enmasse-namespace-admin system:serviceaccount:enmasse:enmasse-admin
+oc adm policy add-cluster-role-to-user enmasse-admin system:serviceaccount:enmasse:enmasse-admin
 ----
 +
 *Note*: You can log back in as the regular user after this step.

--- a/templates/include/enmasse-kubernetes.jsonnet
+++ b/templates/include/enmasse-kubernetes.jsonnet
@@ -14,8 +14,7 @@ local roles = import "roles.jsonnet";
     "kind": "List",
     "items": [
       roles.address_admin_role,
-      roles.namespace_admin_role,
-      roles.event_reporter_role,
+      roles.enmasse_admin_role
     ]
   },
 

--- a/templates/include/enmasse-openshift.jsonnet
+++ b/templates/include/enmasse-openshift.jsonnet
@@ -14,8 +14,7 @@ local roles = import "roles.jsonnet";
     "kind": "List",
     "items": [
       roles.address_admin_role,
-      roles.namespace_admin_role,
-      roles.event_reporter_role,
+      roles.enmasse_admin_role
     ]
   },
 
@@ -79,7 +78,7 @@ local roles = import "roles.jsonnet";
         "name": "CONTROLLER_CHECK_INTERVAL",
         "description": "Interval (in seconds) to use between status checks",
         "value": "30"
-      }
+      },
     ]
   }
 }

--- a/templates/include/roles.jsonnet
+++ b/templates/include/roles.jsonnet
@@ -28,123 +28,29 @@
       ]
     },
 
-  // Role for address-controller service account
-  namespace_admin_role::
+  // Cluster role for address-controller service account
+  enmasse_admin_role::
     {
       "apiVersion": "v1",
       "kind": "ClusterRole",
       "metadata": {
-        "name": "enmasse-namespace-admin"
+        "name": "enmasse-admin"
       },
       "rules": [
         {
           "apiGroups": [
             "",
-            "user.openshift.io"
+            "project.openshift.io",
+            "authentication.k8s.io",
+            "authorization.k8s.io"
           ],
           "resources": [
-            "users"
-          ],
-          "verbs": [
-            "impersonate"
-          ]
-        },
-        {
-          "apiGroups": [
-            "",
-            "extensions",
-            "authorization.openshift.io",
-            "route.openshift.io"
-          ],
-          "resources": [
-            "clusterrolebindings",
-            "rolebindings",
-            "events",
-            "policybindings",
-            "deployments",
-            "pods",
-            "configmaps",
-            "routes",
-            "serviceaccounts",
-            "secrets",
-            "services",
-            "persistentvolumeclaims"
-          ],
-          "verbs": [
-            "create",
-            "delete",
-            "get",
-            "list",
-            "patch",
-            "update",
-            "watch"
-          ]
-        },
-        {
-          "apiGroups": [
-            "rbac.authorization.k8s.io"
-          ],
-          "resources": [
-            "clusterrolebindings",
-            "rolebindings",
-          ],
-          "verbs": [
-            "create",
-            "delete",
-            "get",
-            "list",
-            "patch",
-            "update",
-            "watch"
-          ]
-        },
-        {
-          "apiGroups": [
-            "authentication.k8s.io"
-          ],
-          "resources": [
+            "projectrequests",
+            "localsubjectaccessreviews",
             "tokenreviews"
           ],
           "verbs": [
             "create"
-          ]
-        },
-        {
-          "apiGroups": [
-            ""
-          ],
-          "resources": [
-            "namespaces"
-          ],
-          "verbs": [
-            "get",
-            "list",
-            "watch"
-          ]
-        }
-      ]
-    },
-
-  event_reporter_role::
-    {
-      "apiVersion": "v1",
-      "kind": "ClusterRole",
-      "metadata": {
-        "name": "event-reporter"
-      },
-      "rules": [
-        {
-          "apiGroups": [
-            ""
-          ],
-          "resources": [
-            "events"
-          ],
-          "verbs": [
-            "create",
-            "get",
-            "update",
-            "patch"
           ]
         }
       ]

--- a/templates/install/ansible/roles/address_controller_multitenant/tasks/main.yml
+++ b/templates/install/ansible/roles/address_controller_multitenant/tasks/main.yml
@@ -6,7 +6,7 @@
 - name: Create cluster wide roles used by enmasse-admin service account
   shell: oc apply -n {{ namespace }} -f {{ playbook_dir }}/templates/cluster-roles.yaml
 - name: Grant cluster admin privileges to service account
-  shell: oc adm policy add-cluster-role-to-user enmasse-namespace-admin system:serviceaccount:{{ namespace }}:enmasse-admin
+  shell: oc adm policy add-cluster-role-to-user enmasse-admin system:serviceaccount:{{ namespace }}:enmasse-admin
 - name: Grant view policy to default SA
   shell: oc policy add-role-to-user view system:serviceaccount:{{ namespace }}:default
 - name: Grant admin policy to enmasse-admin

--- a/templates/install/deploy-openshift.sh
+++ b/templates/install/deploy-openshift.sh
@@ -192,11 +192,11 @@ if [ $MODE == "multitenant" ]; then
     then
         runcmd "oc login -u system:admin" "Logging in as system:admin"
         runcmd "oc create -f $CLUSTER_ROLES -n $NAMESPACE" "Create cluster roles needed for RBAC"
-        runcmd "oc adm policy add-cluster-role-to-user enmasse-namespace-admin system:serviceaccount:${NAMESPACE}:enmasse-admin" "Granting admin rights to enmasse-admin"
+        runcmd "oc adm policy add-cluster-role-to-user enmasse-admin system:serviceaccount:${NAMESPACE}:enmasse-admin" "Granting admin rights to enmasse-admin"
         runcmd "oc login -u $OS_USER $OC_ARGS $MASTER_URI" "Login as $OS_USER"
     else
         echo "Please create cluster roles required to run EnMasse with RBAC: 'oc create -f $CLUSTER_ROLES -n $NAMESPACE'"
-        echo "Please add enmasse-namespace-admin role to system:serviceaccount:${NAMESPACE}:enmasse-admin before creating instances: 'oc adm policy add-cluster-role-to-user enmasse-namespace-admin system:serviceaccount:${NAMESPACE}:enmasse-admin'"
+        echo "Please add enmasse-admin role to system:serviceaccount:${NAMESPACE}:enmasse-admin before creating instances: 'oc adm policy add-cluster-role-to-user enmasse-admin system:serviceaccount:${NAMESPACE}:enmasse-admin'"
     fi
 fi
 

--- a/templates/install/kubernetes/cluster-roles.yaml
+++ b/templates/install/kubernetes/cluster-roles.yaml
@@ -20,80 +20,17 @@ items:
 - apiVersion: v1
   kind: ClusterRole
   metadata:
-    name: enmasse-namespace-admin
+    name: enmasse-admin
   rules:
   - apiGroups:
     - ''
-    - user.openshift.io
-    resources:
-    - users
-    verbs:
-    - impersonate
-  - apiGroups:
-    - ''
-    - extensions
-    - authorization.openshift.io
-    - route.openshift.io
-    resources:
-    - clusterrolebindings
-    - rolebindings
-    - events
-    - policybindings
-    - deployments
-    - pods
-    - configmaps
-    - routes
-    - serviceaccounts
-    - secrets
-    - services
-    - persistentvolumeclaims
-    verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - rbac.authorization.k8s.io
-    resources:
-    - clusterrolebindings
-    - rolebindings
-    verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
+    - project.openshift.io
     - authentication.k8s.io
+    - authorization.k8s.io
     resources:
+    - projectrequests
+    - localsubjectaccessreviews
     - tokenreviews
     verbs:
     - create
-  - apiGroups:
-    - ''
-    resources:
-    - namespaces
-    verbs:
-    - get
-    - list
-    - watch
-- apiVersion: v1
-  kind: ClusterRole
-  metadata:
-    name: event-reporter
-  rules:
-  - apiGroups:
-    - ''
-    resources:
-    - events
-    verbs:
-    - create
-    - get
-    - update
-    - patch
 kind: List

--- a/templates/install/openshift/cluster-roles.yaml
+++ b/templates/install/openshift/cluster-roles.yaml
@@ -20,80 +20,17 @@ items:
 - apiVersion: v1
   kind: ClusterRole
   metadata:
-    name: enmasse-namespace-admin
+    name: enmasse-admin
   rules:
   - apiGroups:
     - ''
-    - user.openshift.io
-    resources:
-    - users
-    verbs:
-    - impersonate
-  - apiGroups:
-    - ''
-    - extensions
-    - authorization.openshift.io
-    - route.openshift.io
-    resources:
-    - clusterrolebindings
-    - rolebindings
-    - events
-    - policybindings
-    - deployments
-    - pods
-    - configmaps
-    - routes
-    - serviceaccounts
-    - secrets
-    - services
-    - persistentvolumeclaims
-    verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - rbac.authorization.k8s.io
-    resources:
-    - clusterrolebindings
-    - rolebindings
-    verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
+    - project.openshift.io
     - authentication.k8s.io
+    - authorization.k8s.io
     resources:
+    - projectrequests
+    - localsubjectaccessreviews
     - tokenreviews
     verbs:
     - create
-  - apiGroups:
-    - ''
-    resources:
-    - namespaces
-    verbs:
-    - get
-    - list
-    - watch
-- apiVersion: v1
-  kind: ClusterRole
-  metadata:
-    name: event-reporter
-  rules:
-  - apiGroups:
-    - ''
-    resources:
-    - events
-    verbs:
-    - create
-    - get
-    - update
-    - patch
 kind: List


### PR DESCRIPTION
This reduces the scope of cluster admin needed for the enmasse-admin SA
to:

* Create projectrequests
* Create tokenreviews

The use of impersonation is removed.

This fixes #1072