### PR TITLE
Set per-address address settings to limit max size

### DIFF
--- a/agent/bin/agent.js
+++ b/agent/bin/agent.js
@@ -16,10 +16,12 @@
 'use strict';
 
 var AddressSource = require('../lib/internal_address_source.js');
+var BrokerAddressSettings = require('../lib/broker_address_settings.js');
 var ConsoleServer = require('../lib/console_server.js');
 var kubernetes = require('../lib/kubernetes.js');
 var Ragent = require('../lib/ragent.js');
 var tls_options = require('../lib/tls_options.js');
+var myutils = require('../lib/utils.js');
 
 function bind_event(source, event, target, method) {
     source.on(event, target[method || event].bind(target));
@@ -50,6 +52,8 @@ function start(env) {
             stats.init(console_server);
 
             var ragent = new Ragent();
+            var address_settings = new BrokerAddressSettings(env);
+            ragent.broker_address_settings = address_settings.get_address_settings_async.bind(address_settings);
             bind_event(address_source, 'addresses_ready', ragent, 'sync_addresses')
             ragent.start_listening(env);
             ragent.listen_probe({PROBE_PORT:8888});

--- a/agent/lib/artemis.js
+++ b/agent/lib/artemis.js
@@ -340,6 +340,47 @@ Artemis.prototype.deleteAddress = function (name) {
     return this._request('broker', 'deleteAddress', [name]);
 };
 
+var address_settings_fields = {
+    'DLA':'',
+    'expiryAddress':'',
+    'expiryDelay':-1,
+    'lastValueQueue':false,
+    'deliveryAttempts':-1,
+    'maxSizeBytes':-1,
+    'pageSizeBytes':-1,
+    'pageMaxCacheSize':-1,
+    'redeliveryDelay':-1,
+    'redeliveryMultiplier':-1,
+    'maxRedeliveryDelay':-1,
+    'redistributionDelay':-1,
+    'sendToDLAOnNoRoute':false,
+    'addressFullMessagePolicy': 'FAIL',
+    'slowConsumerThreshold':-1,
+    'slowConsumerCheckPeriod':-1,
+    'slowConsumerPolicy':'DROP',
+    'autoCreateJmsQueues':false,
+    'autoDeleteJmsQueues':false,
+    'autoCreateJmsTopics':false,
+    'autoDeleteJmsTopics':false,
+    'autoCreateQueues':false,
+    'autoDeleteQueues':false,
+    'autoCreateAddresses':false,
+    'autoDeleteAddresses':false
+};
+
+Artemis.prototype.addAddressSettings = function (match, settings) {
+    var args = [match];
+    for (var name in address_settings_fields) {
+        var v = settings[name] || address_settings_fields[name];
+        args.push(v);
+    }
+    return this._request('broker', 'addAddressSettings', args);
+};
+
+Artemis.prototype.removeAddressSettings = function (match) {
+    return this._request('broker', 'removeAddressSettings', [match]);
+};
+
 Artemis.prototype.deleteAddressAndBindings = function (address) {
     var self = this;
     return this.deleteBindingsFor(address).then(function () {
@@ -468,6 +509,11 @@ Artemis.prototype.listProducers = function () {
     return this._request('broker', 'listProducersInfoAsJSON', []).then(function (result) {
         return JSON.parse(result);
     });
+}
+
+Artemis.prototype.getGlobalMaxSize = function ()
+{
+    return this._request('broker', 'getGlobalMaxSize', []);
 }
 
 /**

--- a/agent/lib/broker_address_settings.js
+++ b/agent/lib/broker_address_settings.js
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2018 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+var log = require("./log.js").logger();
+var kubernetes = require('./kubernetes.js');
+var myutils = require('./utils.js');
+
+function kubernetes_resource_compare(a, b) {
+    return myutils.string_compare(a.metadata.name, b.metadata.name);
+}
+
+function extract_address_plan(object) {
+    try {
+        return JSON.parse(object.data['definition']);
+    } catch (e) {
+        log.error('Failed to parse definition for address plan: %s %j', e, object);
+    }
+}
+
+function required_broker_resource(plan) {
+    var brokerRequired = plan.requiredResources ? plan.requiredResources.filter(function (o) { return o.name === 'broker'; })[0] : undefined;
+    return brokerRequired ? brokerRequired.credit : undefined;
+}
+
+function same_broker_resource(a, b) {
+    return required_broker_resource(a) === required_broker_resource(b);
+}
+
+function BrokerAddressSettings(config) {
+    this.watcher = kubernetes.watch('configmaps', myutils.merge({selector: 'type=address-plan'}, config));
+    this.watcher.on('updated', this.updated.bind(this));
+    this.required_broker_resource = {};
+    this.last = undefined;
+}
+
+BrokerAddressSettings.prototype.wait_for_plans = function () {
+    var self = this;
+    return new Promise(function (resolve, reject) {
+        self.watcher.once('updated', function () {
+            log.info('plans have been retrieved');
+        });
+    });
+}
+
+BrokerAddressSettings.prototype.update_settings = function (plan) {
+    var r = required_broker_resource(plan);
+    if (r && r > 0 && r < 1) {
+        this.required_broker_resource[plan.metadata.name] = r;
+        log.info('updated required broker resource for %s: %d', plan.metadata.name, this.required_broker_resource[plan.metadata.name]);
+    }
+};
+
+BrokerAddressSettings.prototype.generate_address_settings = function (plan, global_max_size) {
+    if (global_max_size) {
+        var r = this.required_broker_resource[plan];
+        if (r) {
+            return {
+                maxSizeBytes: r * global_max_size,
+                addressFullMessagePolicy: 'FAIL'
+            };
+        } else {
+            log.info('no broker resource required for %s, therefore not applying address settings', plan);
+        }
+    } else {
+        log.info('no global max, therefore not applying address settings');
+    }
+};
+
+BrokerAddressSettings.prototype.delete_settings = function (plan) {
+    delete this.required_broker_resource[plan.metadata.name];
+    log.info('deleted required broker resource for %s', plan.metadata.name);
+};
+
+BrokerAddressSettings.prototype.updated = function (objects) {
+    var plans = objects.map(extract_address_plan).filter(required_broker_resource);
+    plans.sort(kubernetes_resource_compare);
+    var changes = myutils.changes(this.last, plans, kubernetes_resource_compare, same_broker_resource);
+    this.last = plans;
+    if (changes) {
+        log.info('address plans: %s', changes.description);
+        changes.added.map(this.update_settings.bind(this));
+        changes.modified.map(this.update_settings.bind(this));
+        changes.removed.map(this.delete_settings.bind(this));
+    }
+};
+
+BrokerAddressSettings.prototype.get_address_settings_async = function (address, global_max_size_promise) {
+    var self = this;
+    if (this.last === undefined) {
+        return this.wait_for_plans().then(function () {
+            return global_max_size_promise.then(function (global_max_size) {
+                var settings = self.generate_address_settings(address.plan, global_max_size);
+                log.info('using settings %j for %s', settings, address.address);
+                return settings;
+            });
+        });
+    } else {
+        return global_max_size_promise.then(function (global_max_size) {
+            var settings = self.generate_address_settings(address.plan, global_max_size);
+            log.info('using settings %j for %s', settings, address.address);
+            return settings;
+        });
+    }
+};
+
+module.exports = BrokerAddressSettings;

--- a/agent/lib/ragent.js
+++ b/agent/lib/ragent.js
@@ -275,7 +275,7 @@ Ragent.prototype.configure_handlers = function () {
                 router.on('provisioned', self.check_router_connectors.bind(self));
             });
         } else if (product === 'apache-activemq-artemis') {
-            var broker = broker_controller.create_controller(context.connection);
+            var broker = broker_controller.create_controller(context.connection, self.broker_address_settings, self.event_sink);
             self.connected_brokers[broker.id] = broker;
             self.sync_broker(broker, self.address_list);
             context.connection.on('disconnected', self.on_broker_disconnect.bind(self));

--- a/agent/lib/router.js
+++ b/agent/lib/router.js
@@ -165,7 +165,7 @@ function is_topic(address) {
 }
 
 function to_link_route(direction, address) {
-    return {name:address.name + '_' + direction, prefix:address.address, dir:direction, containerId:address.allocated_to};
+    return {name:address.name + '_' + direction, prefix:address.address, dir:direction, containerId: address.allocated_to ? address.address : undefined};
 }
 
 function to_in_link_route(address) {
@@ -302,8 +302,7 @@ ConnectedRouter.prototype.delete_address = function (address) {
 ConnectedRouter.prototype.define_autolink = function (address, direction) {
     var name = (direction == "in" ? "autoLinkIn" : "autoLinkOut") + address.name;
     log.info('[%s] defining %s autolink for %s', this.container_id, direction, address.name);
-    var brokerId = address.allocated_to || address.address;
-    return this.create_entity('org.apache.qpid.dispatch.router.config.autoLink', name, {dir:direction, addr:address.address, containerId:brokerId});
+    return this.create_entity('org.apache.qpid.dispatch.router.config.autoLink', name, {dir:direction, addr:address.address, containerId:address.address});
 }
 
 ConnectedRouter.prototype.delete_autolink = function (address, direction) {

--- a/agent/lib/utils.js
+++ b/agent/lib/utils.js
@@ -173,7 +173,7 @@ module.exports.changes = function (last, current, compare, unchanged, stringify)
             added: current,
             removed: [],
             modified: [],
-            decription: util.format('initial %s', description(current))
+            description: util.format('initial %s', description(current))
         };
     } else {
         let d = {

--- a/agent/testlib/mock_resource_server.js
+++ b/agent/testlib/mock_resource_server.js
@@ -370,8 +370,11 @@ ConfigMapServer.prototype.add_address_plan = function (params) {
         shortDescription: params.shortDescription,
         longDescription: params.longDescription,
         displayOrder: params.displayOrder,
-        addressType: params.address_type
+        addressType: params.address_type,
     };
+    if (params.required_resources) {
+        plan.requiredResources = params.required_resources;
+    }
     this.add_resource(get_config_map(plan.name, 'address-plan', 'definition', plan));
 };
 

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/RouterStatus.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/RouterStatus.java
@@ -134,7 +134,7 @@ class RouterStatus {
                 String dir = linkRoute.get(2);
                 String operStatus = linkRoute.get(3);
 
-                if (addr.equals(address.getAddress()) && brokerId != null && brokerId.equals(containerId) && operStatus.equals("active")) {
+                if (addr.equals(address.getAddress()) && operStatus.equals("active")) {
                     active.add(dir);
                 }
             }


### PR DESCRIPTION
(This requires using a connector per address, created on the broker after the queue is created,
in order to ensure the autolinks do not fire before address settings and queue have been created
explicitly, as triggering the links will cause implicit creation of queue)