### PR TITLE
NEW script for wait until machine is completely prepared

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,6 +20,14 @@ pipeline {
         timeout(time: 1, unit: 'HOURS')
     }
     stages {
+        stage('wait for agent ready') {
+            environment {
+                EXPECTED_DIR = '/tmp/agent_ready'
+            }
+            steps {
+                sh "./systemtests/scripts/wait_until_agent_ready.sh ${env.EXPECTED_DIR}"
+            }
+        }
         stage('cleanup registry') {
             environment {
                 REGISTRY_URL = credentials('internal-registry')

--- a/systemtests/scripts/wait_until_agent_ready.sh
+++ b/systemtests/scripts/wait_until_agent_ready.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+EXPECTED_FILE="${1}"
+TIMEOUT="${2:-600}"
+
+function err() {
+    echo "ERROR: ${1}" >&2
+    exit ${2:-1}
+}
+
+function info() {
+    echo "INFO: ${1}"
+}
+
+if [[ -z "${EXPECTED_FILE}" ]]; then
+    err "Argument missing, file name required!" 2
+fi
+
+END=$(( SECONDS + TIMEOUT ))
+info "Waiting until ${EXPECTED_FILE} will be presented within ${TIMEOUT} seconds timeout!"
+while [[ ! -f "${EXPECTED_FILE}" ]]
+do
+    if (( SECONDS >= END )); then
+        err "Timeout reached!"
+    fi
+    info "${EXPECTED_FILE} doesn't exist yet!"
+    sleep 5
+done
+info "All dependencies successfully installed"


### PR DESCRIPTION
Jobs in Jenkins are triggered before all commands from "Manage file" are finished, so we need to check that all required dependencies are installed. At the bottom of "Manage file" is now "touch /tmp/agent_ready" command and Jenkinsfile is extended about wait until this file exists.