### PR TITLE
alternate approach to per address limits

### DIFF
--- a/agent/lib/artemis.js
+++ b/agent/lib/artemis.js
@@ -473,6 +473,12 @@ Artemis.prototype.removeAddressSettings = function (match) {
     return this._request('broker', 'removeAddressSettings', [match]);
 };
 
+Artemis.prototype.getAddressSettings = function (match) {
+    return this._request('broker', 'getAddressSettingsAsJSON', [match]).then(function (result) {
+        return JSON.parse(result);
+    });
+}
+
 Artemis.prototype.deleteAddressAndBindings = function (address) {
     var self = this;
     return this.deleteBindingsFor(address).then(function () {

--- a/agent/lib/auth_service.js
+++ b/agent/lib/auth_service.js
@@ -25,14 +25,11 @@ function authenticate(credentials, options) {
         if( credentials && credentials.username ) {
             options.username = credentials.username;
             if (credentials.password) {
-                log.info('authenticating as %s using PLAIN', options.username);
                 options.password = credentials.password;
             } else if (credentials.token) {
-                log.info('authenticating as %s using XOAUTH2', options.username);
                 options.token = credentials.token;
             }
         } else {
-            log.info('authenticating as anonymous');
             options.username = "anonymous";
         }
 

--- a/agent/lib/broker_address_settings.js
+++ b/agent/lib/broker_address_settings.js
@@ -15,12 +15,23 @@
  */
 'use strict';
 
-var log = require("./log.js").logger();
+var events = require('events');
+var util = require('util');
+var log = require('./log.js').logger();
 var kubernetes = require('./kubernetes.js');
 var myutils = require('./utils.js');
+var artemis = require('./artemis.js');
 
-function kubernetes_resource_compare(a, b) {
-    return myutils.string_compare(a.metadata.name, b.metadata.name);
+function match_compare(a, b) {
+    return myutils.string_compare(a.match, b.match);
+}
+
+function get_match(name) {
+    return name + '/#';
+}
+
+function extract_match(o) {
+    return o.match;
 }
 
 function extract_address_plan(object) {
@@ -36,85 +47,130 @@ function required_broker_resource(plan) {
     return brokerRequired ? brokerRequired.credit : undefined;
 }
 
-function same_broker_resource(a, b) {
-    return required_broker_resource(a) === required_broker_resource(b);
+function equivalent_settings(a, b) {
+    return a.maxSizeBytes === b.maxSizeBytes && a.addressFullMessagePolicy === b.addressFullMessagePolicy;
+}
+
+function to_routing_type(address_type) {
+    if (address_type === 'queue') {
+        return 'ANYCAST';
+    } else if (address_type === 'topic') {
+        return 'MULTICAST';
+    } else {
+        return undefined;
+    }
+}
+
+function to_address_setting(global_max_size, plan) {
+    var r = required_broker_resource(plan);
+    var routing_type = to_routing_type(plan.addressType);
+    if (r && r > 0 && r < 1 && routing_type) {
+        return {
+            match: get_match(plan.metadata.name),
+            maxSizeBytes: r * global_max_size,
+            addressFullMessagePolicy: 'FAIL',
+            defaultAddressRoutingType: routing_type
+        }
+    } else {
+        log.info('not applying address settings for %s', plan.metadata.name);
+        return undefined;
+    }
+};
+
+function defined(o) {
+    return o !== undefined;
 }
 
 function BrokerAddressSettings(config) {
+    events.EventEmitter.call(this);
+    this.plans = [];
     this.watcher = kubernetes.watch('configmaps', myutils.merge({selector: 'type=address-plan'}, config));
     this.watcher.on('updated', this.updated.bind(this));
-    this.required_broker_resource = {};
-    this.last = undefined;
 }
 
-BrokerAddressSettings.prototype.wait_for_plans = function () {
-    var self = this;
-    return new Promise(function (resolve, reject) {
-        self.watcher.once('updated', function () {
-            log.info('plans have been retrieved');
-        });
-    });
-}
+util.inherits(BrokerAddressSettings, events.EventEmitter);
 
-BrokerAddressSettings.prototype.update_settings = function (plan) {
-    var r = required_broker_resource(plan);
-    if (r && r > 0 && r < 1) {
-        this.required_broker_resource[plan.metadata.name] = r;
-        log.info('updated required broker resource for %s: %d', plan.metadata.name, this.required_broker_resource[plan.metadata.name]);
-    }
-};
-
-BrokerAddressSettings.prototype.generate_address_settings = function (plan, global_max_size) {
-    if (global_max_size) {
-        var r = this.required_broker_resource[plan];
-        if (r) {
-            return {
-                maxSizeBytes: r * global_max_size,
-                addressFullMessagePolicy: 'FAIL'
-            };
-        } else {
-            log.info('no broker resource required for %s, therefore not applying address settings', plan);
-        }
-    } else {
-        log.info('no global max, therefore not applying address settings');
-    }
-};
-
-BrokerAddressSettings.prototype.delete_settings = function (plan) {
-    delete this.required_broker_resource[plan.metadata.name];
-    log.info('deleted required broker resource for %s', plan.metadata.name);
+BrokerAddressSettings.prototype.close = function () {
+    this.watcher.close();
 };
 
 BrokerAddressSettings.prototype.updated = function (objects) {
-    var plans = objects.map(extract_address_plan).filter(required_broker_resource);
-    plans.sort(kubernetes_resource_compare);
-    var changes = myutils.changes(this.last, plans, kubernetes_resource_compare, same_broker_resource);
-    this.last = plans;
-    if (changes) {
-        log.info('address plans: %s', changes.description);
-        changes.added.map(this.update_settings.bind(this));
-        changes.modified.map(this.update_settings.bind(this));
-        changes.removed.map(this.delete_settings.bind(this));
-    }
+    this.plans = objects.map(extract_address_plan);
+    this.emit('changed', this.plans);
 };
 
-BrokerAddressSettings.prototype.get_address_settings_async = function (address, global_max_size_promise) {
+BrokerAddressSettings.prototype.create_controller = function (connection) {
+    var controller = new AddressSettingsController(connection);
+    if (this.plans.length) {
+        controller.on_changed(this.plans);
+    }
+    this.on('changed', controller.on_changed.bind(controller));
+    return controller;
+};
+
+function AddressSettingsController(connection) {
+    this.broker = new artemis.Artemis(connection);
     var self = this;
-    if (this.last === undefined) {
-        return this.wait_for_plans().then(function () {
-            return global_max_size_promise.then(function (global_max_size) {
-                var settings = self.generate_address_settings(address.plan, global_max_size);
-                log.info('using settings %j for %s', settings, address.address);
-                return settings;
-            });
-        });
-    } else {
-        return global_max_size_promise.then(function (global_max_size) {
-            var settings = self.generate_address_settings(address.plan, global_max_size);
-            log.info('using settings %j for %s', settings, address.address);
-            return settings;
-        });
-    }
+    this.global_max_size = this.broker.getGlobalMaxSize();
+}
+
+AddressSettingsController.prototype.close = function () {
+    this.broker.close();
 };
 
-module.exports = BrokerAddressSettings;
+AddressSettingsController.prototype.on_changed = function (plans) {
+    var id = this.broker.connection.container_id;
+    var self = this;
+    this.global_max_size.then(function (global_max_size) {
+        if (global_max_size) {
+            log.info('global max size for broker %s is %d', id, global_max_size);
+            var desired_address_settings = plans.map(to_address_setting.bind(null, global_max_size)).filter(defined);
+            self.check_address_settings(desired_address_settings);
+        } else {
+            log.info('no global max size retrieved for %s, will not create address-settings', id);
+        }
+    }).catch(function (error) {
+        log.info('could not retrieve global max size for %s: %s', id, error);
+    });
+};
+
+AddressSettingsController.prototype.check_address_settings = function (desired_address_settings) {
+    var id = this.broker.connection.container_id;
+    var broker = this.broker;
+    function ensure_address_settings (match, settings) {
+        return broker.getAddressSettings(match).then(function (result) {
+            if (!result) {
+                return broker.addAddressSettings(match, settings).then(function () {
+                    log.info('address settings %s created on %s', match, id);
+                });
+            } else if (!equivalent_settings(settings, result)) {
+                log.info('recreating address settings %s on %s (%j != %j)', match, id, settings, result);
+                console.log('recreating address settings %s on %s', match, id);
+                return broker.removeAddressSettings(match).then(function() {
+                    log.info('address settings %s removed on %s', match, id);
+                    broker.addAddressSettings(match, settings);
+                }).then(function () {
+                    log.info('address settings %s created on %s', match, id);
+                });
+            } else {
+                log.info('address settings %s exist on %s', match, id);
+            }
+        });
+    };
+    var promise;
+    for (var i = 0; i < desired_address_settings.length; i++) {
+        var s = desired_address_settings[i];
+        if (promise) {
+            promise.then(ensure_address_settings.bind(null, s.match, s));
+        } else {
+            promise = ensure_address_settings(s.match, s);
+        }
+    }
+    promise.then(function () {
+        log.info('desired address settings created on %s', id);
+    });
+};
+
+module.exports.controller_factory = function (env) {
+    return new BrokerAddressSettings(env);
+}

--- a/agent/lib/broker_address_settings.js
+++ b/agent/lib/broker_address_settings.js
@@ -26,8 +26,8 @@ function match_compare(a, b) {
     return myutils.string_compare(a.match, b.match);
 }
 
-function get_match(name) {
-    return name + '/#';
+function get_match(plan) {
+    return plan.addressType + '://' + plan.metadata.name + '/#';
 }
 
 function extract_match(o) {
@@ -51,25 +51,13 @@ function equivalent_settings(a, b) {
     return a.maxSizeBytes === b.maxSizeBytes && a.addressFullMessagePolicy === b.addressFullMessagePolicy;
 }
 
-function to_routing_type(address_type) {
-    if (address_type === 'queue') {
-        return 'ANYCAST';
-    } else if (address_type === 'topic') {
-        return 'MULTICAST';
-    } else {
-        return undefined;
-    }
-}
-
 function to_address_setting(global_max_size, plan) {
     var r = required_broker_resource(plan);
-    var routing_type = to_routing_type(plan.addressType);
-    if (r && r > 0 && r < 1 && routing_type) {
+    if (r && r > 0 && r < 1) {
         return {
-            match: get_match(plan.metadata.name),
+            match: get_match(plan),
             maxSizeBytes: r * global_max_size,
-            addressFullMessagePolicy: 'FAIL',
-            defaultAddressRoutingType: routing_type
+            addressFullMessagePolicy: 'FAIL'
         }
     } else {
         log.info('not applying address settings for %s', plan.metadata.name);
@@ -130,7 +118,7 @@ AddressSettingsController.prototype.on_changed = function (plans) {
             log.info('no global max size retrieved for %s, will not create address-settings', id);
         }
     }).catch(function (error) {
-        log.info('could not retrieve global max size for %s: %s', id, error);
+        log.error('could not retrieve global max size for %s: %s', id, error);
     });
 };
 

--- a/agent/lib/broker_stats.js
+++ b/agent/lib/broker_stats.js
@@ -49,6 +49,16 @@ function merge() {
     return c;
 }
 
+function strip_prefix(name) {
+    if (name.indexOf('queue://') === 0 || name.indexOf('topic://') === 0) {
+        var parts = name.substring(8).split('/');
+        var plan = parts.shift();
+        return parts.join('/');
+    } else {
+        return name;
+    }
+}
+
 function BrokerStats (env) {
     this.queues = {};
     this.brokers = create_podgroup();
@@ -73,9 +83,10 @@ BrokerStats.prototype._retrieve = function() {
     return Promise.all(brokers.map(list_addresses)).then(function (results) {
         var stats = {};
         for (var i = 0; i < results.length; i++) {
-            for (var name in results[i]) {
+            for (var n in results[i]) {
+                var name = strip_prefix(n);
                 var s = get_stats_for_address(stats, name);
-                var shard = merge(results[i][name], {name:brokers[i].connection.container_id});
+                var shard = merge(results[i][n], {name:brokers[i].connection.container_id});
                 s.depth += shard.messages;
                 s.shards.push(shard);
             }

--- a/agent/test/ragent.js
+++ b/agent/test/ragent.js
@@ -1051,10 +1051,10 @@ describe('broker configuration', function() {
         broker_a.global_max_size = 100;
         connect_broker(broker_a).then(function () {
             address_source.add_address_plan({plan_name:'small', address_type:'queue', required_resources:[{name:'broker',credit:0.2}]});
-            address_source.add_address_plan({plan_name:'medium', address_type:'queue', required_resources:[{name:'broker',credit:0.5}]});
+            address_source.add_address_plan({plan_name:'medium', address_type:'topic', required_resources:[{name:'broker',credit:0.5}]});
             setTimeout(function () {
                 //verify address settings:
-                broker_a.verify_address_settings([{match:'small/#', maxSizeBytes:20, addressFullMessagePolicy:'FAIL'}, {match:'medium/#', maxSizeBytes:50, addressFullMessagePolicy:'FAIL'}]);
+                broker_a.verify_address_settings([{match:'queue://small/#', maxSizeBytes:20, addressFullMessagePolicy:'FAIL'}, {match:'topic://medium/#', maxSizeBytes:50, addressFullMessagePolicy:'FAIL'}]);
                 done();
             }, 1000/*1 second wait for propagation*/);//TODO: add ability to be notified of propagation in some way
         }).catch(done);

--- a/agent/test/ragent.js
+++ b/agent/test/ragent.js
@@ -25,7 +25,7 @@ var http = require('http');
 var rhea = require('rhea');
 
 var Ragent = require('../lib/ragent.js');
-var BrokerAddressSettings = require('../lib/broker_address_settings.js');
+var broker_address_settings = require('../lib/broker_address_settings.js');
 var tls_options = require('../lib/tls_options.js');
 var MockBroker = require('../testlib/mock_broker.js');
 var MockRouter = require('../testlib/mock_router.js');
@@ -111,9 +111,9 @@ function verify_addresses(inputs, router, verify_extra) {
         for (var i = 0; i < inputs.length; i++) {
             var a = inputs[i];
             if (a.type === 'queue') {
-                verify_queue(a.address, addresses, autolinks);
+                verify_queue(a.address, addresses, autolinks, a.allocated_to);
             } else if (a.type === 'topic') {
-                verify_topic(a.address, linkroutes);
+                verify_topic(a.address, linkroutes, a.allocated_to);
             } else if (a.type === 'anycast') {
                 verify_anycast(a.address, addresses);
             } else if (a.type === 'multicast') {
@@ -1011,9 +1011,6 @@ describe('broker configuration', function() {
                 //verify queues on respective brokers:
                 broker_a.verify_addresses([{address:'a', type:'queue'}]);
                 broker_b.verify_addresses([{address:'b', type:'queue'}]);
-                //verify connectors exist:
-                broker_a.verify_connectors([{name:'a'}]);
-                broker_b.verify_connectors([{name:'b'}]);
                 done();
             }, 1000/*1 second wait for propagation*/);//TODO: add ability to be notified of propagation in some way
         }).catch(done);
@@ -1032,18 +1029,12 @@ describe('broker configuration', function() {
                 //verify queues on respective brokers:
                 broker_a.verify_addresses([{address:'a', type:'queue'}, {address:'c', type:'queue'}]);
                 broker_b.verify_addresses([{address:'b', type:'queue'}]);
-                //verify connectors:
-                broker_a.verify_connectors([{name:'a'}, {name:'c'}]);
-                broker_b.verify_connectors([{name:'b'}]);
                 //delete configmap
                 address_source.remove_resource_by_name('address-config-a');
                 setTimeout(function () {
                     verify_addresses([{address:'b', type:'queue', allocated_to:'broker_b'}, {address:'c', type:'queue', allocated_to:'broker_a'}], router);
                     broker_a.verify_addresses([{address:'c', type:'queue'}]);
                     broker_b.verify_addresses([{address:'b', type:'queue'}]);
-                    //verify connector for a was deleted:
-                    broker_a.verify_connectors([{name:'c'}]);
-                    broker_b.verify_connectors([{name:'b'}]);
                     done();
                 }, 1000/*1 second wait for propagation*/);//TODO: add ability to be notified of propagation in some way
             }, 500);
@@ -1051,24 +1042,19 @@ describe('broker configuration', function() {
     });
 
     it('creates address-settings on broker', function (done) {
-        var settings = new BrokerAddressSettings({port:address_source.port, host:'localhost', token:'foo', namespace:'default'});
-        ragent.broker_address_settings = settings.get_address_settings_async.bind(settings);
+        var address_settings = broker_address_settings.controller_factory({port:address_source.port, host:'localhost', token:'foo', namespace:'default'});
+        ragent.create_broker_controller = function (connection) {
+            return address_settings.create_controller(connection);
+        }
         var router = routers.new_router();
         var broker_a = new MockBroker('broker_a');
         broker_a.global_max_size = 100;
         connect_broker(broker_a).then(function () {
             address_source.add_address_plan({plan_name:'small', address_type:'queue', required_resources:[{name:'broker',credit:0.2}]});
             address_source.add_address_plan({plan_name:'medium', address_type:'queue', required_resources:[{name:'broker',credit:0.5}]});
-            address_source.add_address_definition({address:'a', type:'queue', plan:'small'}, undefined, {'enmasse.io/broker-id':'broker_a'});
-            address_source.add_address_definition({address:'b', type:'queue', plan:'medium'}, undefined, {'enmasse.io/broker-id':'broker_a'});
             setTimeout(function () {
-                //verify router config:
-                verify_addresses([{address:'a', type:'queue', allocated_to:'broker_a'}, {address:'b', type:'queue', allocated_to:'broker_a'}], router);
-                //verify queues on broker:
-                broker_a.verify_addresses([{address:'a', type:'queue'}, {address:'b', type:'queue'}]);
                 //verify address settings:
-                broker_a.verify_address_settings([{match:'a', maxSizeBytes:20, addressFullMessagePolicy:'FAIL'}, {match:'b', maxSizeBytes:50, addressFullMessagePolicy:'FAIL'}]);
-                settings.watcher.close();
+                broker_a.verify_address_settings([{match:'small/#', maxSizeBytes:20, addressFullMessagePolicy:'FAIL'}, {match:'medium/#', maxSizeBytes:50, addressFullMessagePolicy:'FAIL'}]);
                 done();
             }, 1000/*1 second wait for propagation*/);//TODO: add ability to be notified of propagation in some way
         }).catch(done);

--- a/agent/testlib/mock_broker.js
+++ b/agent/testlib/mock_broker.js
@@ -165,8 +165,11 @@ function MockBroker (name) {
         },
         removeAddressSettings : function (match) {
             if (myutils.remove(self.objects, function (o) { return o.type === 'address_settings' && o.match === match; }) !== 1) {
-                throw new Error('error deleting address settings ' + match);
+                throw new Error('error deleting address settings %j', match);
             }
+        },
+        getAddressSettingsAsJSON : function (match) {
+            return JSON.stringify(self.objects.filter(function (o) { return o.type === 'address_settings' && o.match === match; })[0]);
         },
         listAddresses : function () {
             var items = self.get('address');
@@ -247,7 +250,7 @@ MockBroker.prototype.on_message = function (context) {
             throw new Error('no such resource: ' + resource);
         }
     } catch (e) {
-        console.log('invocation of ' + operation + ' on ' + resource + ' failed: ' + e);
+        console.log('invocation of %s on %s failed: %s', operation, resource, e);
         if (reply_link) {
             reply_link.send({application_properties:{_AMQ_OperationSucceeded:false}, body:util.format('%s', e)});
         }

--- a/artemis/config_templates/standard/colocated/broker.xml
+++ b/artemis/config_templates/standard/colocated/broker.xml
@@ -69,7 +69,7 @@ under the License.
 
       <acceptors>
          <acceptor name="artemis">tcp://0.0.0.0:61616?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576</acceptor>
-         <acceptor name="amqp">tcp://0.0.0.0:5673?protocols=AMQP;sslEnabled=true;keyStorePath=${KEYSTORE_PATH};keyStorePassword=enmasse;trustStorePath=${TRUSTSTORE_PATH};trustStorePassword=enmasse;verifyHost=false;needClientAuth=true</acceptor>
+         <acceptor name="amqp">tcp://0.0.0.0:5673?protocols=AMQP;multicastPrefix=topic://;anycastPrefix=queue://;sslEnabled=true;keyStorePath=${KEYSTORE_PATH};keyStorePassword=enmasse;trustStorePath=${TRUSTSTORE_PATH};trustStorePassword=enmasse;verifyHost=false;needClientAuth=true</acceptor>
       </acceptors>
 
 

--- a/router/Dockerfile
+++ b/router/Dockerfile
@@ -1,4 +1,4 @@
-FROM enmasseproject/qdrouterd-base:master-2018-03-14
+FROM gordons/qdrouterd-base:add_external_prefix
 ARG version=latest
 
 COPY ./run_qdr.sh ./qdrouterd.conf.template colocated-topic.snippet subscriptions.snippet amqp-kafka-bridge.snippet /etc/qpid-dispatch/

--- a/systemtests/src/main/java/io/enmasse/systemtest/amqp/Receiver.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/amqp/Receiver.java
@@ -16,6 +16,7 @@ import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Predicate;
@@ -35,7 +36,7 @@ public class Receiver extends ClientHandlerBase<List<Message>> {
 
     @Override
     protected void connectionOpened(ProtonConnection conn) {
-        connectionOpened(conn, linkOptions.getLinkName().orElse(linkOptions.getSource().getAddress()), linkOptions.getSource());
+        connectionOpened(conn, linkOptions.getLinkName().orElse(UUID.randomUUID().toString()), linkOptions.getSource());
     }
 
     private void connectionOpened(ProtonConnection conn, String linkName, Source source) {
@@ -64,7 +65,7 @@ public class Receiver extends ClientHandlerBase<List<Message>> {
                 log.info("Receiver link redirected to '" + relocated + "'");
                 Source newSource = linkOptions.getSource();
                 newSource.setAddress(relocated);
-                String newLinkName = linkOptions.getLinkName().orElse(newSource.getAddress());
+                String newLinkName = linkOptions.getLinkName().orElse(UUID.randomUUID().toString());
 
                 vertx.runOnContext(id -> connectionOpened(conn, newLinkName, newSource));
             } else {


### PR DESCRIPTION
Instead of creating an address-settings instance per address (which doesn't scale well at all in the broker), this uses an address-setting per plan and has the router add prefixes to the queue/topic as seen by the broker in order to associate it with the right plan.