### PR TITLE
Fix address controller deployment order

### DIFF
--- a/documentation/service_admin/installing-kubernetes.adoc
+++ b/documentation/service_admin/installing-kubernetes.adoc
@@ -145,9 +145,9 @@ kubectl secret tls address-controller-cert --cert=address-controller-cert/tls.cr
 +
 [options="nowrap"]
 ----
+kubectl apply -f ./resources/address-controller/address-space-definitions.yaml
 kubectl apply -f ./resources/address-controller/deployment.yaml
 kubectl apply -f ./resources/address-controller/service.yaml
-kubectl apply -f ./resources/address-controller/address-space-definitions.yaml
 ----
 +
 The deployments required for running {ProductName} are now created.

--- a/documentation/service_admin/installing-openshift.adoc
+++ b/documentation/service_admin/installing-openshift.adoc
@@ -269,10 +269,10 @@ oc create configmap address-controller-config --from-literal=enableRbac=true
 +
 [options="nowrap"]
 ----
+oc create -f ./resources/address-controller/address-space-definitions.yaml
 oc create -f ./resources/address-controller/deployment.yaml
 oc create -f ./resources/address-controller/service.yaml
 oc create -f ./resources/address-controller/route.yaml
-oc create -f ./resources/address-controller/address-space-definitions.yaml
 ----
 +
 The deployments required for running {ProductName} are now created.

--- a/templates/install/ansible/roles/address_controller/tasks/main.yml
+++ b/templates/install/ansible/roles/address_controller/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
+- name: Create the address controller config map
+  shell: oc create configmap address-controller-config --from-literal=enableRbac={{ enable_rbac }} --from-literal=environment={{ enmasse_environment }}
+- name: Create the address space definitions
+  shell: oc apply -f {{ playbook_dir }}/resources/address-controller/address-space-definitions.yaml
 - name: Create the address controller deployment
   shell: oc apply -f {{ playbook_dir }}/resources/address-controller/deployment.yaml
 - name: Create the address controller service
   shell: oc apply -f {{ playbook_dir }}/resources/address-controller/service.yaml
 - name: Create the address controller route
   shell: oc apply -f {{ playbook_dir }}/resources/address-controller/route.yaml
-- name: Create the address space definitions
-  shell: oc apply -f {{ playbook_dir }}/resources/address-controller/address-space-definitions.yaml
-- name: Create the address controller config map
-  shell: oc create configmap address-controller-config --from-literal=enableRbac={{ enable_rbac }} --from-literal=environment={{ enmasse_environment }}


### PR DESCRIPTION
Ensure that `address-space-definitions.yaml` is applied before deploying the address controller.

This prevents errors in address controller about the ConfigMap `address-space-definitions` not being found.