### PR TITLE
Remove health URI from HttpV1RootService

### DIFF
--- a/address-controller/src/main/java/io/enmasse/controller/api/v1/http/HttpV1RootService.java
+++ b/address-controller/src/main/java/io/enmasse/controller/api/v1/http/HttpV1RootService.java
@@ -24,7 +24,6 @@ public class HttpV1RootService {
         URI baseUri = uriInfo.getBaseUri();
         uriList.add(baseUri.resolve("/apis/enmasse.io/v1/addressspaces"));
         uriList.add(baseUri.resolve("/apis/enmasse.io/v1/addresses"));
-        uriList.add(baseUri.resolve("/apis/enmasse.io/v1/health"));
         uriList.add(baseUri.resolve("/apis/enmasse.io/v1/schema"));
         return Response.status(200).entity(uriList).build();
     }


### PR DESCRIPTION
The Health endpoint is not available under `/apis/enmasse.io/v1/` any more.