### PR TITLE
Allow max message size to be configured for MQTT and set it to 128K by default

### DIFF
--- a/mqtt-gateway/src/main/java/enmasse/mqtt/MqttGateway.java
+++ b/mqtt-gateway/src/main/java/enmasse/mqtt/MqttGateway.java
@@ -31,6 +31,8 @@ public class MqttGateway extends AbstractVerticle {
     // binding info for listening
     private String bindAddress;
     private int listenPort;
+    // mqtt server options
+    private int maxMessageSize;
     // connection info to the messaging service
     private String messagingServiceHost;
     private int messagingServicePort;
@@ -65,6 +67,18 @@ public class MqttGateway extends AbstractVerticle {
     @Value(value = "${enmasse.mqtt.listenport:1883}")
     public MqttGateway setListenPort(int listePort) {
         this.listenPort = listePort;
+        return this;
+    }
+
+    /**
+     * Set max message size for MQTT Gateway
+     *
+     * @param maxMessageSize   max message size for MQTT messages
+     * @return  current MQTT gateway instance
+     */
+    @Value(value = "${enmasse.mqtt.maxmessagesize:131072}")
+    public MqttGateway setMaxMessageSize(int maxMessageSize) {
+        this.maxMessageSize = maxMessageSize;
         return this;
     }
 
@@ -136,6 +150,7 @@ public class MqttGateway extends AbstractVerticle {
     private void bindMqttServer(Future<Void> startFuture) {
 
         MqttServerOptions options = new MqttServerOptions();
+        options.setMaxMessageSize(this.maxMessageSize);
         options.setHost(this.bindAddress).setPort(this.listenPort);
 
         if (this.ssl) {

--- a/mqtt-gateway/src/test/java/enmasse/mqtt/MockMqttGatewayTestBase.java
+++ b/mqtt-gateway/src/test/java/enmasse/mqtt/MockMqttGatewayTestBase.java
@@ -29,6 +29,7 @@ public abstract class MockMqttGatewayTestBase {
     public static final String MQTT_BIND_ADDRESS = "localhost";
     public static final int MQTT_LISTEN_PORT = 1883;
     public static final int MQTT_TLS_LISTEN_PORT = 8883;
+    public static final int MQTT_MAX_MESSAGE_SIZE = 131072;
 
 
     public static final String MESSAGING_SERVICE_HOST = "localhost";
@@ -68,6 +69,7 @@ public abstract class MockMqttGatewayTestBase {
         this.mqttGateway
                 .setBindAddress(MQTT_BIND_ADDRESS)
                 .setListenPort(port)
+                .setMaxMessageSize(MQTT_MAX_MESSAGE_SIZE)
                 .setMessagingServiceHost(MESSAGING_SERVICE_HOST)
                 .setMessagingServicePort(router.getNormalPort());
 

--- a/mqtt-gateway/src/test/java/enmasse/mqtt/PublishTest.java
+++ b/mqtt-gateway/src/test/java/enmasse/mqtt/PublishTest.java
@@ -28,6 +28,8 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.Collections;
+
 /**
  * Tests related to publish
  */
@@ -36,6 +38,7 @@ public class PublishTest extends MockMqttGatewayTestBase {
 
     private static final String MQTT_TOPIC = "mytopic";
     private static final String MQTT_MESSAGE = "Hello MQTT on EnMasse";
+    private static final String MQTT_LARGE_MESSAGE = String.join("a", Collections.nCopies(64000, ""));
     private static final String SUBSCRIBER_ID = "my_subscriber_id";
     private static final String PUBLISHER_ID = "my_publisher_id";
 
@@ -100,6 +103,17 @@ public class PublishTest extends MockMqttGatewayTestBase {
     }
 
     @Test
+    public void mqttPublishLargeQoS1toMqtt(TestContext context) {
+
+        Async messageReceived = context.async();
+        this.mqttReceiver(context, MQTT_TOPIC, 1, messageReceived);
+        this.mqttPublish(context, MQTT_TOPIC, MQTT_LARGE_MESSAGE, 1);
+
+        messageReceived.await();
+        context.assertTrue(true);
+    }
+
+    @Test
     public void mqttPublishQoS2toMqtt(TestContext context) {
 
         Async messageReceived = context.async();
@@ -127,6 +141,17 @@ public class PublishTest extends MockMqttGatewayTestBase {
         Async messageReceived = context.async();
         this.amqpReceiver(context, MQTT_TOPIC, 1, messageReceived);
         this.mqttPublish(context, MQTT_TOPIC, MQTT_MESSAGE, 1);
+
+        messageReceived.await();
+        context.assertTrue(true);
+    }
+
+    @Test
+    public void mqttPublishLargeQoS1toAmqp(TestContext context) {
+
+        Async messageReceived = context.async();
+        this.amqpReceiver(context, MQTT_TOPIC, 1, messageReceived);
+        this.mqttPublish(context, MQTT_TOPIC, MQTT_LARGE_MESSAGE, 1);
 
         messageReceived.await();
         context.assertTrue(true);

--- a/templates/include/address-space-definitions.yaml
+++ b/templates/include/address-space-definitions.yaml
@@ -1859,6 +1859,8 @@ data:
                 value: /etc/mqtt-gateway/ssl/tls.crt
               - name: ENMASSE_MQTT_LISTENPORT
                 value: '8883'
+              - name: ENMASSE_MQTT_MAXMESSAGESIZE
+                value: ${MQTT_MAXMESSAGESIZE}
               image: ${MQTT_GATEWAY_IMAGE}
               livenessProbe:
                 initialDelaySeconds: 60
@@ -1983,6 +1985,9 @@ data:
     - description: The service account with address space admin privileges
       name: ADDRESS_SPACE_ADMIN_SA
       value: address-space-admin
+    - description: Maximum message size allowed by the MQTT Gateway
+      name: MQTT_MAXMESSAGESIZE
+      value: '131072'
   brokered-space-infra.yaml: |-
     apiVersion: v1
     kind: Template

--- a/templates/install/resources/address-space-controller/address-space-definitions.yaml
+++ b/templates/install/resources/address-space-controller/address-space-definitions.yaml
@@ -1859,6 +1859,8 @@ data:
                 value: /etc/mqtt-gateway/ssl/tls.crt
               - name: ENMASSE_MQTT_LISTENPORT
                 value: '8883'
+              - name: ENMASSE_MQTT_MAXMESSAGESIZE
+                value: ${MQTT_MAXMESSAGESIZE}
               image: docker.io/enmasseproject/mqtt-gateway:latest
               livenessProbe:
                 initialDelaySeconds: 60
@@ -1983,6 +1985,9 @@ data:
     - description: The service account with address space admin privileges
       name: ADDRESS_SPACE_ADMIN_SA
       value: address-space-admin
+    - description: Maximum message size allowed by the MQTT Gateway
+      name: MQTT_MAXMESSAGESIZE
+      value: '131072'
   brokered-space-infra.yaml: |-
     apiVersion: v1
     kind: Template


### PR DESCRIPTION
Fixes #1231 
