### PR TITLE
Change naming of AddressSpace ConfigMap

### DIFF
--- a/k8s-api/src/main/java/io/enmasse/k8s/api/ConfigMapAddressSpaceApi.java
+++ b/k8s-api/src/main/java/io/enmasse/k8s/api/ConfigMapAddressSpaceApi.java
@@ -37,7 +37,7 @@ public class ConfigMapAddressSpaceApi implements AddressSpaceApi, ListerWatcher<
     }
 
     private static String getConfigMapName(String namespace, String name) {
-        return namespace + name;
+        return namespace + "." + name;
     }
 
     @Override
@@ -65,6 +65,7 @@ public class ConfigMapAddressSpaceApi implements AddressSpaceApi, ListerWatcher<
     public void replaceAddressSpace(AddressSpace addressSpace) throws Exception {
         ConfigMap previous = client.configMaps().withName(getConfigMapName(addressSpace.getNamespace(), addressSpace.getName())).get();
         if (previous == null) {
+            log.warn("Cannot replace addressSpace {}: No previous configMap found", addressSpace.getName());
             return;
         }
         try {

--- a/templates/include/address-space.yaml
+++ b/templates/include/address-space.yaml
@@ -6,7 +6,7 @@ objects:
   - apiVersion: v1
     kind: ConfigMap
     metadata:
-      name: ${NAME}
+      name: ${NAMESPACE}.${NAME}
       labels:
         type: address-space
     data:

--- a/templates/install/common.sh
+++ b/templates/install/common.sh
@@ -42,7 +42,7 @@ function create_address_space() {
     \"apiVersion\": \"v1\",
     \"kind\": \"ConfigMap\",
     \"metadata\": {
-        \"name\": \"${name}\",
+        \"name\": \"${NAMESPACE}.${name}\",
         \"labels\": {
             \"type\": \"address-space\",
             \"namespace\": \"${NAMESPACE}\"

--- a/templates/install/resources/templates/address-space.yaml
+++ b/templates/install/resources/templates/address-space.yaml
@@ -6,7 +6,7 @@ objects:
   - apiVersion: v1
     kind: ConfigMap
     metadata:
-      name: ${NAME}
+      name: ${NAMESPACE}.${NAME}
       labels:
         type: address-space
     data:


### PR DESCRIPTION
This introduces a separator char between namespace and AddressSpace name in the name of the AddressSpace ConfigMap in order to prevent potential naming clashes.
The dot has been chosen as separator char since it isn't allowed in a K8s namespace name.

Usage of the AddressSpace ConfigMap naming scheme has been adopted to places where such a ConfigMap gets created.