### PR TITLE
Add optional oauthUrl entry in keycloak-config (#1197)

### DIFF
--- a/address-space-controller/src/main/java/io/enmasse/controller/Main.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/Main.java
@@ -104,7 +104,7 @@ public class Main extends AbstractVerticle {
                 resolverMap.put(AuthenticationServiceType.STANDARD, new StandardAuthenticationServiceResolver(
                         config.getData().get("hostname"),
                         Integer.parseInt(config.getData().get("port")),
-                        config.getData().get("httpUrl"),
+                        config.getData().get("oauthUrl"),
                         config.getData().get("caSecretName")));
             } else {
                 log.warn("Skipping standard authentication service: configmap {} not found", authService.getConfigMap());

--- a/documentation/service_admin/installing-kubernetes.adoc
+++ b/documentation/service_admin/installing-kubernetes.adoc
@@ -87,26 +87,56 @@ kubectl create secret generic keycloak-credentials --from-literal=admin.username
 [options="nowrap"]
 ----
 kubectl apply -f ./resources/standard-authservice/service.yaml
-kubectl apply -f ./resources/standard-authservice/keycloak-deployment.yaml
-kubectl apply -f ./resources/standard-authservice/controller-deployment.yaml
+kubectl apply -f ./resources/standard-authservice/external-service.yaml
 kubectl apply -f ./resources/standard-authservice/pvc.yaml
 ----
 
-. Create keycloak configuration used by controller and service. For the messaging console and
-keycloak controller to work, you need to specify the `httpUrl` setting. To get the service ip:
+. Create keycloak configuration used by controller and service. To make the standard authservice
+accessible for the messaging console and keycloak controller, you need to specify the `httpUrl` and the `oauthUrl`
+settings in the keycloak configuration. For the `httpUrl`, use the internal service IP:
 +
 [options="nowrap"]
 ----
 kubectl get service standard-authservice -o jsonpath={.spec.clusterIP}
+----
++
+Set the HTTP_URL environment variable:
++
+----
+HTTP_URL=https://<clusterIP from above>:8443/auth
+----
+
+. For the `oauthUrl`, use the load balancer host name if it is set:
++
+[options="nowrap"]
+----
+kubectl get service standard-authservice-external -o 'jsonpath={.status.loadBalancer.ingress.hostname}'
+----
++
+Otherwise use the node/VM IP and the service NodePort:
++
+----
+kubectl get service standard-authservice-external -o 'jsonpath={.spec.ports[?(@.name=="https")].nodePort}'
+----
+Set the OAUTH_URL environment variable:
++
+----
+OAUTH_URL=https://<service host from above or node/VM IP together with NodePort from above>/auth
 ----
 
 . Create keycloak configuration:
 +
 [options="nowrap"]
 ----
-AUTH_HOST=<value from one of the previous commands>
-AUTH_PORT=8443 if using the service ip, 443 if using the route host
-kubectl create configmap keycloak-config --from-literal=hostname=standard-authservice --from-literal=port=5671 --from-literal=httpUrl=https://$AUTH_HOST:$AUTH_PORT/auth --from-literal=caSecretName=standard-authservice-cert
+kubectl create configmap keycloak-config --from-literal=hostname=standard-authservice --from-literal=port=5671 --from-literal=httpUrl=$HTTP_URL --from-literal=oauthUrl=$OAUTH_URL --from-literal=caSecretName=standard-authservice-cert
+----
+
+. Deploy keycloak and controller:
++
+[options="nowrap"]
+----
+kubectl create -f ./resources/standard-authservice/keycloak-deployment.yaml
+kubectl create -f ./resources/standard-authservice/controller-deployment.yaml
 ----
 
 ==== Deploying {ProductName}

--- a/documentation/service_admin/installing-openshift.adoc
+++ b/documentation/service_admin/installing-openshift.adoc
@@ -92,36 +92,51 @@ oc adm policy add-role-to-user view system:serviceaccount:enmasse:default
 [options="nowrap"]
 ----
 oc create -f ./resources/standard-authservice/service.yaml
-oc create -f ./resources/standard-authservice/keycloak-deployment.yaml
-oc create -f ./resources/standard-authservice/controller-deployment.yaml
-oc create -f ./resources/standard-authservice/pvc.yaml
 oc create -f ./resources/standard-authservice/route.yaml
+oc create -f ./resources/standard-authservice/pvc.yaml
 ----
 
 . Create keycloak configuration used by controller and service. To make the standard authservice
-accessible for the messaging console and keycloak operator, you need to specify the `httpUrl`
-setting. If you are running a local OpenShift cluster without a public DNS, use the internal service
-IP for the hostname, otherwise use the hostname of the external route. To get the service ip:
+accessible for the messaging console and keycloak operator, you need to specify the `httpUrl` and the `oauthUrl`
+settings in the keycloak configuration. For the `httpUrl`, use the internal service IP:
 +
 [options="nowrap"]
 ----
 oc get service standard-authservice -o jsonpath={.spec.clusterIP}
 ----
 +
-. Or, if you have a public hostname:
+Set the HTTP_URL environment variable:
++
+----
+HTTP_URL=https://<clusterIP from above>:8443/auth
+----
+
+. For the `oauthUrl`, use the hostname from the route
 +
 [options="nowrap"]
 ----
 oc get route keycloak -o jsonpath={.spec.host}
+----
++
+Set the OAUTH_URL environment variable:
++
+----
+OAUTH_URL=https://<route host from above>/auth
 ----
 
 . Create keycloak configuration:
 +
 [options="nowrap"]
 ----
-AUTH_HOST=<value from one of the previous commands>
-AUTH_PORT=8443 if using the service ip, 443 if using the route host
-oc create configmap keycloak-config --from-literal=hostname=standard-authservice --from-literal=port=5671 --from-literal=httpUrl=https://$AUTH_HOST:$AUTH_PORT/auth --from-literal=caSecretName=standard-authservice-cert
+oc create configmap keycloak-config --from-literal=hostname=standard-authservice --from-literal=port=5671 --from-literal=httpUrl=$HTTP_URL --from-literal=oauthUrl=$OAUTH_URL --from-literal=caSecretName=standard-authservice-cert
+----
+
+. Deploy keycloak and controller:
++
+[options="nowrap"]
+----
+oc create -f ./resources/standard-authservice/keycloak-deployment.yaml
+oc create -f ./resources/standard-authservice/controller-deployment.yaml
 ----
 
 ==== Deploying {ProductName}

--- a/keycloak-controller/src/main/java/io/enmasse/keycloak/controller/KeycloakManager.java
+++ b/keycloak-controller/src/main/java/io/enmasse/keycloak/controller/KeycloakManager.java
@@ -35,8 +35,10 @@ public class KeycloakManager implements Watcher<AddressSpace>
     private String getConsoleRedirectURI(AddressSpace addressSpace) {
         if (addressSpace.getEndpoints() != null) {
             for (Endpoint endpoint : addressSpace.getEndpoints()) {
-                if (endpoint.getName().equals("console") && endpoint.getHost().isPresent()) {
-                    String uri = "https://" + endpoint.getHost().get() + "/*";
+                if ((endpoint.getName().equals("console") || endpoint.getName().equals("console-external")) 
+                        && endpoint.getHost().isPresent()) {
+                    String portSuffix = (endpoint.getPort() != 443 ? ":" + endpoint.getPort() : "");
+                    String uri = "https://" + endpoint.getHost().get() + portSuffix + "/*";
                     log.info("Using {} as redirect URI for enmasse-console", uri);
                     return uri;
                 }

--- a/templates/include/auth-service.jsonnet
+++ b/templates/include/auth-service.jsonnet
@@ -264,8 +264,9 @@ local images = import "images.jsonnet";
                     "name": "KEYCLOAK_SASL_XOAUTH_BASE_URI", 
                     "valueFrom": {
                       "configMapKeyRef": {
+                        "optional": true,
                         "name": "keycloak-config",
-                        "key": "httpUrl"
+                        "key": "oauthUrl"
                       }
                     }
                   },

--- a/templates/install/ansible/roles/standard_authservice/tasks/main.yml
+++ b/templates/install/ansible/roles/standard_authservice/tasks/main.yml
@@ -33,9 +33,17 @@
   when: config_exists.failed and (keycloak_http_url is not defined)
   shell: oc get service -n {{ namespace }} standard-authservice -o jsonpath={.spec.clusterIP}
   register: authservice_clusterip
+- name: Retrieve route host
+  when: config_exists.failed and (keycloak_oauth_url is not defined)
+  shell: oc get route -n {{ namespace }} keycloak -o yaml -o jsonpath={.spec.host}
+  register: authroute_host
+
 - set_fact:
     keycloak_http_url: "https://{{ authservice_clusterip.stdout }}:8443/auth"
   when: config_exists.failed and (keycloak_http_url is not defined)
+- set_fact:
+    keycloak_oauth_url: "https://{{ authroute_host.stdout }}/auth"
+  when: config_exists.failed and (keycloak_oauth_url is not defined)
 
 - name: Check if OAUTH service account exists
   shell: oc get sa -n {{ namespace }} kc-oauth
@@ -53,5 +61,5 @@
     oauth_token: "{{ token_result.stdout }}"
 
 - name: Create configmap with the keycloak info
-  when: config_exists.failed and (keycloak_http_url is defined)
-  shell: oc create configmap keycloak-config -n {{ namespace }} --from-literal=hostname=standard-authservice.{{ namespace }}.svc --from-literal=port=5671 --from-literal=caSecretName=standard-authservice-cert --from-literal=httpUrl={{ keycloak_http_url }} --from-literal=identityProviderClientId=system:serviceaccount:{{ namespace }}:kc-oauth --from-literal=identityProviderClientSecret={{ oauth_token }}
+  when: config_exists.failed and (keycloak_http_url is defined) and (keycloak_oauth_url is defined)
+  shell: oc create configmap keycloak-config -n {{ namespace }} --from-literal=hostname=standard-authservice.{{ namespace }}.svc --from-literal=port=5671 --from-literal=caSecretName=standard-authservice-cert --from-literal=httpUrl={{ keycloak_http_url }} --from-literal=oauthUrl={{ keycloak_oauth_url }} --from-literal=identityProviderClientId=system:serviceaccount:{{ namespace }}:kc-oauth --from-literal=identityProviderClientSecret={{ oauth_token }}


### PR DESCRIPTION
This config entry is mapped to AUTHENTICATION_SERVICE_OAUTH_URL of the agent config. By making it optional, OAuth can be disabled for the agent console login. This is used for the deploy.sh Kubernetes deployment where the external keycloak URL cannot be determined in all cases.
