### PR TITLE
Add optional oauthDisabled entry in keycloak-config (#1197)

### DIFF
--- a/address-space-controller/src/main/java/io/enmasse/controller/Main.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/Main.java
@@ -104,7 +104,7 @@ public class Main extends AbstractVerticle {
                 resolverMap.put(AuthenticationServiceType.STANDARD, new StandardAuthenticationServiceResolver(
                         config.getData().get("hostname"),
                         Integer.parseInt(config.getData().get("port")),
-                        config.getData().get("httpUrl"),
+                        Boolean.valueOf(config.getData().get("oauthDisabled")) ? null: config.getData().get("httpUrl"),
                         config.getData().get("caSecretName")));
             } else {
                 log.warn("Skipping standard authentication service: configmap {} not found", authService.getConfigMap());

--- a/templates/install/deploy.sh
+++ b/templates/install/deploy.sh
@@ -190,17 +190,20 @@ do
         KEYCLOAK_PASSWORD=`random_string`
         create_self_signed_cert "$CMD" "standard-authservice.${NAMESPACE}.svc.cluster.local" "standard-authservice-cert"
         runcmd "$CMD create -n ${NAMESPACE} secret generic keycloak-credentials --from-literal=admin.username=admin --from-literal=admin.password=$KEYCLOAK_PASSWORD" "Create secret with keycloak admin credentials"
-        runcmd "$CMD create -n ${NAMESPACE} -f ${RESOURCE_DIR}/standard-authservice/keycloak-deployment.yaml" "Create standard authservice deployment"
         runcmd "$CMD create -n ${NAMESPACE} -f ${RESOURCE_DIR}/standard-authservice/service.yaml" "Create standard authservice service"
-        runcmd "$CMD create -n ${NAMESPACE} -f ${RESOURCE_DIR}/standard-authservice/controller-deployment.yaml" "Create standard authservice controller"
-        runcmd "$CMD create -n ${NAMESPACE} -f ${RESOURCE_DIR}/standard-authservice/pvc.yaml" "Create standard authservice persistent volume"
         if [ -n "$USE_OPENSHIFT" ]; then
             runcmd "oc create -n ${NAMESPACE} -f ${RESOURCE_DIR}/standard-authservice/route.yaml" "Create standard authservice route"
+            OAUTH_DISABLED="false"
+            HTTP_URL="https://$(oc get route keycloak -o yaml -o jsonpath={.spec.host})/auth"
         else
             runcmd "kubectl create -n ${NAMESPACE} -f ${RESOURCE_DIR}/standard-authservice/external-service.yaml" "Create standard authservice external service"
+            OAUTH_DISABLED="true"
+            HTTP_URL="https://$($CMD get service standard-authservice -n ${NAMESPACE} -o jsonpath={.spec.clusterIP}):8443/auth"
         fi
-        httpUrl="https://$($CMD get service standard-authservice -n ${NAMESPACE} -o jsonpath={.spec.clusterIP}):8443/auth"
-        runcmd "$CMD create -n ${NAMESPACE} configmap keycloak-config --from-literal=hostname=standard-authservice.${NAMESPACE}.svc --from-literal=httpUrl=$httpUrl --from-literal=port=5671 --from-literal=caSecretName=standard-authservice-cert" "Create standard authentication service configuration"
+        runcmd "$CMD create -n ${NAMESPACE} configmap keycloak-config --from-literal=hostname=standard-authservice.${NAMESPACE}.svc --from-literal=oauthDisabled=${OAUTH_DISABLED} --from-literal=httpUrl=${HTTP_URL} --from-literal=port=5671 --from-literal=caSecretName=standard-authservice-cert" "Create standard authentication service configuration"
+        runcmd "$CMD create -n ${NAMESPACE} -f ${RESOURCE_DIR}/standard-authservice/pvc.yaml" "Create standard authservice persistent volume"
+        runcmd "$CMD create -n ${NAMESPACE} -f ${RESOURCE_DIR}/standard-authservice/keycloak-deployment.yaml" "Create standard authservice deployment"
+        runcmd "$CMD create -n ${NAMESPACE} -f ${RESOURCE_DIR}/standard-authservice/controller-deployment.yaml" "Create standard authservice controller"
     fi
 done
 


### PR DESCRIPTION
With this, OAuth can be disabled for the agent console login. This is used for the deploy.sh Kubernetes deployment where the external Keycloak URL cannot be determined in all cases.

(Corresponding changes to the manual installation guide will go in a separate PR.)