### PR TITLE
Fallback to kubernetes service URL if the well-known URI is localhost

### DIFF
--- a/templates/include/auth-service.jsonnet
+++ b/templates/include/auth-service.jsonnet
@@ -136,6 +136,16 @@ local images = import "images.jsonnet";
                     }
                   },
                   {
+                    "name": "OAUTH_IDENTITY_PROVIDER_URL",
+                    "valueFrom": {
+                      "configMapKeyRef": {
+                        "optional": true,
+                        "name": "keycloak-config",
+                        "key": "identityProviderUrl"
+                      }
+                    }
+                  },
+                  {
                     "name": "OAUTH_IDENTITY_PROVIDER_CLIENT_ID",
                     "valueFrom": {
                       "configMapKeyRef": {

--- a/templates/install/ansible/roles/standard_authservice/tasks/main.yml
+++ b/templates/install/ansible/roles/standard_authservice/tasks/main.yml
@@ -51,7 +51,19 @@
   register: token_result
 - set_fact:
     oauth_token: "{{ token_result.stdout }}"
+- name: Get OpenShift OAuth URL
+  shell: oc get --raw=/.well-known/oauth-authorization-server
+  ignore_errors: True
+  register: result
+- name: Set identity provider
+  when: result.rc == 0
+  set_fact:
+    identity_url: "{{ (result.stdout | from_json).get('issuer') }}"
+- name: Unset identity provider if using local cluster
+  when: identity_url is match("https://127.0.0.1:8443") or identity_url is match("https://localhost:8443")
+  set_fact:
+    identity_url: null
 
 - name: Create configmap with the keycloak info
   when: config_exists.failed and (keycloak_http_url is defined)
-  shell: oc create configmap keycloak-config -n {{ namespace }} --from-literal=hostname=standard-authservice.{{ namespace }}.svc --from-literal=port=5671 --from-literal=caSecretName=standard-authservice-cert --from-literal=httpUrl={{ keycloak_http_url }} --from-literal=identityProviderClientId=system:serviceaccount:{{ namespace }}:kc-oauth --from-literal=identityProviderClientSecret={{ oauth_token }}
+  shell: oc create configmap keycloak-config -n {{ namespace }} --from-literal=hostname=standard-authservice.{{ namespace }}.svc --from-literal=port=5671 --from-literal=caSecretName=standard-authservice-cert --from-literal=httpUrl={{ keycloak_http_url }} --from-literal=identityProviderClientId=system:serviceaccount:{{ namespace }}:kc-oauth --from-literal=identityProviderClientSecret={{ oauth_token }} --from-literal=identityProviderUrl={{ identity_url }}

--- a/templates/install/deploy.sh
+++ b/templates/install/deploy.sh
@@ -221,7 +221,7 @@ elif [ $MODE == "multitenant" ]; then
     runcmd "$CMD create -n ${NAMESPACE} -f $RESOURCE_DIR/plans/standard-plans.yaml" "Create standard address space plans"
     runcmd "$CMD create -n ${NAMESPACE} -f $RESOURCE_DIR/plans/brokered-plans.yaml" "Create brokered address space plans"
     if [ "$USE_OPENSHIFT" == "true" ]; then
-        runcmd "$CMD create -n ${NAMESPACE} configmap api-server-config --from-literal=enableRbac=true" "Create api-server configmap"
+        runcmd "$CMD create -n ${NAMESPACE} configmap api-server-config --from-literal=enableRbac=false" "Create api-server configmap"
     fi
 else
     echo "Unknown deployment mode $MODE"
@@ -237,7 +237,7 @@ runcmd "$CMD create -n ${NAMESPACE} -f ${RESOURCE_DIR}/api-server/deployment.yam
 runcmd "$CMD create -n ${NAMESPACE} -f ${RESOURCE_DIR}/api-server/service.yaml" "Create api server service"
 
 if [ "$USE_OPENSHIFT" == "true" ]; then
-    runcmd "oc create route passthrough restapi -n ${NAMESPACE} --service=api-server" "Create restapi route"
+    runcmd "oc create -n ${NAMESPACE} -f ${RESOURCE_DIR}/api-server/route.yaml" "Create restapi route"
 else
     runcmd "kubectl expose service api-server -n ${NAMESPACE} --port=443 --target-port=8443 --name=restapi --type=LoadBalancer" "Create external restapi service"
 fi

--- a/templates/install/resources/standard-authservice/controller-deployment.yaml
+++ b/templates/install/resources/standard-authservice/controller-deployment.yaml
@@ -19,6 +19,12 @@ spec:
             configMapKeyRef:
               key: httpUrl
               name: keycloak-config
+        - name: OAUTH_IDENTITY_PROVIDER_URL
+          valueFrom:
+            configMapKeyRef:
+              key: identityProviderUrl
+              name: keycloak-config
+              optional: true
         - name: OAUTH_IDENTITY_PROVIDER_CLIENT_ID
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
This allows oc cluster up to work out of the box with Keycloak + OpenShift Identity Provider without specifying public-hostname.