### PR TITLE
Fix missing to-lowercase change in create_address_space

### DIFF
--- a/templates/install/common.sh
+++ b/templates/install/common.sh
@@ -42,7 +42,7 @@ function create_address_space() {
     \"apiVersion\": \"v1\",
     \"kind\": \"ConfigMap\",
     \"metadata\": {
-        \"name\": \"${NAMESPACE}.${name}\",
+        \"name\": \"${namespace}.${name}\",
         \"labels\": {
             \"type\": \"address-space\",
             \"namespace\": \"${namespace}\"


### PR DESCRIPTION
The change to lower-case [here](https://github.com/EnMasseProject/enmasse/commit/51dfa8ef5bc69f8136d699a3e84b0512a6fd82d2#diff-e108f3c1f5c3a556bda94d26ad0a313e) wasn't in the PR that got merged later.