### PR TITLE
Fix missing namespace label on AddressSpace ConfigMap (#1275)

### DIFF
--- a/k8s-api/src/main/java/io/enmasse/k8s/api/ConfigMapAddressSpaceApi.java
+++ b/k8s-api/src/main/java/io/enmasse/k8s/api/ConfigMapAddressSpaceApi.java
@@ -80,6 +80,7 @@ public class ConfigMapAddressSpaceApi implements AddressSpaceApi, ListerWatcher<
         Map<String, String> labels = new HashMap<>(addressSpace.getLabels());
         String name = getConfigMapName(addressSpace.getNamespace(), addressSpace.getName());
         labels.put(LabelKeys.TYPE, "address-space");
+        labels.put(LabelKeys.NAMESPACE, addressSpace.getNamespace());
         config.withNewMetadata()
                 .withName(name)
                 .addToLabels(labels)


### PR DESCRIPTION
This fixes an empty AddressSpaceList being returned by the API-Server (#1275)