### PR TITLE
Enable client TLS authentication for API server

### DIFF
--- a/api-common/src/main/java/io/enmasse/api/auth/AllowAllAuthInterceptor.java
+++ b/api-common/src/main/java/io/enmasse/api/auth/AllowAllAuthInterceptor.java
@@ -7,69 +7,32 @@ package io.enmasse.api.auth;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.core.SecurityContext;
-import java.io.IOException;
 import java.security.Principal;
 
 public class AllowAllAuthInterceptor implements ContainerRequestFilter {
 
-    private static final String X_REMOTE_USER = "X-Remote-User";
-    private final AuthApi authApi;
-    private final boolean doUserLookup;
-
-    public AllowAllAuthInterceptor(AuthApi authApi, boolean doUserLookup) {
-        this.authApi = authApi;
-        this.doUserLookup = doUserLookup;
-    }
-
     @Override
-    public void filter(ContainerRequestContext requestContext) throws IOException {
-        if (doUserLookup && requestContext.getHeaderString(X_REMOTE_USER) != null) {
-            String userName = requestContext.getHeaderString(X_REMOTE_USER);
-            String userId = authApi.getUserId(userName);
+    public void filter(ContainerRequestContext requestContext) {
+        requestContext.setSecurityContext(new SecurityContext() {
+            @Override
+            public Principal getUserPrincipal() {
+                return RbacSecurityContext.getUserPrincipal("anonymous", "");
+            }
 
-            requestContext.setSecurityContext(new SecurityContext() {
-                @Override
-                public Principal getUserPrincipal() {
-                    return RbacSecurityContext.getUserPrincipal(userName, userId);
-                }
+            @Override
+            public boolean isUserInRole(String role) {
+                return true;
+            }
 
-                @Override
-                public boolean isUserInRole(String role) {
-                    return true;
-                }
+            @Override
+            public boolean isSecure() {
+                return true;
+            }
 
-                @Override
-                public boolean isSecure() {
-                    return true;
-                }
-
-                @Override
-                public String getAuthenticationScheme() {
-                    return "dummy";
-                }
-            });
-        } else {
-            requestContext.setSecurityContext(new SecurityContext() {
-                @Override
-                public Principal getUserPrincipal() {
-                    return RbacSecurityContext.getUserPrincipal("anonymous", "");
-                }
-
-                @Override
-                public boolean isUserInRole(String role) {
-                    return true;
-                }
-
-                @Override
-                public boolean isSecure() {
-                    return true;
-                }
-
-                @Override
-                public String getAuthenticationScheme() {
-                    return "dummy";
-                }
-            });
-        }
+            @Override
+            public String getAuthenticationScheme() {
+                return "dummy";
+            }
+        });
     }
 }

--- a/api-common/src/main/java/io/enmasse/api/auth/AllowAllAuthInterceptor.java
+++ b/api-common/src/main/java/io/enmasse/api/auth/AllowAllAuthInterceptor.java
@@ -8,15 +8,19 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.core.SecurityContext;
 import java.security.Principal;
+import java.util.Optional;
+
+import static io.enmasse.api.auth.AuthInterceptor.X_REMOTE_USER;
 
 public class AllowAllAuthInterceptor implements ContainerRequestFilter {
 
     @Override
     public void filter(ContainerRequestContext requestContext) {
+        String username = Optional.ofNullable(requestContext.getHeaderString(X_REMOTE_USER)).orElse("system:anonymous");
         requestContext.setSecurityContext(new SecurityContext() {
             @Override
             public Principal getUserPrincipal() {
-                return RbacSecurityContext.getUserPrincipal("anonymous", "");
+                return RbacSecurityContext.getUserPrincipal(username, "");
             }
 
             @Override

--- a/api-common/src/main/java/io/enmasse/api/auth/AuthApi.java
+++ b/api-common/src/main/java/io/enmasse/api/auth/AuthApi.java
@@ -6,7 +6,8 @@ package io.enmasse.api.auth;
 
 public interface AuthApi {
     TokenReview performTokenReview(String token);
-    SubjectAccessReview performSubjectAccessReview(String user, String namespace, String resource, String verb);
+    SubjectAccessReview performSubjectAccessReviewResource(String user, String namespace, String resource, String verb);
+    SubjectAccessReview performSubjectAccessReviewPath(String user, String path, String verb);
     String getCert(String secretName, String namespace);
     String getNamespace();
     String getUserId(String userName);

--- a/api-common/src/main/java/io/enmasse/api/auth/AuthApi.java
+++ b/api-common/src/main/java/io/enmasse/api/auth/AuthApi.java
@@ -10,5 +10,4 @@ public interface AuthApi {
     SubjectAccessReview performSubjectAccessReviewPath(String user, String path, String verb);
     String getCert(String secretName, String namespace);
     String getNamespace();
-    String getUserId(String userName);
 }

--- a/api-common/src/main/java/io/enmasse/api/auth/AuthInterceptor.java
+++ b/api-common/src/main/java/io/enmasse/api/auth/AuthInterceptor.java
@@ -24,7 +24,7 @@ public class AuthInterceptor implements ContainerRequestFilter {
     public static final String BEARER_PREFIX = "Bearer ";
     private final AuthApi authApi;
     private final Predicate<String> pathFilter;
-    private static final String X_REMOTE_USER = "X-Remote-User";
+    public static final String X_REMOTE_USER = "X-Remote-User";
 
     @Context
     private HttpServerRequest request;
@@ -61,8 +61,7 @@ public class AuthInterceptor implements ContainerRequestFilter {
             try {
                 connection.peerCertificateChain();
                 log.debug("Client certificates trusted... impersonating {}", userName);
-                String userId = authApi.getUserId(userName);
-                requestContext.setSecurityContext(new RbacSecurityContext(new TokenReview(userName, userId, true), authApi, requestContext.getUriInfo()));
+                requestContext.setSecurityContext(new RbacSecurityContext(new TokenReview(userName, "", true), authApi, requestContext.getUriInfo()));
             } catch (SSLPeerUnverifiedException e) {
                 log.debug("Peer certificate not valid, proceeding as anonymous");
                 requestContext.setSecurityContext(new RbacSecurityContext(new TokenReview("system:anonymous", "", false), authApi, requestContext.getUriInfo()));

--- a/api-common/src/main/java/io/enmasse/api/auth/KubeAuthApi.java
+++ b/api-common/src/main/java/io/enmasse/api/auth/KubeAuthApi.java
@@ -5,7 +5,6 @@
 package io.enmasse.api.auth;
 
 import io.fabric8.kubernetes.api.model.Secret;
-import io.fabric8.openshift.api.model.User;
 import io.fabric8.openshift.client.NamespacedOpenShiftClient;
 import io.vertx.core.json.JsonObject;
 import okhttp3.*;
@@ -182,14 +181,4 @@ public class KubeAuthApi implements AuthApi {
     public String getNamespace() {
         return client.getNamespace();
     }
-
-    @Override
-    public String getUserId(String userName) {
-        User user = client.users().withName(userName).get();
-        if (user != null) {
-            return user.getMetadata().getUid();
-        }
-        return null;
-    }
-
 }

--- a/api-common/src/main/java/io/enmasse/api/auth/TokenReview.java
+++ b/api-common/src/main/java/io/enmasse/api/auth/TokenReview.java
@@ -15,15 +15,15 @@ public class TokenReview {
         this.isAuthenticated = isAuthenticated;
     }
 
-    public boolean isAuthenticated() {
-        return isAuthenticated;
-    }
-
     public String getUserName() {
         return userName;
     }
 
     public String getUserId() {
         return userId;
+    }
+
+    public boolean isAuthenticated() {
+        return isAuthenticated;
     }
 }

--- a/api-common/src/main/java/io/enmasse/api/common/DefaultExceptionMapper.java
+++ b/api-common/src/main/java/io/enmasse/api/common/DefaultExceptionMapper.java
@@ -28,22 +28,24 @@ public class DefaultExceptionMapper implements ExceptionMapper<Exception> {
         if (exception instanceof WebApplicationException) {
             WebApplicationException webApplicationException = (WebApplicationException) exception;
             status = Response.Status.fromStatusCode(webApplicationException.getResponse().getStatus());
-            response = webApplicationException.getResponse();
+            response = Response.status(status)
+                    .entity(new ErrorResponse(status.getStatusCode(), status.getReasonPhrase(), exception.getMessage()))
+                    .build();
         } else if (exception instanceof UnresolvedAddressException || exception instanceof UnresolvedAddressSpaceException || exception instanceof DeserializeException) {
             status = Response.Status.BAD_REQUEST;
             response = Response.status(status)
-                    .entity(new ErrorResponse(null, exception.getMessage()))
+                    .entity(new ErrorResponse(status.getStatusCode(), status.getReasonPhrase(), exception.getMessage()))
                     .build();
         } else if (exception instanceof KubernetesClientException) {
             Status kubeStatus = ((KubernetesClientException) exception).getStatus();
             status = Response.Status.fromStatusCode(kubeStatus.getCode());
             response = Response.status(kubeStatus.getCode())
-                    .entity(new ErrorResponse(null, kubeStatus.getMessage()))
+                    .entity(new ErrorResponse(status.getStatusCode(), status.getReasonPhrase(), exception.getMessage()))
                     .build();
         } else {
             status = Response.Status.INTERNAL_SERVER_ERROR;
             response = Response.status(status)
-                    .entity(new ErrorResponse(null, exception.getMessage()))
+                    .entity(new ErrorResponse(status.getStatusCode(), status.getReasonPhrase(), exception.getMessage()))
                     .build();
         }
 

--- a/api-common/src/main/java/io/enmasse/api/common/ErrorResponse.java
+++ b/api-common/src/main/java/io/enmasse/api/common/ErrorResponse.java
@@ -17,35 +17,42 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 public class ErrorResponse {
     private static final ObjectMapper mapper = new ObjectMapper();
 
-    private String error;
-    private String description;
+    private int statusCode;
+    private String reason;
+    private String message;
 
-    public ErrorResponse(String error, String description) {
-        this.error = error;
-        this.description = description;
+    public ErrorResponse(int statusCode, String reason, String message) {
+        this.statusCode = statusCode;
+        this.reason = reason;
+        this.message = message;
     }
 
-    public String getError() {
-        return error;
+    public String getReason() {
+        return reason;
     }
 
-    public String getDescription() {
-        return description;
+    public String getMessage() {
+        return message;
     }
 
-    public void setDescription(String description) {
-        this.description = description;
+    public int getStatusCode() {
+        return statusCode;
     }
 
     protected static class Serializer extends JsonSerializer<ErrorResponse> {
         @Override
         public void serialize(ErrorResponse value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
             ObjectNode node = mapper.createObjectNode();
-            if (value.getError() != null) {
-                node.put("error", value.getError());
+            node.put("apiVersion", "v1");
+            node.put("kind", "Status");
+            node.put("status", "Failure");
+            node.put("code", value.getStatusCode());
+            if (value.getReason() != null) {
+                node.put("reason", value.getReason());
             }
-            if (value.getDescription() != null) {
-                node.put("description", value.getDescription());
+
+            if (value.getMessage() != null) {
+                node.put("message", value.getMessage());
             }
             mapper.writeValue(gen, node);
         }

--- a/api-common/src/main/java/io/enmasse/api/common/Exceptions.java
+++ b/api-common/src/main/java/io/enmasse/api/common/Exceptions.java
@@ -50,13 +50,13 @@ public class Exceptions {
 
     private static Response buildResponse(Response.Status status, String error, String message) {
         return Response.status(status)
-                .entity(new ErrorResponse(error, message))
+                .entity(new ErrorResponse(status.getStatusCode(), status.getReasonPhrase(), message))
                 .build();
     }
 
     private static Response buildResponse(int status, String error, String message) {
         return Response.status(status)
-                .entity(new ErrorResponse(error, message))
+                .entity(new ErrorResponse(status, error, message))
                 .build();
     }
 }

--- a/api-server/src/main/java/io/enmasse/api/server/ApiServer.java
+++ b/api-server/src/main/java/io/enmasse/api/server/ApiServer.java
@@ -41,10 +41,8 @@ public class ApiServer extends AbstractVerticle {
 
         AuthApi authApi = new KubeAuthApi(controllerClient, null, controllerClient.getConfiguration().getOauthToken());
 
-        AuthWrapper wrapper = new AuthWrapper(authApi, options.isEnableRbac(), options.isEnableUserLookup());
-
         deployVerticles(startPromise,
-                new Deployment(new HTTPServer(addressSpaceApi, schemaProvider, options.getCertDir(), options.getClientCa(), wrapper), new DeploymentOptions().setWorker(true)));
+                new Deployment(new HTTPServer(addressSpaceApi, schemaProvider, options.getCertDir(), options.getClientCa(), options.getRequestHeaderClientCa(), authApi, options.isEnableRbac()), new DeploymentOptions().setWorker(true)));
     }
 
     private void deployVerticles(Future<Void> startPromise, Deployment ... deployments) {

--- a/api-server/src/main/java/io/enmasse/api/server/ApiServerOptions.java
+++ b/api-server/src/main/java/io/enmasse/api/server/ApiServerOptions.java
@@ -18,8 +18,8 @@ public class ApiServerOptions {
     private String certDir;
     private Duration resyncInterval;
     private String clientCa;
+    private String requestHeaderClientCa;
     private boolean enableRbac;
-    private boolean enableUserLookup;
 
     public String getNamespace() {
         return namespace;
@@ -55,13 +55,13 @@ public class ApiServerOptions {
         options.setCertDir(getEnv(env, "CERT_DIR").orElse("/api-server-cert"));
 
         options.setClientCa(getEnv(env, "CLIENT_CA").orElse(null));
+        options.setRequestHeaderClientCa(getEnv(env, "REQUEST_HEADER_CLIENT_CA").orElse(null));
 
         options.setResyncInterval(getEnv(env, "RESYNC_INTERVAL")
                 .map(i -> Duration.ofSeconds(Long.parseLong(i)))
                 .orElse(Duration.ofMinutes(5)));
 
         options.setEnableRbac(Boolean.parseBoolean(getEnv(env, "ENABLE_RBAC").orElse("false")));
-        options.setEnableUserLookup(Boolean.parseBoolean(getEnv(env, "ENABLE_USER_LOOKUP").orElse(getEnv(env,"ENABLE_RBAC").orElse("false"))));
 
         return options;
     }
@@ -94,11 +94,11 @@ public class ApiServerOptions {
         this.enableRbac = enableRbac;
     }
 
-    public boolean isEnableUserLookup() {
-        return enableUserLookup;
+    public void setRequestHeaderClientCa(String clientCa) {
+        this.requestHeaderClientCa = clientCa;
     }
 
-    public void setEnableUserLookup(boolean enableUserLookup) {
-        this.enableUserLookup = enableUserLookup;
+    public String getRequestHeaderClientCa() {
+        return requestHeaderClientCa;
     }
 }

--- a/api-server/src/main/java/io/enmasse/api/v1/http/HttpApiRootService.java
+++ b/api-server/src/main/java/io/enmasse/api/v1/http/HttpApiRootService.java
@@ -4,12 +4,17 @@
  */
 package io.enmasse.api.v1.http;
 
+import io.enmasse.api.auth.RbacSecurityContext;
+import io.enmasse.api.common.Exceptions;
 import io.enmasse.api.v1.types.*;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.UriInfo;
 import java.util.Arrays;
 
 @Path("/apis")
@@ -22,16 +27,24 @@ public class HttpApiRootService {
 
     private static final APIGroupList apiGroupList = new APIGroupList(Arrays.asList(apiGroup));
 
+    private static void verifyAuthorized(SecurityContext securityContext, String method, String path) {
+        if (!securityContext.isUserInRole(RbacSecurityContext.rbacToRole(path, method))) {
+            throw Exceptions.notAuthorizedException();
+        }
+    }
+
     @GET
     @Produces({MediaType.APPLICATION_JSON})
-    public APIGroupList getApiGroupList() {
+    public APIGroupList getApiGroupList(@Context SecurityContext securityContext, @Context UriInfo uriInfo) {
+        verifyAuthorized(securityContext, "get", uriInfo.getPath());
         return apiGroupList;
     }
 
     @GET
     @Path("enmasse.io")
     @Produces({MediaType.APPLICATION_JSON})
-    public APIGroup getApiGroup() {
+    public APIGroup getApiGroup(@Context SecurityContext securityContext, @Context UriInfo uriInfo) {
+        verifyAuthorized(securityContext, "get", uriInfo.getPath());
         return apiGroup;
     }
 
@@ -46,7 +59,8 @@ public class HttpApiRootService {
     @GET
     @Path("enmasse.io/v1alpha1")
     @Produces({MediaType.APPLICATION_JSON})
-    public APIResourceList getApiGroupV1() {
+    public APIResourceList getApiGroupV1(@Context SecurityContext securityContext, @Context UriInfo uriInfo) {
+        verifyAuthorized(securityContext, "get", uriInfo.getPath());
         return apiResourceList;
     }
 }

--- a/api-server/src/test/java/io/enmasse/api/server/HTTPServerTest.java
+++ b/api-server/src/test/java/io/enmasse/api/server/HTTPServerTest.java
@@ -47,9 +47,9 @@ public class HTTPServerTest {
         AuthApi authApi = mock(AuthApi.class);
         when(authApi.getNamespace()).thenReturn("controller");
         when(authApi.performTokenReview(eq("mytoken"))).thenReturn(new TokenReview("foo", "myid", true));
-        when(authApi.performSubjectAccessReview(eq("foo"), any(), any(), any())).thenReturn(new SubjectAccessReview("foo", true));
-        when(authApi.performSubjectAccessReview(eq("foo"), any(), any(), any())).thenReturn(new SubjectAccessReview("foo", true));
-        vertx.deployVerticle(new HTTPServer(instanceApi, new TestSchemaProvider(),"/doesnotexist", null, new AuthWrapper(null, false, false)), context.asyncAssertSuccess());
+        when(authApi.performSubjectAccessReviewResource(eq("foo"), any(), any(), any())).thenReturn(new SubjectAccessReview("foo", true));
+        when(authApi.performSubjectAccessReviewResource(eq("foo"), any(), any(), any())).thenReturn(new SubjectAccessReview("foo", true));
+        vertx.deployVerticle(new HTTPServer(instanceApi, new TestSchemaProvider(),"/doesnotexist", null, null, authApi, false), context.asyncAssertSuccess());
     }
 
     @After
@@ -76,7 +76,7 @@ public class HTTPServerTest {
         instanceApi.withAddressSpace(addressSpace).createAddress(
             new Address.Builder()
                     .setAddressSpace("myinstance")
-                .setName("addr1")
+                .setName("myinstance.addr1")
                 .setAddress("addR1")
                 .setNamespace("ns")
                 .setType("queue")
@@ -91,7 +91,7 @@ public class HTTPServerTest {
                 response.bodyHandler(buffer -> {
                     JsonObject data = buffer.toJsonObject();
                     context.assertTrue(data.containsKey("items"));
-                    context.assertEquals("addr1", data.getJsonArray("items").getJsonObject(0).getJsonObject("metadata").getString("name"));
+                    context.assertEquals("myinstance.addr1", data.getJsonArray("items").getJsonObject(0).getJsonObject("metadata").getString("name"));
                     async.complete();
                 });
             });
@@ -103,7 +103,7 @@ public class HTTPServerTest {
                     JsonObject data = buffer.toJsonObject();
                     System.out.println(data);
                     context.assertTrue(data.containsKey("metadata"));
-                    context.assertEquals("addr1", data.getJsonObject("metadata").getString("name"));
+                    context.assertEquals("myinstance.addr1", data.getJsonObject("metadata").getString("name"));
                     async.complete();
                 });
             });

--- a/documentation/service_admin/installing-manual.adoc
+++ b/documentation/service_admin/installing-manual.adoc
@@ -83,11 +83,12 @@ openssl req -new -x509 -batch -nodes -days 11000 -subj "/O=io.enmasse/CN=standar
 ----
 
 ifeval::["{cmdcli}" == "oc"]
-. Give view permissions for the keycloak controller:
+. Grant privileges to service account:
 +
-[options="nowrap",subs="attributes"]
+[options="nowrap"]
 ----
-{cmdcli} adm policy add-role-to-user view system:serviceaccount:enmasse:default
+oc login -u system:admin
+oc adm policy add-cluster-role-to-user enmasse.io:keycloak-controller system:serviceaccount:enmasse:enmasse-admin
 ----
 endif::[]
 

--- a/keycloak-controller/src/main/java/io/enmasse/keycloak/controller/KubeApi.java
+++ b/keycloak-controller/src/main/java/io/enmasse/keycloak/controller/KubeApi.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2017-2018, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.keycloak.controller;
+
+public interface KubeApi {
+    String findUserId(String userName);
+}

--- a/keycloak-controller/src/test/java/io/enmasse/keycloak/controller/KeycloakManagerTest.java
+++ b/keycloak-controller/src/test/java/io/enmasse/keycloak/controller/KeycloakManagerTest.java
@@ -15,16 +15,22 @@ import org.mockito.internal.util.collections.Sets;
 import java.util.*;
 
 import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class KeycloakManagerTest {
     private KeycloakManager manager;
     private Set<String> realms;
     private Map<String, String> realmAdminUsers;
+    private KubeApi mockKubeApi;
 
     @Before
     public void setup() {
         realms = new HashSet<>();
         realmAdminUsers = new HashMap<>();
+        mockKubeApi = mock(KubeApi.class);
+        when(mockKubeApi.findUserId(any())).thenReturn("");
         manager = new KeycloakManager(new KeycloakApi() {
             @Override
             public Set<String> getRealmNames() {
@@ -41,7 +47,7 @@ public class KeycloakManagerTest {
             public void deleteRealm(String realmName) {
                 realms.remove(realmName);
             }
-        });
+        }, mockKubeApi);
     }
 
     @Test

--- a/service-broker/src/main/java/io/enmasse/osb/HTTPServer.java
+++ b/service-broker/src/main/java/io/enmasse/osb/HTTPServer.java
@@ -71,7 +71,7 @@ public class HTTPServer extends AbstractVerticle {
                     path.startsWith(HttpConsoleService.BASE_URI)));
         } else {
             log.info("Disabling authentication and authorization for REST API");
-            deployment.getProviderFactory().registerProviderInstance(new AllowAllAuthInterceptor(null, false));
+            deployment.getProviderFactory().registerProviderInstance(new AllowAllAuthInterceptor());
         }
 
         deployment.getRegistry().addSingletonResource(new HttpHealthService());

--- a/service-broker/src/main/java/io/enmasse/osb/api/provision/OSBProvisioningService.java
+++ b/service-broker/src/main/java/io/enmasse/osb/api/provision/OSBProvisioningService.java
@@ -55,9 +55,6 @@ public class OSBProvisioningService extends OSBServiceBase {
             JsonObject object = new JsonObject(Buffer.buffer(Base64.getDecoder().decode(originatingIdentity.split(" +")[1])));
             userName = object.getString("username");
             userId = object.getString("uid");
-            if (userId == null || userId.isEmpty()) {
-                userId = getAuthApi().getUserId(userName);
-            }
         }
 
         if (!acceptsIncomplete) {

--- a/service-broker/src/test/java/io/enmasse/osb/HTTPServerTest.java
+++ b/service-broker/src/test/java/io/enmasse/osb/HTTPServerTest.java
@@ -49,8 +49,8 @@ public class HTTPServerTest {
         AuthApi authApi = mock(AuthApi.class);
         when(authApi.getNamespace()).thenReturn("controller");
         when(authApi.performTokenReview(eq("mytoken"))).thenReturn(new TokenReview("foo", "myid", true));
-        when(authApi.performSubjectAccessReview(eq("foo"), any(), any(), any())).thenReturn(new SubjectAccessReview("foo", true));
-        when(authApi.performSubjectAccessReview(eq("foo"), any(), any(), any())).thenReturn(new SubjectAccessReview("foo", true));
+        when(authApi.performSubjectAccessReviewResource(eq("foo"), any(), any(), any())).thenReturn(new SubjectAccessReview("foo", true));
+        when(authApi.performSubjectAccessReviewResource(eq("foo"), any(), any(), any())).thenReturn(new SubjectAccessReview("foo", true));
         httpServer = new HTTPServer(instanceApi, new TestSchemaProvider(),authApi, null, false, null, 0, "http://localhost/console");
         vertx.deployVerticle(httpServer, context.asyncAssertSuccess());
     }

--- a/templates/include/api-server.jsonnet
+++ b/templates/include/api-server.jsonnet
@@ -72,6 +72,16 @@ local images = import "images.jsonnet";
                   }
                 },
                 {
+                  "name": "REQUEST_HEADER_CLIENT_CA",
+                  "valueFrom": {
+                    "secretKeyRef": {
+                      "name": "api-server-client-ca",
+                      "key": "request-header-ca.crt",
+                      "optional": true
+                    }
+                  }
+                },
+                {
                   "name": "CERT_DIR",
                   "value": "/api-server-cert"
                 },
@@ -81,16 +91,6 @@ local images = import "images.jsonnet";
                     "configMapKeyRef": {
                       "name": "api-server-config",
                       "key": "enableRbac",
-                      "optional": true
-                    }
-                  }
-                },
-                {
-                  "name": "ENABLE_USER_LOOKUP",
-                  "valueFrom": {
-                    "configMapKeyRef": {
-                      "name": "api-server-config",
-                      "key": "enableUserLookup",
                       "optional": true
                     }
                   }

--- a/templates/include/auth-service.jsonnet
+++ b/templates/include/auth-service.jsonnet
@@ -113,6 +113,7 @@ local images = import "images.jsonnet";
             }
           },
           "spec": {
+            "serviceAccount": "enmasse-admin",
             "containers": [
               {
                 "image": images.keycloak_controller,

--- a/templates/include/cluster-roles/api-server.yaml
+++ b/templates/include/cluster-roles/api-server.yaml
@@ -3,9 +3,6 @@ kind: ClusterRole
 metadata:
   name: enmasse.io:api-server
 rules:
-  - apiGroups: [ "", "user.openshift.io" ]
-    resources: [ "users" ]
-    verbs: [ "get" ]
   - apiGroups: [ "enmasse.io" ]
     resources: [ "addresses", "addressspaces" ]
     verbs: [ "create", "get", "update", "delete", "list", "watch", "patch" ]

--- a/templates/include/cluster-roles/keycloak-controller.yaml
+++ b/templates/include/cluster-roles/keycloak-controller.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ClusterRole
+metadata:
+  name: enmasse.io:keycloak-controller
+rules:
+  - apiGroups: [ "", "user.openshift.io" ]
+    resources: [ "users" ]
+    verbs: [ "get" ]

--- a/templates/include/cluster-roles/service-broker.yaml
+++ b/templates/include/cluster-roles/service-broker.yaml
@@ -3,9 +3,6 @@ kind: ClusterRole
 metadata:
   name: enmasse.io:service-broker
 rules:
-  - apiGroups: [ "", "user.openshift.io" ]
-    resources: [ "users" ]
-    verbs: [ "get" ]
   - apiGroups: [ "enmasse.io" ]
     resources: [ "addressspaces" ]
     verbs: [ "create", "get", "update", "delete", "list", "watch", "patch" ]

--- a/templates/install/ansible/inventory/multitenant-api-server.example
+++ b/templates/install/ansible/inventory/multitenant-api-server.example
@@ -4,9 +4,9 @@ localhost ansible_connection=local
 [enmasse:vars]
 namespace=enmasse
 multitenant=true
-enable_rbac=false
-enable_user_lookup=true
+enable_rbac=true
 api_server=true
 register_api_server=true
+secure_api_server=true
 keycloak_admin_password=admin
 authentication_services=["standard"]

--- a/templates/install/ansible/roles/api_server/tasks/main.yml
+++ b/templates/install/ansible/roles/api_server/tasks/main.yml
@@ -16,7 +16,7 @@
   ignore_errors: True
 - name: Create API Server Config
   when: config_exists.failed
-  shell: oc create -n {{ namespace }} configmap api-server-config --from-literal=enableRbac={{ enable_rbac }} --from-literal=enableUserLookup={{ enable_user_lookup | default(enable_rbac) }}
+  shell: oc create -n {{ namespace }} configmap api-server-config --from-literal=enableRbac={{ enable_rbac }}
 - name: Create EnMasse API Server Deployment
   shell: oc apply -n {{ namespace }} -f "{{ playbook_dir }}/resources/api-server/deployment.yaml"
 - name: Create EnMasse API Server Service
@@ -33,6 +33,13 @@
 - set_fact:
     client_ca: "{{ clientca_result.stdout }}"
   when: secure_api_server and secret_exists.failed
+- name: Extract API Request Header Client CA
+  when: secure_api_server and secret_exists.failed
+  shell: oc get configmap extension-apiserver-authentication -n kube-system -o jsonpath={.data.requestheader-client-ca-file}
+  register: requestheaderclientca_result
+- set_fact:
+    request_header_client_ca: "{{ requestheaderclientca_result.stdout }}"
+  when: secure_api_server and secret_exists.failed
 - name: Store API Client CA in secret
   when: secure_api_server and secret_exists.failed
   shell:
@@ -46,6 +53,7 @@
       type: tls
       data:
         ca.crt: "{{ client_ca | b64encode }}"
+        request-header-ca.crt: "{{ request_header_client_ca | b64encode }}"
       EOF
 - name: Create route for API server
   shell: oc create route passthrough restapi -n {{ namespace }} --service=api-server

--- a/templates/install/ansible/roles/standard_authservice/tasks/main.yml
+++ b/templates/install/ansible/roles/standard_authservice/tasks/main.yml
@@ -12,8 +12,8 @@
 - name: Create secret with the keycloak credentials
   when: secret_exists.failed
   shell: oc create secret generic -n {{ namespace }} keycloak-credentials --from-literal=admin.username=admin --from-literal=admin.password={{ keycloak_admin_password }}
-- name: Give view permissions for the keycloak controller
-  shell: oc adm policy add-role-to-user view system:serviceaccount:{{ namespace }}:default
+- name: Give user lookup permissions for the keycloak controller
+  shell: oc adm policy add-cluster-role-to-user enmasse.io:keycloak-controller system:serviceaccount:{{ namespace }}:enmasse-admin
 - name: Create the standard authentication service service
   shell: oc apply -n {{ namespace }} -f {{ playbook_dir }}/resources/standard-authservice/service.yaml
 - name: Create the standard authentication service deployment

--- a/templates/install/deploy.sh
+++ b/templates/install/deploy.sh
@@ -272,12 +272,15 @@ if [ $MODE == "multitenant" ]; then
         runcmd "oc create -f ${RESOURCE_DIR}/cluster-roles/api-server.yaml -n $NAMESPACE" "Create cluster roles needed for multitenant api server"
         runcmd "oc adm policy add-cluster-role-to-user enmasse.io:address-space-controller system:serviceaccount:${NAMESPACE}:enmasse-admin" "Granting address-space-controller rights to enmasse-admin"
         runcmd "oc adm policy add-cluster-role-to-user enmasse.io:api-server system:serviceaccount:${NAMESPACE}:enmasse-admin" "Granting api-server rights to enmasse-admin"
+        runcmd "oc adm policy add-cluster-role-to-user enmasse.io:keycloak-controller system:serviceaccount:${NAMESPACE}:enmasse-admin" "Granting keycloak-controller rights to enmasse-admin"
         runcmd "oc adm policy add-cluster-role-to-user system:auth-delegator system:serviceaccount:${NAMESPACE}:enmasse-admin" "Granting auth-delegator rights to enmasse-admin"
         runcmd "oc login -u $KUBE_USER $OC_ARGS $MASTER_URI" "Login as $KUBE_USER"
     elif [ -n "$USE_OPENSHIFT" ]; then
         echo "Please create cluster roles required to run EnMasse with RBAC: 'oc create -f ${RESOURCE_DIR}/cluster-roles/*.yaml'"
         echo "Please add enmasse.io:address-space-controller to system:serviceaccount:${NAMESPACE}:enmasse-admin before creating instances: 'oc adm policy add-cluster-role-to-user enmasse.io:address-space-controller system:serviceaccount:${NAMESPACE}:enmasse-admin'"
         echo "Please add enmasse.io:api-server to system:serviceaccount:${NAMESPACE}:enmasse-admin before creating instances: 'oc adm policy add-cluster-role-to-user enmasse.io:api-server system:serviceaccount:${NAMESPACE}:enmasse-admin'"
+        echo "Please add enmasse.io:keycloak-controller to
+        system:serviceaccount:${NAMESPACE}:enmasse-admin before creating instances: 'oc adm policy add-cluster-role-to-user enmasse.io:keycloak-controller system:serviceaccount:${NAMESPACE}:enmasse-admin'"
         echo "Please add system:auth-delegator to system:serviceaccount:${NAMESPACE}:enmasse-admin before creating instances: 'oc adm policy add-cluster-role-to-user system:auth-delegator system:serviceaccount:${NAMESPACE}:enmasse-admin'"
     fi
 fi

--- a/templates/install/resources/api-server/deployment.yaml
+++ b/templates/install/resources/api-server/deployment.yaml
@@ -21,18 +21,18 @@ spec:
               key: ca.crt
               name: api-server-client-ca
               optional: true
+        - name: REQUEST_HEADER_CLIENT_CA
+          valueFrom:
+            secretKeyRef:
+              key: request-header-ca.crt
+              name: api-server-client-ca
+              optional: true
         - name: CERT_DIR
           value: /api-server-cert
         - name: ENABLE_RBAC
           valueFrom:
             configMapKeyRef:
               key: enableRbac
-              name: api-server-config
-              optional: true
-        - name: ENABLE_USER_LOOKUP
-          valueFrom:
-            configMapKeyRef:
-              key: enableUserLookup
               name: api-server-config
               optional: true
         image: docker.io/enmasseproject/api-server:latest

--- a/templates/install/resources/cluster-roles/api-server.yaml
+++ b/templates/install/resources/cluster-roles/api-server.yaml
@@ -3,9 +3,6 @@ kind: ClusterRole
 metadata:
   name: enmasse.io:api-server
 rules:
-  - apiGroups: [ "", "user.openshift.io" ]
-    resources: [ "users" ]
-    verbs: [ "get" ]
   - apiGroups: [ "enmasse.io" ]
     resources: [ "addresses", "addressspaces" ]
     verbs: [ "create", "get", "update", "delete", "list", "watch", "patch" ]

--- a/templates/install/resources/cluster-roles/keycloak-controller.yaml
+++ b/templates/install/resources/cluster-roles/keycloak-controller.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ClusterRole
+metadata:
+  name: enmasse.io:keycloak-controller
+rules:
+  - apiGroups: [ "", "user.openshift.io" ]
+    resources: [ "users" ]
+    verbs: [ "get" ]

--- a/templates/install/resources/cluster-roles/service-broker.yaml
+++ b/templates/install/resources/cluster-roles/service-broker.yaml
@@ -3,9 +3,6 @@ kind: ClusterRole
 metadata:
   name: enmasse.io:service-broker
 rules:
-  - apiGroups: [ "", "user.openshift.io" ]
-    resources: [ "users" ]
-    verbs: [ "get" ]
   - apiGroups: [ "enmasse.io" ]
     resources: [ "addressspaces" ]
     verbs: [ "create", "get", "update", "delete", "list", "watch", "patch" ]

--- a/templates/install/resources/standard-authservice/controller-deployment.yaml
+++ b/templates/install/resources/standard-authservice/controller-deployment.yaml
@@ -59,3 +59,4 @@ spec:
             memory: 256Mi
           requests:
             memory: 256Mi
+      serviceAccount: enmasse-admin


### PR DESCRIPTION
* Support auth delegation when client certificates are valid
* Allow anonymous access but leave auth decisions up to kubernetes
* Remove enable_user_lookup setting
* Add additional cert to api server trust store
* Report proper v1.Status error responses

Fixes #1265