### PR TITLE
Wait for subscribers in roundRobin test

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/clients/ClientTestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/clients/ClientTestBase.java
@@ -89,7 +89,7 @@ public abstract class ClientTestBase extends TestBaseWithShared {
                 String.format("Expected %d received messages", expectedMsgCount));
     }
 
-    protected void doRoundRobinReceiverTest(AbstractClient sender, AbstractClient receiver, AbstractClient receiver2)
+    protected void doRoundRobinReceiverTest(ArtemisManagement artemisManagement, AbstractClient sender, AbstractClient receiver, AbstractClient receiver2)
             throws Exception {
         clients.addAll(Arrays.asList(sender, receiver, receiver2));
         int expectedMsgCount = 10;
@@ -109,6 +109,12 @@ public abstract class ClientTestBase extends TestBaseWithShared {
 
         Future<Boolean> recResult = receiver.runAsync();
         Future<Boolean> rec2Result = receiver2.runAsync();
+
+        if (isBrokered(sharedAddressSpace)) {
+            waitForSubscribers(artemisManagement, sharedAddressSpace, dest.getAddress(), 2);
+        } else {
+            waitForSubscribersConsole(sharedAddressSpace, dest, 2);
+        }
 
         arguments.put(ClientArgument.COUNT, Integer.toString(expectedMsgCount));
         arguments.put(ClientArgument.MSG_CONTENT, "msg no. %d");

--- a/systemtests/src/test/java/io/enmasse/systemtest/brokered/clients/artemis/MsgPatternsTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/brokered/clients/artemis/MsgPatternsTest.java
@@ -22,8 +22,8 @@ class MsgPatternsTest extends ClientTestBase implements ITestBaseBrokered {
     }
 
     @Test
-    void testRoundRobinReceiver() throws Exception {
-        doRoundRobinReceiverTest(new ArtemisJMSClientSender(), new ArtemisJMSClientReceiver(), new ArtemisJMSClientReceiver());
+    void testRoundRobinReceiver(ArtemisManagement artemisManagement) throws Exception {
+        doRoundRobinReceiverTest(artemisManagement, new ArtemisJMSClientSender(), new ArtemisJMSClientReceiver(), new ArtemisJMSClientReceiver());
     }
 
     @Test

--- a/systemtests/src/test/java/io/enmasse/systemtest/brokered/clients/openwire/MsgPatternsTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/brokered/clients/openwire/MsgPatternsTest.java
@@ -23,8 +23,8 @@ class MsgPatternsTest extends ClientTestBase implements ITestBaseBrokered {
     }
 
     @Test
-    void testRoundRobinReceiver() throws Exception {
-        doRoundRobinReceiverTest(new OpenwireJMSClientSender(), new OpenwireJMSClientReceiver(), new OpenwireJMSClientReceiver());
+    void testRoundRobinReceiver(ArtemisManagement artemisManagement) throws Exception {
+        doRoundRobinReceiverTest(artemisManagement, new OpenwireJMSClientSender(), new OpenwireJMSClientReceiver(), new OpenwireJMSClientReceiver());
     }
 
     @Test

--- a/systemtests/src/test/java/io/enmasse/systemtest/brokered/clients/proton/java/MsgPatternsTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/brokered/clients/proton/java/MsgPatternsTest.java
@@ -22,8 +22,8 @@ class MsgPatternsTest extends ClientTestBase implements ITestBaseBrokered {
     }
 
     @Test
-    void testRoundRobinReceiver() throws Exception {
-        doRoundRobinReceiverTest(new ProtonJMSClientSender(logPath), new ProtonJMSClientReceiver(logPath), new ProtonJMSClientReceiver(logPath));
+    void testRoundRobinReceiver(ArtemisManagement artemisManagement) throws Exception {
+        doRoundRobinReceiverTest(artemisManagement, new ProtonJMSClientSender(logPath), new ProtonJMSClientReceiver(logPath), new ProtonJMSClientReceiver(logPath));
     }
 
     @Test

--- a/systemtests/src/test/java/io/enmasse/systemtest/brokered/clients/proton/python/MsgPatternsTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/brokered/clients/proton/python/MsgPatternsTest.java
@@ -22,8 +22,8 @@ class MsgPatternsTest extends ClientTestBase implements ITestBaseBrokered {
     }
 
     @Test
-    void testRoundRobinReceiver() throws Exception {
-        doRoundRobinReceiverTest(new PythonClientSender(logPath), new PythonClientReceiver(logPath), new PythonClientReceiver(logPath));
+    void testRoundRobinReceiver(ArtemisManagement artemisManagement) throws Exception {
+        doRoundRobinReceiverTest(artemisManagement, new PythonClientSender(logPath), new PythonClientReceiver(logPath), new PythonClientReceiver(logPath));
     }
 
     @Test

--- a/systemtests/src/test/java/io/enmasse/systemtest/brokered/clients/rhea/MsgPatternsTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/brokered/clients/rhea/MsgPatternsTest.java
@@ -27,8 +27,8 @@ class MsgPatternsTest extends ClientTestBase implements ITestBaseBrokered {
     }
 
     @Test
-    void testRoundRobinReceiver() throws Exception {
-        doRoundRobinReceiverTest(new RheaClientSender(logPath), new RheaClientReceiver(logPath), new RheaClientReceiver(logPath));
+    void testRoundRobinReceiver(ArtemisManagement artemisManagement) throws Exception {
+        doRoundRobinReceiverTest(artemisManagement, new RheaClientSender(logPath), new RheaClientReceiver(logPath), new RheaClientReceiver(logPath));
     }
 
     @Test

--- a/systemtests/src/test/java/io/enmasse/systemtest/standard/clients/proton/java/MsgPatternsTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/standard/clients/proton/java/MsgPatternsTest.java
@@ -23,8 +23,8 @@ class MsgPatternsTest extends ClientTestBase implements ITestBaseStandard {
     }
 
     @Test
-    void testRoundRobinReceiver() throws Exception {
-        doRoundRobinReceiverTest(new ProtonJMSClientSender(logPath), new ProtonJMSClientReceiver(logPath), new ProtonJMSClientReceiver(logPath));
+    void testRoundRobinReceiver(ArtemisManagement artemisManagement) throws Exception {
+        doRoundRobinReceiverTest(artemisManagement, new ProtonJMSClientSender(logPath), new ProtonJMSClientReceiver(logPath), new ProtonJMSClientReceiver(logPath));
     }
 
     @Test

--- a/systemtests/src/test/java/io/enmasse/systemtest/standard/clients/proton/python/MsgPatternsTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/standard/clients/proton/python/MsgPatternsTest.java
@@ -23,8 +23,8 @@ class MsgPatternsTest extends ClientTestBase implements ITestBaseStandard {
     }
 
     @Test
-    void testRoundRobinReceiver() throws Exception {
-        doRoundRobinReceiverTest(new PythonClientSender(logPath), new PythonClientReceiver(logPath), new PythonClientReceiver(logPath));
+    void testRoundRobinReceiver(ArtemisManagement artemisManagement) throws Exception {
+        doRoundRobinReceiverTest(artemisManagement, new PythonClientSender(logPath), new PythonClientReceiver(logPath), new PythonClientReceiver(logPath));
     }
 
     @Test

--- a/systemtests/src/test/java/io/enmasse/systemtest/standard/clients/rhea/MsgPatternsTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/standard/clients/rhea/MsgPatternsTest.java
@@ -29,8 +29,8 @@ class MsgPatternsTest extends ClientTestBase implements ITestBaseStandard {
     }
 
     @Test
-    void testRoundRobinReceiver() throws Exception {
-        doRoundRobinReceiverTest(new RheaClientSender(logPath), new RheaClientReceiver(logPath), new RheaClientReceiver(logPath));
+    void testRoundRobinReceiver(ArtemisManagement artemisManagement) throws Exception {
+        doRoundRobinReceiverTest(artemisManagement, new RheaClientSender(logPath), new RheaClientReceiver(logPath), new RheaClientReceiver(logPath));
     }
 
     @Test


### PR DESCRIPTION
This will fix issue when receivers are not attached to queue when sender tries to send messages in testRoudRobinReceiver. 