### PR TITLE
Remodel AddressSpace definition to split endpoints into spec and status

### DIFF
--- a/address-model-lib/src/main/java/io/enmasse/address/model/AddressSpace.java
+++ b/address-model-lib/src/main/java/io/enmasse/address/model/AddressSpace.java
@@ -4,8 +4,6 @@
  */
 package io.enmasse.address.model;
 
-import io.enmasse.config.AnnotationKeys;
-
 import java.util.*;
 
 /**
@@ -22,12 +20,12 @@ public class AddressSpace {
     private final Map<String, String> labels;
     private final Map<String, String> annotations;
 
-    private final List<Endpoint> endpointList;
+    private final List<EndpointSpec> endpointList;
     private final String planName;
     private final AuthenticationService authenticationService;
-    private final Status status;
+    private final AddressSpaceStatus status;
 
-    private AddressSpace(String name, String namespace, String typeName, String selfLink, String creationTimestamp, String resourceVersion, List<Endpoint> endpointList, String planName, AuthenticationService authenticationService, Status status, String uid, Map<String, String> labels, Map<String, String> annotations) {
+    private AddressSpace(String name, String namespace, String typeName, String selfLink, String creationTimestamp, String resourceVersion, List<EndpointSpec> endpointList, String planName, AuthenticationService authenticationService, AddressSpaceStatus status, String uid, Map<String, String> labels, Map<String, String> annotations) {
         this.name = name;
         this.namespace = namespace;
         this.typeName = typeName;
@@ -55,7 +53,7 @@ public class AddressSpace {
         return typeName;
     }
 
-    public List<io.enmasse.address.model.Endpoint> getEndpoints() {
+    public List<EndpointSpec> getEndpoints() {
         if (endpointList != null) {
             return Collections.unmodifiableList(endpointList);
         }
@@ -70,7 +68,7 @@ public class AddressSpace {
         return uid;
     }
 
-    public Status getStatus() {
+    public AddressSpaceStatus getStatus() {
         return status;
     }
 
@@ -120,7 +118,8 @@ public class AddressSpace {
                 .append("namespace=").append(namespace).append(",")
                 .append("type=").append(typeName).append(",")
                 .append("plan=").append(planName).append(",")
-                .append("endpoints=").append(endpointList).append("}");
+                .append("endpoints=").append(endpointList).append(",")
+                .append("status=").append(status).append("}");
         return sb.toString();
     }
 
@@ -148,10 +147,10 @@ public class AddressSpace {
         private String resourceVersion;
 
         private String type;
-        private List<io.enmasse.address.model.Endpoint> endpointList = new ArrayList<>();
+        private List<EndpointSpec> endpointList = new ArrayList<>();
         private String plan;
         private AuthenticationService authenticationService = new AuthenticationService.Builder().build();
-        private Status status = new Status(false);
+        private AddressSpaceStatus status = new AddressSpaceStatus(false);
         private String uid;
         private Map<String, String> labels = new HashMap<>();
         private Map<String, String> annotations = new HashMap<>();
@@ -169,7 +168,7 @@ public class AddressSpace {
                 this.endpointList = null;
             }
             this.plan = addressSpace.getPlan();
-            this.status = new Status(addressSpace.getStatus());
+            this.status = new AddressSpaceStatus(addressSpace.getStatus());
             this.authenticationService = addressSpace.getAuthenticationService();
             this.uid = addressSpace.getUid();
             this.labels = new HashMap<>(addressSpace.getLabels());
@@ -218,7 +217,7 @@ public class AddressSpace {
             return this;
         }
 
-        public Builder setEndpointList(List<Endpoint> endpointList) {
+        public Builder setEndpointList(List<EndpointSpec> endpointList) {
             if (endpointList != null) {
                 this.endpointList = new ArrayList<>(endpointList);
             } else {
@@ -227,7 +226,7 @@ public class AddressSpace {
             return this;
         }
 
-        public Builder appendEndpoint(Endpoint endpoint) {
+        public Builder appendEndpoint(EndpointSpec endpoint) {
             this.endpointList.add(endpoint);
             return this;
         }
@@ -242,7 +241,7 @@ public class AddressSpace {
             return this;
         }
 
-        public Builder setStatus(Status status) {
+        public Builder setStatus(AddressSpaceStatus status) {
             this.status = status;
             return this;
         }
@@ -285,11 +284,11 @@ public class AddressSpace {
             return name;
         }
 
-        public List<Endpoint> getEndpoints() {
+        public List<EndpointSpec> getEndpoints() {
             return endpointList;
         }
 
-        public Status getStatus() {
+        public AddressSpaceStatus getStatus() {
             return status;
         }
     }

--- a/address-model-lib/src/main/java/io/enmasse/address/model/AddressSpaceStatus.java
+++ b/address-model-lib/src/main/java/io/enmasse/address/model/AddressSpaceStatus.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017-2018, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.address.model;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Represents the status of an address
+ */
+public class AddressSpaceStatus {
+    private boolean isReady = false;
+    private List<EndpointStatus> endpointStatuses = new ArrayList<>();
+    private Set<String> messages = new HashSet<>();
+
+    public AddressSpaceStatus(boolean isReady) {
+        this.isReady = isReady;
+    }
+
+    public AddressSpaceStatus(AddressSpaceStatus other) {
+        this.isReady = other.isReady();
+        this.endpointStatuses = new ArrayList<>(other.getEndpointStatuses());
+        this.messages.addAll(other.getMessages());
+    }
+
+    public boolean isReady() {
+        return isReady;
+    }
+
+    public AddressSpaceStatus setReady(boolean isReady) {
+        this.isReady = isReady;
+        return this;
+    }
+
+    public Set<String> getMessages() {
+        return messages;
+    }
+
+    public AddressSpaceStatus appendMessage(String message) {
+        this.messages.add(message);
+        return this;
+    }
+
+    public AddressSpaceStatus clearMessages() {
+        this.messages.clear();
+        return this;
+    }
+
+    public AddressSpaceStatus setMessages(Set<String> messages) {
+        this.messages = messages;
+        return this;
+    }
+
+    public List<EndpointStatus> getEndpointStatuses() {
+        return Collections.unmodifiableList(endpointStatuses);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AddressSpaceStatus status = (AddressSpaceStatus) o;
+        return isReady == status.isReady &&
+                Objects.equals(endpointStatuses, status.endpointStatuses) &&
+                Objects.equals(messages, status.messages);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(isReady, endpointStatuses, messages);
+    }
+
+
+    @Override
+    public String toString() {
+        return new StringBuilder()
+                .append("{isReady=").append(isReady)
+                .append(",").append("endpointStatuses=").append(endpointStatuses)
+                .append(",").append("messages=").append(messages)
+                .append("}")
+                .toString();
+    }
+
+    public AddressSpaceStatus setEndpointStatuses(List<EndpointStatus> endpointStatuses) {
+        this.endpointStatuses = new ArrayList<>(endpointStatuses);
+        return this;
+    }
+
+    public AddressSpaceStatus appendEndpointStatus(EndpointStatus endpointStatus) {
+        endpointStatuses.add(endpointStatus);
+        return this;
+    }
+}

--- a/address-model-lib/src/main/java/io/enmasse/address/model/AddressSpaceType.java
+++ b/address-model-lib/src/main/java/io/enmasse/address/model/AddressSpaceType.java
@@ -14,14 +14,14 @@ public class AddressSpaceType {
     private final String description;
     private final List<AddressSpacePlan> plans;
     private final List<AddressType> addressTypes;
-    private final List<String> serviceNames;
+    private final List<EndpointSpec> availableEndpoints;
 
-    public AddressSpaceType(String name, String description, List<AddressSpacePlan> plans, List<AddressType> addressTypes, List<String> serviceNames) {
+    public AddressSpaceType(String name, String description, List<AddressSpacePlan> plans, List<AddressType> addressTypes, List<EndpointSpec> availableEndpoints) {
         this.name = name;
         this.description = description;
         this.plans = plans;
         this.addressTypes = addressTypes;
-        this.serviceNames = serviceNames;
+        this.availableEndpoints = availableEndpoints;
     }
 
     public String getName() {
@@ -49,8 +49,8 @@ public class AddressSpaceType {
         return Optional.empty();
     }
 
-    public List<String> getServiceNames() {
-        return Collections.unmodifiableList(serviceNames);
+    public List<EndpointSpec> getAvailableEndpoints() {
+        return Collections.unmodifiableList(availableEndpoints);
     }
 
     public Optional<AddressType> findAddressType(String type) {
@@ -67,7 +67,7 @@ public class AddressSpaceType {
         private String description;
         private List<AddressType> addressTypes;
         private List<AddressSpacePlan> addressSpacePlans;
-        private List<String> serviceNames;
+        private List<EndpointSpec> availableEndpoints;
 
         public Builder setName(String name) {
             this.name = name;
@@ -89,8 +89,8 @@ public class AddressSpaceType {
             return this;
         }
 
-        public Builder setServiceNames(List<String> serviceNames) {
-            this.serviceNames = new ArrayList<>(serviceNames);
+        public Builder setAvailableEndpoints(List<EndpointSpec> availableEndpoints) {
+            this.availableEndpoints = new ArrayList<>(availableEndpoints);
             return this;
         }
 
@@ -99,9 +99,9 @@ public class AddressSpaceType {
             Objects.requireNonNull(description);
             Objects.requireNonNull(addressSpacePlans);
             Objects.requireNonNull(addressTypes);
-            Objects.requireNonNull(serviceNames);
+            Objects.requireNonNull(availableEndpoints);
 
-            return new AddressSpaceType(name, description, addressSpacePlans, addressTypes, serviceNames);
+            return new AddressSpaceType(name, description, addressSpacePlans, addressTypes, availableEndpoints);
         }
     }
 }

--- a/address-model-lib/src/main/java/io/enmasse/address/model/CertSpec.java
+++ b/address-model-lib/src/main/java/io/enmasse/address/model/CertSpec.java
@@ -4,11 +4,11 @@
  */
 package io.enmasse.address.model;
 
-import java.util.Objects;
-
 public class CertSpec {
-    private final String provider;
+    private String provider;
     private String secretName;
+
+    public CertSpec() { }
 
     public CertSpec(String provider) {
         this.provider = provider;
@@ -21,6 +21,11 @@ public class CertSpec {
 
     public String getProvider() {
         return provider;
+    }
+
+    public CertSpec setProvider(String provider) {
+        this.provider = provider;
+        return this;
     }
 
     public String getSecretName() {

--- a/address-model-lib/src/main/java/io/enmasse/address/model/EndpointSpec.java
+++ b/address-model-lib/src/main/java/io/enmasse/address/model/EndpointSpec.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2018, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.address.model;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * An endpoint
+ */
+public class EndpointSpec {
+    private final String name;
+    private final String service;
+    private final String servicePort;
+    private final String host;
+    private final CertSpec certSpec;
+
+    public EndpointSpec(String name, String service, String servicePort, String host, CertSpec certSpec) {
+        this.name = name;
+        this.service = service;
+        this.servicePort = servicePort;
+        this.host = host;
+        this.certSpec = certSpec;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getService() {
+        return service;
+    }
+
+    public String getServicePort() {
+        return servicePort;
+    }
+
+    public Optional<String> getHost() {
+        return Optional.ofNullable(host);
+    }
+
+    public Optional<CertSpec> getCertSpec() {
+        return Optional.ofNullable(certSpec);
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder()
+                .append("{name=").append(name).append(",")
+                .append("host=").append(host).append(",")
+                .append("service=").append(service).append(",")
+                .append("servicePort=").append(servicePort).append(",")
+                .append("cert=").append(certSpec).append("}")
+                .toString();
+    }
+
+    public static class Builder {
+        private String name;
+        private String service;
+        private String servicePort;
+        private String host;
+        private CertSpec certSpec;
+
+        public Builder() {}
+
+        public Builder(EndpointSpec endpoint) {
+            this.name = endpoint.getName();
+            this.service = endpoint.getService();
+            this.servicePort = endpoint.getServicePort();
+            this.host = endpoint.getHost().orElse(null);
+            this.certSpec = endpoint.getCertSpec().orElse(null);
+        }
+
+        public Builder setName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder setService(String service) {
+            this.service = service;
+            return this;
+        }
+
+        public Builder setHost(String host) {
+            this.host = host;
+            return this;
+        }
+
+        public Builder setServicePort(String servicePort) {
+            this.servicePort = servicePort;
+            return this;
+        }
+
+
+        public Builder setCertSpec(CertSpec certSpec) {
+            this.certSpec = certSpec;
+            return this;
+        }
+
+        public EndpointSpec build() {
+            Objects.requireNonNull(name, "name not set");
+            Objects.requireNonNull(service, "service not set");
+            Objects.requireNonNull(servicePort, "service port not set");
+            return new EndpointSpec(name, service, servicePort, host, certSpec);
+        }
+    }
+}

--- a/address-model-lib/src/main/java/io/enmasse/address/model/EndpointStatus.java
+++ b/address-model-lib/src/main/java/io/enmasse/address/model/EndpointStatus.java
@@ -4,34 +4,35 @@
  */
 package io.enmasse.address.model;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 
 /**
  * An endpoint
  */
-public class Endpoint {
+public class EndpointStatus {
     private final String name;
-    private final String service;
     private final String host;
     private final int port;
+    private final String serviceHost;
     private final Map<String, Integer> servicePorts;
-    private final CertSpec certSpec;
 
-    public Endpoint(String name, String service, String host, int port, Map<String, Integer> servicePorts, CertSpec certSpec) {
+    public EndpointStatus(String name, String serviceHost, String host, int port, Map<String, Integer> servicePorts) {
         this.name = name;
-        this.service = service;
+        this.serviceHost = serviceHost;
         this.host = host;
         this.port = port;
         this.servicePorts = servicePorts;
-        this.certSpec = certSpec;
     }
 
     public String getName() {
         return name;
     }
 
-    public String getService() {
-        return service;
+    public String getServiceHost() {
+        return serviceHost;
     }
 
     public int getPort() {
@@ -42,12 +43,8 @@ public class Endpoint {
         return Collections.unmodifiableMap(servicePorts);
     }
 
-    public Optional<String> getHost() {
-        return Optional.ofNullable(host);
-    }
-
-    public Optional<CertSpec> getCertSpec() {
-        return Optional.ofNullable(certSpec);
+    public String getHost() {
+        return host;
     }
 
     @Override
@@ -55,28 +52,25 @@ public class Endpoint {
         return new StringBuilder()
                 .append("{name=").append(name).append(",")
                 .append("host=").append(host).append(",")
-                .append("service=").append(service).append(",")
-                .append("port=").append(port).append(",")
-                .append("certProviderSpec=").append(certSpec).append("}")
+                .append("serviceHost=").append(serviceHost).append(",")
+                .append("port=").append(port).append("}")
                 .toString();
     }
 
     public static class Builder {
         private String name;
-        private String service;
+        private String serviceHost;
         private String host;
         private int port = 0;
-        private CertSpec certSpec;
         private Map<String, Integer> servicePorts = new HashMap<>();
 
         public Builder() {}
 
-        public Builder(io.enmasse.address.model.Endpoint endpoint) {
+        public Builder(EndpointStatus endpoint) {
             this.name = endpoint.getName();
             this.port = endpoint.getPort();
-            this.service = endpoint.getService();
-            this.host = endpoint.getHost().orElse(null);
-            this.certSpec = endpoint.getCertSpec().orElse(null);
+            this.serviceHost = endpoint.getServiceHost();
+            this.host = endpoint.getHost();
             this.servicePorts = new HashMap<>(endpoint.getServicePorts());
         }
 
@@ -85,8 +79,8 @@ public class Endpoint {
             return this;
         }
 
-        public Builder setService(String service) {
-            this.service = service;
+        public Builder setServiceHost(String serviceHost) {
+            this.serviceHost = serviceHost;
             return this;
         }
 
@@ -106,15 +100,10 @@ public class Endpoint {
             return this;
         }
 
-        public Builder setCertSpec(CertSpec certSpec) {
-            this.certSpec = certSpec;
-            return this;
-        }
-
-        public Endpoint build() {
+        public EndpointStatus build() {
             Objects.requireNonNull(name, "name not set");
-            Objects.requireNonNull(service, "service not set");
-            return new Endpoint(name, service, host, port, servicePorts, certSpec);
+            Objects.requireNonNull(serviceHost, "service host not set");
+            return new EndpointStatus(name, serviceHost, host, port, servicePorts);
         }
     }
 }

--- a/address-model-lib/src/main/java/io/enmasse/address/model/v1/Fields.java
+++ b/address-model-lib/src/main/java/io/enmasse/address/model/v1/Fields.java
@@ -14,8 +14,11 @@ interface Fields {
     String NAME = "name";
     String NAMESPACE = "namespace";
     String ENDPOINTS = "endpoints";
+    String ENDPOINT_STATUSES = "endpointStatuses";
     String HOST = "host";
     String SERVICE = "service";
+    String SERVICE_HOST = "serviceHost";
+    String SERVICE_PORT = "servicePort";
     String CERT = "cert";
     String SECRET_NAME = "secretName";
     String PROVIDER = "provider";

--- a/address-model-lib/src/test/java/io/enmasse/address/model/AddressSpaceTest.java
+++ b/address-model-lib/src/test/java/io/enmasse/address/model/AddressSpaceTest.java
@@ -27,7 +27,7 @@ public class AddressSpaceTest {
         assertThat(space.getName(), is("name"));
         assertThat(space.getType(), is("type"));
         assertThat(space.getPlan(), is("plan"));
-        assertThat(space.getStatus(), is(new Status(false)));
+        assertThat(space.getStatus(), is(new AddressSpaceStatus(false)));
         assertNotNull(space.getEndpoints());
         assertThat(space.getEndpoints().size(), is(0));
         assertNotNull(space.getAuthenticationService());

--- a/address-model-lib/src/test/java/io/enmasse/address/model/v1/address/SerializationTest.java
+++ b/address-model-lib/src/test/java/io/enmasse/address/model/v1/address/SerializationTest.java
@@ -5,7 +5,6 @@
 package io.enmasse.address.model.v1.address;
 
 import io.enmasse.address.model.*;
-import io.enmasse.address.model.Endpoint;
 import io.enmasse.address.model.v1.CodecV1;
 import io.enmasse.address.model.v1.DeserializeException;
 import org.junit.Test;
@@ -118,11 +117,18 @@ public class SerializationTest {
                 .setCreationTimestamp("some date")
                 .setResourceVersion("1234")
                 .setSelfLink("/my/resource")
-                .setStatus(new Status(true).appendMessage("hello"))
-                .setEndpointList(Arrays.asList(new Endpoint.Builder()
+                .setStatus(new AddressSpaceStatus(true).appendMessage("hello").appendEndpointStatus(
+                        new EndpointStatus.Builder()
+                        .setName("myendpoint")
+                        .setHost("example.com")
+                        .setPort(443)
+                        .setServiceHost("messaging.svc")
+                        .setServicePorts(Collections.singletonMap("amqp", 5672))
+                        .build()))
+                .setEndpointList(Arrays.asList(new EndpointSpec.Builder()
                         .setName("myendpoint")
                         .setService("messaging")
-                        .setServicePorts(Collections.singletonMap("amqp", 5672))
+                        .setServicePort("amqp")
                         .setCertSpec(new CertSpec("provider").setSecretName("secret"))
                         .build()))
                 .setAuthenticationService(new AuthenticationService.Builder()
@@ -149,10 +155,15 @@ public class SerializationTest {
         assertThat(deserialized.getResourceVersion(), is(addressSpace.getResourceVersion()));
         assertThat(deserialized.getStatus().isReady(), is(addressSpace.getStatus().isReady()));
         assertThat(deserialized.getStatus().getMessages(), is(addressSpace.getStatus().getMessages()));
+        assertThat(deserialized.getStatus().getEndpointStatuses().size(), is(addressSpace.getEndpoints().size()));
+        assertThat(deserialized.getStatus().getEndpointStatuses().get(0).getName(), is(addressSpace.getStatus().getEndpointStatuses().get(0).getName()));
+        assertThat(deserialized.getStatus().getEndpointStatuses().get(0).getHost(), is(addressSpace.getStatus().getEndpointStatuses().get(0).getHost()));
+        assertThat(deserialized.getStatus().getEndpointStatuses().get(0).getPort(), is(addressSpace.getStatus().getEndpointStatuses().get(0).getPort()));
+        assertThat(deserialized.getStatus().getEndpointStatuses().get(0).getServiceHost(), is(addressSpace.getStatus().getEndpointStatuses().get(0).getServiceHost()));
+        assertThat(deserialized.getStatus().getEndpointStatuses().get(0).getServicePorts(), is(addressSpace.getStatus().getEndpointStatuses().get(0).getServicePorts()));
         assertThat(deserialized.getEndpoints().size(), is(addressSpace.getEndpoints().size()));
         assertThat(deserialized.getEndpoints().get(0).getName(), is(addressSpace.getEndpoints().get(0).getName()));
         assertThat(deserialized.getEndpoints().get(0).getService(), is(addressSpace.getEndpoints().get(0).getService()));
-        assertThat(deserialized.getEndpoints().get(0).getServicePorts().get("amqp"), is(5672));
         assertThat(deserialized.getEndpoints().get(0).getCertSpec().get().getProvider(), is(addressSpace.getEndpoints().get(0).getCertSpec().get().getProvider()));
         assertThat(deserialized.getEndpoints().get(0).getCertSpec().get().getSecretName(), is(addressSpace.getEndpoints().get(0).getCertSpec().get().getSecretName()));
         assertThat(deserialized.getAuthenticationService().getType(), is(addressSpace.getAuthenticationService().getType()));
@@ -179,7 +190,7 @@ public class SerializationTest {
                 .setNamespace("mynamespace")
                 .setPlan("default")
                 .setType("standard")
-                .setStatus(new Status(true).appendMessage("hello"))
+                .setStatus(new AddressSpaceStatus(true).appendMessage("hello"))
                 .setEndpointList(null)
                 .build();
 
@@ -409,10 +420,11 @@ public class SerializationTest {
                 .setNamespace("mynamespace")
                 .setPlan("myplan")
                 .setType("standard")
-                .setStatus(new Status(true).appendMessage("hello"))
-                .setEndpointList(Arrays.asList(new Endpoint.Builder()
+                .setStatus(new AddressSpaceStatus(true).appendMessage("hello"))
+                .setEndpointList(Arrays.asList(new EndpointSpec.Builder()
                         .setName("myendpoint")
                         .setService("messaging")
+                        .setServicePort("amqp")
                         .build()))
                 .build();
 
@@ -421,10 +433,11 @@ public class SerializationTest {
                 .setNamespace("myothernamespace")
                 .setPlan("myotherplan")
                 .setType("brokered")
-                .setStatus(new Status(false))
-                .setEndpointList(Arrays.asList(new Endpoint.Builder()
+                .setStatus(new AddressSpaceStatus(false))
+                .setEndpointList(Arrays.asList(new EndpointSpec.Builder()
                         .setName("bestendpoint")
                         .setService("mqtt")
+                        .setServicePort("mqtts")
                         .setCertSpec(new CertSpec("mysecret"))
                         .build()))
                 .build();

--- a/address-space-controller/src/main/java/io/enmasse/controller/ControllerChain.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/ControllerChain.java
@@ -116,8 +116,11 @@ public class ControllerChain extends AbstractVerticle implements Watcher<Address
         for (AddressSpace addressSpace : resources) {
             try {
                 for (Controller controller : chain) {
+                    log.debug("Controller {} input: {}", controller.getClass().getName(), addressSpace);
                     addressSpace = controller.handle(addressSpace);
                 }
+
+                log.debug("Controller chain output: {}", addressSpace);
 
                 addressSpaceApi.replaceAddressSpace(addressSpace);
             } catch (KubernetesClientException e) {

--- a/address-space-controller/src/main/java/io/enmasse/controller/Main.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/Main.java
@@ -51,10 +51,10 @@ public class Main extends AbstractVerticle {
         CertProviderFactory certProviderFactory = createCertProviderFactory(options, certManager);
         AuthController authController = new AuthController(certManager, eventLogger, certProviderFactory);
 
-        InfraResourceFactory infraResourceFactory = new TemplateInfraResourceFactory(kubernetes, schemaProvider, resolverFactory, authController.getDefaultCertProvider());
+        InfraResourceFactory infraResourceFactory = new TemplateInfraResourceFactory(kubernetes, schemaProvider, resolverFactory);
 
         ControllerChain controllerChain = new ControllerChain(kubernetes, addressSpaceApi, schemaProvider, eventLogger, options.getRecheckInterval(), options.getResyncInterval());
-        controllerChain.addController(new CreateController(kubernetes, schemaProvider, infraResourceFactory, kubernetes.getNamespace(), eventLogger));
+        controllerChain.addController(new CreateController(kubernetes, schemaProvider, infraResourceFactory, kubernetes.getNamespace(), eventLogger, authController.getDefaultCertProvider()));
         controllerChain.addController(new StatusController(kubernetes, infraResourceFactory));
         controllerChain.addController(new EndpointController(controllerClient));
         controllerChain.addController(authController);

--- a/address-space-controller/src/main/java/io/enmasse/controller/TemplateInfraResourceFactory.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/TemplateInfraResourceFactory.java
@@ -17,7 +17,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 public class TemplateInfraResourceFactory implements InfraResourceFactory {
     private static final Logger log = LoggerFactory.getLogger(TemplateInfraResourceFactory.class.getName());
@@ -25,13 +24,11 @@ public class TemplateInfraResourceFactory implements InfraResourceFactory {
     private final Kubernetes kubernetes;
     private final SchemaProvider schemaProvider;
     private final AuthenticationServiceResolverFactory authResolverFactory;
-    private final String defaultCertProvider;
 
-    public TemplateInfraResourceFactory(Kubernetes kubernetes, SchemaProvider schemaProvider, AuthenticationServiceResolverFactory authResolverFactory, String defaultCertProvider) {
+    public TemplateInfraResourceFactory(Kubernetes kubernetes, SchemaProvider schemaProvider, AuthenticationServiceResolverFactory authResolverFactory) {
         this.kubernetes = kubernetes;
         this.schemaProvider = schemaProvider;
         this.authResolverFactory = authResolverFactory;
-        this.defaultCertProvider = defaultCertProvider;
     }
 
     @Override
@@ -58,63 +55,21 @@ public class TemplateInfraResourceFactory implements InfraResourceFactory {
             authResolver.getSaslInitHost(addressSpace, authService).ifPresent(saslInitHost -> parameters.put(TemplateParameter.AUTHENTICATION_SERVICE_SASL_INIT_HOST, saslInitHost));
             authResolver.getOAuthURL(authService).ifPresent(url -> parameters.put(TemplateParameter.AUTHENTICATION_SERVICE_OAUTH_URL, url));
 
-            // Step 1: Validate endpoints and remove unknown
-            List<String> availableServices = addressSpaceType.getServiceNames();
-            Map<String, CertSpec> serviceCertProviders = new HashMap<>();
-
-            List<Endpoint> endpoints = null;
-            if (addressSpace.getEndpoints() != null) {
-                endpoints = new ArrayList<>(addressSpace.getEndpoints());
-                Iterator<Endpoint> it = endpoints.iterator();
-                while (it.hasNext()) {
-                    Endpoint endpoint = it.next();
-                    if (!availableServices.contains(endpoint.getService())) {
-                        log.info("Unknown service {} for endpoint {}, removing", endpoint.getService(), endpoint.getName());
-                        it.remove();
-                    } else {
-                        endpoint.getCertSpec().ifPresent(certProvider -> serviceCertProviders.put(endpoint.getService(), certProvider));
-                    }
-                }
-            } else {
-            // Step 2: Create endpoints if the user didnt supply any
-                endpoints = availableServices.stream()
-                        .map(service -> new Endpoint.Builder().setName(service).setService(service).build())
-                        .collect(Collectors.toList());
+            Map<String, CertSpec> serviceCertMapping = new HashMap<>();
+            for (EndpointSpec endpoint : addressSpace.getEndpoints()) {
+                endpoint.getCertSpec().ifPresent(cert -> {
+                    serviceCertMapping.put(endpoint.getService(), cert);
+                });
             }
 
-            // Step 3: Create missing secrets if not specified
-            for (String service : availableServices) {
-                if (!serviceCertProviders.containsKey(service)) {
-                    serviceCertProviders.put(service, new CertSpec(defaultCertProvider));
-                }
+            if (serviceCertMapping.containsKey("messaging")) {
+                parameters.put(TemplateParameter.MESSAGING_SECRET, serviceCertMapping.get("messaging").getSecretName());
             }
-
-            // Step 3: Ensure all endpoints have their certProviders set
-            endpoints = endpoints.stream()
-                    .map(endpoint -> {
-                        if (!endpoint.getCertSpec().isPresent()) {
-                            return new Endpoint.Builder(endpoint)
-                                    .setCertSpec(serviceCertProviders.get(endpoint.getService()))
-                                    .build();
-                        } else {
-                            return endpoint;
-                        }
-                    }).collect(Collectors.toList());
-
-            for (Map.Entry<String, CertSpec> entry : serviceCertProviders.entrySet()) {
-                if (entry.getValue().getSecretName() == null) {
-                    entry.getValue().setSecretName("external-certs-" + entry.getKey());
-                }
+            if (serviceCertMapping.containsKey("console")) {
+                parameters.put(TemplateParameter.CONSOLE_SECRET, serviceCertMapping.get("console").getSecretName());
             }
-
-            if (availableServices.contains("messaging")) {
-                parameters.put(TemplateParameter.MESSAGING_SECRET, serviceCertProviders.get("messaging").getSecretName());
-            }
-            if (availableServices.contains("console")) {
-                parameters.put(TemplateParameter.CONSOLE_SECRET, serviceCertProviders.get("console").getSecretName());
-            }
-            if (availableServices.contains("mqtt")) {
-                parameters.put(TemplateParameter.MQTT_SECRET, serviceCertProviders.get("mqtt").getSecretName());
+            if (serviceCertMapping.containsKey("mqtt")) {
+                parameters.put(TemplateParameter.MQTT_SECRET, serviceCertMapping.get("mqtt").getSecretName());
             }
 
             parameters.putAll(resourceDefinition.getTemplateParameters());
@@ -127,7 +82,7 @@ public class TemplateInfraResourceFactory implements InfraResourceFactory {
             // Step 5: Create infrastructure
             resourceList.addAll(kubernetes.processTemplate(resourceDefinition.getTemplateName().get(), parameterValues.toArray(new ParameterValue[0])).getItems());
 
-            for (Endpoint endpoint : endpoints) {
+            for (EndpointSpec endpoint : addressSpace.getEndpoints()) {
                 Service service = null;
                 for (HasMetadata resource : resourceList) {
                     if (resource.getKind().equals("Service") && resource.getMetadata().getName().equals(endpoint.getService())) {

--- a/address-space-controller/src/main/java/io/enmasse/controller/auth/AuthController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/auth/AuthController.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import io.enmasse.address.model.AddressSpace;
-import io.enmasse.address.model.Endpoint;
+import io.enmasse.address.model.EndpointSpec;
 import io.enmasse.address.model.KubeUtil;
 import io.enmasse.config.AnnotationKeys;
 import io.enmasse.controller.CertProviderFactory;
@@ -43,9 +43,9 @@ public class AuthController implements Controller {
     }
 
     public void issueExternalCertificates(AddressSpace addressSpace) throws Exception {
-        List<Endpoint> endpoints = addressSpace.getEndpoints();
+        List<EndpointSpec> endpoints = addressSpace.getEndpoints();
         if (endpoints != null) {
-            for (Endpoint endpoint : endpoints) {
+            for (EndpointSpec endpoint : endpoints) {
                 if (endpoint.getCertSpec().isPresent()) {
                     try {
                         CertProvider certProvider = certProviderFactory.createProvider(endpoint.getCertSpec().get());

--- a/address-space-controller/src/main/java/io/enmasse/controller/auth/CertProvider.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/auth/CertProvider.java
@@ -5,9 +5,9 @@
 package io.enmasse.controller.auth;
 
 import io.enmasse.address.model.AddressSpace;
-import io.enmasse.address.model.Endpoint;
+import io.enmasse.address.model.EndpointSpec;
 import io.fabric8.kubernetes.api.model.Secret;
 
 public interface CertProvider {
-    Secret provideCert(AddressSpace addressSpace, Endpoint endpoint);
+    Secret provideCert(AddressSpace addressSpace, EndpointSpec endpoint);
 }

--- a/address-space-controller/src/main/java/io/enmasse/controller/auth/SelfsignedCertProvider.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/auth/SelfsignedCertProvider.java
@@ -6,7 +6,7 @@ package io.enmasse.controller.auth;
 
 import io.enmasse.address.model.AddressSpace;
 import io.enmasse.address.model.CertSpec;
-import io.enmasse.address.model.Endpoint;
+import io.enmasse.address.model.EndpointSpec;
 import io.enmasse.config.AnnotationKeys;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.openshift.client.OpenShiftClient;
@@ -26,7 +26,7 @@ public class SelfsignedCertProvider implements CertProvider {
     }
 
     @Override
-    public Secret provideCert(AddressSpace addressSpace, Endpoint endpoint) {
+    public Secret provideCert(AddressSpace addressSpace, EndpointSpec endpoint) {
         Secret secret = client.secrets().inNamespace(addressSpace.getAnnotation(AnnotationKeys.NAMESPACE)).withName(certSpec.getSecretName()).get();
         if (secret == null) {
             log.info("Creating self-signed certificates for {}", endpoint);

--- a/address-space-controller/src/main/java/io/enmasse/controller/auth/WildcardCertProvider.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/auth/WildcardCertProvider.java
@@ -6,7 +6,7 @@ package io.enmasse.controller.auth;
 
 import io.enmasse.address.model.AddressSpace;
 import io.enmasse.address.model.CertSpec;
-import io.enmasse.address.model.Endpoint;
+import io.enmasse.address.model.EndpointSpec;
 import io.enmasse.config.AnnotationKeys;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -29,7 +29,7 @@ public class WildcardCertProvider implements CertProvider {
     }
 
     @Override
-    public Secret provideCert(AddressSpace addressSpace, Endpoint endpoint) {
+    public Secret provideCert(AddressSpace addressSpace, EndpointSpec endpoint) {
         Secret secret = client.secrets().inNamespace(addressSpace.getAnnotation(AnnotationKeys.NAMESPACE)).withName(certSpec.getSecretName()).get();
         if (secret == null) {
             Secret wildcardSecret = null;

--- a/address-space-controller/src/main/java/io/enmasse/controller/common/Kubernetes.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/common/Kubernetes.java
@@ -5,9 +5,7 @@
 package io.enmasse.controller.common;
 
 import io.enmasse.address.model.AddressSpace;
-import io.enmasse.address.model.Endpoint;
-import io.enmasse.api.auth.SubjectAccessReview;
-import io.enmasse.api.auth.TokenReview;
+import io.enmasse.address.model.EndpointSpec;
 import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.api.model.extensions.Deployment;
 import io.fabric8.openshift.client.ParameterValue;
@@ -34,7 +32,7 @@ public interface Kubernetes {
 
     boolean hasService(String service);
 
-    HasMetadata createEndpoint(Endpoint endpoint, Service service, String addressSpaceName, String namespace);
+    HasMetadata createEndpoint(EndpointSpec endpoint, Service service, String addressSpaceName, String namespace);
 
     Set<Deployment> getReadyDeployments();
 

--- a/address-space-controller/src/test/java/io/enmasse/controller/ControllerChainTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/ControllerChainTest.java
@@ -5,6 +5,7 @@
 package io.enmasse.controller;
 
 import io.enmasse.address.model.AddressSpace;
+import io.enmasse.address.model.AddressSpaceStatus;
 import io.enmasse.address.model.Status;
 import io.enmasse.controller.common.Kubernetes;
 import io.enmasse.k8s.api.EventLogger;
@@ -58,14 +59,14 @@ public class ControllerChainTest {
                 .setName("myspace")
                 .setType("type1")
                 .setPlan("myplan")
-                .setStatus(new Status(false))
+                .setStatus(new AddressSpaceStatus(false))
                 .build();
 
         AddressSpace a2 = new AddressSpace.Builder()
                 .setName("myspace2")
                 .setType("type1")
                 .setPlan("myplan")
-                .setStatus(new Status(false))
+                .setStatus(new AddressSpaceStatus(false))
                 .build();
 
         when(mockController.handle(eq(a1))).thenReturn(a1);

--- a/address-space-controller/src/test/java/io/enmasse/controller/CreateControllerTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/CreateControllerTest.java
@@ -40,7 +40,7 @@ public class CreateControllerTest {
         when(mockResourceFactory.createResourceList(eq(addressSpace))).thenReturn(Collections.emptyList());
 
         SchemaProvider testSchema = new TestSchemaProvider();
-        CreateController createController = new CreateController(kubernetes, testSchema, mockResourceFactory, "test", eventLogger);
+        CreateController createController = new CreateController(kubernetes, testSchema, mockResourceFactory, "test", eventLogger, null);
 
         createController.handle(addressSpace);
 

--- a/address-space-controller/src/test/java/io/enmasse/controller/EndpointControllerTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/EndpointControllerTest.java
@@ -28,6 +28,7 @@ public class EndpointControllerTest {
         AddressSpace addressSpace = new AddressSpace.Builder()
                 .setName("myspace")
                 .setNamespace("mynamespace")
+                .putAnnotation(AnnotationKeys.NAMESPACE, "myns")
                 .setType("type1")
                 .setPlan("myplan")
                 .build();
@@ -46,8 +47,6 @@ public class EndpointControllerTest {
                 .addToLabels(LabelKeys.TYPE, "loadbalancer")
                 .addToAnnotations(AnnotationKeys.ADDRESS_SPACE, addressSpace.getName())
                 .addToAnnotations(AnnotationKeys.SERVICE_NAME, "messaging")
-                .addToAnnotations(AnnotationKeys.CERT_PROVIDER, "selfsigned")
-                .addToAnnotations(AnnotationKeys.CERT_SECRET_NAME, "mysecret")
                 .endMetadata()
                 .editOrNewSpec()
                 .withHost("messaging.example.com")
@@ -65,10 +64,9 @@ public class EndpointControllerTest {
 
         AddressSpace newspace = controller.handle(addressSpace);
 
-        assertThat(newspace.getEndpoints().size(), is(1));
-        assertThat(newspace.getEndpoints().get(0).getName(), is("myservice-external"));
-        assertTrue(newspace.getEndpoints().get(0).getHost().isPresent());
-        assertThat(newspace.getEndpoints().get(0).getHost().get(), is("messaging.example.com"));
-        assertTrue(newspace.getEndpoints().get(0).getCertSpec().isPresent());
+        assertThat(newspace.getStatus().getEndpointStatuses().size(), is(1));
+        assertThat(newspace.getStatus().getEndpointStatuses().get(0).getName(), is("myservice-external"));
+        assertThat(newspace.getStatus().getEndpointStatuses().get(0).getHost(), is("messaging.example.com"));
+        assertThat(newspace.getStatus().getEndpointStatuses().get(0).getServiceHost(), is("messaging.myns.svc"));
     }
 }

--- a/address-space-controller/src/test/java/io/enmasse/controller/auth/WildcardCertProviderTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/auth/WildcardCertProviderTest.java
@@ -6,7 +6,7 @@ package io.enmasse.controller.auth;
 
 import io.enmasse.address.model.AddressSpace;
 import io.enmasse.address.model.CertSpec;
-import io.enmasse.address.model.Endpoint;
+import io.enmasse.address.model.EndpointSpec;
 import io.enmasse.config.AnnotationKeys;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
@@ -46,10 +46,11 @@ public class WildcardCertProviderTest {
                 .setPlan("myplan")
                 .build();
 
-        Endpoint endpoint = new Endpoint.Builder()
+        EndpointSpec endpoint = new EndpointSpec.Builder()
                 .setCertSpec(new CertSpec("wildcard", "mycerts"))
                 .setName("messaging")
                 .setService("svc")
+                .setServicePort("amqps")
                 .build();
 
         certProvider.provideCert(space, endpoint);
@@ -65,10 +66,11 @@ public class WildcardCertProviderTest {
                 .setType("standard")
                 .build();
 
-        Endpoint endpoint = new Endpoint.Builder()
+        EndpointSpec endpoint = new EndpointSpec.Builder()
                 .setCertSpec(new CertSpec("wildcard", "mycerts"))
                 .setName("messaging")
                 .setService("svc")
+                .setServicePort("amqps")
                 .build();
 
         client.secrets().create(new SecretBuilder()

--- a/api-server/src/main/resources/swagger.json
+++ b/api-server/src/main/resources/swagger.json
@@ -754,25 +754,11 @@
                             "service": {
                                 "type": "string"
                             },
-                            "host": {
+                            "servicePort": {
                                 "type": "string"
                             },
-                            "port": {
-                                "type": "integer"
-                            },
-                            "servicePorts": {
-                                "type": "array",
-                                "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "name": {
-                                            "type": "string"
-                                        },
-                                        "port": {
-                                            "type": "integer"
-                                        }
-                                    }
-                                }
+                            "host": {
+                                "type": "string"
                             },
                             "cert": {
                                 "type": "object",
@@ -811,6 +797,40 @@
                     "type": "array",
                     "items": {
                         "type": "string"
+                    }
+                },
+                "endpointStatuses": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "serviceHost": {
+                                "type": "string"
+                            },
+                            "host": {
+                                "type": "string"
+                            },
+                            "port": {
+                                "type": "integer"
+                            },
+                            "servicePorts": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "port": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/api-server/src/test/java/io/enmasse/api/server/HTTPServerTest.java
+++ b/api-server/src/test/java/io/enmasse/api/server/HTTPServerTest.java
@@ -63,10 +63,11 @@ public class HTTPServerTest {
                 .setNamespace(name)
                 .setType("mytype")
                 .setPlan("myplan")
-                .setStatus(new io.enmasse.address.model.Status(false))
-                .appendEndpoint(new Endpoint.Builder()
+                .setStatus(new io.enmasse.address.model.AddressSpaceStatus(false))
+                .appendEndpoint(new EndpointSpec.Builder()
                         .setName("foo")
                         .setService("messaging")
+                        .setServicePort("amqps")
                         .build())
                 .build();
     }

--- a/api-server/src/test/java/io/enmasse/api/v1/http/HttpAddressSpaceServiceTest.java
+++ b/api-server/src/test/java/io/enmasse/api/v1/http/HttpAddressSpaceServiceTest.java
@@ -6,7 +6,7 @@ package io.enmasse.api.v1.http;
 
 import io.enmasse.address.model.AddressSpace;
 import io.enmasse.address.model.AddressSpaceList;
-import io.enmasse.address.model.Endpoint;
+import io.enmasse.address.model.EndpointSpec;
 import io.enmasse.api.common.DefaultExceptionMapper;
 import io.enmasse.api.server.TestSchemaProvider;
 import io.enmasse.k8s.api.TestAddressSpaceApi;
@@ -46,15 +46,15 @@ public class HttpAddressSpaceServiceTest {
                 .setType("type1")
                 .setPlan("myplan")
                 .setEndpointList(Arrays.asList(
-                        new Endpoint.Builder()
+                        new EndpointSpec.Builder()
                             .setName("messaging")
                             .setService("messaging")
-                            .setHost("messaging.example.com")
+                            .setServicePort("amqps")
                         .build(),
-                        new Endpoint.Builder()
+                        new EndpointSpec.Builder()
                             .setName("mqtt")
                             .setService("mqtt")
-                            .setHost("mqtt.example.com")
+                            .setServicePort("mqtts")
                         .build()))
                 .build();
 

--- a/k8s-api-testutil/src/main/java/io/enmasse/k8s/api/TestAddressSpaceApi.java
+++ b/k8s-api-testutil/src/main/java/io/enmasse/k8s/api/TestAddressSpaceApi.java
@@ -6,6 +6,7 @@ package io.enmasse.k8s.api;
 
 import io.enmasse.address.model.Address;
 import io.enmasse.address.model.AddressSpace;
+import io.enmasse.address.model.AddressSpaceStatus;
 import io.enmasse.address.model.Status;
 
 import java.time.Duration;
@@ -84,6 +85,6 @@ public class TestAddressSpaceApi implements AddressSpaceApi {
     public void setAllInstancesReady(boolean ready) {
         addressSpaces.entrySet().stream().forEach(entry -> addressSpaces.put(
                 entry.getKey(),
-                new AddressSpace.Builder(entry.getValue()).setStatus(new Status(ready)).build()));
+                new AddressSpace.Builder(entry.getValue()).setStatus(new AddressSpaceStatus(ready)).build()));
     }
 }

--- a/k8s-api-testutil/src/main/java/io/enmasse/k8s/api/TestSchemaApi.java
+++ b/k8s-api-testutil/src/main/java/io/enmasse/k8s/api/TestSchemaApi.java
@@ -32,7 +32,11 @@ public class TestSchemaApi implements SchemaApi {
                         new AddressSpaceType.Builder()
                                 .setName("type1")
                                 .setDescription("Test Type")
-                                .setServiceNames(Collections.singletonList("messaging"))
+                                .setAvailableEndpoints(Collections.singletonList(new EndpointSpec.Builder()
+                                        .setName("messaging")
+                                        .setService("messaging")
+                                        .setServicePort("amqps")
+                                        .build()))
                                 .setAddressTypes(Arrays.asList(
                                         new AddressType.Builder()
                                                 .setName("anycast")

--- a/k8s-api/src/main/java/io/enmasse/k8s/api/ConfigMapSchemaApi.java
+++ b/k8s-api/src/main/java/io/enmasse/k8s/api/ConfigMapSchemaApi.java
@@ -152,13 +152,26 @@ public class ConfigMapSchemaApi implements SchemaApi, ListerWatcher<ConfigMap, C
         return assembleSchema(maps);
     }
 
+    private EndpointSpec createEndpointSpec(String name, String port) {
+        return new EndpointSpec.Builder()
+                .setName(name)
+                .setService(name)
+                .setServicePort(port)
+                .setCertSpec(new CertSpec(null, "external-certs-" + name))
+                .build();
+    }
+
     private AddressSpaceType createStandardType(List<AddressSpacePlan> addressSpacePlans, List<AddressPlan> addressPlans) {
         AddressSpaceType.Builder builder = new AddressSpaceType.Builder();
         builder.setName("standard");
         builder.setDescription("A standard address space consists of an AMQP router network in combination with " +
                 "attachable 'storage units'. The implementation of a storage unit is hidden from the client " +
                         "and the routers with a well defined API.");
-        builder.setServiceNames(Arrays.asList("messaging", "mqtt", "console"));
+
+        builder.setAvailableEndpoints(Arrays.asList(
+                createEndpointSpec("messaging", "amqps"),
+                createEndpointSpec("mqtt", "secure-mqtt"),
+                createEndpointSpec("console", "https")));
 
         List<AddressSpacePlan> filteredAddressSpaceplans = addressSpacePlans.stream()
                 .filter(plan -> "standard".equals(plan.getAddressSpaceType()))
@@ -200,7 +213,10 @@ public class ConfigMapSchemaApi implements SchemaApi, ListerWatcher<ConfigMap, C
         AddressSpaceType.Builder builder = new AddressSpaceType.Builder();
         builder.setName("brokered");
         builder.setDescription("A brokered address space consists of a broker combined with a console for managing addresses.");
-        builder.setServiceNames(Arrays.asList("messaging", "console", "brokerconsole"));
+
+        builder.setAvailableEndpoints(Arrays.asList(
+                createEndpointSpec("messaging", "amqps"),
+                createEndpointSpec("console", "https")));
 
         List<AddressSpacePlan> filteredAddressSpaceplans = addressSpacePlans.stream()
                 .filter(plan -> "brokered".equals(plan.getAddressSpaceType()))

--- a/keycloak-controller/src/main/java/io/enmasse/keycloak/controller/KeycloakManager.java
+++ b/keycloak-controller/src/main/java/io/enmasse/keycloak/controller/KeycloakManager.java
@@ -7,7 +7,7 @@ package io.enmasse.keycloak.controller;
 
 import io.enmasse.address.model.AddressSpace;
 import io.enmasse.address.model.AuthenticationServiceType;
-import io.enmasse.address.model.Endpoint;
+import io.enmasse.address.model.EndpointStatus;
 import io.enmasse.config.AnnotationKeys;
 import io.enmasse.k8s.api.Watcher;
 import org.slf4j.Logger;
@@ -32,17 +32,14 @@ public class KeycloakManager implements Watcher<AddressSpace>
     }
 
     private String getConsoleRedirectURI(AddressSpace addressSpace) {
-        if (addressSpace.getEndpoints() != null) {
-            for (Endpoint endpoint : addressSpace.getEndpoints()) {
-                if (endpoint.getName().equals("console") && endpoint.getHost().isPresent()) {
-                    String uri = "https://" + endpoint.getHost().get() + "/*";
-                    log.info("Using {} as redirect URI for enmasse-console", uri);
-                    return uri;
-                }
+        for (EndpointStatus endpoint : addressSpace.getStatus().getEndpointStatuses()) {
+            if (endpoint.getName().equals("console") && endpoint.getHost() != null) {
+                String uri = "https://" + endpoint.getHost() + "/*";
+                log.info("Using {} as redirect URI for enmasse-console", uri);
+                return uri;
             }
-        } else {
-            log.info("Address space {} has no endpoints defined", addressSpace.getName());
         }
+        log.info("Address space {} has no endpoints defined", addressSpace.getName());
         return null;
     }
 

--- a/service-broker/src/main/java/io/enmasse/osb/api/console/HttpConsoleService.java
+++ b/service-broker/src/main/java/io/enmasse/osb/api/console/HttpConsoleService.java
@@ -5,7 +5,7 @@
 package io.enmasse.osb.api.console;
 
 import io.enmasse.address.model.AddressSpace;
-import io.enmasse.address.model.Endpoint;
+import io.enmasse.address.model.EndpointStatus;
 import io.enmasse.k8s.api.AddressSpaceApi;
 
 import javax.ws.rs.*;
@@ -39,9 +39,9 @@ public class HttpConsoleService {
     }
 
     private Optional<URI> getConsoleURL(AddressSpace addressSpace) {
-        List<Endpoint> endpoints = addressSpace.getEndpoints();
+        List<EndpointStatus> endpoints = addressSpace.getStatus().getEndpointStatuses();
         return endpoints == null ? Optional.empty() : endpoints.stream()
                 .filter(endpoint -> endpoint.getName().equals("console"))
-                .findAny().flatMap(e -> e.getHost()).map(s -> URI.create("https://" + s));
+                .findAny().map(e -> URI.create("https://" + e.getHost()));
     }
 }

--- a/service-broker/src/test/java/io/enmasse/osb/HTTPServerTest.java
+++ b/service-broker/src/test/java/io/enmasse/osb/HTTPServerTest.java
@@ -6,8 +6,8 @@
 package io.enmasse.osb;
 
 import io.enmasse.address.model.AddressSpace;
-import io.enmasse.address.model.Endpoint;
-import io.enmasse.address.model.Status;
+import io.enmasse.address.model.AddressSpaceStatus;
+import io.enmasse.address.model.EndpointSpec;
 import io.enmasse.api.auth.AuthApi;
 import io.enmasse.api.auth.SubjectAccessReview;
 import io.enmasse.api.auth.TokenReview;
@@ -66,10 +66,11 @@ public class HTTPServerTest {
                 .setNamespace(name)
                 .setType("mytype")
                 .setPlan("myplan")
-                .setStatus(new Status(false))
-                .appendEndpoint(new Endpoint.Builder()
+                .setStatus(new AddressSpaceStatus(false))
+                .appendEndpoint(new EndpointSpec.Builder()
                         .setName("foo")
                         .setService("messaging")
+                        .setServicePort("amqps")
                         .build())
                 .build();
     }

--- a/standard-controller/src/test/java/io/enmasse/controller/standard/StandardControllerSchema.java
+++ b/standard-controller/src/test/java/io/enmasse/controller/standard/StandardControllerSchema.java
@@ -7,6 +7,7 @@ package io.enmasse.controller.standard;
 import io.enmasse.address.model.*;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class StandardControllerSchema {
@@ -40,7 +41,11 @@ public class StandardControllerSchema {
                 .setName("standard")
                 .setDescription("standard")
                 .setAddressSpacePlans(Arrays.asList(plan))
-                .setServiceNames(Arrays.asList("messaging"))
+                .setAvailableEndpoints(Collections.singletonList(new EndpointSpec.Builder()
+                        .setName("messaging")
+                        .setService("messaging")
+                        .setServicePort("amqps")
+                        .build()))
                 .setAddressTypes(Arrays.asList(
                         new AddressType.Builder()
                                 .setName("anycast")

--- a/standard-controller/src/test/java/io/enmasse/controller/standard/TemplateBrokerSetGeneratorTest.java
+++ b/standard-controller/src/test/java/io/enmasse/controller/standard/TemplateBrokerSetGeneratorTest.java
@@ -77,9 +77,10 @@ public class TemplateBrokerSetGeneratorTest {
                 .setName(name)
                 .setNamespace(name)
                 .setType("standard")
-                .appendEndpoint(new Endpoint.Builder()
+                .appendEndpoint(new EndpointSpec.Builder()
                         .setName("foo")
                         .setService("messaging")
+                        .setServicePort("amqps")
                         .setCertSpec(new CertSpec("mysecret", "mysecret"))
                         .build())
                 .build();

--- a/systemtests/src/main/java/io/enmasse/systemtest/AddressSpaceEndpoint.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/AddressSpaceEndpoint.java
@@ -7,22 +7,14 @@ package io.enmasse.systemtest;
 public class AddressSpaceEndpoint {
     private String name;
     private String service;
+    private String servicePort;
     private String host;
     private int port;
 
-    public AddressSpaceEndpoint(String name, String service) {
+    public AddressSpaceEndpoint(String name, String service, String servicePort) {
         this.name = name;
         this.service = service;
-    }
-
-    public AddressSpaceEndpoint(String name, String service, String host) {
-        this(name, service);
-        this.host = host;
-    }
-
-    public AddressSpaceEndpoint(String name, String service, String host, int port) {
-        this(name, service, host);
-        this.port = port;
+        this.servicePort = servicePort;
     }
 
     public String getName() {
@@ -48,6 +40,15 @@ public class AddressSpaceEndpoint {
     public void setService(String service) {
         this.service = service;
     }
+
+    public String getServicePort() {
+        return servicePort;
+    }
+
+    public void setServicePort(String servicePort) {
+        this.servicePort = servicePort;
+    }
+
 
     public int getPort() {
         return port;

--- a/systemtests/src/main/java/io/enmasse/systemtest/TestUtils.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/TestUtils.java
@@ -405,7 +405,7 @@ public class TestUtils {
             Thread.sleep(1000);
         }
         if (!endpointsReady) {
-            throw new IllegalStateException(String.format("Address-space '%s' have no ready endpoints!"));
+            throw new IllegalStateException(String.format("Address-space '%s' have no ready endpoints!", name));
         }
     }
 
@@ -576,9 +576,34 @@ public class TestUtils {
             for (int i = 0; i < endpointsJson.size(); i++) {
                 JsonObject endpointJson = endpointsJson.getJsonObject(i);
                 endpoints.add(new AddressSpaceEndpoint(endpointJson.getString("name"),
-                        endpointJson.getString("service"),
-                        endpointJson.getString("host"),
-                        endpointJson.getInteger("port")));
+                        endpointJson.getString("service"), endpointJson.getString("servicePort")));
+            }
+        }
+
+        JsonArray endpointsStatusJson = addressSpaceJson.getJsonObject("status").getJsonArray("endpointStatuses");
+        if (endpointsStatusJson != null) {
+            for (int i = 0; i < endpointsStatusJson.size(); i++) {
+                JsonObject endpointJson = endpointsJson.getJsonObject(i);
+                String ename = endpointJson.getString("name");
+
+                String host = null;
+                int port = 0;
+
+                if (endpointJson.containsKey("host")) {
+                    host = endpointJson.getString("host");
+                }
+
+                if (endpointJson.containsKey("port")) {
+                    port = endpointJson.getInteger("port");
+                }
+
+
+                for (AddressSpaceEndpoint endpoint : endpoints) {
+                    if (endpoint.getName().equals(ename)) {
+                        endpoint.setHost(host);
+                        endpoint.setPort(port);
+                    }
+                }
             }
         }
         AddressSpace addrSpace = new AddressSpace(name, namespace, type, plan, authService);

--- a/systemtests/src/main/java/io/enmasse/systemtest/apiclients/AddressApiClient.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/apiclients/AddressApiClient.java
@@ -87,6 +87,7 @@ public class AddressApiClient extends ApiClient {
             JsonObject endpointJson = new JsonObject();
             endpointJson.put("name", endpoint.getName());
             endpointJson.put("service", endpoint.getService());
+            endpointJson.put("servicePort", endpoint.getServicePort());
             endpointsJson.add(endpointJson);
         }
         return endpointsJson;

--- a/systemtests/src/test/java/io/enmasse/systemtest/common/api/ApiServerTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/common/api/ApiServerTest.java
@@ -92,9 +92,9 @@ class ApiServerTest extends TestBase {
         AddressSpace addressSpace = new AddressSpace("routes-space", AddressSpaceType.STANDARD, AuthService.STANDARD);
         String endpointPrefix = "test-endpoint-";
         addressSpace.setEndpoints(Arrays.asList(
-                new AddressSpaceEndpoint(endpointPrefix + "messaging", "messaging"),
-                new AddressSpaceEndpoint(endpointPrefix + "console", "console"),
-                new AddressSpaceEndpoint(endpointPrefix + "mqtt", "mqtt")));
+                new AddressSpaceEndpoint(endpointPrefix + "messaging", "messaging", "amqps"),
+                new AddressSpaceEndpoint(endpointPrefix + "console", "console", "https"),
+                new AddressSpaceEndpoint(endpointPrefix + "mqtt", "mqtt", "secure-mqtt")));
         createAddressSpace(addressSpace);
 
         KeycloakCredentials luckyUser = new KeycloakCredentials("Lucky", "luckyPswd");

--- a/templates/include/address-space-definitions.yaml
+++ b/templates/include/address-space-definitions.yaml
@@ -20,7 +20,6 @@ data:
           addressSpace: ${ADDRESS_SPACE}
           enmasse.io/service-port.amqp: 5672
           enmasse.io/service-port.amqps: 5671
-          io.enmasse.endpointPort: amqps
           service.alpha.openshift.io/dependencies: '[{"kind": "Service", "name": "queue-scheduler",
             "namespace": ""}, {"kind": "Service", "name": "configuration", "namespace":
             ""}, {"kind": "Service", "name": "ragent", "namespace": ""}, {"kind": "Service",
@@ -370,7 +369,6 @@ data:
       metadata:
         annotations:
           addressSpace: ${ADDRESS_SPACE}
-          io.enmasse.endpointPort: https
         labels:
           app: enmasse
         name: console
@@ -918,7 +916,6 @@ data:
           addressSpace: ${ADDRESS_SPACE}
           enmasse.io/service-port.amqp: 5672
           enmasse.io/service-port.amqps: 5671
-          io.enmasse.endpointPort: amqps
           service.alpha.openshift.io/dependencies: '[{"kind": "Service", "name": "queue-scheduler",
             "namespace": ""}, {"kind": "Service", "name": "configuration", "namespace":
             ""}, {"kind": "Service", "name": "ragent", "namespace": ""}, {"kind": "Service",
@@ -1284,7 +1281,6 @@ data:
       metadata:
         annotations:
           addressSpace: ${ADDRESS_SPACE}
-          io.enmasse.endpointPort: https
         labels:
           app: enmasse
         name: console
@@ -1813,7 +1809,6 @@ data:
           addressSpace: ${ADDRESS_SPACE}
           enmasse.io/service-port.mqtt: 1883
           enmasse.io/service-port.mqtts: 8883
-          io.enmasse.endpointPort: secure-mqtt
         labels:
           app: enmasse
         name: mqtt
@@ -2141,7 +2136,6 @@ data:
       metadata:
         annotations:
           addressSpace: ${ADDRESS_SPACE}
-          io.enmasse.endpointPort: amqps
         labels:
           app: enmasse
         name: messaging
@@ -2255,7 +2249,6 @@ data:
       metadata:
         annotations:
           addressSpace: ${ADDRESS_SPACE}
-          io.enmasse.endpointPort: https
         labels:
           app: enmasse
         name: console

--- a/templates/install/resources/address-space-controller/address-space-definitions.yaml
+++ b/templates/install/resources/address-space-controller/address-space-definitions.yaml
@@ -20,7 +20,6 @@ data:
           addressSpace: ${ADDRESS_SPACE}
           enmasse.io/service-port.amqp: 5672
           enmasse.io/service-port.amqps: 5671
-          io.enmasse.endpointPort: amqps
           service.alpha.openshift.io/dependencies: '[{"kind": "Service", "name": "queue-scheduler",
             "namespace": ""}, {"kind": "Service", "name": "configuration", "namespace":
             ""}, {"kind": "Service", "name": "ragent", "namespace": ""}, {"kind": "Service",
@@ -370,7 +369,6 @@ data:
       metadata:
         annotations:
           addressSpace: ${ADDRESS_SPACE}
-          io.enmasse.endpointPort: https
         labels:
           app: enmasse
         name: console
@@ -918,7 +916,6 @@ data:
           addressSpace: ${ADDRESS_SPACE}
           enmasse.io/service-port.amqp: 5672
           enmasse.io/service-port.amqps: 5671
-          io.enmasse.endpointPort: amqps
           service.alpha.openshift.io/dependencies: '[{"kind": "Service", "name": "queue-scheduler",
             "namespace": ""}, {"kind": "Service", "name": "configuration", "namespace":
             ""}, {"kind": "Service", "name": "ragent", "namespace": ""}, {"kind": "Service",
@@ -1284,7 +1281,6 @@ data:
       metadata:
         annotations:
           addressSpace: ${ADDRESS_SPACE}
-          io.enmasse.endpointPort: https
         labels:
           app: enmasse
         name: console
@@ -1813,7 +1809,6 @@ data:
           addressSpace: ${ADDRESS_SPACE}
           enmasse.io/service-port.mqtt: 1883
           enmasse.io/service-port.mqtts: 8883
-          io.enmasse.endpointPort: secure-mqtt
         labels:
           app: enmasse
         name: mqtt
@@ -2141,7 +2136,6 @@ data:
       metadata:
         annotations:
           addressSpace: ${ADDRESS_SPACE}
-          io.enmasse.endpointPort: amqps
         labels:
           app: enmasse
         name: messaging
@@ -2255,7 +2249,6 @@ data:
       metadata:
         annotations:
           addressSpace: ${ADDRESS_SPACE}
-          io.enmasse.endpointPort: https
         labels:
           app: enmasse
         name: console


### PR DESCRIPTION
* This completes the goal of making spec contain declarative state from
user (and any defaults set by server) and status containing mutable
state changed by server
* Allows creating multiple endpoints pointing to different ports on the
same service

Fixes #1091