### PR TITLE
Add extra validation for POST/PUT api-server requests

### DIFF
--- a/api-common/src/main/java/io/enmasse/api/common/UnprocessableEntityException.java
+++ b/api-common/src/main/java/io/enmasse/api/common/UnprocessableEntityException.java
@@ -11,6 +11,10 @@ public class UnprocessableEntityException extends ClientErrorException {
 
     public static final int STATUS = 422;
 
+    public UnprocessableEntityException(String message) {
+        super(message, STATUS);
+    }
+    
     public UnprocessableEntityException(String message, Response response) {
         super(message, response);
     }

--- a/api-server/src/main/java/io/enmasse/api/v1/http/HttpNestedAddressService.java
+++ b/api-server/src/main/java/io/enmasse/api/v1/http/HttpNestedAddressService.java
@@ -49,8 +49,8 @@ public class HttpNestedAddressService extends HttpAddressServiceBase {
     @Produces({MediaType.APPLICATION_JSON})
     @Consumes({MediaType.APPLICATION_JSON})
     @Path("{addressName}")
-    public Response replaceAddresses(@Context SecurityContext securityContext, @PathParam("namespace") String namespace, @PathParam("addressSpace") String addressSpace, @NotNull Address address) throws Exception {
-        return super.replaceAddresses(securityContext, namespace, addressSpace, address);
+    public Response replaceAddress(@Context SecurityContext securityContext, @PathParam("namespace") String namespace, @PathParam("addressSpace") String addressSpace, @PathParam("addressName") String addressName, @NotNull Address payload) throws Exception {
+        return super.replaceAddress(securityContext, namespace, addressSpace, addressName, payload);
     }
 
     @DELETE

--- a/api-server/src/test/java/io/enmasse/api/v1/http/HttpAddressSpaceServiceTest.java
+++ b/api-server/src/test/java/io/enmasse/api/v1/http/HttpAddressSpaceServiceTest.java
@@ -19,7 +19,9 @@ import javax.ws.rs.core.SecurityContext;
 import java.util.Arrays;
 import java.util.concurrent.Callable;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
@@ -133,6 +135,23 @@ public class HttpAddressSpaceServiceTest {
         assertThat(response.getStatus(), is(500));
     }
 
+    @Test
+    public void testPut() {
+        addressSpaceApi.createAddressSpace(a1);
+        AddressSpace a1Adapted = new AddressSpace.Builder(a1).setNamespace("ns").build();
+        assertThat(a1Adapted, not(equalTo(a1)));
+        Response response = invoke(() -> addressSpaceService.replaceAddressSpace(securityContext, null, a1Adapted.getName(), a1Adapted));
+        assertThat(response.getStatus(), is(200));
+
+        assertThat(addressSpaceApi.listAddressSpaces(null), hasItem(a1Adapted));
+    }
+
+    @Test
+    public void testPutNonMatchingAddressSpaceName() {
+        Response response = invoke(() -> addressSpaceService.replaceAddressSpace(securityContext, null, "xxxxxx", a1));
+        assertThat(response.getStatus(), is(400));
+    }
+    
     @Test
     public void testDelete() {
         addressSpaceApi.createAddressSpace(a1);

--- a/api-server/src/test/java/io/enmasse/api/v1/http/HttpNestedAddressServiceTest.java
+++ b/api-server/src/test/java/io/enmasse/api/v1/http/HttpNestedAddressServiceTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
+import java.util.Set;
 import java.util.concurrent.Callable;
 
 import static org.hamcrest.CoreMatchers.hasItem;
@@ -162,6 +163,33 @@ public class HttpNestedAddressServiceTest {
                 .build();
         Response response = invoke(() -> addressService.createAddress(securityContext, null, "ns", "myspace", Either.createLeft(a2)));
         assertThat(response.getStatus(), is(500));
+    }
+
+    @Test
+    public void testPut() {
+        Set<Address> addresses = addressApi.listAddresses("ns");
+        assertThat(addresses.isEmpty(), is(false));
+        Address address = addresses.iterator().next();
+        Address a1 = new Address.Builder(address).setPlan("plan1").build();
+        
+        Response response = invoke(() -> addressService.replaceAddress(securityContext, "ns", "myspace", a1.getName(), a1));
+        assertThat(response.getStatus(), is(200));
+
+        Address a2ns = new Address.Builder(a1).setNamespace("ns").build();
+        assertThat(addressApi.listAddresses("ns"), hasItem(a2ns));
+    }
+
+    @Test
+    public void testPutNonMatchingAddressName() {
+        Address a2 = new Address.Builder()
+                .setName("a2")
+                .setAddress("a2")
+                .setType("anycast")
+                .setPlan("plan1")
+                .setAddressSpace("myspace")
+                .build();
+        Response response = invoke(() -> addressService.replaceAddress(securityContext, "ns", "myspace", "xxxxxxx", a2));
+        assertThat(response.getStatus(), is(400));
     }
 
     @Test

--- a/k8s-api/src/main/java/io/enmasse/k8s/api/ConfigMapAddressApi.java
+++ b/k8s-api/src/main/java/io/enmasse/k8s/api/ConfigMapAddressApi.java
@@ -124,6 +124,7 @@ public class ConfigMapAddressApi implements AddressApi, ListerWatcher<ConfigMap,
         String name = getConfigMapName(address.getName());
         ConfigMap previous = client.configMaps().inNamespace(namespace).withName(name).get();
         if (previous == null) {
+            log.warn("Cannot replace address {}: No previous configMap found", address.getName());
             return;
         }
         ConfigMap newMap = create(address);


### PR DESCRIPTION
Validates given object name (of address/addressSpace) and corresponding URL part for POST/PUT requests on the "addresses" and "addressspaces" endpoints.

Changed resources:
`/apis/enmasse.io/v1alpha1/namespaces/{namespace}/addresses`
POST: added check that address.getName is set - prevents NPE
PUT /{addressName}: added check that address.getName is set - prevents NPE
PUT /{addressName}: added check that address.getName matches {addressName}

`/apis/enmasse.io/v1alpha1/namespaces/{namespace}/addressspaces`
PUT {addressSpace}: added checks for existence of addressSpace.getName, matching of addressSpace.getName with {addressSpace}.

`/apis/enmasse.io/v1alpha1/namespaces/{namespace}/addressspaces/{addressSpace}/addresses`
PUT {addressName}: added checks for existence of address.getName, matching of address.getName with {addressName}.

Returned exceptions correspond to the ones returned by the K8s API server.