### PR TITLE
Make broker memory settings configurable in brokered address space

### DIFF
--- a/artemis/config_templates/brokered/broker.xml
+++ b/artemis/config_templates/brokered/broker.xml
@@ -48,9 +48,8 @@ under the License.
       <journal-pool-files>-1</journal-pool-files>
 
       <journal-file-size>10M</journal-file-size>
-      
-      <journal-buffer-timeout>2212000</journal-buffer-timeout>
 
+      <journal-buffer-timeout>2212000</journal-buffer-timeout>
 
       <!-- how often we are looking for how many bytes are being used on the disk in ms -->
       <disk-scan-period>5000</disk-scan-period>
@@ -67,6 +66,8 @@ under the License.
       <critical-analyzer-check-period>60000</critical-analyzer-check-period>
 
       <critical-analyzer-policy>HALT</critical-analyzer-policy>
+
+      <global-max-size>${GLOBAL_MAX_SIZE}</global-max-size>
 
       <acceptors>
          <acceptor name="amqp">tcp://0.0.0.0:5672?protocols=AMQP,CORE,OPENWIRE,MQTT;saslMechanisms=PLAIN</acceptor>
@@ -89,7 +90,7 @@ under the License.
             <dead-letter-address>DLQ</dead-letter-address>
             <redelivery-delay>0</redelivery-delay>
             <!-- with -1 only the global-max-size is in use for limiting -->
-            <max-size-bytes>52428800</max-size-bytes>
+            <max-size-bytes>-1</max-size-bytes>
             <message-counter-history-day-limit>10</message-counter-history-day-limit>
             <address-full-policy>FAIL</address-full-policy>
          </address-setting>

--- a/templates/include/address-space-definitions.yaml
+++ b/templates/include/address-space-definitions.yaml
@@ -2070,6 +2070,8 @@ data:
                 value: brokered
               - name: CERT_DIR
                 value: /etc/enmasse-certs
+              - name: GLOBAL_MAX_SIZE
+                value: ${GLOBAL_MAX_SIZE}
               - name: AUTHENTICATION_SERVICE_HOST
                 value: ${AUTHENTICATION_SERVICE_HOST}
               - name: AUTHENTICATION_SERVICE_PORT
@@ -2107,6 +2109,11 @@ data:
                   - -c
                   - $ARTEMIS_HOME/bin/probe.sh
                 initialDelaySeconds: 10
+              resources:
+                limits:
+                  memory: ${BROKER_MEMORY_LIMIT}
+                requests:
+                  memory: ${BROKER_MEMORY_LIMIT}
               volumeMounts:
               - mountPath: /var/run/artemis
                 name: data
@@ -2317,3 +2324,10 @@ data:
     - description: The service account with address space admin privileges
       name: ADDRESS_SPACE_ADMIN_SA
       value: address-space-admin
+    - description: Memory limits for container
+      name: BROKER_MEMORY_LIMIT
+      value: 512Mi
+    - description: Global max size for all addresses in broker. Cannot be larger than
+        a quarter of BROKER_MEMORY_LIMIT
+      name: GLOBAL_MAX_SIZE
+      value: 128Mb

--- a/templates/install/resources/address-space-controller/address-space-definitions.yaml
+++ b/templates/install/resources/address-space-controller/address-space-definitions.yaml
@@ -2070,6 +2070,8 @@ data:
                 value: brokered
               - name: CERT_DIR
                 value: /etc/enmasse-certs
+              - name: GLOBAL_MAX_SIZE
+                value: ${GLOBAL_MAX_SIZE}
               - name: AUTHENTICATION_SERVICE_HOST
                 value: ${AUTHENTICATION_SERVICE_HOST}
               - name: AUTHENTICATION_SERVICE_PORT
@@ -2107,6 +2109,11 @@ data:
                   - -c
                   - $ARTEMIS_HOME/bin/probe.sh
                 initialDelaySeconds: 10
+              resources:
+                limits:
+                  memory: ${BROKER_MEMORY_LIMIT}
+                requests:
+                  memory: ${BROKER_MEMORY_LIMIT}
               volumeMounts:
               - mountPath: /var/run/artemis
                 name: data
@@ -2317,3 +2324,10 @@ data:
     - description: The service account with address space admin privileges
       name: ADDRESS_SPACE_ADMIN_SA
       value: address-space-admin
+    - description: Memory limits for container
+      name: BROKER_MEMORY_LIMIT
+      value: 512Mi
+    - description: Global max size for all addresses in broker. Cannot be larger than
+        a quarter of BROKER_MEMORY_LIMIT
+      name: GLOBAL_MAX_SIZE
+      value: 128Mb


### PR DESCRIPTION
This adopts the usage of the broker related BROKER_MEMORY_LIMIT and GLOBAL_MAX_SIZE settings to the brokered address space.