### PR TITLE
Enable fixed cli-rhea test and testRouterScale

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/TestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/TestBase.java
@@ -620,7 +620,7 @@ public abstract class TestBase implements ITestBase, ITestSeparator {
 
     protected void waitForRouterReplicas(AddressSpace addressSpace, int expectedReplicas) throws
             InterruptedException {
-        TimeoutBudget budget = new TimeoutBudget(1, TimeUnit.MINUTES);
+        TimeoutBudget budget = new TimeoutBudget(3, TimeUnit.MINUTES);
         TestUtils.waitForNReplicas(kubernetes, addressSpace.getNamespace(), expectedReplicas, Collections.singletonMap("name", "qdrouterd"), budget);
     }
 
@@ -628,7 +628,7 @@ public abstract class TestBase implements ITestBase, ITestSeparator {
         log.info("Set '{}' replicas and wait for autoscale to '{}'", setValue, expectedValue);
         CompletableFuture<Void> scaleCheckerDown = CompletableFuture.runAsync(() -> {
             try {
-                waitForBrokerReplicas(addressSpace, dest, setValue, false, new TimeoutBudget(2, TimeUnit.MINUTES), 1);
+                waitForBrokerReplicas(addressSpace, dest, setValue, false, new TimeoutBudget(3, TimeUnit.MINUTES), 1);
                 log.info("Waiting for expected replicas {} finished!", setValue);
             } catch (InterruptedException e) {
                 e.printStackTrace();

--- a/systemtests/src/test/java/io/enmasse/systemtest/standard/AnycastTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/standard/AnycastTest.java
@@ -66,7 +66,6 @@ public class AnycastTest extends TestBaseWithShared implements ITestBaseStandard
     }
 
     @Test
-    @Disabled("due to failure, debugging is in separated branch")
     void testScaleRouterAutomatically() throws Exception {
         //deploy addresses
         ArrayList<Destination> dest = new ArrayList<>();

--- a/systemtests/src/test/java/io/enmasse/systemtest/standard/clients/rhea/MsgPatternsTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/standard/clients/rhea/MsgPatternsTest.java
@@ -28,7 +28,6 @@ class MsgPatternsTest extends ClientTestBase implements ITestBaseStandard {
     }
 
     @Test
-    @Disabled("Due to issue with rhea, will be fixed in cli-rhea")
     void testRoundRobinReceiver(ArtemisManagement artemisManagement) throws Exception {
         doRoundRobinReceiverTest(artemisManagement, new RheaClientSender(logPath), new RheaClientReceiver(logPath), new RheaClientReceiver(logPath));
     }


### PR DESCRIPTION
@lulf this issue was fixed in cli-rhea and published in 2.1.4, so I have enabled test and it passed.