### PR TITLE
Add label to roles to auto-add them to edit and view roles

### DIFF
--- a/templates/include/cluster-roles/tenant-edit.yaml
+++ b/templates/include/cluster-roles/tenant-edit.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ClusterRole
+metadata:
+  name: enmasse.io:tenant-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+  - apiGroups: [ "enmasse.io" ]
+    resources: [ "addresses", "addressspaces" ]
+    verbs: [ "create", "get", "update", "delete", "list", "watch", "patch" ]

--- a/templates/include/cluster-roles/tenant-view.yaml
+++ b/templates/include/cluster-roles/tenant-view.yaml
@@ -1,8 +1,10 @@
 apiVersion: v1
 kind: ClusterRole
 metadata:
-  name: enmasse.io:tenant
+  name: enmasse.io:tenant-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
   - apiGroups: [ "enmasse.io" ]
     resources: [ "addresses", "addressspaces" ]
-    verbs: [ "create", "get", "update", "delete", "list", "watch", "patch" ]
+    verbs: [ "get", "list" ]


### PR DESCRIPTION
This should allow users having the 'edit' and 'admin' roles inside a project to be able to create address spaces when this role is granted to a group like system:authenticated.