### PR TITLE
Add /openapi/v2 handler for api server

### DIFF
--- a/api-server/src/main/java/io/enmasse/api/server/HTTPServer.java
+++ b/api-server/src/main/java/io/enmasse/api/server/HTTPServer.java
@@ -11,14 +11,7 @@ import io.enmasse.api.auth.AuthInterceptor;
 import io.enmasse.api.common.DefaultExceptionMapper;
 import io.enmasse.api.common.JacksonConfig;
 import io.enmasse.api.common.SchemaProvider;
-import io.enmasse.api.v1.http.HttpAddressService;
-import io.enmasse.api.v1.http.HttpAddressSpaceService;
-import io.enmasse.api.v1.http.HttpApiRootService;
-import io.enmasse.api.v1.http.HttpHealthService;
-import io.enmasse.api.v1.http.HttpNestedAddressService;
-import io.enmasse.api.v1.http.HttpRootService;
-import io.enmasse.api.v1.http.HttpSchemaService;
-import io.enmasse.api.v1.http.SwaggerSpecEndpoint;
+import io.enmasse.api.v1.http.*;
 import io.enmasse.k8s.api.AddressSpaceApi;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.CompositeFuture;
@@ -85,6 +78,7 @@ public class HTTPServer extends AbstractVerticle {
         }
 
         deployment.getRegistry().addSingletonResource(new SwaggerSpecEndpoint());
+        deployment.getRegistry().addSingletonResource(new HttpOpenApiService());
         deployment.getRegistry().addSingletonResource(new HttpNestedAddressService(addressSpaceApi, schemaProvider));
         deployment.getRegistry().addSingletonResource(new HttpAddressService(addressSpaceApi, schemaProvider));
         deployment.getRegistry().addSingletonResource(new HttpSchemaService(schemaProvider));

--- a/api-server/src/main/java/io/enmasse/api/v1/http/HttpOpenApiService.java
+++ b/api-server/src/main/java/io/enmasse/api/v1/http/HttpOpenApiService.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.api.v1.http;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.io.InputStream;
+
+@Path("/openapi/v2")
+public class HttpOpenApiService {
+
+    @GET
+    @Produces({MediaType.APPLICATION_JSON})
+    public InputStream getOpenApiSpec() {
+        return getClass().getResourceAsStream("/swagger.json");
+    }
+}


### PR DESCRIPTION
This prevents an error in the log for the API server when registered
with the kubernetes master on version 1.10 an newer.