### PR TITLE
    Fix to default variable setting in ocenv.sh (missing colons)

### DIFF
--- a/systemtests/scripts/ocenv.sh
+++ b/systemtests/scripts/ocenv.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 HOST=${1:-localhost}
-NAMESPACE=${2-myproject}
-USER=${3-developer}
+NAMESPACE=${2:-myproject}
+USER=${3:-developer}
 
 export OPENSHIFT_USER=$USER
 export OPENSHIFT_USE_TLS=true


### PR DESCRIPTION
minor fix for ocenv.sh variable setting 