### PR TITLE
Enable Jolokia Agent (#349)

### DIFF
--- a/artemis/Makefile
+++ b/artemis/Makefile
@@ -30,6 +30,10 @@ build_tar:
 	mkdir -p $(ARTIFACT_BASE)/jmx_exporter
 	cp -f jmx_exporter/target/lib/jmx_prometheus_javaagent-0.1.0.jar $(ARTIFACT_BASE)/jmx_exporter/
 
+	mkdir -p $(ARTIFACT_BASE)/jolokia-agent
+	cp -f jolokia-agent/target/lib/jolokia-jvm-*-agent.jar $(ARTIFACT_BASE)/jolokia-agent/agent.jar
+	cp -f jolokia-agent/target/classes/jolokia.properties $(ARTIFACT_BASE)/jolokia-agent/
+
 	tar -czf build/artemis-image-$(VERSION).tar.gz -C build/artemis-image .
 
 package: build_tar build/apache-artemis-bin.tar.gz

--- a/artemis/jolokia-agent/pom.xml
+++ b/artemis/jolokia-agent/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <parent>
+    <groupId>io.enmasse</groupId>
+    <artifactId>artemis</artifactId>
+    <version>0.21-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>jolokia-agent</artifactId>
+  <dependencies>
+    <dependency>
+      <groupId>org.jolokia</groupId>
+      <artifactId>jolokia-jvm</artifactId>
+      <version>${jolokia.version}</version>
+      <classifier>agent</classifier>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/artemis/jolokia-agent/src/main/resources/jolokia.properties
+++ b/artemis/jolokia-agent/src/main/resources/jolokia.properties
@@ -1,0 +1,8 @@
+host=*
+port=7070
+discoveryEnabled=false
+useSslClientAuthentication=true
+extraClientCheck=true
+protocol=https
+caCert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+clientPrincipal=cn=system:master-proxy

--- a/artemis/pom.xml
+++ b/artemis/pom.xml
@@ -14,5 +14,6 @@
      <module>sasl-delegation</module>
      <module>shutdown-hook</module>
      <module>jmx_exporter</module>
+     <module>jolokia-agent</module>
   </modules>
 </project>

--- a/artemis/utils/run-java/java-default-options
+++ b/artemis/utils/run-java/java-default-options
@@ -130,7 +130,11 @@ error_handling() {
   echo "-XX:+ExitOnOutOfMemoryError"
 }
 
+jolokia_agent() {
+  test -r /jolokia-agent/jolokia.properties && echo "-javaagent:/jolokia-agent/agent.jar=config=/jolokia-agent/jolokia.properties"
+}
+
 initialize_container_limits > /dev/null
 
 ## Echo options, trimming trailing and multiple spaces
-echo "$(initial_memory) $(max_memory) $(gc_config) $(diagnostics) $(cpu_core_tunning) $(error_handling)" | awk '$1=$1'
+echo "$(initial_memory) $(max_memory) $(gc_config) $(diagnostics) $(cpu_core_tunning) $(error_handling) $(jolokia_agent)" | awk '$1=$1'

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
         <vertx.version>3.5.1</vertx.version>
         <slf4j.version>1.7.21</slf4j.version>
         <jackson.version>2.9.2</jackson.version>
+        <jolokia.version>1.3.7</jolokia.version>
         <resteasy.version>3.1.0.Final</resteasy.version>
         <mockito.version>2.0.52-beta</mockito.version>
         <hamcrest.version>1.3</hamcrest.version>


### PR DESCRIPTION
This enables the Jolokia agent by properly deploying to an address
that the OpenShift embedded hawt.io web console understands.