### PR TITLE
Allow the name that is displayed in the console, to be set/overridden during the build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ SKIP_TESTS      ?= false
 ifeq ($(SKIP_TESTS),true)
 	MAVEN_ARGS="-DskipTests"
 endif
+ifneq ($(strip $(PROJECT_DISPLAY_NAME)),)
+	MAVEN_ARGS+="-Dapplication.display.name=$(PROJECT_DISPLAY_NAME)"
+endif
+
 
 all: init build_java docker_build
 

--- a/Makefile.java.mk
+++ b/Makefile.java.mk
@@ -3,6 +3,9 @@ include $(TOPDIR)/Makefile.common
 ifeq ($(SKIP_TESTS),true)
 MAVEN_ARGS="-DskipTests"
 endif
+ifneq ($(strip $(PROJECT_DISPLAY_NAME)),)
+	MAVEN_ARGS+="-Dapplication.display.name=$(PROJECT_DISPLAY_NAME)"
+endif
 
 ifneq ($(FULL_BUILD),true)
 build:

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -9,7 +9,28 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.enmasse</groupId>
   <artifactId>agent</artifactId>
+  <properties>
+    <application.display.name>EnMasse</application.display.name>
+  </properties>
   <build>
+    <resources>
+      <resource>
+        <directory>www</directory>
+        <targetPath>${project.basedir}/target/www</targetPath>
+        <excludes>
+          <exclude>index.html</exclude>
+        </excludes>
+        <filtering>false</filtering>
+      </resource>
+      <resource>
+        <directory>www</directory>
+        <targetPath>${project.basedir}/target/www</targetPath>
+        <includes>
+          <include>index.html</include>
+        </includes>
+        <filtering>true</filtering>
+      </resource>
+    </resources>  
     <plugins>
       <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/agent/src/assembly/unix-dist.xml
+++ b/agent/src/assembly/unix-dist.xml
@@ -51,7 +51,7 @@
            <fileMode>0644</fileMode>
         </fileSet>
         <fileSet>
-           <directory>${project.basedir}/www</directory>
+           <directory>${project.basedir}/target/www</directory>
            <outputDirectory>www</outputDirectory>
            <includes>
               <include>**</include>

--- a/agent/www/index.html
+++ b/agent/www/index.html
@@ -51,7 +51,7 @@
   </head>
   <body>
   <div id="verticalNavLayout" class="layout-pf layout-pf-fixed faux-layout" ng-controller="NavCtrl">
-    <div pf-vertical-navigation items="navigationItems" brand-alt="EnMasse"
+    <div pf-vertical-navigation items="navigationItems" brand-alt="${application.display.name}"
           pinnable-menus="true" update-active-items-on-click="true"
           navigate-callback="handleNavigateClick">
       <div>


### PR DESCRIPTION
- Can set the name that appears in the console using -Dapplication.display.name for maven or by setting the env_variable PROJECT_DISPLAY_NAME for make.
- Defaults to EnMasse

Signed-off-by: Vanessa <vbusch@localhost.localdomain>