### PR TITLE
Add log4j.properties for api server

### DIFF
--- a/api-server/Dockerfile
+++ b/api-server/Dockerfile
@@ -3,6 +3,5 @@ FROM enmasseproject/java-base:8-7
 ARG version=latest
 ENV VERSION ${version}
 ADD target/api-server-${VERSION}.jar /api-server.jar
-ENV JAVA_OPTS "-DLOG_LEVEL=info"
 
 CMD ["/opt/run-java/launch_java.sh", "/api-server.jar"]

--- a/api-server/src/main/resources/log4j.properties
+++ b/api-server/src/main/resources/log4j.properties
@@ -1,0 +1,5 @@
+log4j.rootLogger=${LOG_LEVEL},stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n

--- a/service-broker/Dockerfile
+++ b/service-broker/Dockerfile
@@ -3,6 +3,5 @@ FROM enmasseproject/java-base:8-7
 ARG version=latest
 ENV VERSION ${version}
 ADD target/service-broker-${VERSION}.jar /service-broker.jar
-ENV JAVA_OPTS "-DLOG_LEVEL=info"
 
 CMD ["/opt/run-java/launch_java.sh", "/service-broker.jar"]


### PR DESCRIPTION
Allow enabling of debug logging for API server by adding corresponding log4j.properties and remove superfluous LOG_LEVEL setting from Dockerfiles.