### PR TITLE
Remove duplicate dependency on org.junit.platform:junit-platform-laun…

### DIFF
--- a/systemtests/pom.xml
+++ b/systemtests/pom.xml
@@ -123,11 +123,6 @@
                         <artifactId>junit-platform-surefire-provider</artifactId>
                         <version>${junit.platform.version}</version>
                     </dependency>
-                    <dependency>
-                        <groupId>org.junit.jupiter</groupId>
-                        <artifactId>junit-jupiter-engine</artifactId>
-                        <version>${junit.jupiter.version}</version>
-                    </dependency>
                 </dependencies>
             </plugin>
         </plugins>


### PR DESCRIPTION
…cher:jar within systemtests which was causing a build-time error message.