### PR TITLE
Ensure that client connects on each metric collection

### DIFF
--- a/router-metrics/Dockerfile
+++ b/router-metrics/Dockerfile
@@ -5,4 +5,4 @@ ENV VERSION=${version}
 ADD build/router-metrics-${VERSION}.tgz /
 
 EXPOSE 8080
-CMD ["python", "/router-metrics.py"]
+CMD ["python", "-u", "/router-metrics.py"]

--- a/router-metrics/router-metrics.py
+++ b/router-metrics/router-metrics.py
@@ -196,6 +196,7 @@ class RouterCollector(object):
         collector_map = self.create_collector_map()
         fetcher_map = self.create_entity_map(collector_map)
         connection = None
+        print("Collecting metrics")
 
         try:
             connection = BlockingConnection("amqps://" + self.router_host + ":" + str(self.router_port), 30, None, self.ssl_domain, allowed_mechs=self.allowed_mechs, sasl_enabled=self.sasl_enabled, container_id="router-metrics")


### PR DESCRIPTION
This ensures that even if router connection is broken, it will reconnect on next attempt. It is assumed that the cost of creating a new connection for each query is not significant since the collection does not happen frequently.

Fixes #1488