### PR TITLE
MQTT- fix flawed cache expiry logic

### DIFF
--- a/mqtt-gateway/pom.xml
+++ b/mqtt-gateway/pom.xml
@@ -7,9 +7,6 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mqtt-gateway</artifactId>
-  <properties>
-    <google.guava.version>22.0</google.guava.version>
-  </properties>
   <dependencies>
     <dependency>
       <groupId>io.vertx</groupId>
@@ -85,11 +82,6 @@
       <groupId>org.eclipse.paho</groupId>
       <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${google.guava.version}</version>
     </dependency>
   </dependencies>
   <dependencyManagement>


### PR DESCRIPTION
My initial attempt to keep the size of the clientIdSemaphores cache was flawed.  This PR corrects the problem.  It also removes the need for Guava that my previous commit had added.  It also fixes the path through the code when attempt to open a bridge fails. Previously this would have resulted in a client-id becoming locked forever.