### PR TITLE
Fail on any error in the script

### DIFF
--- a/templates/install/deploy.sh
+++ b/templates/install/deploy.sh
@@ -14,6 +14,9 @@
 # Further it will use the user `developer` and project `enmasse`, asking
 # for a login when appropriate.
 # for further parameters please see the help text.
+
+set -e
+
 SCRIPTDIR=`dirname $0`
 source $SCRIPTDIR/common.sh
 TEMPDIR=`tempdir`


### PR DESCRIPTION
This change will let the deploy script fail in case of any command returning a non-zero result.

For example I did run into an issue with `openssl` not properly creating a key/cert. However the script continued to run, spitting out occasional errors about missing files. The initial error of openssl failing was hard to spot.

With `set -e` the script would abort when the `openssl` call failed, leaving this the last message on the console and not create further resources.