### PR TITLE
Add the ability for Maven build time properties to be centralised in …

### DIFF
--- a/.mvn/PURPOSE
+++ b/.mvn/PURPOSE
@@ -1,0 +1,1 @@
+The .mvn directory allows Maven to find the root of a multi-module Maven project. Exposed to the POM as maven.multiModuleProjectDirectory.

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -9,9 +9,6 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.enmasse</groupId>
   <artifactId>agent</artifactId>
-  <properties>
-    <application.display.name>EnMasse</application.display.name>
-  </properties>
   <build>
     <resources>
       <resource>

--- a/pom.properties
+++ b/pom.properties
@@ -1,0 +1,1 @@
+application.display.name=EnMasse

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
         <license-maven-plugin.version>2.11</license-maven-plugin.version>
         <frontend-maven-plugin.version>1.6</frontend-maven-plugin.version>
+        <properties-maven-plugin.version>1.0.0</properties-maven-plugin.version>
         <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
         <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
         <maven-shade-plugin.version>3.1.0</maven-shade-plugin.version>
@@ -534,6 +535,11 @@
                     <artifactId>maven-project-info-reports-plugin</artifactId>
                     <version>${maven-project-info-reports-plugin.version}</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>properties-maven-plugin</artifactId>
+                    <version>${properties-maven-plugin.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -620,6 +626,23 @@
                     <excludes>
                     </excludes>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>properties-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>read-project-properties</goal>
+                        </goals>
+                        <configuration>
+                            <files>
+                                <file>${maven.multiModuleProjectDirectory}/pom.properties</file>
+                            </files>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
…a pom.properties file.

Provides a single convenient single location which can be customised for downstream offerings.