### PR TITLE
Changes to console tests by sdavey based on failing results in CI

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/web/WebConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/web/WebConsoleTest.java
@@ -677,7 +677,7 @@ public abstract class WebConsoleTest extends TestBaseWithShared implements ISele
                 log.info("Creating topic for subscription");
                 consoleWebPage.createAddressWebConsole(dest_topic);
             }
-            for (char special_char : "$#*".toCharArray()) { //   <!@>&% not needed to be tested   . waiting for #1588
+            for (char special_char : "$*".toCharArray()) { //   <!@>&% not needed to be tested   .# waiting for #1588
                 switch (type) {
                     case SUBSCRIPTION:
                         destStart = Destination.subscription(

--- a/systemtests/src/test/java/io/enmasse/systemtest/standard/web/FirefoxWebConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/standard/web/FirefoxWebConsoleTest.java
@@ -163,7 +163,7 @@ public class FirefoxWebConsoleTest extends WebConsoleTest implements ITestBaseSt
     }
 
     @Test
-        //@Disabled("disabled due to #1547")
+    @Disabled("disabled due to #1601")
     void testAddressNameWithHyphens() throws Exception {
         doTestWithStrangeAddressNames(true, false,
                 AddressType.QUEUE, AddressType.ANYCAST, AddressType.MULTICAST, AddressType.TOPIC, AddressType.SUBSCRIPTION
@@ -171,7 +171,6 @@ public class FirefoxWebConsoleTest extends WebConsoleTest implements ITestBaseSt
     }
 
     @Test
-        //@Disabled("disabled due to #1547")
     void testVerylongAddressName() throws Exception {
         doTestWithStrangeAddressNames(false, true,
                 AddressType.QUEUE, AddressType.ANYCAST, AddressType.MULTICAST, AddressType.TOPIC, AddressType.SUBSCRIPTION
@@ -179,7 +178,7 @@ public class FirefoxWebConsoleTest extends WebConsoleTest implements ITestBaseSt
     }
 
     @Test
-        //@Disabled("disabled due to #1547")
+    @Disabled("disabled due to #1601")
     void testCreateAddressWithSpecialChars() throws Exception {
         doTestCreateAddressWithSpecialChars(
                 AddressType.QUEUE, AddressType.ANYCAST, AddressType.MULTICAST, AddressType.TOPIC, AddressType.SUBSCRIPTION


### PR DESCRIPTION
  * Disabled testAddressNameWithHyphens and testCreateAddressWithSpecialChars due to new issue found when creating addresses in console. #1601 

  * Removed # symbol from testCreateAddressWithSpecialChars until #1588 will be fixed