### PR TITLE
Allow underscores in .spec.username field

### DIFF
--- a/user-api/src/main/java/io/enmasse/user/model/v1/UserSpec.java
+++ b/user-api/src/main/java/io/enmasse/user/model/v1/UserSpec.java
@@ -17,7 +17,7 @@ public class UserSpec {
     private final String username;
     private final UserAuthentication authentication;
     private final List<UserAuthorization> authorization;
-    private final Pattern usernamePattern = Pattern.compile("^[a-z0-9]+([a-z0-9\\-]*[a-z0-9]+|[a-z0-9]*)$");
+    private final Pattern usernamePattern = Pattern.compile("^[a-z0-9]+([a-z0-9_\\-]*[a-z0-9]+|[a-z0-9]*)$");
 
     @JsonCreator
     public UserSpec(@JsonProperty("username") String username,

--- a/user-api/src/test/java/io/enmasse/user/model/v1/UserModelTest.java
+++ b/user-api/src/test/java/io/enmasse/user/model/v1/UserModelTest.java
@@ -144,6 +144,15 @@ public class UserModelTest {
         createAndValidate("myspace.user1", "usEr1", false);
         createAndValidate("myspace.user1", "usEr1", false);
         createAndValidate("myspaceuser1", "user1", false);
+
+        createAndValidate("myspace.user1_", "user1", false);
+        createAndValidate("myspace_.user1", "user1", false);
+        createAndValidate("_myspace.user1", "user1", false);
+        createAndValidate("myspace._user1", "user1", false);
+        createAndValidate("myspace.user1", "user1_", false);
+        createAndValidate("myspace.user_1", "user1", false);
+        createAndValidate("myspace.user1", "user_1", true);
+
         createAndValidate("myspace.user1-", "user1", false);
         createAndValidate("myspace-.user1", "user1", false);
         createAndValidate("-myspace.user1", "user1", false);


### PR DESCRIPTION
@kornys Should probably add a systemtest that sets different values for .metadata.name and .spec.username and uses underscores in .spec.username.