### PR TITLE
Handle case where error can be undefined

### DIFF
--- a/agent/lib/auth_service.js
+++ b/agent/lib/auth_service.js
@@ -46,7 +46,9 @@ function authenticate(credentials, options) {
         var handleFailure = function (context) {
             if (!handled) {
                 handled = true;
-                log.error('Authentication failed! error no: '+ context.error.errno + ' syscall: '+context.error.syscall+ ' address: '+context.error.address+ ' port: '+ context.error.port + ' code: '+ context.error.code);
+                if (context.error !== undefined) {
+                    log.error('Authentication failed! error no: '+ context.error.errno + ' syscall: '+context.error.syscall+ ' address: '+context.error.address+ ' port: '+ context.error.port + ' code: '+ context.error.code);
+                }
                 reject(JSON.stringify(context.connection.get_error()));
             }
         };


### PR DESCRIPTION
For some reason, the agent unit tests started failing locally on master for no apparent reason. This PR fixes the build, but it might not be the correct fix.  I'm wondering what the underlying cause could be. 