### PR TITLE
Always update endpoints at start of controller loop

### DIFF
--- a/address-model-lib/src/main/java/io/enmasse/address/model/KubeUtil.java
+++ b/address-model-lib/src/main/java/io/enmasse/address/model/KubeUtil.java
@@ -53,6 +53,22 @@ public class KubeUtil {
         return "sa-" + addressSpace.getAnnotation(AnnotationKeys.INFRA_UUID);
     }
 
+    public static String getAddressSpaceServiceName(String serviceName, AddressSpace addressSpace) {
+        return serviceName + "-" + addressSpace.getAnnotation(AnnotationKeys.INFRA_UUID);
+    }
+
+    public static String getAddressSpaceServiceHost(String serviceName, String namespace, AddressSpace addressSpace) {
+        return getAddressSpaceServiceName(serviceName, addressSpace) + "." + namespace + ".svc";
+    }
+
+    public static String getExternalCertSecretName(String serviceName, AddressSpace addressSpace) {
+        return "external-certs-" + getAddressSpaceServiceName(serviceName, addressSpace);
+    }
+
+    public static String getAddressSpaceRouteName(String routeName, AddressSpace addressSpace) {
+        return routeName + "-" + addressSpace.getAnnotation(AnnotationKeys.INFRA_UUID);
+    }
+
     public static void validateName(String name) {
         if (name == null) {
             return;

--- a/address-space-controller/src/main/java/io/enmasse/controller/CreateController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/CreateController.java
@@ -89,16 +89,8 @@ public class CreateController implements Controller {
         addressSpaceResolver.validate(addressSpace);
         String uuid = addressSpace.getAnnotation(AnnotationKeys.INFRA_UUID);
 
-        if (kubernetes.hasService(uuid, "messaging")) {
-            return addressSpace;
-        }
-
         List<EndpointSpec> endpoints = validateEndpoints(addressSpaceResolver, addressSpace);
         endpoints = replaceServiceNames(uuid, endpoints);
-        Map<String, String> labels = new HashMap<>();
-        labels.put(LabelKeys.INFRA_UUID, addressSpace.getAnnotation(AnnotationKeys.INFRA_UUID));
-        labels.put(LabelKeys.INFRA_TYPE, addressSpace.getType());
-        kubernetes.createServiceAccount(KubeUtil.getAddressSpaceSaName(addressSpace), labels);
 
         // Ensure the required certs are set
         List<EndpointSpec> newEndpoints = new ArrayList<>();
@@ -122,6 +114,15 @@ public class CreateController implements Controller {
                 .setEndpointList(newEndpoints)
                 .build();
 
+        if (kubernetes.hasService(uuid, "messaging")) {
+            return addressSpace;
+        }
+
+        Map<String, String> labels = new HashMap<>();
+        labels.put(LabelKeys.INFRA_UUID, addressSpace.getAnnotation(AnnotationKeys.INFRA_UUID));
+        labels.put(LabelKeys.INFRA_TYPE, addressSpace.getType());
+
+        kubernetes.createServiceAccount(KubeUtil.getAddressSpaceSaName(addressSpace), labels);
         KubernetesList resourceList = new KubernetesListBuilder()
                 .addAllToItems(infraResourceFactory.createResourceList(addressSpace))
                 .build();

--- a/address-space-controller/src/main/java/io/enmasse/controller/CreateController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/CreateController.java
@@ -66,22 +66,6 @@ public class CreateController implements Controller {
         }
     }
 
-    private List<EndpointSpec> replaceServiceNames(String uuid, List<EndpointSpec> endpoints) {
-        List<EndpointSpec> replacedEndpoints = new ArrayList<>();
-        for (EndpointSpec spec : endpoints) {
-            replacedEndpoints.add(
-                    new EndpointSpec.Builder()
-                    .setName(spec.getName())
-                    .setService(spec.getService() + "-" + uuid)
-                    .setCertSpec(spec.getCertSpec().orElse(null))
-                    .setServicePort(spec.getServicePort())
-                    .setHost(spec.getHost().orElse(null))
-                    .build());
-        }
-        return replacedEndpoints;
-    }
-
-
     @Override
     public AddressSpace handle(AddressSpace addressSpace) throws Exception {
         Schema schema = schemaProvider.getSchema();
@@ -90,7 +74,6 @@ public class CreateController implements Controller {
         String uuid = addressSpace.getAnnotation(AnnotationKeys.INFRA_UUID);
 
         List<EndpointSpec> endpoints = validateEndpoints(addressSpaceResolver, addressSpace);
-        endpoints = replaceServiceNames(uuid, endpoints);
 
         // Ensure the required certs are set
         List<EndpointSpec> newEndpoints = new ArrayList<>();
@@ -104,7 +87,7 @@ public class CreateController implements Controller {
             }
 
             if (certSpec.getSecretName() == null) {
-                certSpec.setSecretName("external-certs-" + endpoint.getService());
+                certSpec.setSecretName(KubeUtil.getExternalCertSecretName(endpoint.getService(), addressSpace));
             }
 
             endpointBuilder.setCertSpec(certSpec);

--- a/address-space-controller/src/main/java/io/enmasse/controller/TemplateInfraResourceFactory.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/TemplateInfraResourceFactory.java
@@ -77,7 +77,7 @@ public class TemplateInfraResourceFactory implements InfraResourceFactory {
             Map<String, CertSpec> serviceCertMapping = new HashMap<>();
             for (EndpointSpec endpoint : addressSpace.getEndpoints()) {
                     endpoint.getCertSpec().ifPresent(cert -> {
-                        serviceCertMapping.put(endpoint.getService().split("-")[0], cert);
+                        serviceCertMapping.put(endpoint.getService(), cert);
                 });
             }
             log.info("Service cert mapping: {}", serviceCertMapping);

--- a/address-space-controller/src/test/java/io/enmasse/controller/EndpointControllerTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/EndpointControllerTest.java
@@ -60,7 +60,7 @@ public class EndpointControllerTest {
 
         Service service = new ServiceBuilder()
                 .editOrNewMetadata()
-                .withName("messaging")
+                .withName("messaging-1234")
                 .addToAnnotations(AnnotationKeys.SERVICE_PORT_PREFIX + "amqps", "5671")
                 .addToLabels(LabelKeys.INFRA_UUID, "1234")
                 .endMetadata()
@@ -82,7 +82,7 @@ public class EndpointControllerTest {
 
         assertThat(newspace.getStatus().getEndpointStatuses().size(), is(1));
         assertThat(newspace.getStatus().getEndpointStatuses().get(0).getName(), is("myendpoint"));
-        assertThat(newspace.getStatus().getEndpointStatuses().get(0).getServiceHost(), is("messaging.myns.svc"));
+        assertThat(newspace.getStatus().getEndpointStatuses().get(0).getServiceHost(), is("messaging-1234.myns.svc"));
         assertThat(newspace.getStatus().getEndpointStatuses().get(0).getServicePorts().size(), is(1));
         assertThat(newspace.getStatus().getEndpointStatuses().get(0).getPort(), is(0));
     }
@@ -105,7 +105,7 @@ public class EndpointControllerTest {
 
         Service service = new ServiceBuilder()
                 .editOrNewMetadata()
-                .withName("messaging")
+                .withName("messaging-1234")
                 .addToAnnotations(AnnotationKeys.SERVICE_PORT_PREFIX + "amqps", "5671")
                 .addToLabels(LabelKeys.INFRA_UUID, "1234")
                 .endMetadata()
@@ -132,7 +132,7 @@ public class EndpointControllerTest {
         when(rexternal.get()).thenReturn(null);
 
         Resource<Service, DoneableService> rinternal = mock(Resource.class);
-        when(op.withName(eq("messaging"))).thenReturn(rinternal);
+        when(op.withName(eq("messaging-1234"))).thenReturn(rinternal);
         when(rinternal.get()).thenReturn(service);
 
         EndpointController controller = new EndpointController(client, true, false);
@@ -141,7 +141,7 @@ public class EndpointControllerTest {
 
         assertThat(newspace.getStatus().getEndpointStatuses().size(), is(1));
         assertThat(newspace.getStatus().getEndpointStatuses().get(0).getName(), is("myendpoint"));
-        assertThat(newspace.getStatus().getEndpointStatuses().get(0).getServiceHost(), is("messaging.myns.svc"));
+        assertThat(newspace.getStatus().getEndpointStatuses().get(0).getServiceHost(), is("messaging-1234.myns.svc"));
         assertThat(newspace.getStatus().getEndpointStatuses().get(0).getServicePorts().size(), is(1));
     }
 }

--- a/systemtests/src/main/java/io/enmasse/systemtest/AddressSpace.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/AddressSpace.java
@@ -111,7 +111,7 @@ public class AddressSpace {
         for (AddressSpaceEndpoint addrSpaceEndpoint : endpoints) {
             log.info("Got endpoint: name: {}, service-name: {}, host: {}, port: {}",
                     addrSpaceEndpoint.getName(), addrSpaceEndpoint.getService(), addrSpaceEndpoint.getHost(), addrSpaceEndpoint.getPort());
-            if (addrSpaceEndpoint.getService().equals(String.format("%s-%s", endpointService, infraUuid))) {
+            if (addrSpaceEndpoint.getService().equals(endpointService)) {
                 if (addrSpaceEndpoint.getHost() == null) {
                     return null;
                 } else {
@@ -119,8 +119,8 @@ public class AddressSpace {
                 }
             }
         }
-        throw new IllegalStateException(String.format("Endpoint with service name '%s-%s' doesn't exist in address space '%s'",
-                endpointService, infraUuid, name));
+        throw new IllegalStateException(String.format("Endpoint with service name '%s' doesn't exist in address space '%s'",
+                endpointService, name));
     }
 
     public List<AddressSpaceEndpoint> getEndpoints() {


### PR DESCRIPTION
This should fix the systemtest failures. The certificates are taking longer than necessary to create due to 'stale' address space objects going through the controller loop. This ensures that the address space 'object' is always updated to the 'desired' state.