### PR TITLE
Issue 1692 enforce cert secret name copy

### DIFF
--- a/address-model-lib/src/main/java/io/enmasse/address/model/CertSpec.java
+++ b/address-model-lib/src/main/java/io/enmasse/address/model/CertSpec.java
@@ -5,14 +5,8 @@
 package io.enmasse.address.model;
 
 public class CertSpec {
-    private String provider;
-    private String secretName;
-
-    public CertSpec() { }
-
-    public CertSpec(String provider) {
-        this.provider = provider;
-    }
+    private final String provider;
+    private final String secretName;
 
     public CertSpec(String provider, String secretName) {
         this.provider = provider;
@@ -23,18 +17,41 @@ public class CertSpec {
         return provider;
     }
 
-    public CertSpec setProvider(String provider) {
-        this.provider = provider;
-        return this;
-    }
-
     public String getSecretName() {
         return secretName;
     }
 
-    public CertSpec setSecretName(String secretName) {
-        this.secretName = secretName;
-        return this;
+    public static class Builder {
+        private String provider;
+        private String secretName;
+
+        public Builder() {
+        }
+
+        public Builder(CertSpec certSpec) {
+            this.provider = certSpec.provider;
+            this.secretName = certSpec.secretName;
+        }
+
+        public String getProvider() {
+            return provider;
+        }
+
+        public String getSecretName() {
+            return secretName;
+        }
+
+        public void setProvider(String provider) {
+            this.provider = provider;
+        }
+
+        public void setSecretName(String secretName) {
+            this.secretName = secretName;
+        }
+
+        public CertSpec build() {
+            return new CertSpec(provider, secretName);
+        }
     }
 
     @Override

--- a/address-model-lib/src/main/java/io/enmasse/address/model/v1/AddressSpaceV1Deserializer.java
+++ b/address-model-lib/src/main/java/io/enmasse/address/model/v1/AddressSpaceV1Deserializer.java
@@ -125,7 +125,7 @@ class AddressSpaceV1Deserializer extends JsonDeserializer<AddressSpace> {
 
                 if (endpoint.hasNonNull(Fields.CERT)) {
                     ObjectNode cert = (ObjectNode) endpoint.get(Fields.CERT);
-                    CertSpec certSpec = new CertSpec();
+                    CertSpec.Builder certSpec = new CertSpec.Builder();
                     if (cert.hasNonNull(Fields.PROVIDER)) {
                         certSpec.setProvider(cert.get(Fields.PROVIDER).asText());
                     }
@@ -134,7 +134,7 @@ class AddressSpaceV1Deserializer extends JsonDeserializer<AddressSpace> {
                         certSpec.setSecretName(cert.get(Fields.SECRET_NAME).asText());
                     }
 
-                    b.setCertSpec(certSpec);
+                    b.setCertSpec(certSpec.build());
                 }
                 builder.appendEndpoint(b.build());
             }

--- a/address-model-lib/src/test/java/io/enmasse/address/model/v1/address/SerializationTest.java
+++ b/address-model-lib/src/test/java/io/enmasse/address/model/v1/address/SerializationTest.java
@@ -130,7 +130,7 @@ public class SerializationTest {
                         .setName("myendpoint")
                         .setService("messaging")
                         .setServicePort("amqp")
-                        .setCertSpec(new CertSpec("provider").setSecretName("secret"))
+                        .setCertSpec(new CertSpec("provider", "mysecret"))
                         .build()))
                 .setAuthenticationService(new AuthenticationService.Builder()
                         .setType(AuthenticationServiceType.EXTERNAL)
@@ -404,7 +404,7 @@ public class SerializationTest {
                         .setName("bestendpoint")
                         .setService("mqtt")
                         .setServicePort("mqtts")
-                        .setCertSpec(new CertSpec("mysecret"))
+                        .setCertSpec(new CertSpec("myprovider", "mysecret"))
                         .build()))
                 .build();
 

--- a/address-space-controller/src/main/java/io/enmasse/controller/ControllerChain.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/ControllerChain.java
@@ -115,8 +115,10 @@ public class ControllerChain extends AbstractVerticle implements Watcher<Address
 
         for (AddressSpace addressSpace : resources) {
             try {
+                log.info("Checking address space {}:{}", addressSpace.getNamespace(), addressSpace.getName());
                 for (Controller controller : chain) {
-                    log.debug("Controller {} input: {}", controller.getClass().getName(), addressSpace);
+                    log.info("Controller {}", controller);
+                    log.debug("Address space input: {}", addressSpace);
                     addressSpace = controller.handle(addressSpace);
                 }
 

--- a/address-space-controller/src/main/java/io/enmasse/controller/CreateController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/CreateController.java
@@ -78,10 +78,9 @@ public class CreateController implements Controller {
         // Ensure the required certs are set
         List<EndpointSpec> newEndpoints = new ArrayList<>();
         for (EndpointSpec endpoint : endpoints) {
-            CertSpec certSpec = endpoint.getCertSpec().orElse(new CertSpec());
-
             EndpointSpec.Builder endpointBuilder = new EndpointSpec.Builder(endpoint);
 
+            CertSpec.Builder certSpec = endpoint.getCertSpec().map(CertSpec.Builder::new).orElse(new CertSpec.Builder());
             if (certSpec.getProvider() == null) {
                 certSpec.setProvider(defaultCertProvider);
             }
@@ -90,7 +89,7 @@ public class CreateController implements Controller {
                 certSpec.setSecretName(KubeUtil.getExternalCertSecretName(endpoint.getService(), addressSpace));
             }
 
-            endpointBuilder.setCertSpec(certSpec);
+            endpointBuilder.setCertSpec(certSpec.build());
             newEndpoints.add(endpointBuilder.build());
         }
         addressSpace = new AddressSpace.Builder(addressSpace)

--- a/address-space-controller/src/main/java/io/enmasse/controller/EndpointController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/EndpointController.java
@@ -58,7 +58,7 @@ public class EndpointController implements Controller {
             statuses = endpoints.stream().map(e -> e.endpointStatus).collect(Collectors.toList());
         }
 
-        log.info("Updating endpoints for " + addressSpace.getName() + " to " + statuses);
+        log.debug("Updating endpoints for " + addressSpace.getName() + " to " + statuses);
         addressSpace.getStatus().setEndpointStatuses(statuses);
     }
 

--- a/address-space-controller/src/main/java/io/enmasse/controller/StatusController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/StatusController.java
@@ -45,6 +45,6 @@ public class StatusController implements Controller {
 
     @Override
     public String toString() {
-        return "EndpointController";
+        return "StatusController";
     }
 }

--- a/k8s-api/src/main/java/io/enmasse/k8s/api/ConfigMapSchemaApi.java
+++ b/k8s-api/src/main/java/io/enmasse/k8s/api/ConfigMapSchemaApi.java
@@ -120,7 +120,6 @@ public class ConfigMapSchemaApi implements SchemaApi, ListerWatcher<ConfigMap, C
                 .setName(name)
                 .setService(name)
                 .setServicePort(port)
-                .setCertSpec(new CertSpec(null, null))
                 .build();
     }
 


### PR DESCRIPTION
Ensure that cert spec is always copied and not reused between address space
    
This fixes a bug when 2 address spaces are created within the same controller loop cycle, which caused the cert secret names to be wrong. This broke the brokered SmokeTest in Jenkins.
