### PR TITLE
Keep the 'Next' button disabled, until there is a valid & unique name

### DIFF
--- a/agent/www/components/addresses/addresses_ctrl.js
+++ b/agent/www/components/addresses/addresses_ctrl.js
@@ -421,7 +421,7 @@ angular.module('patternfly.wizard').controller('WizardController', ['$scope', '$
             };
 
             $scope.updateName = function() {
-                $scope.semantics_complete = angular.isDefined($scope.data.address) && $scope.data.address.length > 0 && address_service.is_unique_name($scope.data.address)
+                $scope.semantics_complete = angular.isDefined($scope.data.address) && $scope.data.address.length > 0 && address_service.is_unique_valid_name($scope.data.address)
                     && $scope.data.type.length > 0 && ($scope.data.type !== 'subscription' || ($scope.data.topic && $scope.data.topic.length));
             };
             $scope.nextButtonTitle = "Next >";
@@ -500,11 +500,8 @@ angular.module('patternfly.wizard').controller('SemanticsController', ['$rootSco
         function ($rootScope, $scope, address_service) {
             'use strict';
             $scope.isValidationDisabled = false;
-            $scope.unique_address_name = function (input) {
-                return address_service.is_unique_name(input);
-            }
             $scope.valid_address_name = function (input) {
-                return input.match(/^[^#*\/\s\.:]+$/) && address_service.is_unique_name(input);
+                return address_service.is_unique_valid_name(input);
             }
         }
     ]);

--- a/agent/www/shared/address_service.js
+++ b/agent/www/shared/address_service.js
@@ -210,8 +210,8 @@ AddressService.prototype.delete_selected = function () {
     if (changed && this.callback) this.callback('address_deleted');
 }
 
-AddressService.prototype.is_unique_name = function (name) {
-    return !this.addresses.some(function (a) { return a.address === name; });
+AddressService.prototype.is_unique_valid_name = function (name) {
+    return !this.addresses.some(function (a) { return a.address === name; }) && name.match(/^[^#*\/\s\.:]+$/);
 }
 
 AddressService.prototype.create_user = function (obj) {


### PR DESCRIPTION
Issue #1588 added the client side check to make sure the name is valid.  This uses that logic, to keep the 'next' button disabled until there is a valid name.

Signed-off-by: Vanessa <vbusch@redhat.com>