### PR TITLE
New webconsole systemtest  doTestFilterAddressWithRegexSymbols

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/web/WebConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/web/WebConsoleTest.java
@@ -190,7 +190,7 @@ public abstract class WebConsoleTest extends TestBaseWithShared implements ISele
     }
 
     protected void doTestFilterAddressWithRegexSymbols() throws Exception {
-        int addressCount = 8;
+        int addressCount = 4;
         ArrayList<Destination> addresses = generateQueueTopicList("via-web", IntStream.range(0, addressCount));
 
         consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), addressApiClient,
@@ -200,7 +200,7 @@ public abstract class WebConsoleTest extends TestBaseWithShared implements ISele
         assertThat(String.format("Console failed, does not contain %d addresses", addressCount),
                 consoleWebPage.getAddressItems().size(), is(addressCount));
 
-        //valid filter, will show 4 results
+        //valid filter, will show 2 results
         String subText = "topic";
         consoleWebPage.addAddressesFilter(FilterType.NAME, subText);
         List<AddressWebItem> items = consoleWebPage.getAddressItems();
@@ -215,7 +215,7 @@ public abstract class WebConsoleTest extends TestBaseWithShared implements ISele
         WebElement regexAlert = selenium.getWebElement(() -> selenium.getDriver().findElement(By.className("pficon-error-circle-o")));
         assertTrue(regexAlert.isDisplayed());
 
-        //valid regex filter (.*), will show 8 results
+        //valid regex filter (.*), will show 4 results
         subText = ".*";
         consoleWebPage.addAddressesFilter(FilterType.NAME, subText);
         items = consoleWebPage.getAddressItems();
@@ -223,7 +223,7 @@ public abstract class WebConsoleTest extends TestBaseWithShared implements ISele
                 String.format("Console failed, does not contain %d addresses", addressCount));
         consoleWebPage.clearAllFilters();
 
-        //valid regex filter ([0-9]\d*$) = any address ending with a number, will show 8 results
+        //valid regex filter ([0-9]\d*$) = any address ending with a number, will show 4 results
         subText = "[0-9]\\d*$";
         consoleWebPage.addAddressesFilter(FilterType.NAME, subText);
         items = consoleWebPage.getAddressItems();

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/web/WebConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/web/WebConsoleTest.java
@@ -189,6 +189,49 @@ public abstract class WebConsoleTest extends TestBaseWithShared implements ISele
                 String.format("Console failed, does not contain %d addresses", addressCount));
     }
 
+    protected void doTestFilterAddressWithRegexSymbols() throws Exception {
+        int addressCount = 8;
+        ArrayList<Destination> addresses = generateQueueTopicList("via-web", IntStream.range(0, addressCount));
+
+        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), addressApiClient,
+                sharedAddressSpace, defaultCredentials);
+        consoleWebPage.openWebConsolePage();
+        consoleWebPage.createAddressesWebConsole(addresses.toArray(new Destination[0]));
+        assertThat(String.format("Console failed, does not contain %d addresses", addressCount),
+                consoleWebPage.getAddressItems().size(), is(addressCount));
+
+        //valid filter, will show 4 results
+        String subText = "topic";
+        consoleWebPage.addAddressesFilter(FilterType.NAME, subText);
+        List<AddressWebItem> items = consoleWebPage.getAddressItems();
+        assertEquals(addressCount / 2, items.size(),
+                String.format("Console failed, does not contain %d addresses", addressCount / 2));
+        assertAddressName("Console failed, does not contain addresses contain " + subText, items, subText);
+        consoleWebPage.clearAllFilters();
+
+        //invalid filter (not regex), error message is shown
+        subText = "*";
+        consoleWebPage.addAddressesFilter(FilterType.NAME, subText);
+        WebElement regexAlert = selenium.getWebElement(() -> selenium.getDriver().findElement(By.className("pficon-error-circle-o")));
+        assertTrue(regexAlert.isDisplayed());
+
+        //valid regex filter (.*), will show 8 results
+        subText = ".*";
+        consoleWebPage.addAddressesFilter(FilterType.NAME, subText);
+        items = consoleWebPage.getAddressItems();
+        assertEquals(addressCount, items.size(),
+                String.format("Console failed, does not contain %d addresses", addressCount));
+        consoleWebPage.clearAllFilters();
+
+        //valid regex filter ([0-9]\d*$) = any address ending with a number, will show 8 results
+        subText = "[0-9]\\d*$";
+        consoleWebPage.addAddressesFilter(FilterType.NAME, subText);
+        items = consoleWebPage.getAddressItems();
+        assertEquals(addressCount, items.size(),
+                String.format("Console failed, does not contain %d addresses", addressCount));
+        consoleWebPage.clearAllFilters();
+    }
+
     protected void doTestSortAddressesByName() throws Exception {
         int addressCount = 4;
         ArrayList<Destination> addresses = generateQueueTopicList("via-web", IntStream.range(0, addressCount));

--- a/systemtests/src/test/java/io/enmasse/systemtest/brokered/web/ChromeWebConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/brokered/web/ChromeWebConsoleTest.java
@@ -43,6 +43,12 @@ class ChromeWebConsoleTest extends WebConsoleTest implements ITestBaseBrokered, 
     }
 
     @Test
+    @Disabled("Only few chrome tests are enabled, rest functionality is covered by firefox")
+    void testFilterAddressWithRegexSymbols() throws Exception {
+        doTestFilterAddressWithRegexSymbols();
+    }
+
+    @Test
     void testSortAddressesByName() throws Exception {
         doTestSortAddressesByName();
     }

--- a/systemtests/src/test/java/io/enmasse/systemtest/brokered/web/FirefoxWebConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/brokered/web/FirefoxWebConsoleTest.java
@@ -38,6 +38,11 @@ class FirefoxWebConsoleTest extends WebConsoleTest implements ITestBaseBrokered,
     }
 
     @Test
+    void testFilterAddressWithRegexSymbols() throws Exception {
+        doTestFilterAddressWithRegexSymbols();
+    }
+
+    @Test
     void testSortAddressesByName() throws Exception {
         doTestSortAddressesByName();
     }

--- a/systemtests/src/test/java/io/enmasse/systemtest/standard/web/ChromeWebConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/standard/web/ChromeWebConsoleTest.java
@@ -63,6 +63,12 @@ public class ChromeWebConsoleTest extends WebConsoleTest implements ITestBaseSta
     }
 
     @Test
+    @Disabled("Only few chrome tests are enabled, rest functionality is covered by firefox")
+    void testFilterAddressWithRegexSymbols() throws Exception {
+        doTestFilterAddressWithRegexSymbols();
+    }
+
+    @Test
     void testSortAddressesByName() throws Exception {
         doTestSortAddressesByName();
     }

--- a/systemtests/src/test/java/io/enmasse/systemtest/standard/web/FirefoxWebConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/standard/web/FirefoxWebConsoleTest.java
@@ -56,6 +56,11 @@ public class FirefoxWebConsoleTest extends WebConsoleTest implements ITestBaseSt
     }
 
     @Test
+    void testFilterAddressWithRegexSymbols() throws Exception {
+        doTestFilterAddressWithRegexSymbols();
+    }
+
+    @Test
     void testSortAddressesByName() throws Exception {
         doTestSortAddressesByName();
     }


### PR DESCRIPTION
    * tests if filtering addresses in console is valid with regex
    * if non valid regex is used the console shows an alert (positive)

test passes