### PR TITLE
Fix test regression caused by c4f33b5bf0 (screen labels on address tab)

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/selenium/resources/AddressWebItem.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/selenium/resources/AddressWebItem.java
@@ -32,8 +32,8 @@ public class AddressWebItem extends WebItem implements Comparable<AddressWebItem
         this.readAdditionalInfo();
         this.sendersCount = getCountOfAdditionalInfoItem("Senders");
         this.receiversCount = getCountOfAdditionalInfoItem("Receivers");
-        this.messagesIn = getCountOfAdditionalInfoItem("Incoming Traffic");
-        this.messagesOut = getCountOfAdditionalInfoItem("Outgoing Traffic");
+        this.messagesIn = getCountOfAdditionalInfoItem("Messages In");
+        this.messagesOut = getCountOfAdditionalInfoItem("Messages Out");
         this.messagesStored = getCountOfAdditionalInfoItem("Stored");
         this.isReady = AddressStatus.READY == this.status;
     }


### PR DESCRIPTION
Fixes test regression `io.enmasse.systemtest.*.web.FirefoxWebConsoleTest#testMessagesMetrics` caused by changes made in c4f33b5bf0 related to screen labels on address tab.