### PR TITLE
Return AlreadyExists instead of Conflict for 409 response codes

### DIFF
--- a/api-common/src/main/java/io/enmasse/api/common/DefaultExceptionMapper.java
+++ b/api-common/src/main/java/io/enmasse/api/common/DefaultExceptionMapper.java
@@ -52,6 +52,9 @@ public class DefaultExceptionMapper implements ExceptionMapper<Exception> {
         if (statusCode == 422) {
             return "Unprocessable Entity";
         }
+        if (statusCode == 409) {
+            return "AlreadyExists";
+        }
         Response.StatusType status = Response.Status.fromStatusCode(statusCode);
         return status != null ? status.getReasonPhrase() : "Unknown code";
     }


### PR DESCRIPTION
This aligns the response with that given by Kubernetes API server for 409 responses. I'm not sure if there is a case where we should set it to 'Conflict', but I think this will be correct for most foreseeable cases.