### PR TITLE
Bump jboss-logging-processor from 2.0.0.Alpha2 to 2.0.1.Final 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <netty.version>4.1.25.Final</netty.version>
         <keycloak.version>3.4.3.Final</keycloak.version>
         <jboss.logging.version>3.3.0.Final</jboss.logging.version>
+        <jboss.logging.processor.version>2.0.1.Final</jboss.logging.processor.version>
         <protonj.version>0.27.1</protonj.version>
         <qpidjms.version>0.34.0</qpidjms.version>
         <selenium.version>3.14.0</selenium.version>
@@ -220,7 +221,7 @@
             <dependency>
                 <groupId>org.jboss.logging</groupId>
                 <artifactId>jboss-logging-processor</artifactId>
-                <version>2.0.0.Alpha2</version>
+                <version>${jboss.logging.processor.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Avoid dependency classed as Alpha.