### PR TITLE
Fix duplicate declaration of version error from Maven

### DIFF
--- a/service-broker/pom.xml
+++ b/service-broker/pom.xml
@@ -26,11 +26,6 @@
     </dependency>
     <dependency>
       <groupId>io.enmasse</groupId>
-      <artifactId>keycloak-user-api</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.enmasse</groupId>
       <artifactId>amqp-utils</artifactId>
       <scope>compile</scope>
     </dependency>


### PR DESCRIPTION
originating from service-broker module (keycloak-user-api dependency duplicate).  No functional change.