### PR TITLE
Dependency manage commons-collections to 3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <jackson-module-jaxb-annotations.version>2.9.6</jackson-module-jaxb-annotations.version>
         <resteasy.version>3.1.0.Final</resteasy.version>
         <mockito.version>2.21.0</mockito.version>
+        <commons-collections.version>3.2.2</commons-collections.version>
         <hamcrest.version>1.3</hamcrest.version>
         <junit.version>4.12</junit.version>
         <junit.jupiter.version>5.1.0</junit.jupiter.version>
@@ -166,6 +167,12 @@
             </dependency>
 
             <!-- Other dependencies -->
+
+            <dependency>
+                <groupId>commons-collections</groupId>
+                <artifactId>commons-collections</artifactId>
+                <version>${commons-collections.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.apache.activemq</groupId>


### PR DESCRIPTION
Avoids dependency on 3.2.1, which is associated with CVE-2017-15708.