### PR TITLE
Migrate default plans

### DIFF
--- a/address-model-lib/src/main/java/io/enmasse/address/model/AddressResolver.java
+++ b/address-model-lib/src/main/java/io/enmasse/address/model/AddressResolver.java
@@ -8,6 +8,8 @@ import io.enmasse.admin.model.v1.AddressPlan;
 import io.enmasse.admin.model.v1.ResourceRequest;
 import io.enmasse.admin.model.v1.StandardInfraConfig;
 
+import java.util.Optional;
+
 public class AddressResolver {
     private final AddressSpaceType addressSpaceType;
 
@@ -16,7 +18,11 @@ public class AddressResolver {
     }
 
     public AddressPlan getPlan(Address address) {
-        return getType(address).findAddressPlan(address.getPlan()).orElseThrow(() -> new UnresolvedAddressException("Unknown address plan " + address.getPlan() + " for address type " + address.getType()));
+        return findPlan(address).orElseThrow(() -> new UnresolvedAddressException("Unknown address plan " + address.getPlan() + " for address type " + address.getType()));
+    }
+
+    public Optional<AddressPlan> findPlan(Address address) {
+        return getType(address).findAddressPlan(address.getPlan());
     }
 
     public AddressPlan getPlan(AddressType addressType, Address address) {

--- a/address-model-lib/src/main/java/io/enmasse/address/model/AddressSpaceResolver.java
+++ b/address-model-lib/src/main/java/io/enmasse/address/model/AddressSpaceResolver.java
@@ -24,6 +24,11 @@ public class AddressSpaceResolver {
         return schema.findAddressSpaceType(type).orElseThrow(() -> new UnresolvedAddressSpaceException("Unknown address space type " + type));
     }
 
+    public Optional<AddressSpacePlan> getPlan(String type, String plan) {
+        AddressSpaceType addressSpaceType = getType(type);
+        return addressSpaceType.findAddressSpacePlan(plan);
+    }
+
     public void validate(AddressSpace addressSpace) {
         getPlan(getType(addressSpace.getType()), addressSpace.getPlan());
     }

--- a/address-model-lib/src/main/java/io/enmasse/address/model/AddressType.java
+++ b/address-model-lib/src/main/java/io/enmasse/address/model/AddressType.java
@@ -55,6 +55,7 @@ public class AddressType {
                 return Optional.of(plan);
             }
         }
+
         return Optional.empty();
     }
 

--- a/address-space-controller/src/main/java/io/enmasse/controller/AddressSpaceController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/AddressSpaceController.java
@@ -102,6 +102,7 @@ public class AddressSpaceController extends AbstractVerticle {
 
         Metrics metrics = new Metrics();
         ControllerChain controllerChain = new ControllerChain(kubernetes, addressSpaceApi, schemaProvider, eventLogger, metrics, options.getVersion(), options.getRecheckInterval(), options.getResyncInterval());
+        controllerChain.addController(new MigrationController(schemaProvider, options.getVersion()));
         controllerChain.addController(new CreateController(kubernetes, schemaProvider, infraResourceFactory, eventLogger, authController.getDefaultCertProvider(), options.getVersion()));
         controllerChain.addController(new StatusController(kubernetes, schemaProvider, infraResourceFactory, userApi));
         controllerChain.addController(new EndpointController(controllerClient, options.isExposeEndpointsByDefault()));

--- a/address-space-controller/src/main/java/io/enmasse/controller/MigrationController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/MigrationController.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017-2018, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.controller;
+
+import io.enmasse.address.model.AddressSpace;
+import io.enmasse.address.model.AddressSpaceResolver;
+import io.enmasse.admin.model.v1.AddressSpacePlan;
+import io.enmasse.admin.model.v1.AddressSpacePlanBuilder;
+import io.enmasse.api.common.SchemaProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MigrationController implements Controller {
+    private final SchemaProvider schemaProvider;
+    private final String version;
+
+    public MigrationController(SchemaProvider schemaProvider, String version) {
+        this.schemaProvider = schemaProvider;
+        this.version = version;
+    }
+
+    @Override
+    public AddressSpace handle(AddressSpace addressSpace) throws Exception {
+        if (version.startsWith("0.24")) {
+            return migratePlanName(addressSpace);
+        } else {
+            return addressSpace;
+        }
+    }
+
+    private AddressSpace migratePlanName(AddressSpace addressSpace) {
+        AddressSpaceResolver resolver = new AddressSpaceResolver(schemaProvider.getSchema());
+        AddressSpacePlan plan = resolver.getPlan(addressSpace.getType(), addressSpace.getPlan())
+                .orElse(null);
+
+        if (plan == null) {
+            AddressSpace.Builder builder = new AddressSpace.Builder(addressSpace);
+            if ("unlimited-brokered".equals(addressSpace.getPlan())) {
+                builder.setPlan("brokered-single-broker");
+            } else if ("unlimited-standard".equals(addressSpace.getPlan())) {
+                builder.setPlan("standard-unlimited-with-mqtt");
+            } else if ("unlimited-standard-without-mqtt".equals(addressSpace.getPlan())) {
+                builder.setPlan("standard-unlimited");
+            }
+            return builder.build();
+        } else {
+            return addressSpace;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "MigrationController";
+    }
+}


### PR DESCRIPTION
In order for users to upgrade from 0.23.0 to 0.24.0 out of the box, the following PR is needed. It will change the address space plan and address plan names to the appropriate new name if they don't exist.