### PR TITLE
Create license metadata for agent too

### DIFF
--- a/agent/create-license-metadata.sh
+++ b/agent/create-license-metadata.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Uses https://github.com/bucharest-gold/license-reporter/ to create license metadata with
+# associated license text files.
+#
+
+function join { local IFS="$1"; shift; echo "${*}"; }
+
+NODE_ROOT=$1
+TARGET_DIR=$2
+NODE_EXE=${NODE_ROOT}/node/node
+LICENSE_REPORTER_EXE=${NODE_ROOT}/bin/license-reporter
+LICENSE_REPORTER_OPTS=${LICENSE_REPORTER_OPTS:---silent}
+shift
+shift
+
+if [ ! -d "${NODE_ROOT}" ]; then
+   >&2 echo "Node install root directory ${NODE_ROOT} not found."
+   exit 1
+fi
+
+if [ ! -x "${NODE_EXE}" ]; then
+   >&2 echo "Node interpreter ${NODE_EXE} not found or not executable."
+   exit 1
+fi
+
+if [ ! -f "${LICENSE_REPORTER_EXE}" ]; then
+   >&2 echo "license-reporter ${LICENSE_REPORTER_EXE} not found.  Check that the npm module is installed."
+   exit 1
+fi
+
+mkdir -p ${TARGET_DIR}/licenses
+
+declare -a license_list
+while [[ $# -gt 0 ]]
+do
+    TREE=$1
+    shift
+
+    pushd ${TREE}
+    # Generates license metadata
+    ${NODE_EXE} ${LICENSE_REPORTER_EXE} save --xml licenses.xml --full-dependency-tree ${LICENSE_REPORTER_OPTS}
+    # Collects the license files from the node modules themselves
+    ${NODE_EXE} ${LICENSE_REPORTER_EXE} report --full-dependency-tree ${LICENSE_REPORTER_OPTS}
+    output=${TREE}/licenses/licenses.xml
+    license_list+=("${output}")
+
+    if compgen -G "licenses/*.TXT" > /dev/null; then
+        cp -f licenses/*.TXT ${TARGET_DIR}/licenses
+    fi
+    popd
+done
+
+list=$(join "," ${license_list[@]})
+
+pushd ${TARGET_DIR}
+# Merges the license metadata together
+${NODE_EXE} ${LICENSE_REPORTER_EXE} merge --merge-project-name agent_all  --merge-license-xmls ${list} --merge-output licenses.xml ${LICENSE_REPORTER_OPTS}
+popd
+

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -12,6 +12,8 @@
   <properties>
       <www-node-install-directory>${project.build.directory}/noderoot/www</www-node-install-directory>
       <agent-node-install-directory>${project.build.directory}/noderoot/agent</agent-node-install-directory>
+      <licensereporter-node-install-directory>${project.build.directory}/noderoot/licensereporter</licensereporter-node-install-directory>
+      <license-reporter-opts>--silent</license-reporter-opts>  <!-- verbose option - details -->
   </properties>
   <build>
     <resources>
@@ -120,7 +122,7 @@
         <artifactId>frontend-maven-plugin</artifactId>
         <executions>
           <execution>
-            <id>install node and npm</id>
+            <id>install node and npm - agent</id>
             <goals>
               <goal>install-node-and-npm</goal>
             </goals>
@@ -278,6 +280,73 @@
             </plugins>
         </build>
     </profile>
-  </profiles>
 
+    <profile>
+      <id>node-license-metadata</id>
+      <activation>
+          <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+          <plugins>
+              <plugin>
+                  <groupId>com.github.eirslett</groupId>
+                  <artifactId>frontend-maven-plugin</artifactId>
+                  <executions>
+                      <execution>
+                          <id>install node and npm - license-reporter</id>
+                          <goals>
+                              <goal>install-node-and-npm</goal>
+                          </goals>
+                          <phase>prepare-package</phase>
+                          <configuration>
+                              <nodeVersion>${node.version}</nodeVersion>
+                              <npmVersion>${npm.version}</npmVersion>
+                              <installDirectory>${licensereporter-node-install-directory}</installDirectory>
+                          </configuration>
+                      </execution>
+                      <execution>
+                          <id>npm install - license-reporter</id>
+                          <goals>
+                              <goal>npm</goal>
+                          </goals>
+                          <phase>prepare-package</phase>
+                          <configuration>
+                              <workingDirectory>${licensereporter-node-install-directory}</workingDirectory>
+                              <arguments>install --prefix ${licensereporter-node-install-directory} -g
+                                  license-reporter@1.2.1
+                              </arguments>
+                          </configuration>
+                      </execution>
+                  </executions>
+              </plugin>
+              <plugin>
+                  <groupId>org.codehaus.mojo</groupId>
+                  <artifactId>exec-maven-plugin</artifactId>
+                  <executions>
+                      <execution>
+                          <id>generate-license-metadata</id>
+                          <goals>
+                              <goal>exec</goal>
+                          </goals>
+                          <phase>package</phase>
+                          <configuration>
+                              <workingDirectory>${project.build.directory}</workingDirectory>
+                              <executable>${project.basedir}/create-license-metadata.sh</executable>
+                              <arguments>
+                                  <argument>${licensereporter-node-install-directory}</argument>
+                                  <argument>${project.build.outputDirectory}</argument>
+                                  <argument>${agent-node-install-directory}</argument>
+                                  <argument>${www-node-install-directory}</argument>
+                              </arguments>
+                              <environmentVariables>
+                                  <LICENSE_REPORTER_OPTS>${license-reporter-opts}</LICENSE_REPORTER_OPTS>
+                              </environmentVariables>
+                          </configuration>
+                      </execution>
+                  </executions>
+              </plugin>
+          </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/agent/src/assembly/unix-dist.xml
+++ b/agent/src/assembly/unix-dist.xml
@@ -73,5 +73,13 @@
            </includes>
            <fileMode>0644</fileMode>
         </fileSet>
+        <fileSet>
+           <directory>${project.build.outputDirectory}</directory>
+            <outputDirectory>/</outputDirectory>
+           <includes>
+              <include>licenses/**</include>
+           </includes>
+           <fileMode>0644</fileMode>
+        </fileSet>
     </fileSets>
 </assembly>


### PR DESCRIPTION
Uses license-reporter to generate a license.xml for both agent and the console.  These artefacts
are then merge into a single file that is included in the distribution.  license-reporter is also
used to create files containing the text of the license themselves. These too are include in the
distribution artefact.

Note that unlike the Maven license-plugin, license-reporter does not actually download the license.  Instead it takes it from the npm module itself.