### PR TITLE
Fix error in grafana deployment spec

### DIFF
--- a/templates/grafana/030-Deployment-grafana.yaml
+++ b/templates/grafana/030-Deployment-grafana.yaml
@@ -31,7 +31,7 @@ spec:
           readOnly: true
         - mountPath: /usr/share/grafana/data
           name: grafana-data
-        readOnly: false
+          readOnly: false
         env:
         - name: GF_INSTALL_PLUGINS
           value: "camptocamp-prometheus-alertmanager-datasource"


### PR DESCRIPTION
Fixes this kind of error when deploying Grafana in Kubernetes:

> error validating "030-Deployment-grafana.yaml": error validating data: ValidationError(Deployment.spec.template.spec.containers[0]): unknown field "readOnly" in io.k8s.api.core.v1.Container; if you choose to ignore these errors, turn validation off with --validate=false

