### PR TITLE
More license metadata automation

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -188,3 +188,9 @@ will listen on port 5858.
 
 On OpenShift, you can then issue a `oc port-forward <pod> <LOCAL_PORT>:<REMOTE_PORT>` command to conveniently route
 traffic to the pod's bound port.  Attach your IDE debugger the host/port.
+
+## Hints to speed up your build/test cycle.
+
+The build process generates license metadata which include license text files.  The latter are downloaded from the
+ internet. In order to save time during your build/test cycle, turn off license artifact generation using
+ `-DskipLicenseArtifactGeneration=true` on the Maven command line.  **Remember not to set this flag during release builds.**

--- a/agent/create-license-metadata.sh
+++ b/agent/create-license-metadata.sh
@@ -29,7 +29,7 @@ if [ ! -f "${LICENSE_REPORTER_EXE}" ]; then
    exit 1
 fi
 
-mkdir -p ${TARGET_DIR}/licenses
+mkdir -p ${TARGET_DIR}
 
 declare -a license_list
 while [[ $# -gt 0 ]]
@@ -46,7 +46,7 @@ do
     license_list+=("${output}")
 
     if compgen -G "licenses/*.TXT" > /dev/null; then
-        cp -f licenses/*.TXT ${TARGET_DIR}/licenses
+        cp -f licenses/*.TXT ${TARGET_DIR}
     fi
     popd
 done
@@ -55,6 +55,6 @@ list=$(join "," ${license_list[@]})
 
 pushd ${TARGET_DIR}
 # Merges the license metadata together
-${NODE_EXE} ${LICENSE_REPORTER_EXE} merge --merge-project-name agent_all  --merge-license-xmls ${list} --merge-output licenses.xml ${LICENSE_REPORTER_OPTS}
+${NODE_EXE} ${LICENSE_REPORTER_EXE} merge --merge-project-name agent_all  --merge-license-xmls ${list} --merge-output licenses.xml --outputDir . ${LICENSE_REPORTER_OPTS}
 popd
 

--- a/agent/licenses.xsl
+++ b/agent/licenses.xsl
@@ -1,0 +1,137 @@
+<?xml version="1.0"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+    <xsl:output method="html" encoding="utf-8" standalone="no" media-type="text/html" />
+    <xsl:param name="version"/>
+    <xsl:param name="applicationDisplayName"/>
+    <xsl:param name="projectArtifactId"/>
+    <xsl:param name="licenseAdviceText"/>
+    <xsl:variable name="lowercase" select="'abcdefghijklmnopqrstuvwxyz '" />
+    <xsl:variable name="uppercase" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ!'" />
+
+    <xsl:template match="/">
+        <html>
+            <head>
+                <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
+                <style>
+                    table {
+                    border-collapse: collapse;
+                    }
+
+                    table, th, td {
+                    border: 1px solid navy;
+                    }
+
+                    th {
+                    text-align: left;
+                    background-color: #BCC6CC;
+
+                    }
+
+                    th, td {
+                    padding: 2px;
+                    text-align: left;
+                    }
+
+                    tr:nth-child(even) {
+                    background-color: #f2f2f2;
+                    }
+                </style>
+            </head>
+            <body>
+                <h2><xsl:value-of select="$applicationDisplayName"/><xsl:text>/</xsl:text><xsl:value-of select="$projectArtifactId"/><xsl:text>:</xsl:text><xsl:value-of select="$version"/></h2>
+                <xsl:if test="$licenseAdviceText">
+                    <p><xsl:value-of select="$licenseAdviceText"/></p>
+                </xsl:if>
+                <table>
+                    <tr>
+                        <th>Package Name</th>
+                        <th>Package Version</th>
+                        <th>Remote Licenses</th>
+                        <th>Local Licenses</th>
+                    </tr>
+                    <xsl:apply-templates select="//dependencies/dependency">
+                        <xsl:sort select="packageName"/>
+                    </xsl:apply-templates>
+                </table>
+            </body>
+        </html>
+    </xsl:template>
+
+    <xsl:template match="dependency">
+        <tr>
+            <td>
+                <xsl:value-of select="packageName"/>
+            </td>
+            <td>
+                <xsl:value-of select="version"/>
+            </td>
+            <td>
+                <xsl:for-each select="licenses/license">
+                    <xsl:choose>
+                        <xsl:when test="name = 'Public Domain'">
+                            <xsl:value-of select="name"/>
+                            <br/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <a href="{./url}">
+                                <xsl:value-of select="name"/>
+                            </a>
+                            <br/>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:for-each>
+            </td>
+            <td>
+                <xsl:for-each select="licenses/license">
+                    <xsl:variable name="filename">
+                        <xsl:call-template name="remap-local-filename">
+                            <xsl:with-param name="packageName" select="../../packageName"/>
+                            <xsl:with-param name="name" select="name"/>
+                            <xsl:with-param name="url" select="url"/>
+                        </xsl:call-template>
+                    </xsl:variable>
+                    <a href="{$filename}">
+                        <xsl:value-of select="$filename"/>
+                    </a>
+                    <br/>
+                </xsl:for-each>
+            </td>
+        </tr>
+
+    </xsl:template>
+
+    <xsl:template name="remap-local-filename">
+        <xsl:param name="packageName"/>
+        <xsl:param name="name"/>
+        <xsl:param name="url"/>
+
+        <xsl:variable name="path">
+            <xsl:call-template name="substring-after-last">
+                <xsl:with-param name="value" select="$url" />
+                <xsl:with-param name="search" select="'/'"/>
+            </xsl:call-template>
+        </xsl:variable>
+
+        <!-- There is insufficient information in the XML to reliably predict the name of the license file
+             all case.  This is a best-effort approach. -->
+        <xsl:value-of select="translate(translate(concat($packageName, '_', $path, '.txt'), $lowercase, $uppercase),' ','_')"/>
+    </xsl:template>
+
+    <xsl:template name="substring-after-last">
+        <xsl:param name="value" />
+        <xsl:param name="search"/>
+
+        <xsl:choose>
+            <xsl:when test="contains($value, $search)">
+                <xsl:call-template name="substring-after-last">
+                    <xsl:with-param name="value" select="substring-after($value, $search)" />
+                    <xsl:with-param name="search" select="$search" />
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="$value" />
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+</xsl:stylesheet>

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -14,6 +14,7 @@
       <agent-node-install-directory>${project.build.directory}/noderoot/agent</agent-node-install-directory>
       <licensereporter-node-install-directory>${project.build.directory}/noderoot/licensereporter</licensereporter-node-install-directory>
       <license-reporter-opts>--silent</license-reporter-opts>  <!-- verbose option - details -->
+      <license-report-stylesheet>${project.basedir}/licenses.xsl</license-report-stylesheet>
   </properties>
   <build>
     <resources>
@@ -148,7 +149,7 @@
             <goals>
               <goal>npm</goal>
             </goals>
-            <phase>package</phase>
+            <phase>process-resources</phase>
             <configuration>
                <workingDirectory>${agent-node-install-directory}</workingDirectory>
                <arguments>install --production --fetch-retry-mintimeout 60000 --fetch-retries 10 --maxsockets 2 --quiet</arguments>
@@ -159,7 +160,7 @@
             <goals>
               <goal>npm</goal>
             </goals>
-            <phase>package</phase>
+            <phase>process-resources</phase>
             <configuration>
                <workingDirectory>${www-node-install-directory}</workingDirectory>
                <arguments>install --production --fetch-retry-mintimeout 60000 --fetch-retries 10 --maxsockets 2</arguments>
@@ -282,11 +283,14 @@
     </profile>
 
     <profile>
-      <id>node-license-metadata</id>
-      <activation>
-          <activeByDefault>true</activeByDefault>
-      </activation>
-      <build>
+        <id>license-artifacts</id>
+        <activation>
+          <property>
+              <name>skipLicenseArtifactGeneration</name>
+              <value>!true</value>
+            </property>
+        </activation>
+        <build>
           <plugins>
               <plugin>
                   <groupId>com.github.eirslett</groupId>
@@ -297,7 +301,6 @@
                           <goals>
                               <goal>install-node-and-npm</goal>
                           </goals>
-                          <phase>prepare-package</phase>
                           <configuration>
                               <nodeVersion>${node.version}</nodeVersion>
                               <npmVersion>${npm.version}</npmVersion>
@@ -309,7 +312,7 @@
                           <goals>
                               <goal>npm</goal>
                           </goals>
-                          <phase>prepare-package</phase>
+                          <phase>process-resources</phase>
                           <configuration>
                               <workingDirectory>${licensereporter-node-install-directory}</workingDirectory>
                               <arguments>install --prefix ${licensereporter-node-install-directory} -g
@@ -328,13 +331,13 @@
                           <goals>
                               <goal>exec</goal>
                           </goals>
-                          <phase>package</phase>
+                          <phase>process-resources</phase>
                           <configuration>
                               <workingDirectory>${project.build.directory}</workingDirectory>
                               <executable>${project.basedir}/create-license-metadata.sh</executable>
                               <arguments>
                                   <argument>${licensereporter-node-install-directory}</argument>
-                                  <argument>${project.build.outputDirectory}</argument>
+                                  <argument>${project.build.outputDirectory}/licenses</argument>
                                   <argument>${agent-node-install-directory}</argument>
                                   <argument>${www-node-install-directory}</argument>
                               </arguments>

--- a/licenses.xsl
+++ b/licenses.xsl
@@ -1,0 +1,163 @@
+<?xml version="1.0"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+    <xsl:output method="html" encoding="utf-8" standalone="no" media-type="text/html" />
+    <xsl:param name="version"/>
+    <xsl:param name="applicationDisplayName"/>
+    <xsl:param name="projectArtifactId"/>
+    <xsl:param name="licenseAdviceText"/>
+    <xsl:variable name="lowercase" select="'abcdefghijklmnopqrstuvwxyz '" />
+    <xsl:variable name="uppercase" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ!'" />
+
+    <xsl:template match="/">
+        <html>
+            <head>
+                <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
+                <style>
+                    table {
+                    border-collapse: collapse;
+                    }
+
+                    table, th, td {
+                    border: 1px solid navy;
+                    }
+
+                    th {
+                    text-align: left;
+                    background-color: #BCC6CC;
+
+                    }
+
+                    th, td {
+                    padding: 2px;
+                    text-align: left;
+                    }
+
+                    tr:nth-child(even) {
+                    background-color: #f2f2f2;
+                    }
+                </style>
+            </head>
+            <body>
+                <h2><xsl:value-of select="$applicationDisplayName"/><xsl:text>/</xsl:text><xsl:value-of select="$projectArtifactId"/><xsl:text>:</xsl:text><xsl:value-of select="$version"/></h2>
+                <xsl:if test="$licenseAdviceText">
+                    <p><xsl:value-of select="$licenseAdviceText"/></p>
+                </xsl:if>
+                <table>
+                    <tr>
+                        <th>Package Group</th>
+                        <th>Package Artifact</th>
+                        <th>Package Version</th>
+                        <th>Remote Licenses</th>
+                        <th>Local Licenses</th>
+                    </tr>
+                    <xsl:apply-templates select="//dependencies/dependency">
+                        <xsl:sort select="concat(groupId, '.', artifactId)"/>
+                    </xsl:apply-templates>
+                </table>
+            </body>
+        </html>
+    </xsl:template>
+
+    <xsl:template match="dependency">
+        <tr>
+            <td>
+                <xsl:value-of select="groupId"/>
+            </td>
+            <td>
+                <xsl:value-of select="artifactId"/>
+            </td>
+            <td>
+                <xsl:value-of select="version"/>
+            </td>
+            <td>
+                <xsl:for-each select="licenses/license">
+                    <xsl:choose>
+                        <xsl:when test="name = 'Public Domain'">
+                            <xsl:value-of select="name"/>
+                            <br/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <a href="{./url}">
+                                <xsl:value-of select="name"/>
+                            </a>
+                            <br/>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:for-each>
+            </td>
+            <td>
+                <xsl:for-each select="licenses/license">
+                    <xsl:variable name="filename">
+                        <xsl:call-template name="remap-local-filename">
+                            <xsl:with-param name="groupId" select="../../groupId"/>
+                            <xsl:with-param name="artifactId" select="../../artifactId"/>
+                            <xsl:with-param name="name" select="name"/>
+                            <xsl:with-param name="url" select="url"/>
+                        </xsl:call-template>
+                    </xsl:variable>
+                    <a href="{$filename}">
+                        <xsl:value-of select="$filename"/>
+                    </a>
+                    <br/>
+                </xsl:for-each>
+            </td>
+        </tr>
+
+    </xsl:template>
+
+    <xsl:template name="remap-local-filename">
+        <xsl:param name="groupId"/>
+        <xsl:param name="artifactId"/>
+        <xsl:param name="name"/>
+        <xsl:param name="url"/>
+
+        <xsl:variable name="path">
+            <xsl:call-template name="substring-after-last">
+                <xsl:with-param name="value" select="$url" />
+                <xsl:with-param name="search" select="'/'"/>
+            </xsl:call-template>
+        </xsl:variable>
+        <xsl:variable name="afterlastdot">
+            <xsl:call-template name="substring-after-last">
+                <xsl:with-param name="value" select="$path" />
+                <xsl:with-param name="search" select="'.'"/>
+            </xsl:call-template>
+        </xsl:variable>
+        <xsl:variable name="ext">
+            <xsl:choose>
+                <xsl:when test="$afterlastdot = 'php'">
+                    <xsl:text>html</xsl:text>
+                </xsl:when>
+                <xsl:when test="string-length($afterlastdot) &gt; 2 and string-length($afterlastdot) &lt;= 4">
+                    <xsl:value-of select="$afterlastdot"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:text>txt</xsl:text>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+
+        <!-- There is insufficient information in the XML to reliably predict the name of the license file
+             all case.  This is a best-effort approach. -->
+        <!-- Java: see org.codehaus.mojo.license.AbstractDownloadLicensesMojo#getLicenseFileName -->
+        <xsl:value-of select="translate(translate(concat($groupId, '.', $artifactId, '_', $name, '.', $ext), $uppercase, $lowercase),' ','_')"/>
+    </xsl:template>
+
+    <xsl:template name="substring-after-last">
+        <xsl:param name="value" />
+        <xsl:param name="search"/>
+
+        <xsl:choose>
+            <xsl:when test="contains($value, $search)">
+                <xsl:call-template name="substring-after-last">
+                    <xsl:with-param name="value" select="substring-after($value, $search)" />
+                    <xsl:with-param name="search" select="$search" />
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="$value" />
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+</xsl:stylesheet>

--- a/pom.properties
+++ b/pom.properties
@@ -1,1 +1,2 @@
 application.display.name=EnMasse
+license.advice.text=EnMasse comprises the following components:

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,9 @@
         <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
         <security-versions-plugin.version>1.0.6</security-versions-plugin.version>
         <dependency-check-maven-plugin.version>3.3.2</dependency-check-maven-plugin.version>
+        <maven-xml-plugin.version>1.0.2</maven-xml-plugin.version>
+
+        <license-report-stylesheet>${maven.multiModuleProjectDirectory}/licenses.xsl</license-report-stylesheet>
     </properties>
 
     <modules>
@@ -683,6 +686,11 @@
                     <artifactId>license-maven-plugin</artifactId>
                     <version>${codehaus-license-maven-plugin.version}</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>xml-maven-plugin</artifactId>
+                    <version>${maven-xml-plugin.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -747,15 +755,6 @@
                         <ENV_VAR_EXISTS_BOOLEAN>true</ENV_VAR_EXISTS_BOOLEAN>
                     </environmentVariables>
                 </configuration>
-                <!--
-                <dependencies>
-                  <dependency>
-                    <groupId>org.junit.platform</groupId>
-                    <artifactId>junit-platform-surefire-provider</artifactId>
-                    <version>${junit.platform.version}</version>
-                  </dependency>
-                </dependencies>
-                -->
             </plugin>
             <plugin>
                 <groupId>com.mycila</groupId>
@@ -810,50 +809,111 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <configuration>
-                    <failIfWarning>true</failIfWarning>
-                    <excludedScopes>provided,test,system</excludedScopes>
-                    <licenseMerges>
-                        <licenseMerge>Apache Software License, Version 2.0|The Apache Software License, Version 2.0|
-                            Apache Software License - Version 2.0|Apache v2|Apache 2|Apache License, Version 2.0|
-                            Apache 2.0|Apache Public License 2.0|Apache License Version 2.0|Apache License, version 2.0|
-                            Apache License 2.0|The Apache License, Version 2.0</licenseMerge>
-                    </licenseMerges>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>generate-thirdparty-summary</id>
-                        <phase>prepare-package</phase>
-                        <configuration>
-                            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
-                        </configuration>
-                        <goals>
-                            <goal>add-third-party</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <!-- Note: the license download can be skipped by setting license.skipDownloadLicenses true -->
-                        <id>download-thirdparty-licenses</id>
-                        <phase>prepare-package</phase>
-                        <configuration>
-                            <licensesOutputFile>${project.build.outputDirectory}/licenses.xml</licensesOutputFile>
-                            <licensesOutputDirectory>${project.build.outputDirectory}/licenses</licensesOutputDirectory>
-                            <!-- org.reactivestreams:reactive-streams is http://creativecommons.org/publicdomain/zero/1.0/,
-                                 but the programmatic download of the license seems to be disallowed by the server. -->
-                            <excludedGroups>org.reactivestreams</excludedGroups>
-                        </configuration>
-                        <goals>
-                            <goal>download-licenses</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
     <profiles>
+        <profile>
+            <id>license-artifacts</id>
+            <activation>
+                <property>
+                    <name>skipLicenseArtifactGeneration</name>
+                    <value>!true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>license-maven-plugin</artifactId>
+                        <configuration>
+                            <failIfWarning>true</failIfWarning>
+                            <excludedScopes>provided,test,system</excludedScopes>
+                            <licenseMerges>
+                                <licenseMerge>Apache Software License, Version 2.0|The Apache Software License, Version 2.0|
+                                    Apache Software License - Version 2.0|Apache v2|Apache 2|Apache License, Version 2.0|
+                                    Apache 2.0|Apache Public License 2.0|Apache License Version 2.0|Apache License, version 2.0|
+                                    Apache License 2.0|The Apache License, Version 2.0</licenseMerge>
+                            </licenseMerges>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>generate-thirdparty-summary</id>
+                                <phase>prepare-package</phase>
+                                <configuration>
+                                    <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                                </configuration>
+                                <goals>
+                                    <goal>add-third-party</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <!-- Note: the license download can be skipped by setting license.skipDownloadLicenses true -->
+                                <id>download-thirdparty-licenses</id>
+                                <phase>prepare-package</phase>
+                                <configuration>
+                                    <licensesOutputFile>${project.build.outputDirectory}/licenses/licenses.xml</licensesOutputFile>
+                                    <licensesOutputDirectory>${project.build.outputDirectory}/licenses</licensesOutputDirectory>
+                                    <!-- org.reactivestreams:reactive-streams is http://creativecommons.org/publicdomain/zero/1.0/,
+                                         but the programmatic download of the license seems to be disallowed by the server. -->
+                                    <excludedGroups>org.reactivestreams</excludedGroups>
+                                    <organizeLicensesByDependencies>true</organizeLicensesByDependencies>
+                                </configuration>
+                                <goals>
+                                    <goal>download-licenses</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>xml-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>produce-license-html</id>
+                                <goals>
+                                    <goal>transform</goal>
+                                </goals>
+                                <phase>prepare-package</phase>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <transformationSets>
+                                <transformationSet>
+                                    <dir>${project.build.outputDirectory}/licenses</dir>
+                                    <includes>licenses.xml</includes>
+                                    <outputDir>${project.build.outputDirectory}/licenses</outputDir>
+                                    <stylesheet>${license-report-stylesheet}</stylesheet>
+                                    <fileMappers>
+                                        <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.FileExtensionMapper">
+                                            <targetExtension>.html</targetExtension>
+                                        </fileMapper>
+                                    </fileMappers>
+                                    <parameters>
+                                        <parameter>
+                                            <name>version</name>
+                                            <value>${project.version}</value>
+                                        </parameter>
+                                        <parameter>
+                                            <name>applicationDisplayName</name>
+                                            <value>${application.display.name}</value>
+                                        </parameter>
+                                        <parameter>
+                                            <name>licenseAdviceText</name>
+                                            <value>${license.advice.text}</value>
+                                        </parameter>
+                                        <parameter>
+                                            <name>projectArtifactId</name>
+                                            <value>${project.artifactId}</value>
+                                        </parameter>
+                                    </parameters>
+                                </transformationSet>
+                            </transformationSets>
+                        </configuration>
+                    </plugin>
+                </plugins>
+
+            </build>
+        </profile>
         <profile>
             <id>coverage</id>
             <build>

--- a/systemtests/pom.xml
+++ b/systemtests/pom.xml
@@ -139,6 +139,13 @@
                     <skipDownloadLicenses>true</skipDownloadLicenses>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>xml-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/templates/Makefile
+++ b/templates/Makefile
@@ -76,7 +76,7 @@ component_install: replace_images
 
 ansible_install: component_install
 	cp -r $(PACKAGE_ANSIBLE_DIR) $(INSTALLDIR)/
-	gln -srf $(INSTALLDIR)/install/components $(INSTALLDIR)/ansible/playbooks/openshift/components
+	ln -srf $(INSTALLDIR)/install/components $(INSTALLDIR)/ansible/playbooks/openshift/components
 
 ENMASSE_WITH_STANDARD_AUTHSERVICE_TEMPLATE=$(PACKAGE_INSTALL_DIR)/templates/enmasse-with-standard-authservice.yaml
 $(ENMASSE_WITH_STANDARD_AUTHSERVICE_TEMPLATE): replace_images

--- a/templates/Makefile
+++ b/templates/Makefile
@@ -76,7 +76,7 @@ component_install: replace_images
 
 ansible_install: component_install
 	cp -r $(PACKAGE_ANSIBLE_DIR) $(INSTALLDIR)/
-	ln -srf $(INSTALLDIR)/install/components $(INSTALLDIR)/ansible/playbooks/openshift/components
+	gln -srf $(INSTALLDIR)/install/components $(INSTALLDIR)/ansible/playbooks/openshift/components
 
 ENMASSE_WITH_STANDARD_AUTHSERVICE_TEMPLATE=$(PACKAGE_INSTALL_DIR)/templates/enmasse-with-standard-authservice.yaml
 $(ENMASSE_WITH_STANDARD_AUTHSERVICE_TEMPLATE): replace_images


### PR DESCRIPTION
Move licenses.xml to within the licenses/ directory.
Generate a per-module `licenses.html` providing a human readable summary and link to the remote/local license.
Allow license artifact production to be surpressed (for reasons of speed during a developer's build/test cycle).