### PR TITLE
Make templates/Makefile run on Mac OS X

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -10,6 +10,12 @@ VERSION         ?= $(shell cat $(TOPDIR)/release.version)
 TAG             ?= latest
 MOCHA_FILE      ?= build/test-results/test/TEST-$(PROJECT_NAME).xml
 SKIP_TESTS      ?= false
+UNAME_S := $(shell uname -s)
+LN=ln
+
+ifeq ($(UNAME_S),Darwin)
+	LN = gln
+endif
 
 all: init build test package docker_build
 

--- a/templates/Makefile
+++ b/templates/Makefile
@@ -76,7 +76,7 @@ component_install: replace_images
 
 ansible_install: component_install
 	cp -r $(PACKAGE_ANSIBLE_DIR) $(INSTALLDIR)/
-	ln -srf $(INSTALLDIR)/install/components $(INSTALLDIR)/ansible/playbooks/openshift/components
+	$(LN) -srf $(INSTALLDIR)/install/components $(INSTALLDIR)/ansible/playbooks/openshift/components
 
 ENMASSE_WITH_STANDARD_AUTHSERVICE_TEMPLATE=$(PACKAGE_INSTALL_DIR)/templates/enmasse-with-standard-authservice.yaml
 $(ENMASSE_WITH_STANDARD_AUTHSERVICE_TEMPLATE): replace_images


### PR DESCRIPTION
(Assumes coreutils installed from brew or MacPorts)