### PR TITLE
Add namespace suffix to name of role binding

### DIFF
--- a/templates/api-server/030-RoleBinding-apiserver-authentication-reader.yaml
+++ b/templates/api-server/030-RoleBinding-apiserver-authentication-reader.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: "enmasse.io:apiserver-authentication-reader"
+  name: "enmasse.io:apiserver-authentication-reader-${NAMESPACE}"
   namespace: kube-system
   labels:
     app: enmasse


### PR DESCRIPTION
This is to allow applying the EnMasse installation instructions multiple times (in multiple namespaces).