### PR TITLE
Replace deprecated serviceAccount field with serviceAccountName

### DIFF
--- a/templates/address-space-controller/020-ConfigMap-address-space-definitions.yaml
+++ b/templates/address-space-controller/020-ConfigMap-address-space-definitions.yaml
@@ -500,7 +500,7 @@ data:
               - mountPath: /opt/agent/messaging-cert
                 name: messaging-cert
                 readOnly: true
-            serviceAccount: ${ADDRESS_SPACE_ADMIN_SA}
+            serviceAccountName: ${ADDRESS_SPACE_ADMIN_SA}
             volumes:
             - name: console-secret
               secret:
@@ -1215,7 +1215,7 @@ data:
               - mountPath: /opt/agent/messaging-cert
                 name: messaging-cert
                 readOnly: true
-            serviceAccount: ${ADDRESS_SPACE_ADMIN_SA}
+            serviceAccountName: ${ADDRESS_SPACE_ADMIN_SA}
             volumes:
             - name: authservice-ca
               secret:

--- a/templates/address-space-controller/050-Deployment-address-space-controller.yaml
+++ b/templates/address-space-controller/050-Deployment-address-space-controller.yaml
@@ -93,7 +93,7 @@ spec:
         - mountPath: /address-space-definitions
           name: address-space-definitions
           readOnly: true
-      serviceAccount: address-space-controller
+      serviceAccountName: address-space-controller
       volumes:
       - configMap:
           name: address-space-definitions

--- a/templates/api-server/050-Deployment-api-server.yaml
+++ b/templates/api-server/050-Deployment-api-server.yaml
@@ -68,7 +68,7 @@ spec:
         - mountPath: /api-server-cert
           name: api-server-cert
           readOnly: true
-      serviceAccount: api-server
+      serviceAccountName: api-server
       volumes:
       - name: api-server-cert
         secret:

--- a/templates/kube-state-metrics/030-Deployment-kube-state-metrics.yaml
+++ b/templates/kube-state-metrics/030-Deployment-kube-state-metrics.yaml
@@ -28,4 +28,4 @@ spec:
           - --telemetry-port=8081
           - --namespace=${NAMESPACE}
           - --collectors=pods
-      serviceAccount: kube-state-metrics
+      serviceAccountName: kube-state-metrics

--- a/templates/prometheus/030-Deployment-prometheus.yaml
+++ b/templates/prometheus/030-Deployment-prometheus.yaml
@@ -29,7 +29,7 @@ spec:
         - mountPath: /prometheus
           name: prometheus-data
           readOnly: false
-      serviceAccount: prometheus-server
+      serviceAccountName: prometheus-server
       volumes:
       - configMap:
           name: prometheus-config

--- a/templates/service-broker/050-Deployment-service-broker.yaml
+++ b/templates/service-broker/050-Deployment-service-broker.yaml
@@ -56,7 +56,7 @@ spec:
         - mountPath: /service-broker-cert
           name: service-broker-cert
           readOnly: true
-      serviceAccount: service-broker
+      serviceAccountName: service-broker
       volumes:
       - name: service-broker-cert
         secret:

--- a/templates/standard-authservice/050-Deployment-keycloak-controller.yaml
+++ b/templates/standard-authservice/050-Deployment-keycloak-controller.yaml
@@ -35,4 +35,4 @@ spec:
             memory: 256Mi
           requests:
             memory: 256Mi
-      serviceAccount: keycloak-controller
+      serviceAccountName: keycloak-controller


### PR DESCRIPTION
`serviceAccount` is deprecated in K8s 1.7 already.