### PR TITLE
Handle all exceptions of processing an address space

### DIFF
--- a/address-space-controller/src/main/java/io/enmasse/controller/ControllerChain.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/ControllerChain.java
@@ -129,6 +129,8 @@ public class ControllerChain extends AbstractVerticle implements Watcher<Address
             } catch (KubernetesClientException e) {
                 log.warn("Error syncing address space {}", addressSpace.getName(), e);
                 eventLogger.log(AddressSpaceSyncFailed, "Error syncing address space: " + e.getMessage(), Warning, ControllerKind.AddressSpace, addressSpace.getName());
+            } catch (Exception e) {
+                log.warn("Error processing address space {}", addressSpace.getName(), e);
             }
         }
         retainAddressSpaces(resources);


### PR DESCRIPTION
This prevents an issue where controller could not clean up old address spaces if there were issues processing an address space in the list.