### PR TITLE
Downgrade kubernetes-model from 3.0.3 to 3.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <fabric8.kubernetes-client.version>4.0.4</fabric8.kubernetes-client.version>
-        <fabric8.kubernetes-model.version>3.0.3</fabric8.kubernetes-model.version>
+        <fabric8.kubernetes-model.version>3.0.2</fabric8.kubernetes-model.version>
         <sundrio.version>0.7.1</sundrio.version>
         <vertx.version>3.5.3</vertx.version>
         <slf4j.version>1.7.21</slf4j.version>


### PR DESCRIPTION
Avoid configuration management problems (release 3.0.3 is not tagged).