### PR TITLE
Patch secret if cert bundle has changed

### DIFF
--- a/address-model-lib/src/main/java/io/enmasse/address/model/AddressSpace.java
+++ b/address-model-lib/src/main/java/io/enmasse/address/model/AddressSpace.java
@@ -138,6 +138,11 @@ public class AddressSpace {
 
     public void validate() {
         KubeUtil.validateName(name);
+        if (endpointList != null) {
+            for (EndpointSpec endpointSpec : endpointList) {
+                endpointSpec.validate();
+            }
+        }
     }
 
     public static class Builder {

--- a/address-model-lib/src/main/java/io/enmasse/address/model/CertSpec.java
+++ b/address-model-lib/src/main/java/io/enmasse/address/model/CertSpec.java
@@ -4,6 +4,9 @@
  */
 package io.enmasse.address.model;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
 public class CertSpec {
     private final String provider;
     private final String secretName;
@@ -29,8 +32,21 @@ public class CertSpec {
         return tlsKey;
     }
 
+    public void validate() {
+        if (tlsKey != null) {
+            requireBase64(tlsKey);
+        }
+        if (tlsCert != null) {
+            requireBase64(tlsCert);
+        }
+    }
+
     public String getTlsCert() {
         return tlsCert;
+    }
+
+    private static void requireBase64(String value) {
+        Base64.getDecoder().decode(value.getBytes(StandardCharsets.UTF_8));
     }
 
     public static class Builder {

--- a/address-model-lib/src/main/java/io/enmasse/address/model/EndpointSpec.java
+++ b/address-model-lib/src/main/java/io/enmasse/address/model/EndpointSpec.java
@@ -49,6 +49,12 @@ public class EndpointSpec {
                 .toString();
     }
 
+    public void validate() {
+        if (certSpec != null) {
+            certSpec.validate();
+        }
+    }
+
     public static class Builder {
         private String name;
         private String service;

--- a/address-space-controller/src/main/java/io/enmasse/controller/auth/CertBundleCertProvider.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/auth/CertBundleCertProvider.java
@@ -43,17 +43,8 @@ public class CertBundleCertProvider implements CertProvider {
             return;
         }
 
-        boolean isPemFormat = tlsCert.startsWith("-----BEGIN");
-        if (isPemFormat) {
-            Base64.Encoder b64enc = Base64.getEncoder();
-            String tlsKeyB64 = b64enc.encodeToString(tlsKey.getBytes(StandardCharsets.UTF_8));
-            String tlsCertB64 = b64enc.encodeToString(tlsCert.getBytes(StandardCharsets.UTF_8));
-            data.put("tls.key", tlsKeyB64);
-            data.put("tls.crt", tlsCertB64);
-        } else { // Assume already base64 encoded
-            data.put("tls.key", tlsKey);
-            data.put("tls.crt", tlsCert);
-        }
+        data.put("tls.key", tlsKey.replace("\r\n", "").replace("\n", ""));
+        data.put("tls.crt", tlsCert.replace("\r\n", "").replace("\n", ""));
 
         Secret secret = new SecretBuilder()
                 .editOrNewMetadata()

--- a/address-space-controller/src/main/java/io/enmasse/controller/auth/CertBundleCertProvider.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/auth/CertBundleCertProvider.java
@@ -43,7 +43,6 @@ public class CertBundleCertProvider implements CertProvider {
 
         data.put("tls.key", tlsKey);
         data.put("tls.crt", tlsCert);
-        log.info("Creating cert secret with certBundle input");
 
         Secret secret = new SecretBuilder()
                 .editOrNewMetadata()
@@ -59,8 +58,10 @@ public class CertBundleCertProvider implements CertProvider {
 
         Secret existing = client.secrets().inNamespace(namespace).withName(endpointInfo.getCertSpec().getSecretName()).get();
         if (existing == null) {
+            log.info("Creating cert secret {} with certBundle input", secret.getMetadata().getName());
             client.secrets().inNamespace(namespace).createOrReplace(secret);
-        } else if (!existing.getData().equals(secret.getData())) {
+        } else if (!secret.getData().equals(existing.getData())) {
+            log.info("Replacing cert secret {} with certBundle input", secret.getMetadata().getName());
             client.secrets().inNamespace(namespace).withName(endpointInfo.getCertSpec().getSecretName()).patch(secret);
         }
     }

--- a/address-space-controller/src/main/java/io/enmasse/controller/auth/CertBundleCertProvider.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/auth/CertBundleCertProvider.java
@@ -41,8 +41,8 @@ public class CertBundleCertProvider implements CertProvider {
             return;
         }
 
-        data.put("tls.key", tlsKey);
-        data.put("tls.crt", tlsCert);
+        data.put("tls.key", tlsKey.replace("\n", ""));
+        data.put("tls.crt", tlsCert.replace("\n", ""));
 
         Secret secret = new SecretBuilder()
                 .editOrNewMetadata()
@@ -60,7 +60,7 @@ public class CertBundleCertProvider implements CertProvider {
         if (existing == null) {
             log.info("Creating cert secret {} with certBundle input", secret.getMetadata().getName());
             client.secrets().inNamespace(namespace).createOrReplace(secret);
-        } else if (!secret.getData().equals(existing.getData())) {
+        } else if (!data.equals(existing.getData())) {
             log.info("Replacing cert secret {} with certBundle input", secret.getMetadata().getName());
             client.secrets().inNamespace(namespace).withName(endpointInfo.getCertSpec().getSecretName()).patch(secret);
         }

--- a/address-space-controller/src/test/java/io/enmasse/controller/auth/CertBundleCertProviderTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/auth/CertBundleCertProviderTest.java
@@ -68,11 +68,35 @@ public class CertBundleCertProviderTest {
                 .setTlsCert("d29ybGQ=")
                 .build();
 
+        space.validate();
+
         certProvider.provideCert(space, new EndpointInfo("messaging", spec));
 
         Secret cert = client.secrets().withName("mycerts").get();
         assertNotNull(cert);
-        assertThat(cert.getData().get("tls.key"), is(Base64.getEncoder().encodeToString(spec.getTlsKey().getBytes(StandardCharsets.UTF_8))));
-        assertThat(cert.getData().get("tls.crt"), is(Base64.getEncoder().encodeToString(spec.getTlsCert().getBytes(StandardCharsets.UTF_8))));
+        assertThat(cert.getData().get("tls.key"), is(spec.getTlsKey()));
+        assertThat(cert.getData().get("tls.crt"), is(spec.getTlsCert()));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testValidateBadKey() {
+        new CertSpec.Builder()
+                .setProvider("certBundle")
+                .setSecretName("mycerts")
+                .setTlsKey("/%^$lkg")
+                .setTlsCert("d29ybGQ=")
+                .build()
+                .validate();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testValidateBadCert() {
+        new CertSpec.Builder()
+                .setProvider("certBundle")
+                .setSecretName("mycerts")
+                .setTlsKey("d29ybGQ=")
+                .setTlsCert("/%^$lkg")
+                .build()
+                .validate();
     }
 }

--- a/address-space-controller/src/test/java/io/enmasse/controller/auth/CertBundleCertProviderTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/auth/CertBundleCertProviderTest.java
@@ -13,6 +13,9 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 
@@ -69,7 +72,7 @@ public class CertBundleCertProviderTest {
 
         Secret cert = client.secrets().withName("mycerts").get();
         assertNotNull(cert);
-        assertThat(cert.getData().get("tls.key"), is(spec.getTlsKey()));
-        assertThat(cert.getData().get("tls.crt"), is(spec.getTlsCert()));
+        assertThat(cert.getData().get("tls.key"), is(Base64.getEncoder().encodeToString(spec.getTlsKey().getBytes(StandardCharsets.UTF_8))));
+        assertThat(cert.getData().get("tls.crt"), is(Base64.getEncoder().encodeToString(spec.getTlsCert().getBytes(StandardCharsets.UTF_8))));
     }
 }

--- a/agent/npm-shrinkwrap.json
+++ b/agent/npm-shrinkwrap.json
@@ -326,9 +326,9 @@
             }
         },
         "eslint": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.7.0.tgz",
-            "integrity": "sha512-zYCeFQahsxffGl87U2aJ7DPyH8CbWgxBC213Y8+TCanhUTf2gEvfq3EKpHmEcozTLyPmGe9LZdMAwC/CpJBM5A==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.8.0.tgz",
+            "integrity": "sha512-Zok6Bru3y2JprqTNm14mgQ15YQu/SMDkWdnmHfFg770DIUlmMFd/gqqzCHekxzjHZJxXv3tmTpH0C1icaYJsRQ==",
             "requires": {
                 "@babel/code-frame": "7.0.0",
                 "ajv": "6.5.4",

--- a/api-server/src/main/java/io/enmasse/api/v1/http/HttpAddressSpaceService.java
+++ b/api-server/src/main/java/io/enmasse/api/v1/http/HttpAddressSpaceService.java
@@ -134,6 +134,7 @@ public class HttpAddressSpaceService {
                 addressSpace.putAnnotation(AnnotationKeys.CREATED_BY_UID, createdByUid);
             }
         } else {
+            validateChanges(existing, addressSpace);
             Map<String, String> annotations = existing.getAnnotations();
             if (annotations == null) {
                 annotations = new HashMap<>();
@@ -154,6 +155,45 @@ public class HttpAddressSpaceService {
         }
 
         return addressSpace;
+    }
+
+    private void validateChanges(AddressSpace existing, AddressSpace addressSpace) {
+        if (!existing.getType().equals(addressSpace.getType())) {
+            throw new BadRequestException("Cannot change type of address space " + addressSpace.getName() + " from " + existing.getType() + " to " + addressSpace.getType());
+        }
+
+        if (!existing.getPlan().equals(addressSpace.getPlan())) {
+            throw new BadRequestException("Cannot change plan of address space " + addressSpace.getName() + " from " + existing.getPlan() + " to " + addressSpace.getPlan());
+        }
+
+        if (!existing.getAuthenticationService().equals(addressSpace.getAuthenticationService())) {
+            throw new BadRequestException("Cannot change authentication service of address space " + addressSpace.getName() + " from " + existing.getAuthenticationService() + " to " + addressSpace.getAuthenticationService());
+        }
+
+        validateAnnotation(existing, addressSpace, AnnotationKeys.REALM_NAME);
+        validateAnnotation(existing, addressSpace, AnnotationKeys.INFRA_UUID);
+        validateAnnotation(existing, addressSpace, AnnotationKeys.CREATED_BY);
+        validateAnnotation(existing, addressSpace, AnnotationKeys.CREATED_BY_UID);
+        validateLabel(existing, addressSpace, LabelKeys.ADDRESS_SPACE_TYPE);
+        validateLabel(existing, addressSpace, LabelKeys.NAMESPACE);
+    }
+
+    private static void validateAnnotation(AddressSpace existing, AddressSpace addressSpace, String annotationKey) {
+        if (existing.getAnnotation(annotationKey) == null) {
+            return;
+        }
+        if (!existing.getAnnotation(annotationKey).equals(addressSpace.getAnnotation(annotationKey))) {
+            throw new BadRequestException("Cannot change annotation " + annotationKey + " of existing address space " + addressSpace.getName());
+        }
+    }
+
+    private static void validateLabel(AddressSpace existing, AddressSpace addressSpace, String labelKey) {
+        if (existing.getLabel(labelKey) == null) {
+            return;
+        }
+        if (!existing.getLabel(labelKey).equals(addressSpace.getLabel(labelKey))) {
+            throw new BadRequestException("Cannot change label " + labelKey + " of existing address space " + addressSpace.getName());
+        }
     }
 
     private AddressSpaceList removeSecrets(AddressSpaceList addressSpaceList) {

--- a/api-server/src/main/java/io/enmasse/api/v1/http/HttpAddressSpaceService.java
+++ b/api-server/src/main/java/io/enmasse/api/v1/http/HttpAddressSpaceService.java
@@ -231,6 +231,7 @@ public class HttpAddressSpaceService {
             verifyAuthorized(securityContext, namespace, ResourceVerb.update);
             AddressSpace existing = addressSpaceApi.getAddressSpaceWithName(namespace, addressSpaceName).orElse(null);
             AddressSpace addressSpace = setAddressSpaceDefaults(securityContext, namespace, payload, existing);
+            addressSpace.validate();
 
             AddressSpaceResolver addressSpaceResolver = new AddressSpaceResolver(schemaProvider.getSchema());
             addressSpaceResolver.validate(addressSpace);

--- a/api-server/src/test/java/io/enmasse/api/v1/http/HttpAddressSpaceServiceTest.java
+++ b/api-server/src/test/java/io/enmasse/api/v1/http/HttpAddressSpaceServiceTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -137,12 +138,28 @@ public class HttpAddressSpaceServiceTest {
     @Test
     public void testPut() {
         addressSpaceApi.createAddressSpace(a1);
-        AddressSpace a1Adapted = new AddressSpace.Builder(a1).setNamespace("ns").build();
-        assertThat(a1Adapted, not(equalTo(a1)));
+        AddressSpace a1Adapted = new AddressSpace.Builder(a1).putAnnotation("foo", "bar").build();
         Response response = invoke(() -> addressSpaceService.replaceAddressSpace(securityContext, null, a1Adapted.getName(), a1Adapted));
         assertThat(response.getStatus(), is(200));
 
-        assertThat(addressSpaceApi.listAddressSpaces(null), hasItem(a1Adapted));
+        assertFalse(addressSpaceApi.listAddressSpaces(null).isEmpty());
+        assertThat(addressSpaceApi.listAddressSpaces(null).iterator().next().getAnnotation("foo"), is("bar"));
+    }
+
+    @Test
+    public void testPutChangeType() {
+        addressSpaceApi.createAddressSpace(a1);
+        AddressSpace a1Adapted = new AddressSpace.Builder(a1).setType("type2").build();
+        Response response = invoke(() -> addressSpaceService.replaceAddressSpace(securityContext, null, a1Adapted.getName(), a1Adapted));
+        assertThat(response.getStatus(), is(400));
+    }
+
+    @Test
+    public void testPutChangePlan() {
+        addressSpaceApi.createAddressSpace(a1);
+        AddressSpace a1Adapted = new AddressSpace.Builder(a1).setPlan("otherplan").build();
+        Response response = invoke(() -> addressSpaceService.replaceAddressSpace(securityContext, null, a1Adapted.getName(), a1Adapted));
+        assertThat(response.getStatus(), is(400));
     }
 
     @Test


### PR DESCRIPTION
This allows address spaces to have annotations, labels and endpoints replaced. The certBundle endpoints also switch the certificate in the secret, allowing users to perform certificate rotation without downtime.