### PR TITLE
Prevent the StandardController from overwriting address configmaps

### DIFF
--- a/k8s-api/src/main/java/io/enmasse/k8s/api/ConfigMapAddressApi.java
+++ b/k8s-api/src/main/java/io/enmasse/k8s/api/ConfigMapAddressApi.java
@@ -66,10 +66,7 @@ public class ConfigMapAddressApi implements AddressApi, ListerWatcher<ConfigMap,
                 builder.setUid(configMap.getMetadata().getUid());
             }
 
-// resourceVersion is server assigned when the update is received, so any value from the config.json will always be stale.
-//            if (address.getResourceVersion() == null) {
-//                builder.setResourceVersion(configMap.getMetadata().getResourceVersion());
-//            }
+            builder.setResourceVersion(configMap.getMetadata().getResourceVersion());
 
             if (address.getCreationTimestamp() == null) {
                 builder.setCreationTimestamp(configMap.getMetadata().getCreationTimestamp());

--- a/k8s-api/src/main/java/io/enmasse/k8s/api/ConfigMapAddressApi.java
+++ b/k8s-api/src/main/java/io/enmasse/k8s/api/ConfigMapAddressApi.java
@@ -156,11 +156,15 @@ public class ConfigMapAddressApi implements AddressApi, ListerWatcher<ConfigMap,
                 .addToLabels(LabelKeys.INFRA_UUID, infraUuid)
                 .addToLabels(LabelKeys.INFRA_TYPE, "any")
                 .addToAnnotations(address.getAnnotations())
-// I think that resourceVersion is always assigned by the server, so I think doing this unconditionally is safe.
-                .withResourceVersion(address.getResourceVersion())
                 // TODO: Support other ways of doing this
                 .addToAnnotations(AnnotationKeys.ADDRESS_SPACE, address.getAddressSpace())
                 .endMetadata();
+
+        if (address.getResourceVersion() != null) {
+            builder.editOrNewMetadata()
+                    .withResourceVersion(address.getResourceVersion())
+                    .endMetadata();
+        }
 
         try {
             builder.addToData("config.json", mapper.writeValueAsString(address));

--- a/k8s-api/src/main/java/io/enmasse/k8s/api/ConfigMapAddressApi.java
+++ b/k8s-api/src/main/java/io/enmasse/k8s/api/ConfigMapAddressApi.java
@@ -132,11 +132,19 @@ public class ConfigMapAddressApi implements AddressApi, ListerWatcher<ConfigMap,
             return false;
         }
         ConfigMap newMap = create(address);
-        client.configMaps()
-                .inNamespace(namespace)
-                .withName(name)
-                .lockResourceVersion(address.getResourceVersion())
-                .replace(newMap);
+        if (address.getResourceVersion() != null) {
+            client.configMaps()
+                    .inNamespace(namespace)
+                    .withName(name)
+                    .lockResourceVersion(address.getResourceVersion())
+                    .replace(newMap);
+
+        } else {
+            client.configMaps()
+                    .inNamespace(namespace)
+                    .withName(name)
+                    .replace(newMap);
+        }
         return true;
     }
 

--- a/k8s-api/src/main/java/io/enmasse/k8s/api/ResourceChecker.java
+++ b/k8s-api/src/main/java/io/enmasse/k8s/api/ResourceChecker.java
@@ -43,8 +43,8 @@ public class ResourceChecker<T> implements Watcher<T>, Runnable {
         synchronized (monitor) {
             try {
                 monitor.wait(recheckInterval.toMillis());
-                watcher.onUpdate(items);
                 log.debug("Woke up from monitor");
+                watcher.onUpdate(items);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             } catch (Exception e) {

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/AddressProvisioner.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/AddressProvisioner.java
@@ -175,18 +175,18 @@ public class AddressProvisioner {
     }
 
     private boolean scheduleSubscription(Address subscription, Address topic, Map<String, UsageInfo> brokerUsage, Map<String, UsageInfo> subscriptionUsage, ResourceRequest requested) {
-        String cluster = topic.getAnnotations().get(AnnotationKeys.CLUSTER_ID);
-        String broker = topic.getAnnotations().get(AnnotationKeys.BROKER_ID);
+        String cluster = topic.getAnnotation(AnnotationKeys.CLUSTER_ID);
+        String broker = topic.getAnnotation(AnnotationKeys.BROKER_ID);
 
         boolean isPooled = broker !=null;
 
-        subscription.getAnnotations().put(AnnotationKeys.CLUSTER_ID, cluster);
+        subscription.putAnnotation(AnnotationKeys.CLUSTER_ID, cluster);
 
         if (isPooled) {
             UsageInfo usageInfo = subscriptionUsage.computeIfAbsent(broker, k -> new UsageInfo());
             if (usageInfo.getUsed()+requested.getCredit() <= 1) {
                 usageInfo.addUsed(requested.getCredit());
-                subscription.getAnnotations().put(AnnotationKeys.BROKER_ID, broker);
+                subscription.putAnnotation(AnnotationKeys.BROKER_ID, broker);
             } else {
                 log.info("no quota available on broker {} for {} on topic {}", cluster, subscription.getAddress(), topic.getAddress());
             }
@@ -208,13 +208,13 @@ public class AddressProvisioner {
             for (BrokerInfo brokerInfo : shardedBrokers) {
                 UsageInfo usageInfo = subscriptionUsage.computeIfAbsent(brokerInfo.getBrokerId(), k -> new UsageInfo());
                 if (brokerInfo.getCredit() + requested.getCredit() < 1) {
-                    subscription.getAnnotations().put(AnnotationKeys.BROKER_ID, brokerInfo.getBrokerId());
+                    subscription.putAnnotation(AnnotationKeys.BROKER_ID, brokerInfo.getBrokerId());
                     usageInfo.addUsed(requested.getCredit());
                     break;
                 }
             }
         }
-        return subscription.getAnnotations().get(AnnotationKeys.BROKER_ID) != null;
+        return subscription.getAnnotation(AnnotationKeys.BROKER_ID) != null;
     }
 
     private Map<String, Map<String, UsageInfo>> checkQuotaForAddress(Map<String, Double> limits, Map<String, Map<String, UsageInfo>> usage, Address address, Set<Address> addressSet) {
@@ -270,7 +270,7 @@ public class AddressProvisioner {
 
                     for (BrokerInfo brokerInfo : brokers) {
                         if (brokerInfo.getCredit() + resourceRequest.getCredit() < 1) {
-                            address.getAnnotations().put(AnnotationKeys.BROKER_ID, brokerInfo.getBrokerId());
+                            address.putAnnotation(AnnotationKeys.BROKER_ID, brokerInfo.getBrokerId());
                             UsageInfo used = resourceUsage.get(brokerInfo.getBrokerId());
                             used.addUsed(resourceRequest.getCredit());
                             break;
@@ -439,7 +439,7 @@ public class AddressProvisioner {
 
         for (BrokerInfo brokerInfo : brokers) {
             if (brokerInfo.getCredit() + credit < 1) {
-                address.getAnnotations().put(AnnotationKeys.BROKER_ID, brokerInfo.getBrokerId());
+                address.putAnnotation(AnnotationKeys.BROKER_ID, brokerInfo.getBrokerId());
                 UsageInfo used = usageMap.get(brokerInfo.getBrokerId());
                 used.addUsed(credit);
                 return true;

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/RouterStatus.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/RouterStatus.java
@@ -104,7 +104,6 @@ class RouterStatus {
     public static int checkActiveLinkRoute(Address address, List<RouterStatus> routerStatusList) {
         int ok = 0;
         Set<String> active = new HashSet<>();
-        String brokerId = address.getAnnotations().get(AnnotationKeys.BROKER_ID);
 
         for (RouterStatus routerStatus : routerStatusList) {
 


### PR DESCRIPTION
@lulf I took an alternative approach to solving this problem to one that was discussed a few weeks ago.  I tried caching state locally but I couldn't get an implementation that wasn't ugly.   This approach guards the standard controller from acting on an address if its representation is stale.  This staleness may occur owing to the relative actions of the refresh/watchers.  This approach is also appealing because should we start to support patching of addresses (say to allow the user to add their own annotations), then this approach will mean that the standard controller cannot overwrite these changes.

I left some commented out code only for discussion purposes.  My intention is to remove it.

Also there are some analogous changes which I think need to be reflected into the address-space API.

