### PR TITLE
Remove redundant calls to inNamespace() when interacting with openshift API.

### DIFF
--- a/k8s-api/src/main/java/io/enmasse/k8s/api/ConfigMapAddressSpaceApi.java
+++ b/k8s-api/src/main/java/io/enmasse/k8s/api/ConfigMapAddressSpaceApi.java
@@ -11,14 +11,16 @@ import io.enmasse.config.LabelKeys;
 import io.enmasse.address.model.AddressSpace;
 import io.enmasse.k8s.api.cache.*;
 import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.ConfigMapList;
-import io.fabric8.kubernetes.api.model.DoneableConfigMap;
 import io.fabric8.kubernetes.client.RequestConfig;
 import io.fabric8.kubernetes.client.RequestConfigBuilder;
 import io.fabric8.openshift.client.NamespacedOpenShiftClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.*;
@@ -52,51 +54,68 @@ public class ConfigMapAddressSpaceApi implements AddressSpaceApi, ListerWatcher<
     }
 
     @Override
-    public void createAddressSpace(AddressSpace addressSpace) throws Exception {
-        try {
-            create(client.configMaps().createNew(), addressSpace);
-        } catch (Exception e) {
-            log.error("Error creating {}", addressSpace.getName());
-            throw e;
-        }
+    public void createAddressSpace(AddressSpace addressSpace) {
+        String name = getConfigMapName(addressSpace.getNamespace(), addressSpace.getName());
+        ConfigMap map = create(addressSpace);
+        client.configMaps().withName(name).create(map);
     }
 
     @Override
-    public boolean replaceAddressSpace(AddressSpace addressSpace) throws Exception {
-        ConfigMap previous = client.configMaps().withName(getConfigMapName(addressSpace.getNamespace(), addressSpace.getName())).get();
+    public boolean replaceAddressSpace(AddressSpace addressSpace) {
+        String name = getConfigMapName(addressSpace.getNamespace(), addressSpace.getName());
+        ConfigMap previous = client.configMaps().withName(name).get();
         if (previous == null) {
             log.warn("Cannot replace addressSpace {}: No previous configMap found", addressSpace.getName());
             return false;
         }
-        try {
-            create(client.configMaps().createOrReplaceWithNew(), addressSpace);
-        } catch (Exception e) {
-            log.error("Error replacing {}", addressSpace.getName());
-            throw e;
+
+        ConfigMap newMap = create(addressSpace);
+        if (addressSpace.getResourceVersion() != null) {
+            client.configMaps()
+                    .withName(name)
+                    .lockResourceVersion(addressSpace.getResourceVersion())
+                    .replace(newMap);
+
+        } else {
+            client.configMaps()
+                    .withName(name)
+                    .replace(newMap);
         }
         return true;
     }
 
-    private void create(DoneableConfigMap config, AddressSpace addressSpace) throws Exception {
-        Map<String, String> labels = new HashMap<>(addressSpace.getLabels());
+    private ConfigMap create(AddressSpace addressSpace) {
+        Map<String, String> labels = addressSpace.getLabels();
         String name = getConfigMapName(addressSpace.getNamespace(), addressSpace.getName());
         labels.put(LabelKeys.TYPE, "address-space");
         labels.put(LabelKeys.NAMESPACE, addressSpace.getNamespace());
-        config.withNewMetadata()
+        ConfigMapBuilder builder = new ConfigMapBuilder()
+                .editOrNewMetadata()
                 .withName(name)
                 .addToLabels(labels)
-                .withResourceVersion(addressSpace.getResourceVersion())
                 .addToAnnotations(addressSpace.getAnnotations())
-                .endMetadata()
-                .addToData("config.json", mapper.writeValueAsString(addressSpace))
-                .done();
+                .endMetadata();
+
+        if (addressSpace.getResourceVersion() != null) {
+            builder.editOrNewMetadata()
+                    .withResourceVersion(addressSpace.getResourceVersion())
+                    .endMetadata();
+        }
+
+        try {
+            builder.addToData("config.json", mapper.writeValueAsString(addressSpace));
+            return builder.build();
+        } catch (IOException e) {
+            log.info("Error serializing addressspace for {}", addressSpace, e);
+            throw new UncheckedIOException(e);
+        }
     }
 
     @Override
     public boolean deleteAddressSpace(AddressSpace addressSpace) {
         String name = getConfigMapName(addressSpace.getNamespace(), addressSpace.getName());
         Boolean deleted = client.configMaps().withName(name).delete();
-        return deleted != null && deleted.booleanValue();
+        return deleted != null && deleted;
     }
 
     @Override
@@ -137,9 +156,7 @@ public class ConfigMapAddressSpaceApi implements AddressSpaceApi, ListerWatcher<
                 builder.setUid(map.getMetadata().getUid());
             }
 
-            if (addressSpace.getResourceVersion() == null) {
-                builder.setResourceVersion(map.getMetadata().getResourceVersion());
-            }
+            builder.setResourceVersion(map.getMetadata().getResourceVersion());
 
             if (addressSpace.getCreationTimestamp() == null) {
                 builder.setCreationTimestamp(map.getMetadata().getCreationTimestamp());
@@ -150,9 +167,9 @@ public class ConfigMapAddressSpaceApi implements AddressSpaceApi, ListerWatcher<
             }
 
             return builder.build();
-        } catch (Exception e) {
-            log.error("Error decoding address space", e);
-            throw new RuntimeException(e);
+        } catch (IOException e) {
+            log.error("Error decoding address space from configmap : {}", map, e);
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/k8s-api/src/test/java/io/enmasse/k8s/api/ConfigMapAddressApiTest.java
+++ b/k8s-api/src/test/java/io/enmasse/k8s/api/ConfigMapAddressApiTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2017-2018, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.k8s.api;
+
+import io.enmasse.address.model.Address;
+import io.fabric8.openshift.client.NamespacedOpenShiftClient;
+import io.fabric8.openshift.client.server.mock.OpenShiftServer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+public class ConfigMapAddressApiTest {
+    private static final String ADDRESS = "myaddress";
+    private static final String ADDRESS_TYPE = "mytype";
+    private static final String ADDRESS_PLAN = "myplan";
+    private static final String ADDRESS_SPACE_NAMESPACE = "myproject";
+    private static final String ADDRESS_SPACE = "myspace";
+    private static final String ADDRESS_NAME = String.format("%s.%s", ADDRESS_SPACE, ADDRESS);
+    @Rule
+    public OpenShiftServer openShiftServer = new OpenShiftServer(false, true);
+    private AddressApi api;
+
+    @Before
+    public void setUp() {
+        NamespacedOpenShiftClient client = openShiftServer.getOpenshiftClient();
+        api = new ConfigMapAddressApi(client, ADDRESS_SPACE_NAMESPACE, UUID.randomUUID().toString());
+    }
+
+    @Test
+    public void create() {
+        Address address = createAddress(ADDRESS_SPACE_NAMESPACE, ADDRESS_NAME);
+
+        api.createAddress(address);
+        Optional<Address> readAddress = api.getAddressWithName(ADDRESS_SPACE_NAMESPACE, ADDRESS_NAME);
+
+        assertTrue(readAddress.isPresent());
+        Address read = readAddress.get();
+
+        assertEquals(ADDRESS, read.getAddress());
+        assertEquals(ADDRESS_SPACE, read.getAddressSpace());
+        assertEquals(ADDRESS_NAME, read.getName());
+        assertEquals(ADDRESS_TYPE, read.getType());
+        assertEquals(ADDRESS_PLAN, read.getPlan());
+    }
+
+    @Test
+    public void replace() {
+        Address adddress = createAddress(ADDRESS_SPACE_NAMESPACE, ADDRESS_NAME);
+        final String annotationKey = "myannotation";
+        String annotationValue = "value";
+        Address update = new Address.Builder(adddress).putAnnotation(annotationKey, annotationValue).build();
+
+        api.createAddress(adddress);
+        assertTrue(api.getAddressWithName(ADDRESS_SPACE_NAMESPACE, ADDRESS_NAME).isPresent());
+
+        boolean replaced = api.replaceAddress(update);
+        assertTrue(replaced);
+
+        Address read = api.getAddressWithName(ADDRESS_SPACE_NAMESPACE, ADDRESS_NAME).get();
+
+        assertEquals(ADDRESS_NAME, read.getName());
+        assertEquals(annotationValue, read.getAnnotation(annotationKey));
+    }
+
+    @Test
+    public void replaceNotFound() {
+        Address address = createAddress(ADDRESS_SPACE_NAMESPACE, ADDRESS_NAME);
+
+        boolean replaced = api.replaceAddress(address);
+        assertFalse(replaced);
+    }
+
+    @Test
+    public void delete() {
+        Address space = createAddress(ADDRESS_SPACE_NAMESPACE, ADDRESS_NAME);
+
+        api.createAddress(space);
+
+        boolean deleted = api.deleteAddress(space);
+        assertTrue(deleted);
+
+        assertFalse(api.getAddressWithName(ADDRESS_SPACE_NAMESPACE, ADDRESS_NAME).isPresent());
+
+        boolean deletedAgain = api.deleteAddress(space);
+        assertFalse(deletedAgain);
+    }
+
+    private Address createAddress(String namespace, String name) {
+        return new Address.Builder()
+                .setName(name)
+                .setNamespace(namespace)
+                .setAddress(ADDRESS)
+                .setAddressSpace(ADDRESS_SPACE)
+                .setType(ADDRESS_TYPE)
+                .setPlan(ADDRESS_PLAN)
+                .build();
+    }
+}

--- a/k8s-api/src/test/java/io/enmasse/k8s/api/ConfigMapAddressSpaceApiTest.java
+++ b/k8s-api/src/test/java/io/enmasse/k8s/api/ConfigMapAddressSpaceApiTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017-2018, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.k8s.api;
+
+import io.enmasse.address.model.AddressSpace;
+import io.fabric8.openshift.client.NamespacedOpenShiftClient;
+import io.fabric8.openshift.client.server.mock.OpenShiftServer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.junit.Assert.*;
+
+/**
+ * The mock server does not emulate behaviour with respect to resourceVersion.
+ */
+public class ConfigMapAddressSpaceApiTest {
+    private static final String ADDRESS_SPACE_NAME = "myspace";
+    private static final String ADDRESS_SPACE_TYPE = "mytype";
+    private static final String ADDRESS_SPACE_PLAN = "myplan";
+    private static final String ADDRESS_SPACE_NAMESPACE = "myproject";
+    @Rule
+    public OpenShiftServer openShiftServer = new OpenShiftServer(false, true);
+    private AddressSpaceApi api;
+
+    @Before
+    public void setUp() {
+        NamespacedOpenShiftClient client = openShiftServer.getOpenshiftClient();
+        api = new ConfigMapAddressSpaceApi(client);
+    }
+
+    @Test
+    public void create() throws Exception {
+        AddressSpace space = createAddressSpace(ADDRESS_SPACE_NAMESPACE, ADDRESS_SPACE_NAME);
+
+        api.createAddressSpace(space);
+        Optional<AddressSpace> readAddressSpace = api.getAddressSpaceWithName(ADDRESS_SPACE_NAMESPACE, ADDRESS_SPACE_NAME);
+
+        assertTrue(readAddressSpace.isPresent());
+        AddressSpace read = readAddressSpace.get();
+
+        assertEquals(ADDRESS_SPACE_NAME, read.getName());
+        assertEquals(ADDRESS_SPACE_TYPE, read.getType());
+        assertEquals(ADDRESS_SPACE_PLAN, read.getPlan());
+    }
+
+    @Test
+    public void replace() throws Exception {
+        AddressSpace space = createAddressSpace(ADDRESS_SPACE_NAMESPACE, ADDRESS_SPACE_NAME);
+        final String annotationKey = "myannotation";
+        String annotationValue = "value";
+        AddressSpace update = new AddressSpace.Builder(space).putAnnotation(annotationKey, annotationValue).build();
+
+        api.createAddressSpace(space);
+        assertTrue(api.getAddressSpaceWithName(ADDRESS_SPACE_NAMESPACE, ADDRESS_SPACE_NAME).isPresent());
+
+        boolean replaced = api.replaceAddressSpace(update);
+        assertTrue(replaced);
+
+        AddressSpace read = api.getAddressSpaceWithName(ADDRESS_SPACE_NAMESPACE, ADDRESS_SPACE_NAME).get();
+
+        assertEquals(ADDRESS_SPACE_NAME, read.getName());
+        assertEquals(annotationValue, read.getAnnotation(annotationKey));
+    }
+
+    @Test
+    public void replaceNotFound() throws Exception {
+        AddressSpace space = createAddressSpace(ADDRESS_SPACE_NAMESPACE, ADDRESS_SPACE_NAME);
+
+        boolean replaced = api.replaceAddressSpace(space);
+        assertFalse(replaced);
+    }
+
+    @Test
+    public void delete() throws Exception {
+        AddressSpace space = createAddressSpace(ADDRESS_SPACE_NAMESPACE, ADDRESS_SPACE_NAME);
+
+        api.createAddressSpace(space);
+
+        boolean deleted = api.deleteAddressSpace(space);
+        assertTrue(deleted);
+
+        assertFalse(api.getAddressSpaceWithName(ADDRESS_SPACE_NAMESPACE, ADDRESS_SPACE_NAME).isPresent());
+
+        boolean deletedAgain = api.deleteAddressSpace(space);
+        assertFalse(deletedAgain);
+    }
+
+    private AddressSpace createAddressSpace(String namespace, String name) {
+        return new AddressSpace.Builder()
+                .setName(name)
+                .setNamespace(namespace)
+                .setType(ADDRESS_SPACE_TYPE)
+                .setPlan(ADDRESS_SPACE_PLAN)
+                .build();
+    }
+}


### PR DESCRIPTION
Also make use of openshift API the same between ConfigMapAddressApi/ConfigMapAddressSpaceApi implementations.