### PR TITLE
Non-greedy regex for JMX exporter expressions

### DIFF
--- a/templates/address-space-controller/020-ConfigMap-broker-prometheus-config.yaml
+++ b/templates/address-space-controller/020-ConfigMap-broker-prometheus-config.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 data:
   config.yaml: '{"hostPort": "127.0.0.1:1099", "rules": [{"labels": {"broker":
-    "$1"}, "name": "artemis_connection_count", "pattern": "org.apache.activemq.artemis<broker=\"(.+)\"><>ConnectionCount",
+    "$1"}, "name": "artemis_connection_count", "pattern": "org.apache.activemq.artemis<broker=\"(.+?)\"><>ConnectionCount",
     "type": "GAUGE"}, {"labels": {"address": "$2", "broker": "$1"}, "name": "artemis_consumer_count",
-    "pattern": "org.apache.activemq.artemis<broker=\"(.+)\", component=addresses,
-    address=\"(.+)\".*><>ConsumerCount", "type": "GAUGE"}, {"labels": {"address":
-    "$2", "broker": "$1"}, "name": "artemis_message_count", "pattern": "org.apache.activemq.artemis<broker=\"(.+)\",
-    component=addresses, address=\"(.+)\".*><>MessageCount", "type": "GAUGE"}],
+    "pattern": "org.apache.activemq.artemis<broker=\"(.+?)\", component=addresses,
+    address=\"(.+?)\".*><>ConsumerCount", "type": "GAUGE"}, {"labels": {"address":
+    "$2", "broker": "$1"}, "name": "artemis_message_count", "pattern": "org.apache.activemq.artemis<broker=\"(.+?)\",
+    component=addresses, address=\"(.+?)\".*><>MessageCount", "type": "GAUGE"}],
     "ssl": true}'
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
Non-greedy regex pattern matching should be used in the Prometheus JMX exporter patterns. As of now with greedy matching, the `address` label contains more than just the address .

For example in `artemis_consumer_count`:

**JMX exporter output with greedy regex (incorrect)**
`artemis_consumer_count{address="myqueue\", subcomponent=queues, routing-type=\"anycast\", queue=\"myqueue",broker="broker-pooled-c84ir342pj-0",} 1.0`

(the `address` label contains `myqueue", subcomponent=queues, routing-type="anycast", queue="myqueue`)

Full relevant output of the jmx exporter: [jmx-exporter-output.txt](https://github.com/EnMasseProject/enmasse/files/2603351/jmx-exporter-output.txt)

**JMX exporter output with non-greedy regex (correct)**
`artemis_consumer_count{address="myqueue",broker="c84ir342pj-0",} 1.0`
(the `address` label contains `myqueue`)