### PR TITLE
Issue 1595 - display warning if connection to the server is lost

### DIFF
--- a/agent/bin/agent.js
+++ b/agent/bin/agent.js
@@ -15,6 +15,7 @@
  */
 'use strict';
 
+var log = require("../lib/log.js").logger();
 var AddressSource = require('../lib/internal_address_source.js');
 var BrokerAddressSettings = require('../lib/broker_address_settings.js');
 var ConsoleServer = require('../lib/console_server.js');
@@ -58,6 +59,20 @@ function start(env) {
             ragent.start_listening(env);
             ragent.listen_probe({PROBE_PORT:8888});
         }
+
+        process.on('SIGTERM', function () {
+            log.info('Shutdown started');
+            var exitHandler = function () {
+                process.exit(0);
+            };
+            var timeout = setTimeout(exitHandler, 2000);
+
+            console_server.close(function() {
+                log.info("Console server closed");
+                clearTimeout(timeout);
+                exitHandler();
+            });
+        });
     });
 }
 

--- a/agent/bin/launch_node.sh
+++ b/agent/bin/launch_node.sh
@@ -13,4 +13,4 @@ if [[ ! -z "${_NODE_OPTIONS}" ]]; then
     set -- ${_NODE_OPTIONS} "${@}"
 fi
 
-node "${@}"
+exec node "${@}"

--- a/agent/www/app.module.js
+++ b/agent/www/app.module.js
@@ -1,6 +1,6 @@
 angular.module('enmasse', ['patternfly.navigation', 'ui.router', 'patternfly.views', 'ui.grid', 'ui.grid.autoResize',
         'ui.grid.resizeColumns', 'ui.bootstrap', 'patternfly.toolbars', 'patternfly.charts', 'patternfly.wizard',
-        'patternfly.validation', 'address_service']).config(
+        'patternfly.validation', 'patternfly.modals', 'address_service']).config(
     function ($stateProvider, $urlRouterProvider) {
         $urlRouterProvider.otherwise('/addresses');
         $stateProvider.state('addresses',

--- a/agent/www/components/addresses/addresses_ctrl.js
+++ b/agent/www/components/addresses/addresses_ctrl.js
@@ -394,6 +394,39 @@ angular.module('patternfly.toolbars').controller('ViewCtrl', ['$scope', '$timeou
       }
     ]);
 
+angular.module('patternfly.modals').controller('PeerLostController', ['$scope', '$uibModal', 'address_service',
+    function ($scope, $uibModal, address_service) {
+
+        $scope.openWizardModel = function () {
+            $scope.modalInstance = $uibModal.open({
+                animation: true,
+                backdrop: 'static',
+                templateUrl: '/peer_lost.html',
+                controller: function ($scope, $uibModalInstance) {
+                },
+                size: 'lg'
+            });
+            console.log("modalInstance %s", modalInstance);
+        };
+
+        address_service.add_additional_listener(function(reason) {
+            console.log('callback %s', reason);
+            if (reason === 'peer_disconnected') {
+                if (!$scope.modalInstance) {
+                    console.log("disconnected");
+                    $scope.openWizardModel();
+                }
+            } else if (reason === 'peer_connected') {
+                if ($scope.modalInstance) {
+                    console.log("connected");
+                    $scope.modalInstance.close();
+                    $scope.modalInstance = null;
+                }
+            }
+        });
+    }
+    ]);
+
 angular.module('patternfly.wizard').controller('WizardModalController', ['$scope', '$timeout', '$uibModal', '$rootScope',
    function ($scope, $timeout, $uibModal, $rootScope) {
         $scope.openWizardModel = function () {

--- a/agent/www/index.html
+++ b/agent/www/index.html
@@ -63,18 +63,12 @@
             Server Connection Lost
           </p>
           <p>
-            This may mean that a server component is being restarted. If this is the case, the console
-            will reconnect automatically. <!--Alternatively, the address space to which the console was connected
-            has been deleted, if this is the case, click the Logout button to end the session.-->
+            This may mean that the address space to which the console is connected has been permanently deleted, or it
+            could be indicative of a transient issue such as a network problem or server component restart.  If the
+            issue is transient, the console will reconnect automatically once the problem is resolved.
           </p>
         </div>
       </div>
-      <!--
-      TODO: if the address space is deleted we have no server to handle the logout and no location to direct the browser to.
-      <div class="modal-footer">
-        <a href="logout" class="btn btn-default">Logout</a>
-      </div>
-      -->
     </div>
   </script>
 

--- a/agent/www/index.html
+++ b/agent/www/index.html
@@ -51,6 +51,37 @@
     <script src="components/connections/connections_ctrl.js"></script>
   </head>
   <body>
+
+  <script type="text/ng-template" id="/peer_lost.html">
+    <div class="message-dialog-pf">
+      <div class="modal-header">
+        <h4 class="modal-title" id="myErrorDialogLabel">Server Connection Lost</h4>
+      </div>
+      <div class="modal-body">
+        <div>
+          <p class="lead pficon pficon-error-circle-o">
+            Server Connection Lost
+          </p>
+          <p>
+            This may mean that a server component is being restarted. If this is the case, the console
+            will reconnect automatically. <!--Alternatively, the address space to which the console was connected
+            has been deleted, if this is the case, click the Logout button to end the session.-->
+          </p>
+        </div>
+      </div>
+      <!--
+      TODO: if the address space is deleted we have no server to handle the logout and no location to direct the browser to.
+      <div class="modal-footer">
+        <a href="logout" class="btn btn-default">Logout</a>
+      </div>
+      -->
+    </div>
+  </script>
+
+
+  <div ng-controller="PeerLostController" class="example-container">
+  </div>
+
   <div id="verticalNavLayout" class="layout-pf layout-pf-fixed faux-layout" ng-controller="NavCtrl">
     <div pf-vertical-navigation items="navigationItems" brand-alt="${application.display.name}"
           pinnable-menus="true" update-active-items-on-click="true"


### PR DESCRIPTION
This PR adds a modal dialogue that pops up if the connection to the server is lost.   If the connection reestablishes itself the modal will automatically pop-down.  Scenarios where thus might happen are if the admin pod was restarted, or the user's internet connection dropped temporarily. The user currently has no way to dismiss the dialogue and cannot interact with the app whilst it is popped up.

![serverconnectionlost](https://user-images.githubusercontent.com/18440250/48969923-798f5100-effd-11e8-84ce-ac4fbaafa4ce.png)

My original intent was to offer a [Logout] button.  However, currently the `/logout` url relies on relies on the server (agent) being available.

I think an improvement would be to allow the infra config to specify a site specific `logoutUrl`.  Currently we just redirect back to keycloak (or openshift) but this probably is not too helpful in terms of workflow. The deployer would configure `logoutUrl` to suitable landing page (outside of EnMasse).  EnMasse would direct to this logout url via a [keyclock logoff redirect](https://www.keycloak.org/docs/3.3/securing_apps/topics/oidc/java/logout.html).

If we had `logoutUrl`, and the server side made it available to the client, this facility could be used by this change.
