### PR TITLE
Use same logging patterns for all components

### DIFF
--- a/address-space-controller/Dockerfile
+++ b/address-space-controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM enmasseproject/java-base:8-9
+FROM enmasseproject/java-base:8-10
 
 RUN yum -y install openssl && yum -y clean all
 

--- a/address-space-controller/src/main/resources/log4j.properties
+++ b/address-space-controller/src/main/resources/log4j.properties
@@ -1,5 +1,5 @@
 log4j.rootLogger=${LOG_LEVEL},stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+log4j.appender.stdout.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd}{GMT+0}T%d{HH:mm:ss.SSS}{GMT+0}Z %-5p [%c{1}] %m%n

--- a/agent/lib/log.js
+++ b/agent/lib/log.js
@@ -27,6 +27,7 @@ var levels = {
 function Logger (name) {
     this.logger = require('debug')(name);
     this.level = 2;
+    this.name = name;
 
     if (process.env.LOGLEVEL) {
         var desired_level = levels[process.env.LOGLEVEL];
@@ -36,10 +37,19 @@ function Logger (name) {
     }
 }
 
+function formatLevel(level, spaces) {
+    var nchars = level.length;
+    while (nchars < spaces) {
+        level += " ";
+        nchars++;
+    }
+    return level.toUpperCase();
+}
+
 Logger.prototype.log = function (level, str) {
     var args = Array.prototype.slice.call(arguments, 2);
     if (levels[level] !== undefined && levels[level] <= this.level) {
-        this.logger.apply(this.logger, [level + " " + str].concat(args));
+        this.logger.apply(this.logger, [formatLevel(level, 5) + " " + str].concat(args));
     }
 }
 

--- a/api-server/Dockerfile
+++ b/api-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM enmasseproject/java-base:8-9
+FROM enmasseproject/java-base:8-10
 
 ARG version
 ARG commit

--- a/api-server/src/main/resources/log4j.properties
+++ b/api-server/src/main/resources/log4j.properties
@@ -1,5 +1,5 @@
 log4j.rootLogger=${LOG_LEVEL},stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+log4j.appender.stdout.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd}{GMT+0}T%d{HH:mm:ss.SSS}{GMT+0}Z %-5p [%c{1}] %m%n

--- a/artemis/Dockerfile
+++ b/artemis/Dockerfile
@@ -1,4 +1,4 @@
-FROM enmasseproject/java-base:8-9
+FROM enmasseproject/java-base:8-10
 
 RUN yum -y install which libaio python gettext hostname iputils openssl && yum clean all -y && mkdir -p /var/run/artemis/
 

--- a/artemis/plugin/src/main/resources/logging.properties
+++ b/artemis/plugin/src/main/resources/logging.properties
@@ -23,9 +23,6 @@ loggers=org.eclipse.jetty,org.jboss.logging,org.apache.activemq.artemis.core.ser
 logger.level=INFO
 # ActiveMQ Artemis logger levels
 logger.org.apache.activemq.artemis.core.server.level=INFO
-logger.org.apache.activemq.artemis.core.paging.level=INFO
-logger.org.apache.activemq.artemis.core.paging.impl.level=INFO
-logger.org.apache.activemq.artemis.core.server.level=INFO
 logger.org.apache.activemq.artemis.journal.level=INFO
 logger.org.apache.activemq.artemis.utils.level=INFO
 logger.org.apache.activemq.artemis.jms.level=INFO
@@ -37,11 +34,11 @@ logger.handlers=CONSOLE
 # Console handler configuration
 handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
 handler.CONSOLE.properties=autoFlush
-handler.CONSOLE.level=INFO
+handler.CONSOLE.level=DEBUG
 handler.CONSOLE.autoFlush=true
 handler.CONSOLE.formatter=PATTERN
 
 # Formatter pattern configuration
 formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
 formatter.PATTERN.properties=pattern
-formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p [%c] %s%E%n
+formatter.PATTERN.pattern=%d{yyyy-MM-dd}T%d{HH:mm:ss.SSS}Z %-5p [%c{1}] %m%n

--- a/artemis/plugin/src/main/sh/launch.sh
+++ b/artemis/plugin/src/main/sh/launch.sh
@@ -110,9 +110,7 @@ function configure() {
 
     envsubst < $CONFIG_TEMPLATES/artemis.profile > $instanceDir/etc/artemis.profile
 
-    if [ "$DEBUG_LOGGING" == "true" ]; then
-        cp $CONFIG_TEMPLATES/logging.properties $instanceDir/etc/logging.properties
-    fi
+    cp $CONFIG_TEMPLATES/logging.properties $instanceDir/etc/logging.properties
 }
 
 function init_data_dir() {

--- a/keycloak-controller/Dockerfile
+++ b/keycloak-controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM enmasseproject/java-base:8-9
+FROM enmasseproject/java-base:8-10
 
 ARG version
 ARG commit

--- a/keycloak-controller/src/main/resources/log4j.properties
+++ b/keycloak-controller/src/main/resources/log4j.properties
@@ -1,5 +1,5 @@
 log4j.rootLogger=${LOG_LEVEL},stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+log4j.appender.stdout.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd}{GMT+0}T%d{HH:mm:ss.SSS}{GMT+0}Z %-5p [%c{1}] %m%n

--- a/keycloak-plugin/Dockerfile
+++ b/keycloak-plugin/Dockerfile
@@ -1,4 +1,4 @@
-FROM enmasseproject/java-base:8-9
+FROM enmasseproject/java-base:8-10
 
 RUN yum -y install openssl && yum -y clean all
 

--- a/keycloak-plugin/src/main/configuration/logging.properties
+++ b/keycloak-plugin/src/main/configuration/logging.properties
@@ -34,8 +34,8 @@ formatters=PATTERN
 
 formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
 formatter.PATTERN.properties=pattern
-formatter.PATTERN.pattern=%d{yyyy-MM-dd HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%e%n
+formatter.PATTERN.pattern=%d{yyyy-MM-dd}T%d{HH:mm:ss.SSS}Z %-5p [%c{1}] %m%n
 
 formatter.COLOR-PATTERN=org.jboss.logmanager.formatters.PatternFormatter
 formatter.COLOR-PATTERN.properties=pattern
-formatter.COLOR-PATTERN.pattern=%K{level}%d{HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%e%n
+formatter.COLOR-PATTERN.pattern=%K%d{yyyy-MM-dd}T%d{HH:mm:ss.SSS}Z %-5p [%c{1}] %m%n

--- a/keycloak-plugin/src/main/configuration/standalone.xml
+++ b/keycloak-plugin/src/main/configuration/standalone.xml
@@ -106,10 +106,10 @@
                 </handlers>
             </root-logger>
             <formatter name="PATTERN">
-                <pattern-formatter pattern="%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
+                <pattern-formatter pattern="%d{yyyy-MM-dd}T%d{HH:mm:ss.SSS}Z %-5p [%c{1}] %m%n"/>
             </formatter>
             <formatter name="COLOR-PATTERN">
-                <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
+                <pattern-formatter pattern="%K%d{yyyy-MM-dd}T%d{HH:mm:ss.SSS}Z %-5p [%c{1}] %m%n"/>
             </formatter>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:bean-validation:1.0"/>

--- a/mqtt-gateway/Dockerfile
+++ b/mqtt-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM enmasseproject/java-base:8-9
+FROM enmasseproject/java-base:8-10
 
 ARG version
 ARG commit

--- a/mqtt-gateway/src/main/resources/log4j.properties
+++ b/mqtt-gateway/src/main/resources/log4j.properties
@@ -1,5 +1,5 @@
 log4j.rootLogger=${LOG_LEVEL},stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+log4j.appender.stdout.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd}{GMT+0}T%d{HH:mm:ss.SSS}{GMT+0}Z %-5p [%c{1}] %m%n

--- a/mqtt-lwt/Dockerfile
+++ b/mqtt-lwt/Dockerfile
@@ -1,4 +1,4 @@
-FROM enmasseproject/java-base:8-9
+FROM enmasseproject/java-base:8-10
 
 ARG version
 ARG commit

--- a/mqtt-lwt/src/main/resources/log4j.properties
+++ b/mqtt-lwt/src/main/resources/log4j.properties
@@ -1,5 +1,5 @@
 log4j.rootLogger=${LOG_LEVEL},stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+log4j.appender.stdout.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd}{GMT+0}T%d{HH:mm:ss.SSS}{GMT+0}Z %-5p [%c{1}] %m%n

--- a/router/Dockerfile
+++ b/router/Dockerfile
@@ -1,7 +1,7 @@
 FROM enmasseproject/qdrouterd-base:1.5-SNAPSHOT-DISPATCH-1181
 ARG version
 ARG commit
-ENV VERSION=${version} COMMIT=${commit}
+ENV VERSION=${version} COMMIT=${commit} TZ=GMT0
 
 ADD build/router-${VERSION}.tgz /etc/qpid-dispatch/
 

--- a/service-broker/Dockerfile
+++ b/service-broker/Dockerfile
@@ -1,4 +1,4 @@
-FROM enmasseproject/java-base:8-9
+FROM enmasseproject/java-base:8-10
 
 ARG version
 ARG commit

--- a/standard-controller/Dockerfile
+++ b/standard-controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM enmasseproject/java-base:8-9
+FROM enmasseproject/java-base:8-10
 
 ARG version
 ARG commit

--- a/standard-controller/src/main/resources/log4j.properties
+++ b/standard-controller/src/main/resources/log4j.properties
@@ -1,5 +1,5 @@
 log4j.rootLogger=${LOG_LEVEL},stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+log4j.appender.stdout.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd}{GMT+0}T%d{HH:mm:ss.SSS}{GMT+0}Z %-5p [%c{1}] %m%n

--- a/templates/standard-authservice/050-Deployment-keycloak.yaml
+++ b/templates/standard-authservice/050-Deployment-keycloak.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
       - env:
         - name: JAVA_OPTS
-          value: -Dvertx.cacheDirBase=/tmp -Djboss.bind.address=0.0.0.0 -Djava.net.preferIPv4Stack=true
+          value: -Dvertx.cacheDirBase=/tmp -Djboss.bind.address=0.0.0.0 -Djava.net.preferIPv4Stack=true -Duser.timezone=UTC
             -Xms512m -Xmx1024m
         - name: KEYCLOAK_USER
           valueFrom:

--- a/topic-forwarder/Dockerfile
+++ b/topic-forwarder/Dockerfile
@@ -1,4 +1,4 @@
-FROM enmasseproject/java-base:8-9
+FROM enmasseproject/java-base:8-10
 
 ARG version
 ARG commit

--- a/topic-forwarder/src/main/resources/log4j.properties
+++ b/topic-forwarder/src/main/resources/log4j.properties
@@ -1,5 +1,5 @@
 log4j.rootLogger=${LOG_LEVEL},stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+log4j.appender.stdout.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd}{GMT+0}T%d{HH:mm:ss.SSS}{GMT+0}Z %-5p [%c{1}] %m%n


### PR DESCRIPTION
* Minor difference for agent where component comes before log level due
to debug library needing this.
* Use UTC/GMT for all component logs

Closes #2003