### PR TITLE
Dont show router metrics in connection tab

### DIFF
--- a/agent/lib/router_stats.js
+++ b/agent/lib/router_stats.js
@@ -224,7 +224,7 @@ function is_role_normal (c) {
     return c.role === 'normal';
 }
 
-var internal_identifiers = ['standard-controller', 'agent', 'ragent', 'qdconfigd', 'subserv', 'lwt-service'];
+var internal_identifiers = ['standard-controller', 'agent', 'ragent', 'qdconfigd', 'subserv', 'lwt-service', 'router-metrics'];
 
 function is_internal_identifier (s) {
     return internal_identifiers.indexOf(s) >= 0;


### PR DESCRIPTION
Could potentially make tests unstable if they show up in the connection tab in the console