### PR TITLE
Never call onUpdate on watches before items has received the initial …

### DIFF
--- a/k8s-api/src/main/java/io/enmasse/k8s/api/ResourceChecker.java
+++ b/k8s-api/src/main/java/io/enmasse/k8s/api/ResourceChecker.java
@@ -15,7 +15,7 @@ public class ResourceChecker<T> implements Watcher<T>, Runnable {
     private final Watcher<T> watcher;
     private final Duration recheckInterval;
     private final Object monitor = new Object();
-    private List<T> items = new ArrayList<>();
+    private List<T> items = null;
     private volatile boolean running = false;
 
     private Thread thread;
@@ -44,7 +44,9 @@ public class ResourceChecker<T> implements Watcher<T>, Runnable {
             try {
                 monitor.wait(recheckInterval.toMillis());
                 log.debug("Woke up from monitor");
-                watcher.onUpdate(items);
+                if (items != null) {
+                    watcher.onUpdate(items);
+                }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             } catch (Exception e) {

--- a/k8s-api/src/test/java/io/enmasse/k8s/api/ResourceCheckerTest.java
+++ b/k8s-api/src/test/java/io/enmasse/k8s/api/ResourceCheckerTest.java
@@ -27,6 +27,9 @@ public class ResourceCheckerTest {
 
     @Test
     public void testResourcesUpdated() throws Exception {
+        controller.doWork();
+        verify(watcher, never()).onUpdate(any());
+
         List<String> items = Arrays.asList("hello", "there");
         controller.onUpdate(items);
         controller.doWork();


### PR DESCRIPTION
…update

This could cause the address-space-controller and standard-controller
loops to be invoked with an empty list of resources in the case of
parsing errors, causing them to delete infrastructure.

Closes #2025