### PR TITLE
Add support for node affinity

### DIFF
--- a/templates/address-space-controller/020-ConfigMap-address-space-definitions.yaml
+++ b/templates/address-space-controller/020-ConfigMap-address-space-definitions.yaml
@@ -207,6 +207,16 @@ data:
           infraUuid: ${INFRA_UUID}
         name: qdrouterd-${INFRA_UUID}
       spec:
+        affinity:
+          nodeAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                preference:
+                  matchExcpressions:
+                    - key: enmasse-role
+                      operator: In
+                      values:
+                        - messaging-infra
         serviceName: qdrouterd-headless-${INFRA_UUID}
         replicas: 1
         selector:
@@ -338,6 +348,16 @@ data:
           infraUuid: ${INFRA_UUID}
         name: admin.${INFRA_UUID}
       spec:
+        affinity:
+          nodeAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                preference:
+                  matchExcpressions:
+                    - key: enmasse-role
+                      operator: In
+                      values:
+                        - operator-infra
         replicas: 1
         strategy:
           type: Recreate
@@ -722,6 +742,16 @@ data:
           infraUuid: ${INFRA_UUID}
         name: subserv.${INFRA_UUID}
       spec:
+        affinity:
+          nodeAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                preference:
+                  matchExcpressions:
+                    - key: enmasse-role
+                      operator: In
+                      values:
+                        - messaging-infra
         replicas: 1
         selector:
           matchLabels:
@@ -812,6 +842,16 @@ data:
           infraUuid: ${INFRA_UUID}
         name: mqtt-gateway.${INFRA_UUID}
       spec:
+        affinity:
+          nodeAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                preference:
+                  matchExcpressions:
+                    - key: enmasse-role
+                      operator: In
+                      values:
+                        - messaging-infra
         replicas: 1
         selector:
           matchLabels:
@@ -893,6 +933,16 @@ data:
           infraUuid: ${INFRA_UUID}
         name: mqtt-lwt.${INFRA_UUID}
       spec:
+        affinity:
+          nodeAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                preference:
+                  matchExcpressions:
+                    - key: enmasse-role
+                      operator: In
+                      values:
+                        - messaging-infra
         replicas: 1
         selector:
           matchLabels:
@@ -991,6 +1041,16 @@ data:
           infraUuid: ${INFRA_UUID}
         name: broker.${INFRA_UUID}
       spec:
+        affinity:
+          nodeAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                preference:
+                  matchExcpressions:
+                    - key: enmasse-role
+                      operator: In
+                      values:
+                        - messaging-infra
         replicas: 1
         strategy:
           type: Recreate
@@ -1152,6 +1212,16 @@ data:
           infraUuid: ${INFRA_UUID}
         name: agent.${INFRA_UUID}
       spec:
+        affinity:
+          nodeAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                preference:
+                  matchExcpressions:
+                    - key: enmasse-role
+                      operator: In
+                      values:
+                        - operator-infra
         replicas: 1
         strategy:
           type: Recreate

--- a/templates/address-space-controller/020-ConfigMap-standard-broker-definitions.yaml
+++ b/templates/address-space-controller/020-ConfigMap-standard-broker-definitions.yaml
@@ -45,6 +45,16 @@ data:
           infraUuid: ${INFRA_UUID}
         name: ${NAME}
       spec:
+        affinity:
+          nodeAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                preference:
+                  matchExcpressions:
+                    - key: enmasse-role
+                      operator: In
+                      values:
+                        - messaging-infra
         replicas: 1
         serviceName: ${NAME}
         selector:
@@ -260,6 +270,16 @@ data:
           infraUuid: ${INFRA_UUID}
         name: ${NAME}
       spec:
+        affinity:
+          nodeAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                preference:
+                  matchExcpressions:
+                    - key: enmasse-role
+                      operator: In
+                      values:
+                        - messaging-infra
         replicas: 1
         serviceName: ${NAME}
         selector:

--- a/templates/address-space-controller/050-Deployment-address-space-controller.yaml
+++ b/templates/address-space-controller/050-Deployment-address-space-controller.yaml
@@ -19,6 +19,16 @@ spec:
         app: enmasse
         name: address-space-controller
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              preference:
+                matchExcpressions:
+                  - key: enmasse-role
+                    operator: In
+                    values:
+                      - operator-infra
       containers:
       - env:
         - name: JAVA_OPTS

--- a/templates/alertmanager/030-Deployment-alertmanager.yaml
+++ b/templates/alertmanager/030-Deployment-alertmanager.yaml
@@ -16,6 +16,16 @@ spec:
         app: enmasse
         name: alertmanager
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              preference:
+                matchExcpressions:
+                  - key: enmasse-role
+                    operator: In
+                    values:
+                      - operator-infra
       containers:
       - image: ${ALERTMANAGER_IMAGE}
         imagePullPolicy: ${IMAGE_PULL_POLICY}

--- a/templates/api-server/050-Deployment-api-server.yaml
+++ b/templates/api-server/050-Deployment-api-server.yaml
@@ -17,6 +17,16 @@ spec:
         app: enmasse
         component: api-server
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              preference:
+                matchExcpressions:
+                  - key: enmasse-role
+                    operator: In
+                    values:
+                      - operator-infra
       containers:
       - env:
         - name: JAVA_OPTS

--- a/templates/grafana/030-Deployment-grafana.yaml
+++ b/templates/grafana/030-Deployment-grafana.yaml
@@ -16,6 +16,16 @@ spec:
         app: enmasse
         name: grafana
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              preference:
+                matchExcpressions:
+                  - key: enmasse-role
+                    operator: In
+                    values:
+                      - operator-infra
       containers:
       - name: grafana
         image: ${GRAFANA_IMAGE}

--- a/templates/kube-state-metrics/030-Deployment-kube-state-metrics.yaml
+++ b/templates/kube-state-metrics/030-Deployment-kube-state-metrics.yaml
@@ -16,6 +16,16 @@ spec:
         app: enmasse
         component: kube-metrics
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              preference:
+                matchExcpressions:
+                  - key: enmasse-role
+                    operator: In
+                    values:
+                      - operator-infra
       containers:
       - name: kube-metrics
         image: ${KUBE_STATE_METRICS_IMAGE}

--- a/templates/none-authservice/050-Deployment-none-authservice.yaml
+++ b/templates/none-authservice/050-Deployment-none-authservice.yaml
@@ -16,6 +16,16 @@ spec:
         app: enmasse
         name: none-authservice
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              preference:
+                matchExcpressions:
+                  - key: enmasse-role
+                    operator: In
+                    values:
+                      - operator-infra
       containers:
       - env:
         - name: LISTENPORT

--- a/templates/prometheus/030-Deployment-prometheus.yaml
+++ b/templates/prometheus/030-Deployment-prometheus.yaml
@@ -16,6 +16,16 @@ spec:
         app: enmasse
         name: prometheus
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              preference:
+                matchExcpressions:
+                  - key: enmasse-role
+                    operator: In
+                    values:
+                      - operator-infra
       containers:
       - image: ${PROMETHEUS_IMAGE}
         imagePullPolicy: ${IMAGE_PULL_POLICY}

--- a/templates/service-broker/050-Deployment-service-broker.yaml
+++ b/templates/service-broker/050-Deployment-service-broker.yaml
@@ -19,6 +19,16 @@ spec:
         app: enmasse
         component: service-broker
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              preference:
+                matchExcpressions:
+                  - key: enmasse-role
+                    operator: In
+                    values:
+                      - operator-infra
       containers:
       - env:
         - name: ENABLE_RBAC

--- a/templates/standard-authservice/050-Deployment-keycloak-controller.yaml
+++ b/templates/standard-authservice/050-Deployment-keycloak-controller.yaml
@@ -16,6 +16,16 @@ spec:
         app: enmasse
         name: keycloak-controller
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              preference:
+                matchExcpressions:
+                  - key: enmasse-role
+                    operator: In
+                    values:
+                      - operator-infra
       containers:
       - env:
         - name: AUTO_CREATE

--- a/templates/standard-authservice/050-Deployment-keycloak.yaml
+++ b/templates/standard-authservice/050-Deployment-keycloak.yaml
@@ -19,6 +19,16 @@ spec:
         app: enmasse
         name: keycloak
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              preference:
+                matchExcpressions:
+                  - key: enmasse-role
+                    operator: In
+                    values:
+                      - operator-infra
       containers:
       - env:
         - name: JAVA_OPTS


### PR DESCRIPTION
Introduce 2 node roles that are configured as preferred node affinity:
* enmasse-role: operator-infra - for components that are only responsible for configuration
* enmasse-role: messaging-infra - for components that are involved in messaging