### PR TITLE
Rename node affinity labels

### DIFF
--- a/templates/address-space-controller/020-ConfigMap-address-space-definitions.yaml
+++ b/templates/address-space-controller/020-ConfigMap-address-space-definitions.yaml
@@ -213,10 +213,10 @@ data:
               - weight: 1
                 preference:
                   matchExpressions:
-                    - key: enmasse-role
+                    - key: node-role.enmasse.io/operator-infra
                       operator: In
                       values:
-                        - messaging-infra
+                        - true
         serviceName: qdrouterd-headless-${INFRA_UUID}
         replicas: 1
         selector:
@@ -354,10 +354,10 @@ data:
               - weight: 1
                 preference:
                   matchExpressions:
-                    - key: enmasse-role
+                    - key: node-role.enmasse.io/operator-infra
                       operator: In
                       values:
-                        - operator-infra
+                        - true
         replicas: 1
         strategy:
           type: Recreate
@@ -748,10 +748,10 @@ data:
               - weight: 1
                 preference:
                   matchExpressions:
-                    - key: enmasse-role
+                    - key: node-role.enmasse.io/messaging-infra
                       operator: In
                       values:
-                        - messaging-infra
+                        - true
         replicas: 1
         selector:
           matchLabels:
@@ -848,10 +848,10 @@ data:
               - weight: 1
                 preference:
                   matchExpressions:
-                    - key: enmasse-role
+                    - key: node-role.enmasse.io/messaging-infra
                       operator: In
                       values:
-                        - messaging-infra
+                        - true
         replicas: 1
         selector:
           matchLabels:
@@ -939,10 +939,10 @@ data:
               - weight: 1
                 preference:
                   matchExpressions:
-                    - key: enmasse-role
+                    - key: node-role.enmasse.io/messaging-infra
                       operator: In
                       values:
-                        - messaging-infra
+                        - true
         replicas: 1
         selector:
           matchLabels:
@@ -1047,10 +1047,10 @@ data:
               - weight: 1
                 preference:
                   matchExpressions:
-                    - key: enmasse-role
+                    - key: node-role.enmasse.io/messaging-infra
                       operator: In
                       values:
-                        - messaging-infra
+                        - true
         replicas: 1
         strategy:
           type: Recreate
@@ -1218,10 +1218,10 @@ data:
               - weight: 1
                 preference:
                   matchExpressions:
-                    - key: enmasse-role
+                    - key: node-role.enmasse.io/operator-infra
                       operator: In
                       values:
-                        - operator-infra
+                        - true
         replicas: 1
         strategy:
           type: Recreate

--- a/templates/address-space-controller/020-ConfigMap-address-space-definitions.yaml
+++ b/templates/address-space-controller/020-ConfigMap-address-space-definitions.yaml
@@ -216,7 +216,7 @@ data:
                     - key: node-role.enmasse.io/operator-infra
                       operator: In
                       values:
-                        - true
+                        - "true"
         serviceName: qdrouterd-headless-${INFRA_UUID}
         replicas: 1
         selector:
@@ -357,7 +357,7 @@ data:
                     - key: node-role.enmasse.io/operator-infra
                       operator: In
                       values:
-                        - true
+                        - "true"
         replicas: 1
         strategy:
           type: Recreate
@@ -751,7 +751,7 @@ data:
                     - key: node-role.enmasse.io/messaging-infra
                       operator: In
                       values:
-                        - true
+                        - "true"
         replicas: 1
         selector:
           matchLabels:
@@ -851,7 +851,7 @@ data:
                     - key: node-role.enmasse.io/messaging-infra
                       operator: In
                       values:
-                        - true
+                        - "true"
         replicas: 1
         selector:
           matchLabels:
@@ -942,7 +942,7 @@ data:
                     - key: node-role.enmasse.io/messaging-infra
                       operator: In
                       values:
-                        - true
+                        - "true"
         replicas: 1
         selector:
           matchLabels:
@@ -1050,7 +1050,7 @@ data:
                     - key: node-role.enmasse.io/messaging-infra
                       operator: In
                       values:
-                        - true
+                        - "true"
         replicas: 1
         strategy:
           type: Recreate
@@ -1221,7 +1221,7 @@ data:
                     - key: node-role.enmasse.io/operator-infra
                       operator: In
                       values:
-                        - true
+                        - "true"
         replicas: 1
         strategy:
           type: Recreate

--- a/templates/address-space-controller/020-ConfigMap-standard-broker-definitions.yaml
+++ b/templates/address-space-controller/020-ConfigMap-standard-broker-definitions.yaml
@@ -54,7 +54,7 @@ data:
                     - key: node-role.enmasse.io/messaging-infra
                       operator: In
                       values:
-                        - true
+                        - "true"
         replicas: 1
         serviceName: ${NAME}
         selector:
@@ -279,7 +279,7 @@ data:
                     - key: node-role.enmasse.io/messaging-infra
                       operator: In
                       values:
-                        - true
+                        - "true"
         replicas: 1
         serviceName: ${NAME}
         selector:

--- a/templates/address-space-controller/020-ConfigMap-standard-broker-definitions.yaml
+++ b/templates/address-space-controller/020-ConfigMap-standard-broker-definitions.yaml
@@ -51,10 +51,10 @@ data:
               - weight: 1
                 preference:
                   matchExpressions:
-                    - key: enmasse-role
+                    - key: node-role.enmasse.io/messaging-infra
                       operator: In
                       values:
-                        - messaging-infra
+                        - true
         replicas: 1
         serviceName: ${NAME}
         selector:
@@ -276,10 +276,10 @@ data:
               - weight: 1
                 preference:
                   matchExpressions:
-                    - key: enmasse-role
+                    - key: node-role.enmasse.io/messaging-infra
                       operator: In
                       values:
-                        - messaging-infra
+                        - true
         replicas: 1
         serviceName: ${NAME}
         selector:

--- a/templates/address-space-controller/050-Deployment-address-space-controller.yaml
+++ b/templates/address-space-controller/050-Deployment-address-space-controller.yaml
@@ -28,7 +28,7 @@ spec:
                   - key: node-role.enmasse.io/operator-infra
                     operator: In
                     values:
-                      - true
+                      - "true"
       containers:
       - env:
         - name: JAVA_OPTS

--- a/templates/address-space-controller/050-Deployment-address-space-controller.yaml
+++ b/templates/address-space-controller/050-Deployment-address-space-controller.yaml
@@ -25,10 +25,10 @@ spec:
             - weight: 1
               preference:
                 matchExpressions:
-                  - key: enmasse-role
+                  - key: node-role.enmasse.io/operator-infra
                     operator: In
                     values:
-                      - operator-infra
+                      - true
       containers:
       - env:
         - name: JAVA_OPTS

--- a/templates/alertmanager/030-Deployment-alertmanager.yaml
+++ b/templates/alertmanager/030-Deployment-alertmanager.yaml
@@ -25,7 +25,7 @@ spec:
                   - key: node-role.enmasse.io/operator-infra
                     operator: In
                     values:
-                      - true
+                      - "true"
       containers:
       - image: ${ALERTMANAGER_IMAGE}
         imagePullPolicy: ${IMAGE_PULL_POLICY}

--- a/templates/alertmanager/030-Deployment-alertmanager.yaml
+++ b/templates/alertmanager/030-Deployment-alertmanager.yaml
@@ -22,10 +22,10 @@ spec:
             - weight: 1
               preference:
                 matchExpressions:
-                  - key: enmasse-role
+                  - key: node-role.enmasse.io/operator-infra
                     operator: In
                     values:
-                      - operator-infra
+                      - true
       containers:
       - image: ${ALERTMANAGER_IMAGE}
         imagePullPolicy: ${IMAGE_PULL_POLICY}

--- a/templates/api-server/050-Deployment-api-server.yaml
+++ b/templates/api-server/050-Deployment-api-server.yaml
@@ -23,10 +23,10 @@ spec:
             - weight: 1
               preference:
                 matchExpressions:
-                  - key: enmasse-role
+                  - key: node-role.enmasse.io/operator-infra
                     operator: In
                     values:
-                      - operator-infra
+                      - true
       containers:
       - env:
         - name: JAVA_OPTS

--- a/templates/api-server/050-Deployment-api-server.yaml
+++ b/templates/api-server/050-Deployment-api-server.yaml
@@ -26,7 +26,7 @@ spec:
                   - key: node-role.enmasse.io/operator-infra
                     operator: In
                     values:
-                      - true
+                      - "true"
       containers:
       - env:
         - name: JAVA_OPTS

--- a/templates/grafana/030-Deployment-grafana.yaml
+++ b/templates/grafana/030-Deployment-grafana.yaml
@@ -25,7 +25,7 @@ spec:
                   - key: node-role.enmasse.io/operator-infra
                     operator: In
                     values:
-                      - true
+                      - "true"
       containers:
       - name: grafana
         image: ${GRAFANA_IMAGE}

--- a/templates/grafana/030-Deployment-grafana.yaml
+++ b/templates/grafana/030-Deployment-grafana.yaml
@@ -22,10 +22,10 @@ spec:
             - weight: 1
               preference:
                 matchExpressions:
-                  - key: enmasse-role
+                  - key: node-role.enmasse.io/operator-infra
                     operator: In
                     values:
-                      - operator-infra
+                      - true
       containers:
       - name: grafana
         image: ${GRAFANA_IMAGE}

--- a/templates/kube-state-metrics/030-Deployment-kube-state-metrics.yaml
+++ b/templates/kube-state-metrics/030-Deployment-kube-state-metrics.yaml
@@ -25,7 +25,7 @@ spec:
                   - key: node-role.enmasse.io/operator-infra
                     operator: In
                     values:
-                      - true
+                      - "true"
       containers:
       - name: kube-metrics
         image: ${KUBE_STATE_METRICS_IMAGE}

--- a/templates/kube-state-metrics/030-Deployment-kube-state-metrics.yaml
+++ b/templates/kube-state-metrics/030-Deployment-kube-state-metrics.yaml
@@ -22,10 +22,10 @@ spec:
             - weight: 1
               preference:
                 matchExpressions:
-                  - key: enmasse-role
+                  - key: node-role.enmasse.io/operator-infra
                     operator: In
                     values:
-                      - operator-infra
+                      - true
       containers:
       - name: kube-metrics
         image: ${KUBE_STATE_METRICS_IMAGE}

--- a/templates/none-authservice/050-Deployment-none-authservice.yaml
+++ b/templates/none-authservice/050-Deployment-none-authservice.yaml
@@ -25,7 +25,7 @@ spec:
                   - key: node-role.enmasse.io/operator-infra
                     operator: In
                     values:
-                      - true
+                      - "true"
       containers:
       - env:
         - name: LISTENPORT

--- a/templates/none-authservice/050-Deployment-none-authservice.yaml
+++ b/templates/none-authservice/050-Deployment-none-authservice.yaml
@@ -22,10 +22,10 @@ spec:
             - weight: 1
               preference:
                 matchExpressions:
-                  - key: enmasse-role
+                  - key: node-role.enmasse.io/operator-infra
                     operator: In
                     values:
-                      - operator-infra
+                      - true
       containers:
       - env:
         - name: LISTENPORT

--- a/templates/prometheus/030-Deployment-prometheus.yaml
+++ b/templates/prometheus/030-Deployment-prometheus.yaml
@@ -22,10 +22,10 @@ spec:
             - weight: 1
               preference:
                 matchExpressions:
-                  - key: enmasse-role
+                  - key: node-role.enmasse.io/operator-infra
                     operator: In
                     values:
-                      - operator-infra
+                      - true
       containers:
       - image: ${PROMETHEUS_IMAGE}
         imagePullPolicy: ${IMAGE_PULL_POLICY}

--- a/templates/prometheus/030-Deployment-prometheus.yaml
+++ b/templates/prometheus/030-Deployment-prometheus.yaml
@@ -25,7 +25,7 @@ spec:
                   - key: node-role.enmasse.io/operator-infra
                     operator: In
                     values:
-                      - true
+                      - "true"
       containers:
       - image: ${PROMETHEUS_IMAGE}
         imagePullPolicy: ${IMAGE_PULL_POLICY}

--- a/templates/service-broker/050-Deployment-service-broker.yaml
+++ b/templates/service-broker/050-Deployment-service-broker.yaml
@@ -25,10 +25,10 @@ spec:
             - weight: 1
               preference:
                 matchExpressions:
-                  - key: enmasse-role
+                  - key: node-role.enmasse.io/operator-infra
                     operator: In
                     values:
-                      - operator-infra
+                      - true
       containers:
       - env:
         - name: ENABLE_RBAC

--- a/templates/service-broker/050-Deployment-service-broker.yaml
+++ b/templates/service-broker/050-Deployment-service-broker.yaml
@@ -28,7 +28,7 @@ spec:
                   - key: node-role.enmasse.io/operator-infra
                     operator: In
                     values:
-                      - true
+                      - "true"
       containers:
       - env:
         - name: ENABLE_RBAC

--- a/templates/standard-authservice/050-Deployment-keycloak-controller.yaml
+++ b/templates/standard-authservice/050-Deployment-keycloak-controller.yaml
@@ -25,7 +25,7 @@ spec:
                   - key: node-role.enmasse.io/operator-infra
                     operator: In
                     values:
-                      - true
+                      - "true"
       containers:
       - env:
         - name: AUTO_CREATE

--- a/templates/standard-authservice/050-Deployment-keycloak-controller.yaml
+++ b/templates/standard-authservice/050-Deployment-keycloak-controller.yaml
@@ -22,10 +22,10 @@ spec:
             - weight: 1
               preference:
                 matchExpressions:
-                  - key: enmasse-role
+                  - key: node-role.enmasse.io/operator-infra
                     operator: In
                     values:
-                      - operator-infra
+                      - true
       containers:
       - env:
         - name: AUTO_CREATE

--- a/templates/standard-authservice/050-Deployment-keycloak.yaml
+++ b/templates/standard-authservice/050-Deployment-keycloak.yaml
@@ -28,7 +28,7 @@ spec:
                   - key: node-role.enmasse.io/operator-infra
                     operator: In
                     values:
-                      - true
+                      - "true"
       containers:
       - env:
         - name: JAVA_OPTS

--- a/templates/standard-authservice/050-Deployment-keycloak.yaml
+++ b/templates/standard-authservice/050-Deployment-keycloak.yaml
@@ -25,10 +25,10 @@ spec:
             - weight: 1
               preference:
                 matchExpressions:
-                  - key: enmasse-role
+                  - key: node-role.enmasse.io/operator-infra
                     operator: In
                     values:
-                      - operator-infra
+                      - true
       containers:
       - env:
         - name: JAVA_OPTS


### PR DESCRIPTION
This matches the form used by Openshift node groups and makes it easier to have multiple roles on the same node during openshift install.