### PR TITLE
Added authentication to prometheus, alertmanager

### DIFF
--- a/ansible/inventory/with-standard-authservice.txt
+++ b/ansible/inventory/with-standard-authservice.txt
@@ -10,3 +10,5 @@ register_api_server=True
 keycloak_admin_password=admin
 authentication_services=["standard"]
 enable_monitoring=False
+monitoring_username=admin
+monitoring_password=secret

--- a/ansible/roles/monitoring/tasks/main.yml
+++ b/ansible/roles/monitoring/tasks/main.yml
@@ -47,3 +47,25 @@
   shell: oc apply -n {{ namespace }} -f {{ playbook_dir }}/install/grafana
 - name: Apply the Kube-state-metrics configuration
   shell: oc apply -n {{ namespace }} -f {{ playbook_dir }}/install/kube-state-metrics
+
+
+- name: Create Nginx password hash
+  shell: htpasswd -nb {{ monitoring_username }} {{ monitoring_password }}
+  register: password_hash
+
+- set_fact:
+    creds: "{{ password_hash.stdout }}"
+
+- name: Create secret with the nginx credentials
+  shell: oc create secret generic -n {{ namespace }} nginx-credentials --from-literal=htpasswd='{{ creds }}'
+  register: secret_exists
+  failed_when: secret_exists.stderr != '' and 'already exists' not in secret_exists.stderr
+  changed_when: secret_exists.rc == 1
+
+- name: Grant permissions to Nginx Service account to run container
+  shell: oc adm policy add-scc-to-user privileged system:serviceaccount:enmasse:nginx
+
+- shell: oc adm policy add-scc-to-user anyuid system:serviceaccount:enmasse:nginx
+
+- name: Apply the Nginx configuration
+  shell: oc apply -n {{ namespace }} -f {{ playbook_dir }}/install/nginx

--- a/templates/Makefile
+++ b/templates/Makefile
@@ -22,6 +22,7 @@ PROMETHEUS_IMAGE ?= "prom/prometheus:v2.4.3"
 ALERTMANAGER_IMAGE ?= "prom/alertmanager:v0.15.2"
 GRAFANA_IMAGE ?= "grafana/grafana:5.3.1"
 KUBE_STATE_METRICS_IMAGE ?= "quay.io/coreos/kube-state-metrics:v1.4.0"
+NGINX_IMAGE ?= "nginx:latest"
 DEFAULT_PROJECT ?= "enmasse-infra"
 
 ifeq ($(TAG),latest)
@@ -37,7 +38,7 @@ BUILDDIR=build
 INSTALLNAME=enmasse-$(TAG)
 INSTALLDIR=$(BUILDDIR)/$(INSTALLNAME)
 PACKAGE_INSTALL_DIR=$(INSTALLDIR)/install
-MODULES=address-space-controller extra api-server api-service grafana none-authservice prometheus service-broker cluster-service-broker standard-authservice tenant alertmanager kube-state-metrics
+MODULES=address-space-controller extra api-server api-service grafana none-authservice prometheus service-broker cluster-service-broker standard-authservice tenant alertmanager kube-state-metrics nginx
 
 prepare:
 	mkdir -p $(PACKAGE_INSTALL_DIR)
@@ -70,9 +71,10 @@ replace_images: prepare
 			ALERTMANAGER_IMAGE=$(ALERTMANAGER_IMAGE) \
 			GRAFANA_IMAGE=$(GRAFANA_IMAGE) \
 			KUBE_STATE_METRICS_IMAGE=$(KUBE_STATE_METRICS_IMAGE) \
+			NGINX_IMAGE=$(NGINX_IMAGE) \
 			IMAGE_PULL_POLICY=$(IMAGE_PULL_POLICY) \
 			ENMASSE_VERSION=$(VERSION) \
-			envsubst '$${ENMASSE_VERSION},$${IMAGE_PULL_POLICY},$${ADDRESS_SPACE_CONTROLLER_IMAGE},$${STANDARD_CONTROLLER_IMAGE},$${ROUTER_IMAGE},$${NONE_AUTHSERVICE_IMAGE},$${KEYCLOAK_IMAGE},$${KEYCLOAK_CONTROLLER_IMAGE},$${KEYCLOAK_PLUGIN_IMAGE},$${TOPIC_FORWARDER_IMAGE},$${ARTEMIS_IMAGE},$${ARTEMIS_PLUGIN_IMAGE},$${ROUTER_METRICS_IMAGE},$${SUBSERV_IMAGE},$${API_SERVER_IMAGE},$${SERVICE_BROKER_IMAGE},$${AGENT_IMAGE},$${MQTT_GATEWAY_IMAGE},$${MQTT_LWT_IMAGE},$${PROMETHEUS_IMAGE},$${ALERTMANAGER_IMAGE},$${GRAFANA_IMAGE},$${KUBE_STATE_METRICS_IMAGE}' > $$i.tmp; \
+			envsubst '$${ENMASSE_VERSION},$${IMAGE_PULL_POLICY},$${ADDRESS_SPACE_CONTROLLER_IMAGE},$${STANDARD_CONTROLLER_IMAGE},$${ROUTER_IMAGE},$${NONE_AUTHSERVICE_IMAGE},$${KEYCLOAK_IMAGE},$${KEYCLOAK_CONTROLLER_IMAGE},$${KEYCLOAK_PLUGIN_IMAGE},$${TOPIC_FORWARDER_IMAGE},$${ARTEMIS_IMAGE},$${ARTEMIS_PLUGIN_IMAGE},$${ROUTER_METRICS_IMAGE},$${SUBSERV_IMAGE},$${API_SERVER_IMAGE},$${SERVICE_BROKER_IMAGE},$${AGENT_IMAGE},$${MQTT_GATEWAY_IMAGE},$${MQTT_LWT_IMAGE},$${PROMETHEUS_IMAGE},$${ALERTMANAGER_IMAGE},$${GRAFANA_IMAGE},$${KUBE_STATE_METRICS_IMAGE},$${NGINX_IMAGE}' > $$i.tmp; \
 		mv $$i.tmp $$i; \
 	done
 

--- a/templates/alertmanager/030-Deployment-alertmanager.yaml
+++ b/templates/alertmanager/030-Deployment-alertmanager.yaml
@@ -37,6 +37,12 @@ spec:
         - mountPath: /etc/alertmanager
           name: alertmanager-config
           readOnly: true
+        command:
+          - /bin/alertmanager
+          - --config.file=/etc/alertmanager/alertmanager.yml
+          - --storage.path=/alertmanager
+          - --web.external-url=http://nginx:8080/alertmanager/
+          - --web.route-prefix=/
       volumes:
       - configMap:
           name: alertmanager-config

--- a/templates/nginx/010-ConfigMap-nginx-config.yaml
+++ b/templates/nginx/010-ConfigMap-nginx-config.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: enmasse
+  name: nginx-config
+data:
+  nginx.conf: |
+    http {
+      server {
+        listen 8080;
+
+        location /prometheus {
+          auth_basic           "Prometheus";
+          auth_basic_user_file /usr/local/etc/htpasswd;
+
+          proxy_pass           http://prometheus:9090/;
+        }
+
+        location /prometheus/ {
+          auth_basic           "Prometheus";
+          auth_basic_user_file /usr/local/etc/htpasswd;
+
+          proxy_pass           http://prometheus:9090/;
+        }
+
+        location = /alertmanager {
+          auth_basic           "Alertmanager";
+          auth_basic_user_file /usr/local/etc/htpasswd;
+
+          proxy_pass           http://alertmanager:9093/;
+        }
+
+        location /alertmanager/ {
+          auth_basic           "Alertmanager";
+          auth_basic_user_file /usr/local/etc/htpasswd;
+
+          proxy_pass           http://alertmanager:9093/;
+        }
+      }
+    }
+    events {}

--- a/templates/nginx/010-Service-nginx.yaml
+++ b/templates/nginx/010-Service-nginx.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: enmasse
+  name: nginx
+spec:
+  ports:
+  - name: nginx
+    port: 8080
+    targetPort: 8080
+  selector:
+    name: nginx

--- a/templates/nginx/010-ServiceAccount-nginx.yaml
+++ b/templates/nginx/010-ServiceAccount-nginx.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: enmasse
+  name: nginx

--- a/templates/nginx/030-Deployment-nginx.yaml
+++ b/templates/nginx/030-Deployment-nginx.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: enmasse
+  name: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: enmasse
+      name: nginx
+  template:
+    metadata:
+      labels:
+        app: enmasse
+        name: nginx
+    spec:
+      containers:
+      - image: ${NGINX_IMAGE}
+        imagePullPolicy: ${IMAGE_PULL_POLICY}
+        name: nginx
+        ports:
+        - containerPort: 8080
+          name: nginx
+        volumeMounts:
+        - mountPath: /etc/nginx
+          name: nginx-config
+          readOnly: true
+        - mountPath: /usr/local/etc
+          name: htpasswd
+          readOnly: true
+      serviceAccountName: nginx
+      volumes:
+      - configMap:
+          name: nginx-config
+        name: nginx-config
+      - name: htpasswd
+        secret:
+          secretName: nginx-credentials

--- a/templates/nginx/060-Route-alertmanager.yaml
+++ b/templates/nginx/060-Route-alertmanager.yaml
@@ -3,12 +3,13 @@ kind: Route
 metadata:
   labels:
     app: enmasse
-  name: prometheus
+  name: alertmanager
 spec:
+  path: /alertmanager/
   port:
-    targetPort: prometheus
+    targetPort: nginx
   tls:
     termination: edge
   to:
     kind: Service
-    name: prometheus
+    name: nginx

--- a/templates/nginx/060-Route-prometheus.yaml
+++ b/templates/nginx/060-Route-prometheus.yaml
@@ -3,12 +3,13 @@ kind: Route
 metadata:
   labels:
     app: enmasse
-  name: alertmanager
+  name: prometheus
 spec:
+  path: /prometheus/
   port:
-    targetPort: alertmanager
+    targetPort: nginx
   tls:
     termination: edge
   to:
     kind: Service
-    name: alertmanager
+    name: nginx

--- a/templates/prometheus/030-Deployment-prometheus.yaml
+++ b/templates/prometheus/030-Deployment-prometheus.yaml
@@ -40,6 +40,11 @@ spec:
         - mountPath: /prometheus
           name: prometheus-data
           readOnly: false
+        command:
+          - /bin/prometheus
+          - --config.file=/etc/prometheus/prometheus.yml
+          - --web.external-url=http://nginx:8080/prometheus/
+          - --web.route-prefix=/
       serviceAccountName: prometheus-server
       volumes:
       - configMap:


### PR DESCRIPTION
@lulf What do you think of this for the monitoring authentication? I'm not entirely happy with it myself but it's the only way I've gotten it working. The parts I'm not happy about are the need to run `htpasswd` during installing [1] and the security context constraints [2].

[1] [https://github.com/EnMasseProject/enmasse/compare/master...robshelly:monitoring-authentication?expand=1#diff-a501728a33cc0c36febb64a9e3076673R53](https://github.com/EnMasseProject/enmasse/compare/master...robshelly:monitoring-authentication?expand=1#diff-a501728a33cc0c36febb64a9e3076673R53)

[2] [https://github.com/EnMasseProject/enmasse/compare/master...robshelly:monitoring-authentication?expand=1#diff-a501728a33cc0c36febb64a9e3076673R65](https://github.com/EnMasseProject/enmasse/compare/master...robshelly:monitoring-authentication?expand=1#diff-a501728a33cc0c36febb64a9e3076673R65)
