### PR TITLE
Fixed services for Prometheus, Alertmanager

### DIFF
--- a/templates/alertmanager/010-Service-alertmanager.yaml
+++ b/templates/alertmanager/010-Service-alertmanager.yaml
@@ -8,6 +8,9 @@ metadata:
     app: enmasse
 spec:
   ports:
+  - name: alertmanager
+    port: 9093
+    targetPort: 9093
   - name: proxy
     port: 443
     targetPort: 8443

--- a/templates/alertmanager/030-Deployment-alertmanager.yaml
+++ b/templates/alertmanager/030-Deployment-alertmanager.yaml
@@ -34,6 +34,9 @@ spec:
         - mountPath: /etc/alertmanager
           name: alertmanager-config
           readOnly: true
+        ports:
+        - containerPort: 9093
+          name: alertmanager
       - image: openshift/oauth-proxy:latest
         imagePullPolicy: ${IMAGE_PULL_POLICY}
         name: oauth-proxy

--- a/templates/grafana/010-ConfigMap-grafana-config.yaml
+++ b/templates/grafana/010-ConfigMap-grafana-config.yaml
@@ -10,12 +10,12 @@ data:
     datasources:
     - name: Prometheus
       type: prometheus
-      access: direct
-      url: https://prometheus-enmasse-infra.127.0.0.1.nip.io
+      access: proxy
+      url: http://prometheus:9090
     - name: AlertManager
       type: camptocamp-prometheus-alertmanager-datasource
-      url: https://alertmanager-enmasse-infra.127.0.0.1.nip.io
-      access: direct
+      url: http://alertmanager:9093
+      access: proxy
       jsonData:
         timeInterval: 10s
         severity_critical: "4"

--- a/templates/prometheus/010-Service-prometheus.yaml
+++ b/templates/prometheus/010-Service-prometheus.yaml
@@ -8,6 +8,9 @@ metadata:
     app: enmasse
 spec:
   ports:
+  - name: prometheus
+    port: 9090
+    targetPort: 9090
   - name: proxy
     port: 443
     targetPort: 8443

--- a/templates/prometheus/030-Deployment-prometheus.yaml
+++ b/templates/prometheus/030-Deployment-prometheus.yaml
@@ -37,6 +37,9 @@ spec:
         - mountPath: /prometheus
           name: prometheus-data
           readOnly: false
+        ports:
+        - containerPort: 9090
+          name: prometheus
       - image: ${OAUTH_PROXY_IMAGE}
         imagePullPolicy: ${IMAGE_PULL_POLICY}
         name: oauth-proxy


### PR DESCRIPTION
Fixed a bug in the services for Prometheus and Alertmanager so Grafana
can access them by the correct ports