### PR TITLE
enabled testCreateAlreadyExistingAddress (#346 fixed)

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/TestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/TestBase.java
@@ -288,7 +288,18 @@ public abstract class TestBase implements ITestBase, ITestSeparator {
     protected void setAddresses(AddressSpace addressSpace, int expectedCode, Destination... destinations) throws Exception {
         TimeoutBudget budget = new TimeoutBudget(5, TimeUnit.MINUTES);
         logCollector.collectRouterState("setAddresses");
-        setAddresses(addressSpace, budget, expectedCode, destinations);
+
+        if (expectedCode == 409){
+           try {
+           setAddresses(addressSpace, budget, expectedCode, destinations);
+           } catch( ExecutionException EE) {
+               log.info(EE.getMessage());
+               throw new AddressAlreadyExistsException("Address cannot be created, already exists");
+               }
+           }   
+        else {
+            setAddresses(addressSpace, budget, expectedCode, destinations);
+        }
     }
 
     protected void setAddresses(AddressSpace addressSpace, Destination... destinations) throws Exception {

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/TestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/TestBase.java
@@ -54,6 +54,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
 import static java.net.HttpURLConnection.HTTP_CREATED;
+import static java.net.HttpURLConnection.HTTP_CONFLICT;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -289,15 +290,14 @@ public abstract class TestBase implements ITestBase, ITestSeparator {
         TimeoutBudget budget = new TimeoutBudget(5, TimeUnit.MINUTES);
         logCollector.collectRouterState("setAddresses");
 
-        if (expectedCode == 409){
-           try {
-           setAddresses(addressSpace, budget, expectedCode, destinations);
-           } catch( ExecutionException EE) {
-               log.info(EE.getMessage());
-               throw new AddressAlreadyExistsException("Address cannot be created, already exists");
-               }
-           }   
-        else {
+        if (expectedCode == HTTP_CONFLICT) {
+            try {
+                setAddresses(addressSpace, budget, expectedCode, destinations);
+            } catch (ExecutionException ee) {
+                log.info(ee.getMessage());
+                throw new AddressAlreadyExistsException("Address cannot be created, already exists");
+            }
+        } else {
             setAddresses(addressSpace, budget, expectedCode, destinations);
         }
     }

--- a/systemtests/src/test/java/io/enmasse/systemtest/brokered/SmokeTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/brokered/SmokeTest.java
@@ -6,11 +6,11 @@ package io.enmasse.systemtest.brokered;
 
 import io.enmasse.systemtest.*;
 import io.enmasse.systemtest.ability.ITestBaseBrokered;
+import io.enmasse.systemtest.ability.ITestSeparator;
 import io.enmasse.systemtest.amqp.AmqpClient;
 import io.enmasse.systemtest.bases.TestBaseWithShared;
 import io.enmasse.systemtest.standard.QueueTest;
 import org.apache.qpid.proton.message.Message;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -99,16 +99,16 @@ class SmokeTest extends TestBaseWithShared implements ITestBaseBrokered {
         QueueTest.runQueueTest(amqpQueueCliC, queueB);
     }
 
-    @Test()
-    @Disabled("disabled until #346 will be fixed")
+    @Test
     void testCreateAlreadyExistingAddress() throws Exception {
+        String addr_name = "brokeredAddrA";
         AddressSpace addressSpaceA = new AddressSpace("brokered-a", AddressSpaceType.BROKERED, AuthService.STANDARD);
         createAddressSpace(addressSpaceA);
-        Destination queueA = Destination.queue("brokeredQueueA", getDefaultPlan(AddressType.QUEUE));
+        Destination queueA = Destination.queue(addr_name, getDefaultPlan(AddressType.QUEUE));
         setAddresses(addressSpaceA, queueA);
 
-        Destination topicA = Destination.topic("brokeredTopicA", getDefaultPlan(AddressType.TOPIC));
-        assertThrows(AddressAlreadyExistsException.class, () -> setAddresses(addressSpaceA, topicA),
+        Destination topicA = Destination.topic(addr_name, getDefaultPlan(AddressType.TOPIC));
+        assertThrows(AddressAlreadyExistsException.class, () -> setAddresses(addressSpaceA, 409, topicA),
                 "setAddresses does not throw right exception");
     }
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/brokered/SmokeTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/brokered/SmokeTest.java
@@ -19,6 +19,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static io.enmasse.systemtest.TestTag.nonPR;
+import static java.net.HttpURLConnection.HTTP_CONFLICT;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -107,7 +108,7 @@ class SmokeTest extends TestBaseWithShared implements ITestBaseBrokered {
         setAddresses(addressSpaceA, queueA);
 
         Destination topicA = Destination.topic(addr_name, getDefaultPlan(AddressType.TOPIC));
-        assertThrows(AddressAlreadyExistsException.class, () -> setAddresses(addressSpaceA, 409, topicA),
+        assertThrows(AddressAlreadyExistsException.class, () -> setAddresses(addressSpaceA, HTTP_CONFLICT, topicA),
                 "setAddresses does not throw right exception");
     }
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/brokered/SmokeTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/brokered/SmokeTest.java
@@ -6,7 +6,6 @@ package io.enmasse.systemtest.brokered;
 
 import io.enmasse.systemtest.*;
 import io.enmasse.systemtest.ability.ITestBaseBrokered;
-import io.enmasse.systemtest.ability.ITestSeparator;
 import io.enmasse.systemtest.amqp.AmqpClient;
 import io.enmasse.systemtest.bases.TestBaseWithShared;
 import io.enmasse.systemtest.standard.QueueTest;


### PR DESCRIPTION
    - added try catch as setAddresses was throwing an Execution exception rather than an 
      AddressAlreadyExists exception (fault with test not addressApi)