### PR TITLE
Improve address space status check

### DIFF
--- a/address-space-controller/src/main/java/io/enmasse/controller/StatusController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/StatusController.java
@@ -66,7 +66,7 @@ public class StatusController implements Controller {
             checkStatefulSetsReady(addressSpace, requiredResources);
         } catch (Exception e) {
             String msg = String.format("Error checking for ready components: %s", e.getMessage());
-            log.warn(msg);
+            log.warn(msg, e);
             addressSpace.getStatus().setReady(false);
             addressSpace.getStatus().appendMessage(msg);
         }

--- a/address-space-controller/src/main/java/io/enmasse/controller/StatusController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/StatusController.java
@@ -11,11 +11,13 @@ import io.enmasse.controller.common.Kubernetes;
 import io.enmasse.controller.common.KubernetesHelper;
 import io.enmasse.k8s.api.SchemaProvider;
 import io.enmasse.user.api.UserApi;
+import io.fabric8.kubernetes.api.model.HasMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -35,8 +37,8 @@ public class StatusController implements Controller {
     }
 
     @Override
-    public AddressSpace handle(AddressSpace addressSpace) throws Exception {
-        checkDeploymentsReady(addressSpace);
+    public AddressSpace handle(AddressSpace addressSpace) {
+        checkComponentsReady(addressSpace);
         checkAuthServiceReady(addressSpace);
         return addressSpace;
     }
@@ -55,30 +57,58 @@ public class StatusController implements Controller {
         return type.getInfraConfigDeserializer().fromJson(addressSpace.getAnnotation(AnnotationKeys.APPLIED_INFRA_CONFIG));
     }
 
-    private void checkDeploymentsReady(AddressSpace addressSpace) {
+    private void checkComponentsReady(AddressSpace addressSpace) {
         try {
-            Set<String> readyDeployments = kubernetes.getReadyDeployments().stream()
-                    .map(deployment -> deployment.getMetadata().getName())
-                    .collect(Collectors.toSet());
-
             InfraConfig infraConfig = Optional.ofNullable(parseCurrentInfraConfig(addressSpace)).orElseGet(() -> getInfraConfig(addressSpace));
-            Set<String> requiredDeployments = infraResourceFactory.createInfraResources(addressSpace, infraConfig).stream()
-                    .filter(KubernetesHelper::isDeployment)
-                    .map(item -> item.getMetadata().getName())
-                    .collect(Collectors.toSet());
+            List<HasMetadata> requiredResources = infraResourceFactory.createInfraResources(addressSpace, infraConfig);
 
-            boolean isReady = readyDeployments.containsAll(requiredDeployments);
-            if (!isReady) {
-                Set<String> missing = new HashSet<>(requiredDeployments);
-                missing.removeAll(readyDeployments);
-                addressSpace.getStatus().setReady(false);
-                addressSpace.getStatus().appendMessage("Following deployments and statefulsets are not ready: " + missing);
-            }
+            checkDeploymentsReady(addressSpace, requiredResources);
+            checkStatefulSetsReady(addressSpace, requiredResources);
         } catch (Exception e) {
-            String msg = String.format("Error checking for ready deployments: %s", e.getMessage());
+            String msg = String.format("Error checking for ready components: %s", e.getMessage());
             log.warn(msg);
             addressSpace.getStatus().setReady(false);
             addressSpace.getStatus().appendMessage(msg);
+        }
+    }
+
+    private void checkStatefulSetsReady(AddressSpace addressSpace, List<HasMetadata> requiredResources) {
+        Set<String> readyStatefulSets = kubernetes.getReadyStatefulSets(addressSpace).stream()
+                .map(statefulSet -> statefulSet.getMetadata().getName())
+                .collect(Collectors.toSet());
+
+
+        Set<String> requiredStatefulSets = requiredResources.stream()
+                .filter(KubernetesHelper::isStatefulSet)
+                .map(item -> item.getMetadata().getName())
+                .collect(Collectors.toSet());
+
+        boolean isReady = readyStatefulSets.containsAll(requiredStatefulSets);
+        if (!isReady) {
+            Set<String> missing = new HashSet<>(requiredStatefulSets);
+            missing.removeAll(readyStatefulSets);
+            addressSpace.getStatus().setReady(false);
+            addressSpace.getStatus().appendMessage("The following stateful sets are not ready: " + missing);
+        }
+    }
+
+    private void checkDeploymentsReady(AddressSpace addressSpace, List<HasMetadata> requiredResources) {
+        Set<String> readyDeployments = kubernetes.getReadyDeployments(addressSpace).stream()
+                .map(deployment -> deployment.getMetadata().getName())
+                .collect(Collectors.toSet());
+
+
+        Set<String> requiredDeployments = requiredResources.stream()
+                .filter(KubernetesHelper::isDeployment)
+                .map(item -> item.getMetadata().getName())
+                .collect(Collectors.toSet());
+
+        boolean isReady = readyDeployments.containsAll(requiredDeployments);
+        if (!isReady) {
+            Set<String> missing = new HashSet<>(requiredDeployments);
+            missing.removeAll(readyDeployments);
+            addressSpace.getStatus().setReady(false);
+            addressSpace.getStatus().appendMessage("The following deployments are not ready: " + missing);
         }
     }
 

--- a/address-space-controller/src/main/java/io/enmasse/controller/common/Kubernetes.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/common/Kubernetes.java
@@ -9,12 +9,10 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.openshift.client.ParameterValue;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Interface for Kubernetes operations done by the address space controller
@@ -29,7 +27,8 @@ public interface Kubernetes {
 
     void deleteResourcesNotIn(String[] addressSpaces);
 
-    Set<Deployment> getReadyDeployments();
+    Set<Deployment> getReadyDeployments(AddressSpace addressSpace);
+    Set<StatefulSet> getReadyStatefulSets(AddressSpace addressSpace);
 
     Optional<Secret> getSecret(String secretName);
 

--- a/address-space-controller/src/test/java/io/enmasse/controller/StatusControllerTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/StatusControllerTest.java
@@ -6,6 +6,7 @@ package io.enmasse.controller;
 
 
 import io.enmasse.address.model.AddressSpace;
+import io.enmasse.config.AnnotationKeys;
 import io.enmasse.controller.common.Kubernetes;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
@@ -36,7 +37,7 @@ public class StatusControllerTest {
                 .endStatus()
                 .build();
 
-        when(kubernetes.getReadyDeployments()).thenReturn(Collections.emptySet());
+        when(kubernetes.getReadyDeployments(new AddressSpace.Builder().setName("a").setNamespace("b").setPlan("c").setType("d").putAnnotation(AnnotationKeys.INFRA_UUID, "1234").build())).thenReturn(Collections.emptySet());
 
         StatusController controller = new StatusController(kubernetes, new TestSchemaProvider(), infraResourceFactory, null);
 


### PR DESCRIPTION
* Check statefulsets in addition to deployments
* Less strict: require >= 1 ready pod per deployment/statefulset to pass status check.
* Only check components belonging to address space