### PR TITLE
Update API versions to v1beta1

### DIFF
--- a/address-space-controller/src/main/resources/addressplans/020-AddressPlan-brokered-queue.yaml
+++ b/address-space-controller/src/main/resources/addressplans/020-AddressPlan-brokered-queue.yaml
@@ -1,4 +1,4 @@
-apiVersion: admin.enmasse.io/v1alpha1
+apiVersion: admin.enmasse.io/v1beta1
 kind: AddressPlan
 metadata:
   name: brokered-queue

--- a/address-space-controller/src/main/resources/addressplans/020-AddressPlan-brokered-topic.yaml
+++ b/address-space-controller/src/main/resources/addressplans/020-AddressPlan-brokered-topic.yaml
@@ -1,4 +1,4 @@
-apiVersion: admin.enmasse.io/v1alpha1
+apiVersion: admin.enmasse.io/v1beta1
 kind: AddressPlan
 metadata:
   name: brokered-topic

--- a/address-space-controller/src/main/resources/addressplans/020-AddressPlan-standard-large-anycast.yaml
+++ b/address-space-controller/src/main/resources/addressplans/020-AddressPlan-standard-large-anycast.yaml
@@ -1,4 +1,4 @@
-apiVersion: admin.enmasse.io/v1alpha1
+apiVersion: admin.enmasse.io/v1beta1
 kind: AddressPlan
 metadata:
   name: standard-large-anycast

--- a/address-space-controller/src/main/resources/addressplans/020-AddressPlan-standard-large-multicast.yaml
+++ b/address-space-controller/src/main/resources/addressplans/020-AddressPlan-standard-large-multicast.yaml
@@ -1,4 +1,4 @@
-apiVersion: admin.enmasse.io/v1alpha1
+apiVersion: admin.enmasse.io/v1beta1
 kind: AddressPlan
 metadata:
   name: standard-large-multicast

--- a/address-space-controller/src/main/resources/addressplans/020-AddressPlan-standard-large-queue.yaml
+++ b/address-space-controller/src/main/resources/addressplans/020-AddressPlan-standard-large-queue.yaml
@@ -1,4 +1,4 @@
-apiVersion: admin.enmasse.io/v1alpha1
+apiVersion: admin.enmasse.io/v1beta1
 kind: AddressPlan
 metadata:
   name: standard-large-queue

--- a/address-space-controller/src/main/resources/addressplans/020-AddressPlan-standard-large-subscription.yaml
+++ b/address-space-controller/src/main/resources/addressplans/020-AddressPlan-standard-large-subscription.yaml
@@ -1,4 +1,4 @@
-apiVersion: admin.enmasse.io/v1alpha1
+apiVersion: admin.enmasse.io/v1beta1
 kind: AddressPlan
 metadata:
   name: standard-large-subscription

--- a/address-space-controller/src/main/resources/addressplans/020-AddressPlan-standard-large-topic.yaml
+++ b/address-space-controller/src/main/resources/addressplans/020-AddressPlan-standard-large-topic.yaml
@@ -1,4 +1,4 @@
-apiVersion: admin.enmasse.io/v1alpha1
+apiVersion: admin.enmasse.io/v1beta1
 kind: AddressPlan
 metadata:
   name: standard-large-topic

--- a/address-space-controller/src/main/resources/addressplans/020-AddressPlan-standard-medium-anycast.yaml
+++ b/address-space-controller/src/main/resources/addressplans/020-AddressPlan-standard-medium-anycast.yaml
@@ -1,4 +1,4 @@
-apiVersion: admin.enmasse.io/v1alpha1
+apiVersion: admin.enmasse.io/v1beta1
 kind: AddressPlan
 metadata:
   name: standard-medium-anycast

--- a/address-space-controller/src/main/resources/addressplans/020-AddressPlan-standard-medium-multicast.yaml
+++ b/address-space-controller/src/main/resources/addressplans/020-AddressPlan-standard-medium-multicast.yaml
@@ -1,4 +1,4 @@
-apiVersion: admin.enmasse.io/v1alpha1
+apiVersion: admin.enmasse.io/v1beta1
 kind: AddressPlan
 metadata:
   name: standard-medium-multicast

--- a/address-space-controller/src/main/resources/addressplans/020-AddressPlan-standard-medium-queue.yaml
+++ b/address-space-controller/src/main/resources/addressplans/020-AddressPlan-standard-medium-queue.yaml
@@ -1,4 +1,4 @@
-apiVersion: admin.enmasse.io/v1alpha1
+apiVersion: admin.enmasse.io/v1beta1
 kind: AddressPlan
 metadata:
   name: standard-medium-queue

--- a/address-space-controller/src/main/resources/addressplans/020-AddressPlan-standard-medium-subscription.yaml
+++ b/address-space-controller/src/main/resources/addressplans/020-AddressPlan-standard-medium-subscription.yaml
@@ -1,4 +1,4 @@
-apiVersion: admin.enmasse.io/v1alpha1
+apiVersion: admin.enmasse.io/v1beta1
 kind: AddressPlan
 metadata:
   name: standard-medium-subscription

--- a/address-space-controller/src/main/resources/addressplans/020-AddressPlan-standard-medium-topic.yaml
+++ b/address-space-controller/src/main/resources/addressplans/020-AddressPlan-standard-medium-topic.yaml
@@ -1,4 +1,4 @@
-apiVersion: admin.enmasse.io/v1alpha1
+apiVersion: admin.enmasse.io/v1beta1
 kind: AddressPlan
 metadata:
   name: standard-medium-topic

--- a/address-space-controller/src/main/resources/addressplans/020-AddressPlan-standard-small-anycast.yaml
+++ b/address-space-controller/src/main/resources/addressplans/020-AddressPlan-standard-small-anycast.yaml
@@ -1,4 +1,4 @@
-apiVersion: admin.enmasse.io/v1alpha1
+apiVersion: admin.enmasse.io/v1beta1
 kind: AddressPlan
 metadata:
   name: standard-small-anycast

--- a/address-space-controller/src/main/resources/addressplans/020-AddressPlan-standard-small-multicast.yaml
+++ b/address-space-controller/src/main/resources/addressplans/020-AddressPlan-standard-small-multicast.yaml
@@ -1,4 +1,4 @@
-apiVersion: admin.enmasse.io/v1alpha1
+apiVersion: admin.enmasse.io/v1beta1
 kind: AddressPlan
 metadata:
   name: standard-small-multicast

--- a/address-space-controller/src/main/resources/addressplans/020-AddressPlan-standard-small-queue.yaml
+++ b/address-space-controller/src/main/resources/addressplans/020-AddressPlan-standard-small-queue.yaml
@@ -1,4 +1,4 @@
-apiVersion: admin.enmasse.io/v1alpha1
+apiVersion: admin.enmasse.io/v1beta1
 kind: AddressPlan
 metadata:
   name: standard-small-queue

--- a/address-space-controller/src/main/resources/addressplans/020-AddressPlan-standard-small-subscription.yaml
+++ b/address-space-controller/src/main/resources/addressplans/020-AddressPlan-standard-small-subscription.yaml
@@ -1,4 +1,4 @@
-apiVersion: admin.enmasse.io/v1alpha1
+apiVersion: admin.enmasse.io/v1beta1
 kind: AddressPlan
 metadata:
   name: standard-small-subscription

--- a/address-space-controller/src/main/resources/addressplans/020-AddressPlan-standard-small-topic.yaml
+++ b/address-space-controller/src/main/resources/addressplans/020-AddressPlan-standard-small-topic.yaml
@@ -1,4 +1,4 @@
-apiVersion: admin.enmasse.io/v1alpha1
+apiVersion: admin.enmasse.io/v1beta1
 kind: AddressPlan
 metadata:
   name: standard-small-topic

--- a/address-space-controller/src/main/resources/addressplans/020-AddressPlan-standard-xlarge-queue.yaml
+++ b/address-space-controller/src/main/resources/addressplans/020-AddressPlan-standard-xlarge-queue.yaml
@@ -1,4 +1,4 @@
-apiVersion: admin.enmasse.io/v1alpha1
+apiVersion: admin.enmasse.io/v1beta1
 kind: AddressPlan
 metadata:
   name: standard-xlarge-queue

--- a/address-space-controller/src/main/resources/addressplans/020-AddressPlan-standard-xlarge-topic.yaml
+++ b/address-space-controller/src/main/resources/addressplans/020-AddressPlan-standard-xlarge-topic.yaml
@@ -1,4 +1,4 @@
-apiVersion: admin.enmasse.io/v1alpha1
+apiVersion: admin.enmasse.io/v1beta1
 kind: AddressPlan
 metadata:
   name: standard-xlarge-topic

--- a/address-space-controller/src/main/resources/addressspaceplans/020-AddressSpacePlan-brokered-single-broker.yaml
+++ b/address-space-controller/src/main/resources/addressspaceplans/020-AddressSpacePlan-brokered-single-broker.yaml
@@ -1,4 +1,4 @@
-apiVersion: admin.enmasse.io/v1alpha1
+apiVersion: admin.enmasse.io/v1beta1
 kind: AddressSpacePlan
 metadata:
   name: brokered-single-broker

--- a/address-space-controller/src/main/resources/addressspaceplans/020-AddressSpacePlan-standard-medium.yaml
+++ b/address-space-controller/src/main/resources/addressspaceplans/020-AddressSpacePlan-standard-medium.yaml
@@ -1,4 +1,4 @@
-apiVersion: admin.enmasse.io/v1alpha1
+apiVersion: admin.enmasse.io/v1beta1
 kind: AddressSpacePlan
 metadata:
   name: standard-medium

--- a/address-space-controller/src/main/resources/addressspaceplans/020-AddressSpacePlan-standard-small.yaml
+++ b/address-space-controller/src/main/resources/addressspaceplans/020-AddressSpacePlan-standard-small.yaml
@@ -1,4 +1,4 @@
-apiVersion: admin.enmasse.io/v1alpha1
+apiVersion: admin.enmasse.io/v1beta1
 kind: AddressSpacePlan
 metadata:
   name: standard-small

--- a/address-space-controller/src/main/resources/addressspaceplans/020-AddressSpacePlan-standard-unlimited-with-mqtt.yaml
+++ b/address-space-controller/src/main/resources/addressspaceplans/020-AddressSpacePlan-standard-unlimited-with-mqtt.yaml
@@ -1,4 +1,4 @@
-apiVersion: admin.enmasse.io/v1alpha1
+apiVersion: admin.enmasse.io/v1beta1
 kind: AddressSpacePlan
 metadata:
   name: standard-unlimited-with-mqtt

--- a/address-space-controller/src/main/resources/addressspaceplans/020-AddressSpacePlan-standard-unlimited.yaml
+++ b/address-space-controller/src/main/resources/addressspaceplans/020-AddressSpacePlan-standard-unlimited.yaml
@@ -1,4 +1,4 @@
-apiVersion: admin.enmasse.io/v1alpha1
+apiVersion: admin.enmasse.io/v1beta1
 kind: AddressSpacePlan
 metadata:
   name: standard-unlimited

--- a/address-space-controller/src/main/resources/brokeredinfraconfigs/020-BrokeredInfraConfig-default.yaml
+++ b/address-space-controller/src/main/resources/brokeredinfraconfigs/020-BrokeredInfraConfig-default.yaml
@@ -1,4 +1,4 @@
-apiVersion: admin.enmasse.io/v1alpha1
+apiVersion: admin.enmasse.io/v1beta1
 kind: BrokeredInfraConfig
 metadata:
   name: default

--- a/address-space-controller/src/main/resources/standardinfraconfigs/020-StandardInfraConfig-default-minimal.yaml
+++ b/address-space-controller/src/main/resources/standardinfraconfigs/020-StandardInfraConfig-default-minimal.yaml
@@ -1,4 +1,4 @@
-apiVersion: admin.enmasse.io/v1alpha1
+apiVersion: admin.enmasse.io/v1beta1
 kind: StandardInfraConfig
 metadata:
   name: default-minimal

--- a/address-space-controller/src/main/resources/standardinfraconfigs/020-StandardInfraConfig-default-with-mqtt.yaml
+++ b/address-space-controller/src/main/resources/standardinfraconfigs/020-StandardInfraConfig-default-with-mqtt.yaml
@@ -1,4 +1,4 @@
-apiVersion: admin.enmasse.io/v1alpha1
+apiVersion: admin.enmasse.io/v1beta1
 kind: StandardInfraConfig
 metadata:
   name: default-with-mqtt

--- a/address-space-controller/src/main/resources/standardinfraconfigs/020-StandardInfraConfig-default.yaml
+++ b/address-space-controller/src/main/resources/standardinfraconfigs/020-StandardInfraConfig-default.yaml
@@ -1,4 +1,4 @@
-apiVersion: admin.enmasse.io/v1alpha1
+apiVersion: admin.enmasse.io/v1beta1
 kind: StandardInfraConfig
 metadata:
   name: default

--- a/agent/lib/internal_address_source.js
+++ b/agent/lib/internal_address_source.js
@@ -232,7 +232,7 @@ AddressSource.prototype.create_address = function (definition) {
     var address_name = get_address_name_for_address(definition.address, this.config.ADDRESS_SPACE);
     var configmap_name = this.get_configmap_name(address_name);
     var address = {
-        apiVersion: 'enmasse.io/v1alpha1',
+        apiVersion: 'enmasse.io/v1beta1',
         kind: 'Address',
         metadata: {
             name: address_name,
@@ -300,8 +300,8 @@ function extract_plan_details (plan) {
 
 AddressSource.prototype.get_address_types = function () {
     var options = this.config;
-    var address_space_plan_path = kubernetes.get_path('/apis/admin.enmasse.io/v1alpha1/namespaces/', 'addressspaceplans/' + this.config.ADDRESS_SPACE_PLAN, options);
-    var address_plan_path = kubernetes.get_path('/apis/admin.enmasse.io/v1alpha1/namespaces/', 'addressplans', options);
+    var address_space_plan_path = kubernetes.get_path('/apis/admin.enmasse.io/v1beta1/namespaces/', 'addressspaceplans/' + this.config.ADDRESS_SPACE_PLAN, options);
+    var address_plan_path = kubernetes.get_path('/apis/admin.enmasse.io/v1beta1/namespaces/', 'addressplans', options);
     return kubernetes.get_raw(address_space_plan_path, options).then(function (address_space_plan) {
             return address_space_plan.addressPlans;
         }).then(function (supported_plans) {

--- a/ansible/roles/api_service/tasks/main.yml
+++ b/ansible/roles/api_service/tasks/main.yml
@@ -16,14 +16,14 @@
       apiVersion: apiregistration.k8s.io/v1beta1
       kind: APIService
       metadata:
-        name: v1alpha1.enmasse.io
+        name: v1beta1.enmasse.io
         labels:
           app: enmasse
       spec:
         group: enmasse.io
         groupPriorityMinimum: 1000
         caBundle: "{{ ca_bundle | b64encode }}"
-        version: v1alpha1
+        version: v1beta1
         versionPriority: 10
         service:
           name: api-server
@@ -38,14 +38,14 @@
       apiVersion: apiregistration.k8s.io/v1beta1
       kind: APIService
       metadata:
-        name: v1alpha1.user.enmasse.io
+        name: v1beta1.user.enmasse.io
         labels:
           app: enmasse
       spec:
         group: user.enmasse.io
         groupPriorityMinimum: 1000
         caBundle: "{{ ca_bundle | b64encode }}"
-        version: v1alpha1
+        version: v1beta1
         versionPriority: 10
         service:
           name: api-server

--- a/api-common/src/test/java/io/enmasse/api/auth/AuthInterceptorTest.java
+++ b/api-common/src/test/java/io/enmasse/api/auth/AuthInterceptorTest.java
@@ -53,8 +53,8 @@ public class AuthInterceptorTest {
         mockRequestContext = mock(ContainerRequestContext.class);
 
         mockUriInfo = mock(UriInfo.class);
-        when(mockUriInfo.getAbsolutePath()).thenReturn(URI.create("https://localhost:443/apis/enmasse.io/v1alpha1/addressspaces"));
-        when(mockUriInfo.getPath()).thenReturn("/apis/enmasse.io/v1alpha1/addressspaces");
+        when(mockUriInfo.getAbsolutePath()).thenReturn(URI.create("https://localhost:443/apis/enmasse.io/v1beta1/addressspaces"));
+        when(mockUriInfo.getPath()).thenReturn("/apis/enmasse.io/v1beta1/addressspaces");
         when(mockRequestContext.getUriInfo()).thenReturn(mockUriInfo);
     }
 

--- a/api-model/src/main/java/io/enmasse/address/model/AddressSpaceSchemaList.java
+++ b/api-model/src/main/java/io/enmasse/address/model/AddressSpaceSchemaList.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 @JsonPropertyOrder({"apiVersion", "kind", "metadata", "items"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class AddressSpaceSchemaList {
-    private final String apiVersion = "admin.enmasse.io/v1alpha1";
+    private final String apiVersion = "admin.enmasse.io/v1beta1";
     private final String kind = "AddressSpaceSchemaList";
     private final ListMeta metadata = new ListMeta();
     private final List<AddressSpaceSchema> items;

--- a/api-model/src/main/java/io/enmasse/address/model/v1/AddressListV1Serializer.java
+++ b/api-model/src/main/java/io/enmasse/address/model/v1/AddressListV1Serializer.java
@@ -23,7 +23,7 @@ class AddressListV1Serializer extends JsonSerializer<AddressList> {
     @Override
     public void serialize(AddressList addressList, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException, JsonProcessingException {
         ObjectNode root = (ObjectNode) jsonGenerator.getCodec().createObjectNode();
-        root.put(Fields.API_VERSION, "enmasse.io/v1alpha1");
+        root.put(Fields.API_VERSION, "enmasse.io/v1beta1");
         root.put(Fields.KIND, "AddressList");
         ArrayNode items = root.putArray(Fields.ITEMS);
         for (Address address : addressList) {

--- a/api-model/src/main/java/io/enmasse/address/model/v1/AddressSpaceListV1Serializer.java
+++ b/api-model/src/main/java/io/enmasse/address/model/v1/AddressSpaceListV1Serializer.java
@@ -22,7 +22,7 @@ class AddressSpaceListV1Serializer extends JsonSerializer<AddressSpaceList> {
     @Override
     public void serialize(AddressSpaceList addressSpaceList, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException, JsonProcessingException {
         ObjectNode root = (ObjectNode) jsonGenerator.getCodec().createObjectNode();
-        root.put(Fields.API_VERSION, "enmasse.io/v1alpha1");
+        root.put(Fields.API_VERSION, "enmasse.io/v1beta1");
         root.put(Fields.KIND, "AddressSpaceList");
         ArrayNode items = root.putArray(Fields.ITEMS);
         for (AddressSpace addressSpace : addressSpaceList) {

--- a/api-model/src/main/java/io/enmasse/address/model/v1/AddressSpaceSchemaV1Serializer.java
+++ b/api-model/src/main/java/io/enmasse/address/model/v1/AddressSpaceSchemaV1Serializer.java
@@ -24,7 +24,7 @@ class AddressSpaceSchemaV1Serializer extends JsonSerializer<AddressSpaceSchema> 
     @Override
     public void serialize(AddressSpaceSchema schema, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException, JsonProcessingException {
         ObjectNode root = (ObjectNode) jsonGenerator.getCodec().createObjectNode();
-        root.put(Fields.API_VERSION, "enmasse.io/v1alpha1");
+        root.put(Fields.API_VERSION, "enmasse.io/v1beta1");
         root.put(Fields.KIND, "AddressSpaceSchema");
 
         ObjectNode metadata = root.putObject(Fields.METADATA);

--- a/api-model/src/main/java/io/enmasse/address/model/v1/AddressSpaceV1Serializer.java
+++ b/api-model/src/main/java/io/enmasse/address/model/v1/AddressSpaceV1Serializer.java
@@ -27,7 +27,7 @@ class AddressSpaceV1Serializer extends JsonSerializer<AddressSpace> {
     @Override
     public void serialize(AddressSpace addressSpace, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
         ObjectNode root = (ObjectNode) jsonGenerator.getCodec().createObjectNode();
-        root.put(Fields.API_VERSION, "enmasse.io/v1alpha1");
+        root.put(Fields.API_VERSION, "enmasse.io/v1beta1");
         root.put(Fields.KIND, "AddressSpace");
         serialize(addressSpace, root);
         root.serialize(jsonGenerator, serializerProvider);

--- a/api-model/src/main/java/io/enmasse/address/model/v1/AddressV1Serializer.java
+++ b/api-model/src/main/java/io/enmasse/address/model/v1/AddressV1Serializer.java
@@ -23,7 +23,7 @@ class AddressV1Serializer extends JsonSerializer<Address> {
     @Override
     public void serialize(Address address, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException, JsonProcessingException {
         ObjectNode root = (ObjectNode) jsonGenerator.getCodec().createObjectNode();
-        root.put(Fields.API_VERSION, "enmasse.io/v1alpha1");
+        root.put(Fields.API_VERSION, "enmasse.io/v1beta1");
         root.put(Fields.KIND, "Address");
         serialize(address, root);
         root.serialize(jsonGenerator, serializerProvider);

--- a/api-model/src/main/java/io/enmasse/admin/model/v1/AddressPlan.java
+++ b/api-model/src/main/java/io/enmasse/admin/model/v1/AddressPlan.java
@@ -33,7 +33,7 @@ import io.sundr.builder.annotations.Inline;
 public class AddressPlan extends AbstractHasMetadata<AddressPlan> {
 
     public static final String KIND = "AddressPlan";
-    public static final String VERSION = "v1alpha1";
+    public static final String VERSION = "v1beta1";
     public static final String GROUP = "admin.enmasse.io";
     public static final String API_VERSION = GROUP + "/" + VERSION;
 

--- a/api-model/src/main/java/io/enmasse/admin/model/v1/AddressPlanList.java
+++ b/api-model/src/main/java/io/enmasse/admin/model/v1/AddressPlanList.java
@@ -12,7 +12,7 @@ import io.enmasse.common.model.DefaultCustomResource;
 public class AddressPlanList extends AbstractList<AddressPlan> {
 
     public static final String KIND = "AddressPlanList";
-    public static final String VERSION = "v1alpha1";
+    public static final String VERSION = "v1beta1";
     public static final String GROUP = "admin.enmasse.io";
     public static final String API_VERSION = GROUP + "/" + VERSION;
 

--- a/api-model/src/main/java/io/enmasse/admin/model/v1/AddressSpacePlan.java
+++ b/api-model/src/main/java/io/enmasse/admin/model/v1/AddressSpacePlan.java
@@ -32,7 +32,7 @@ import io.sundr.builder.annotations.Inline;
 public class AddressSpacePlan extends AbstractHasMetadata<AddressSpacePlan> {
 
     public static final String KIND = "AddressSpacePlan";
-    public static final String VERSION = "v1alpha1";
+    public static final String VERSION = "v1beta1";
     public static final String GROUP = "admin.enmasse.io";
     public static final String API_VERSION = GROUP + "/" + VERSION;
 

--- a/api-model/src/main/java/io/enmasse/admin/model/v1/AddressSpacePlanList.java
+++ b/api-model/src/main/java/io/enmasse/admin/model/v1/AddressSpacePlanList.java
@@ -14,7 +14,7 @@ import io.enmasse.common.model.DefaultCustomResource;
 public class AddressSpacePlanList extends AbstractList<AddressSpacePlan> {
 
     public static final String KIND = "AddressSpacePlanList";
-    public static final String VERSION = "v1alpha1";
+    public static final String VERSION = "v1beta1";
     public static final String GROUP = "admin.enmasse.io";
     public static final String API_VERSION = GROUP + "/" + VERSION;
 

--- a/api-model/src/main/java/io/enmasse/admin/model/v1/BrokeredInfraConfig.java
+++ b/api-model/src/main/java/io/enmasse/admin/model/v1/BrokeredInfraConfig.java
@@ -30,7 +30,7 @@ import io.sundr.builder.annotations.Inline;
 public class BrokeredInfraConfig extends AbstractInfraConfig<BrokeredInfraConfig> {
 
     public static final String KIND = "BrokeredInfraConfig";
-    public static final String VERSION = "v1alpha1";
+    public static final String VERSION = "v1beta1";
     public static final String GROUP = "admin.enmasse.io";
     public static final String API_VERSION = GROUP + "/" + VERSION;
 

--- a/api-model/src/main/java/io/enmasse/admin/model/v1/BrokeredInfraConfigList.java
+++ b/api-model/src/main/java/io/enmasse/admin/model/v1/BrokeredInfraConfigList.java
@@ -12,7 +12,7 @@ import io.enmasse.common.model.DefaultCustomResource;
 public class BrokeredInfraConfigList extends AbstractList<BrokeredInfraConfig> {
 
     public static final String KIND = "BrokeredInfraConfigList";
-    public static final String VERSION = "v1alpha1";
+    public static final String VERSION = "v1beta1";
     public static final String GROUP = "admin.enmasse.io";
     public static final String API_VERSION = GROUP + "/" + VERSION;
 

--- a/api-model/src/main/java/io/enmasse/admin/model/v1/StandardInfraConfig.java
+++ b/api-model/src/main/java/io/enmasse/admin/model/v1/StandardInfraConfig.java
@@ -30,7 +30,7 @@ import io.sundr.builder.annotations.Inline;
 public class StandardInfraConfig extends AbstractInfraConfig<StandardInfraConfig> {
 
     public static final String KIND = "StandardInfraConfig";
-    public static final String VERSION = "v1alpha1";
+    public static final String VERSION = "v1beta1";
     public static final String GROUP = "admin.enmasse.io";
     public static final String API_VERSION = GROUP + "/" + VERSION;
 

--- a/api-model/src/main/java/io/enmasse/admin/model/v1/StandardInfraConfigList.java
+++ b/api-model/src/main/java/io/enmasse/admin/model/v1/StandardInfraConfigList.java
@@ -12,7 +12,7 @@ import io.enmasse.common.model.DefaultCustomResource;
 public class StandardInfraConfigList extends AbstractList<StandardInfraConfig>{
 
     public static final String KIND = "StandardInfraConfigList";
-    public static final String VERSION = "v1alpha1";
+    public static final String VERSION = "v1beta1";
     public static final String GROUP = "admin.enmasse.io";
     public static final String API_VERSION = GROUP + "/" + VERSION;
 

--- a/api-model/src/main/java/io/enmasse/user/model/v1/User.java
+++ b/api-model/src/main/java/io/enmasse/user/model/v1/User.java
@@ -32,7 +32,7 @@ public class User extends AbstractHasMetadata<User> {
     private static final Pattern NAME_PATTERN = Pattern.compile("^[a-z]+([a-z0-9\\-]*[a-z0-9]+|[a-z0-9]*)\\.[a-z0-9]+([a-z0-9@.\\-]*[a-z0-9]+|[a-z0-9]*)$");
 
     public static final String KIND = "User";
-    public static final String VERSION = "v1alpha1";
+    public static final String VERSION = "v1beta1";
     public static final String GROUP = "user.enmasse.io";
     public static final String API_VERSION = GROUP +"/" + VERSION;
 

--- a/api-model/src/main/java/io/enmasse/user/model/v1/UserList.java
+++ b/api-model/src/main/java/io/enmasse/user/model/v1/UserList.java
@@ -12,7 +12,7 @@ import io.enmasse.common.model.DefaultCustomResource;
 public class UserList extends AbstractList<User> {
 
     public static final String KIND = "MessagingUserList";
-    public static final String VERSION = "v1alpha1";
+    public static final String VERSION = "v1beta1";
     public static final String GROUP = "user.enmasse.io";
     public static final String API_VERSION = GROUP + "/" + VERSION;
 

--- a/api-model/src/test/java/io/enmasse/address/model/v1/address/SerializationTest.java
+++ b/api-model/src/test/java/io/enmasse/address/model/v1/address/SerializationTest.java
@@ -188,7 +188,7 @@ public class SerializationTest {
     @Test
     public void testDeserializeAddressSpaceCompat() throws IOException {
         String json = "{" +
-                "\"apiVersion\":\"enmasse.io/v1alpha1\"," +
+                "\"apiVersion\":\"enmasse.io/v1beta1\"," +
                 "\"kind\":\"AddressSpace\"," +
                 "\"metadata\":{" +
                 "  \"name\":\"myspace\"" +
@@ -210,20 +210,20 @@ public class SerializationTest {
 
     @Test
     public void testDeserializeAddressSpaceMissingDefaults() throws IOException {
-        String serialized = "{\"kind\": \"AddressSpace\", \"apiVersion\": \"v1alpha1\"}";
+        String serialized = "{\"kind\": \"AddressSpace\", \"apiVersion\": \"v1beta1\"}";
         assertThrows(DeserializeException.class, () -> CodecV1.getMapper().readValue(serialized, AddressSpace.class));
     }
 
     @Test
     public void testDeserializeAddressMissingDefaults() throws IOException {
-        String serialized = "{\"kind\": \"Address\", \"apiVersion\": \"v1alpha1\"}";
+        String serialized = "{\"kind\": \"Address\", \"apiVersion\": \"v1beta1\"}";
         assertThrows(DeserializeException.class, () -> CodecV1.getMapper().readValue(serialized, Address.class));
     }
 
     @Test
     public void testDeserializeAddressSpacePlan() throws IOException {
         String json = "{" +
-                "\"apiVersion\":\"enmasse.io/v1alpha1\"," +
+                "\"apiVersion\":\"enmasse.io/v1beta1\"," +
                 "\"kind\":\"AddressSpacePlan\"," +
                 "\"metadata\":{" +
                 "  \"name\":\"myspace\"," +
@@ -259,7 +259,7 @@ public class SerializationTest {
     @Test
     public void testDeserializeAddressSpacePlanWithDefaults() throws IOException {
         String json = "{" +
-                "\"apiVersion\":\"enmasse.io/v1alpha1\"," +
+                "\"apiVersion\":\"enmasse.io/v1beta1\"," +
                 "\"kind\":\"AddressSpacePlan\"," +
                 "\"metadata\":{" +
                 "  \"name\":\"myspace\"" +
@@ -302,7 +302,7 @@ public class SerializationTest {
     @Test
     public void testDeserializeResourceDefinitionWithTemplate() throws IOException {
         String json = "{" +
-                "\"apiVersion\":\"enmasse.io/v1alpha1\"," +
+                "\"apiVersion\":\"enmasse.io/v1beta1\"," +
                 "\"kind\":\"ResourceDefinition\"," +
                 "\"metadata\":{" +
                 "  \"name\":\"rdef1\"" +
@@ -326,7 +326,7 @@ public class SerializationTest {
     @Test
     public void testDeserializeResourceDefinitionNoTemplate() throws IOException {
         String json = "{" +
-                "\"apiVersion\":\"enmasse.io/v1alpha1\"," +
+                "\"apiVersion\":\"enmasse.io/v1beta1\"," +
                 "\"kind\":\"ResourceDefinition\"," +
                 "\"metadata\":{" +
                 "  \"name\":\"rdef1\"" +
@@ -341,7 +341,7 @@ public class SerializationTest {
     @Test
     public void testDeserializeAddressPlan() throws IOException {
         String json = "{" +
-                "\"apiVersion\":\"enmasse.io/v1alpha1\"," +
+                "\"apiVersion\":\"enmasse.io/v1beta1\"," +
                 "\"kind\":\"AddressPlan\"," +
                 "\"metadata\":{" +
                 "  \"name\":\"plan1\"" +
@@ -369,7 +369,7 @@ public class SerializationTest {
     @Test
     public void testDeserializeAddressPlanWithDefaults() throws IOException {
         String json = "{" +
-                "\"apiVersion\":\"enmasse.io/v1alpha1\"," +
+                "\"apiVersion\":\"enmasse.io/v1beta1\"," +
                 "\"kind\":\"AddressPlan\"," +
                 "\"metadata\":{" +
                 "  \"name\":\"plan1\"" +
@@ -393,7 +393,7 @@ public class SerializationTest {
     @Test
     public void testDeserializeAddressSpaceWithMissingAuthServiceValues() throws IOException {
         String json = "{" +
-                "\"apiVersion\":\"enmasse.io/v1alpha1\"," +
+                "\"apiVersion\":\"enmasse.io/v1beta1\"," +
                 "\"kind\":\"AddressSpace\"," +
                 "\"metadata\":{" +
                 "  \"name\":\"myspace\"" +
@@ -412,7 +412,7 @@ public class SerializationTest {
     @Test
     public void testDeserializeAddressSpaceWithExtraAuthServiceValues() throws IOException {
         String json = "{" +
-                "\"apiVersion\":\"enmasse.i/v1alpha1\"," +
+                "\"apiVersion\":\"enmasse.i/v1beta1\"," +
                 "\"kind\":\"AddressSpace\"," +
                 "\"metadata\":{" +
                 "  \"name\":\"myspace\"" +
@@ -509,7 +509,7 @@ public class SerializationTest {
         assertEquals(infraConfig, deserialized);
 
         serialized = "{" +
-                "\"apiVersion\":\"admin.enmasse.io/v1alpha1\"," +
+                "\"apiVersion\":\"admin.enmasse.io/v1beta1\"," +
                 "\"kind\":\"StandardInfraConfig\"," +
                 "\"metadata\":{" +
                 "  \"name\":\"infra\"," +
@@ -582,7 +582,7 @@ public class SerializationTest {
         assertEquals(infraConfig, deserialized);
 
         serialized = "{" +
-                "\"apiVersion\":\"admin.enmasse.io/v1alpha1\"," +
+                "\"apiVersion\":\"admin.enmasse.io/v1beta1\"," +
                 "\"kind\":\"BrokeredInfraConfig\"," +
                 "\"metadata\":{" +
                 "  \"name\":\"infra\"," +

--- a/api-server/src/main/java/io/enmasse/api/v1/http/HttpAddressService.java
+++ b/api-server/src/main/java/io/enmasse/api/v1/http/HttpAddressService.java
@@ -18,7 +18,7 @@ import java.time.Clock;
 /**
  * HTTP API for operating on addresses within an address space
  */
-@Path("/apis/enmasse.io/v1alpha1/namespaces/{namespace}/addresses")
+@Path("/apis/enmasse.io/v1beta1/namespaces/{namespace}/addresses")
 public class HttpAddressService extends HttpAddressServiceBase {
     public HttpAddressService(AddressSpaceApi addressSpaceApi, SchemaProvider schemaProvider, Clock clock) {
         super(addressSpaceApi, schemaProvider, clock);

--- a/api-server/src/main/java/io/enmasse/api/v1/http/HttpAddressService.java
+++ b/api-server/src/main/java/io/enmasse/api/v1/http/HttpAddressService.java
@@ -18,7 +18,7 @@ import java.time.Clock;
 /**
  * HTTP API for operating on addresses within an address space
  */
-@Path("/apis/enmasse.io/v1beta1/namespaces/{namespace}/addresses")
+@Path("/apis/enmasse.io/{versoin:v1alpha1|v1beta1}/namespaces/{namespace}/addresses")
 public class HttpAddressService extends HttpAddressServiceBase {
     public HttpAddressService(AddressSpaceApi addressSpaceApi, SchemaProvider schemaProvider, Clock clock) {
         super(addressSpaceApi, schemaProvider, clock);

--- a/api-server/src/main/java/io/enmasse/api/v1/http/HttpAddressSpaceService.java
+++ b/api-server/src/main/java/io/enmasse/api/v1/http/HttpAddressSpaceService.java
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
 @Path(HttpAddressSpaceService.BASE_URI)
 public class HttpAddressSpaceService {
 
-    static final String BASE_URI = "/apis/enmasse.io/v1beta1/namespaces/{namespace}/addressspaces";
+    static final String BASE_URI = "/apis/enmasse.io/{version:v1alpha1|v1beta1}/namespaces/{namespace}/addressspaces";
 
     private static final Logger log = LoggerFactory.getLogger(HttpAddressSpaceService.class.getName());
     private final SchemaProvider schemaProvider;

--- a/api-server/src/main/java/io/enmasse/api/v1/http/HttpAddressSpaceService.java
+++ b/api-server/src/main/java/io/enmasse/api/v1/http/HttpAddressSpaceService.java
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
 @Path(HttpAddressSpaceService.BASE_URI)
 public class HttpAddressSpaceService {
 
-    static final String BASE_URI = "/apis/enmasse.io/v1alpha1/namespaces/{namespace}/addressspaces";
+    static final String BASE_URI = "/apis/enmasse.io/v1beta1/namespaces/{namespace}/addressspaces";
 
     private static final Logger log = LoggerFactory.getLogger(HttpAddressSpaceService.class.getName());
     private final SchemaProvider schemaProvider;

--- a/api-server/src/main/java/io/enmasse/api/v1/http/HttpApiRootService.java
+++ b/api-server/src/main/java/io/enmasse/api/v1/http/HttpApiRootService.java
@@ -16,19 +16,22 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 import java.util.Arrays;
+import java.util.List;
 
 @Path("/apis")
 public class HttpApiRootService {
     private static final APIGroup apiGroup =
             new APIGroup("enmasse.io", Arrays.asList(
+                    new APIGroupVersion("enmasse.io/v1beta1", "v1beta1"),
                     new APIGroupVersion("enmasse.io/v1alpha1", "v1alpha1")),
-                    new APIGroupVersion("enmasse.io/v1alpha1", "v1alpha1"),
+                    new APIGroupVersion("enmasse.io/v1beta1", "v1beta1"),
                     null);
 
     private static final APIGroup userApiGroup =
             new APIGroup("user.enmasse.io", Arrays.asList(
-                    new APIGroupVersion("user.enmasse.io/v1alpha1", "v1alpha1")),
                     new APIGroupVersion("user.enmasse.io/v1alpha1", "v1alpha1"),
+                    new APIGroupVersion("user.enmasse.io/v1beta1", "v1beta1")),
+                    new APIGroupVersion("user.enmasse.io/v1beta1", "v1beta1"),
                     null);
 
     private static final APIGroupList apiGroupList = new APIGroupList(Arrays.asList(apiGroup, userApiGroup));
@@ -55,21 +58,33 @@ public class HttpApiRootService {
     }
 
 
-    private static final APIResourceList apiResourceList = new APIResourceList("enmasse.io/v1alpha1",
-        Arrays.asList(
+    private static final List<APIResource> enmasseResources = Arrays.asList(
                 new APIResource("addressspaces", "", true, "AddressSpace",
-                    Arrays.asList("create", "delete", "get", "list")),
+                    Arrays.asList("create", "delete", "get", "update", "list")),
                 new APIResource("addressspaceschemas", "", true, "AddressSpaceSchema",
                         Arrays.asList("get", "list")),
                 new APIResource("addresses", "", true, "Address",
-                                Arrays.asList("create", "delete", "get", "list"))));
+                                Arrays.asList("create", "delete", "get", "update", "list")));
+
+    private static final APIResourceList enmasseV1Alpha1ResourceList = new APIResourceList("enmasse.io/v1alpha1", enmasseResources);
+
 
     @GET
     @Path("enmasse.io/v1alpha1")
     @Produces({MediaType.APPLICATION_JSON})
-    public APIResourceList getApiGroupV1(@Context SecurityContext securityContext, @Context UriInfo uriInfo) {
+    public APIResourceList getApiGroupV1Alpha1(@Context SecurityContext securityContext, @Context UriInfo uriInfo) {
         // verifyAuthorized(securityContext, "get", uriInfo.getPath());
-        return apiResourceList;
+        return enmasseV1Alpha1ResourceList;
+    }
+
+    private static final APIResourceList enmasseV1Beta1ResourceList = new APIResourceList("enmasse.io/v1beta1", enmasseResources);
+
+    @GET
+    @Path("enmasse.io/v1beta1")
+    @Produces({MediaType.APPLICATION_JSON})
+    public APIResourceList getApiGroupV1Beta1(@Context SecurityContext securityContext, @Context UriInfo uriInfo) {
+        // verifyAuthorized(securityContext, "get", uriInfo.getPath());
+        return enmasseV1Beta1ResourceList;
     }
 
     @GET
@@ -80,16 +95,28 @@ public class HttpApiRootService {
         return userApiGroup;
     }
 
-    private static final APIResourceList userApiResourceList = new APIResourceList("user.enmasse.io/v1alpha1",
-            Arrays.asList(
+
+    private static final List<APIResource> enmasseUserResources = Arrays.asList(
                     new APIResource("messagingusers", "", true, "MessagingUser",
-                            Arrays.asList("create", "delete", "get", "list", "update"))));
+                                    Arrays.asList("create", "delete", "get", "list", "update")));
+
+    private static final APIResourceList enmasseV1Alpha1UserResourceList = new APIResourceList("user.enmasse.io/v1alpha1", enmasseUserResources);
 
     @GET
     @Path("user.enmasse.io/v1alpha1")
     @Produces({MediaType.APPLICATION_JSON})
-    public APIResourceList getUserApiGroupV1(@Context SecurityContext securityContext, @Context UriInfo uriInfo) {
+    public APIResourceList getUserApiGroupV1Alpha1(@Context SecurityContext securityContext, @Context UriInfo uriInfo) {
         // verifyAuthorized(securityContext, "get", uriInfo.getPath());
-        return userApiResourceList;
+        return enmasseV1Alpha1UserResourceList;
+    }
+
+    private static final APIResourceList enmasseV1Beta1UserResourceList = new APIResourceList("user.enmasse.io/v1beta1", enmasseUserResources);
+
+    @GET
+    @Path("user.enmasse.io/v1beta1")
+    @Produces({MediaType.APPLICATION_JSON})
+    public APIResourceList getUserApiGroupV1Beta1(@Context SecurityContext securityContext, @Context UriInfo uriInfo) {
+        // verifyAuthorized(securityContext, "get", uriInfo.getPath());
+        return enmasseV1Beta1UserResourceList;
     }
 }

--- a/api-server/src/main/java/io/enmasse/api/v1/http/HttpClusterAddressSpaceService.java
+++ b/api-server/src/main/java/io/enmasse/api/v1/http/HttpClusterAddressSpaceService.java
@@ -41,7 +41,7 @@ import static io.enmasse.api.v1.http.HttpAddressSpaceService.removeSecrets;
 @Path(HttpClusterAddressSpaceService.BASE_URI)
 public class HttpClusterAddressSpaceService {
 
-    static final String BASE_URI = "/apis/enmasse.io/v1alpha1/addressspaces";
+    static final String BASE_URI = "/apis/enmasse.io/v1beta1/addressspaces";
 
     private static final Logger log = LoggerFactory.getLogger(HttpClusterAddressSpaceService.class.getName());
 

--- a/api-server/src/main/java/io/enmasse/api/v1/http/HttpNestedAddressService.java
+++ b/api-server/src/main/java/io/enmasse/api/v1/http/HttpNestedAddressService.java
@@ -18,7 +18,7 @@ import java.time.Clock;
 /**
  * HTTP API for operating on addresses within an address space
  */
-@Path("/apis/enmasse.io/v1beta1/namespaces/{namespace}/addressspaces/{addressSpace}/addresses")
+@Path("/apis/enmasse.io/{version:v1alpha1|v1beta1}/namespaces/{namespace}/addressspaces/{addressSpace}/addresses")
 public class HttpNestedAddressService extends HttpAddressServiceBase {
     public HttpNestedAddressService(AddressSpaceApi addressSpaceApi, SchemaProvider schemaProvider, Clock clock) {
         super(addressSpaceApi, schemaProvider, clock);

--- a/api-server/src/main/java/io/enmasse/api/v1/http/HttpNestedAddressService.java
+++ b/api-server/src/main/java/io/enmasse/api/v1/http/HttpNestedAddressService.java
@@ -18,7 +18,7 @@ import java.time.Clock;
 /**
  * HTTP API for operating on addresses within an address space
  */
-@Path("/apis/enmasse.io/v1alpha1/namespaces/{namespace}/addressspaces/{addressSpace}/addresses")
+@Path("/apis/enmasse.io/v1beta1/namespaces/{namespace}/addressspaces/{addressSpace}/addresses")
 public class HttpNestedAddressService extends HttpAddressServiceBase {
     public HttpNestedAddressService(AddressSpaceApi addressSpaceApi, SchemaProvider schemaProvider, Clock clock) {
         super(addressSpaceApi, schemaProvider, clock);

--- a/api-server/src/main/java/io/enmasse/api/v1/http/HttpRootService.java
+++ b/api-server/src/main/java/io/enmasse/api/v1/http/HttpRootService.java
@@ -24,7 +24,7 @@ public class HttpRootService {
         URI baseUri = uriInfo.getBaseUri();
         uriList.add(baseUri.resolve("/apis"));
         uriList.add(baseUri.resolve("/apis/enmasse.io"));
-        uriList.add(baseUri.resolve("/apis/enmasse.io/v1alpha1"));
+        uriList.add(baseUri.resolve("/apis/enmasse.io/v1beta1"));
         uriList.add(baseUri.resolve("/healthz"));
         uriList.add(baseUri.resolve("/swagger.json"));
         return Response.status(200).entity(uriList).build();

--- a/api-server/src/main/java/io/enmasse/api/v1/http/HttpSchemaService.java
+++ b/api-server/src/main/java/io/enmasse/api/v1/http/HttpSchemaService.java
@@ -22,7 +22,7 @@ import javax.ws.rs.core.Response;
  */
 @Path(HttpSchemaService.BASE_URI)
 public class HttpSchemaService {
-    static final String BASE_URI = "/apis/enmasse.io/v1beta1/namespaces/{namespace}/addressspaceschemas";
+    static final String BASE_URI = "/apis/enmasse.io/{version:v1alpha1|v1beta1}/namespaces/{namespace}/addressspaceschemas";
     private static final Logger log = LoggerFactory.getLogger(HttpSchemaService.class.getName());
 
     private final SchemaProvider schemaProvider;

--- a/api-server/src/main/java/io/enmasse/api/v1/http/HttpSchemaService.java
+++ b/api-server/src/main/java/io/enmasse/api/v1/http/HttpSchemaService.java
@@ -22,7 +22,7 @@ import javax.ws.rs.core.Response;
  */
 @Path(HttpSchemaService.BASE_URI)
 public class HttpSchemaService {
-    static final String BASE_URI = "/apis/enmasse.io/v1alpha1/namespaces/{namespace}/addressspaceschemas";
+    static final String BASE_URI = "/apis/enmasse.io/v1beta1/namespaces/{namespace}/addressspaceschemas";
     private static final Logger log = LoggerFactory.getLogger(HttpSchemaService.class.getName());
 
     private final SchemaProvider schemaProvider;

--- a/api-server/src/main/java/io/enmasse/api/v1/http/HttpUserService.java
+++ b/api-server/src/main/java/io/enmasse/api/v1/http/HttpUserService.java
@@ -59,7 +59,7 @@ import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 @Path(HttpUserService.BASE_URI)
 public class HttpUserService {
 
-    static final String BASE_URI = "/apis/user.enmasse.io/v1alpha1/namespaces/{namespace}/messagingusers";
+    static final String BASE_URI = "/apis/user.enmasse.io/v1beta1/namespaces/{namespace}/messagingusers";
 
     private static final Logger log = LoggerFactory.getLogger(HttpUserService.class.getName());
 

--- a/api-server/src/main/java/io/enmasse/api/v1/http/HttpUserService.java
+++ b/api-server/src/main/java/io/enmasse/api/v1/http/HttpUserService.java
@@ -59,7 +59,7 @@ import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 @Path(HttpUserService.BASE_URI)
 public class HttpUserService {
 
-    static final String BASE_URI = "/apis/user.enmasse.io/v1beta1/namespaces/{namespace}/messagingusers";
+    static final String BASE_URI = "/apis/user.enmasse.io/{version:v1alpha1|v1beta1}/namespaces/{namespace}/messagingusers";
 
     private static final Logger log = LoggerFactory.getLogger(HttpUserService.class.getName());
 

--- a/api-server/src/main/resources/swagger.json
+++ b/api-server/src/main/resources/swagger.json
@@ -67,10 +67,10 @@
         "https"
     ],
     "paths": {
-        "/apis/enmasse.io/v1alpha1/namespaces/{namespace}/addressspaces": {
+        "/apis/enmasse.io/v1beta1/namespaces/{namespace}/addressspaces": {
           "get": {
             "tags": [
-                    "enmasse_v1alpha1",
+                    "enmasse_v1beta1",
                     "addressspaces"
                 ],
                 "description": "list objects of kind AddressSpace",
@@ -91,7 +91,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.v1alpha1.AddressSpaceList"
+                            "$ref": "#/definitions/io.enmasse.v1beta1.AddressSpaceList"
                         }
                     },
                     "401": {
@@ -101,7 +101,7 @@
             },
             "post": {
                 "tags": [
-                    "enmasse_v1alpha1",
+                    "enmasse_v1beta1",
                     "addressspaces"
                 ],
                 "description": "create an AddressSpace",
@@ -118,7 +118,7 @@
                         "name": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.v1alpha1.AddressSpace"
+                            "$ref": "#/definitions/io.enmasse.v1beta1.AddressSpace"
                         }
                     }
                 ],
@@ -126,13 +126,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.v1alpha1.AddressSpace"
+                            "$ref": "#/definitions/io.enmasse.v1beta1.AddressSpace"
                         }
                     },
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.v1alpha1.AddressSpace"
+                            "$ref": "#/definitions/io.enmasse.v1beta1.AddressSpace"
                         }
                     },
                     "401": {
@@ -151,10 +151,10 @@
                 }
             ]
         },
-        "/apis/enmasse.io/v1alpha1/namespaces/{namespace}/addressspaces/{name}": {
+        "/apis/enmasse.io/v1beta1/namespaces/{namespace}/addressspaces/{name}": {
             "get": {
                 "tags": [
-                    "enmasse_v1alpha1",
+                    "enmasse_v1beta1",
                     "addressspaces"
                 ],
                 "description": "read the specified AddressSpace",
@@ -178,7 +178,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.v1alpha1.AddressSpace"
+                            "$ref": "#/definitions/io.enmasse.v1beta1.AddressSpace"
                         }
                     },
                     "401": {
@@ -191,7 +191,7 @@
             },
             "put": {
                 "tags": [
-                    "enmasse_v1alpha1",
+                    "enmasse_v1beta1",
                     "addressspaces"
                 ],
                 "description": "replace the specified AddressSpace",
@@ -212,7 +212,7 @@
                         "name": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.v1alpha1.AddressSpace"
+                            "$ref": "#/definitions/io.enmasse.v1beta1.AddressSpace"
                         }
                     }
                 ],
@@ -220,13 +220,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.v1alpha1.AddressSpace"
+                            "$ref": "#/definitions/io.enmasse.v1beta1.AddressSpace"
                         }
                     },
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.v1alpha1.AddressSpace"
+                            "$ref": "#/definitions/io.enmasse.v1beta1.AddressSpace"
                         }
                     },
                     "401": {
@@ -236,7 +236,7 @@
             },
             "delete": {
                 "tags": [
-                    "enmasse_v1alpha1",
+                    "enmasse_v1beta1",
                     "addressspaces"
                 ],
                 "description": "delete an AddressSpace",
@@ -279,10 +279,10 @@
                 }
             ]
         },
-        "/apis/enmasse.io/v1alpha1/namespaces/{namespace}/addressspaces/{addressSpace}/addresses": {
+        "/apis/enmasse.io/v1beta1/namespaces/{namespace}/addressspaces/{addressSpace}/addresses": {
             "get": {
                 "tags": [
-                    "enmasse_v1alpha1",
+                    "enmasse_v1beta1",
                     "addressspace_addresses"
                 ],
                 "description": "list objects of kind Address in AddressSpace",
@@ -303,7 +303,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.v1alpha1.AddressList"
+                            "$ref": "#/definitions/io.enmasse.v1beta1.AddressList"
                         }
                     },
                     "401": {
@@ -316,7 +316,7 @@
             },
             "post": {
                 "tags": [
-                    "enmasse_v1alpha1",
+                    "enmasse_v1beta1",
                     "addressspace_addresses"
                 ],
                 "description": "create Addresses in an AddressSpace",
@@ -341,7 +341,7 @@
                         "description": "AddressList object",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.v1alpha1.AddressList"
+                            "$ref": "#/definitions/io.enmasse.v1beta1.AddressList"
                         }
                     }
                 ],
@@ -371,10 +371,10 @@
                 }
             ]
         },
-        "/apis/enmasse.io/v1alpha1/namespaces/{namespace}/addressspaces/{addressSpace}/addresses/{address}": {
+        "/apis/enmasse.io/v1beta1/namespaces/{namespace}/addressspaces/{addressSpace}/addresses/{address}": {
             "put": {
                 "tags": [
-                    "enmasse_v1alpha1",
+                    "enmasse_v1beta1",
                     "addressspace_addresses"
                 ],
                 "description": "replace Address in an AddressSpace",
@@ -406,7 +406,7 @@
                         "description": "Address object",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.v1alpha1.Address"
+                            "$ref": "#/definitions/io.enmasse.v1beta1.Address"
                         }
                     }
                 ],
@@ -414,13 +414,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.v1alpha1.Address"
+                            "$ref": "#/definitions/io.enmasse.v1beta1.Address"
                         }
                     },
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.v1alpha1.Address"
+                            "$ref": "#/definitions/io.enmasse.v1beta1.Address"
                         }
                     },
                     "401": {
@@ -433,7 +433,7 @@
             },
             "get": {
                 "tags": [
-                    "enmasse_v1alpha1",
+                    "enmasse_v1beta1",
                     "addressspace_addresses"
                 ],
                 "description": "read the specified Address in AddressSpace",
@@ -461,7 +461,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.v1alpha1.Address"
+                            "$ref": "#/definitions/io.enmasse.v1beta1.Address"
                         }
                     },
                     "401": {
@@ -474,7 +474,7 @@
             },
             "delete": {
                 "tags": [
-                    "enmasse_v1alpha1",
+                    "enmasse_v1beta1",
                     "addressspace_addresses"
                 ],
                 "description": "delete an Address in AddressSpace",
@@ -524,10 +524,10 @@
                 }
             ]
         },
-        "/apis/enmasse.io/v1alpha1/namespaces/{namespace}/addresses": {
+        "/apis/enmasse.io/v1beta1/namespaces/{namespace}/addresses": {
           "get": {
             "tags": [
-                    "enmasse_v1alpha1",
+                    "enmasse_v1beta1",
                     "addresses"
                 ],
                 "description": "list objects of kind Address",
@@ -548,7 +548,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.v1alpha1.AddressList"
+                            "$ref": "#/definitions/io.enmasse.v1beta1.AddressList"
                         }
                     },
                     "401": {
@@ -558,7 +558,7 @@
             },
             "post": {
                 "tags": [
-                    "enmasse_v1alpha1",
+                    "enmasse_v1beta1",
                     "addresses"
                 ],
                 "description": "create an Address",
@@ -575,7 +575,7 @@
                         "name": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.v1alpha1.Address"
+                            "$ref": "#/definitions/io.enmasse.v1beta1.Address"
                         }
                     }
                 ],
@@ -583,13 +583,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.v1alpha1.Address"
+                            "$ref": "#/definitions/io.enmasse.v1beta1.Address"
                         }
                     },
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.v1alpha1.Address"
+                            "$ref": "#/definitions/io.enmasse.v1beta1.Address"
                         }
                     },
                     "401": {
@@ -608,10 +608,10 @@
                 }
             ]
         },
-        "/apis/enmasse.io/v1alpha1/namespaces/{namespace}/addresses/{name}": {
+        "/apis/enmasse.io/v1beta1/namespaces/{namespace}/addresses/{name}": {
             "get": {
                 "tags": [
-                    "enmasse_v1alpha1",
+                    "enmasse_v1beta1",
                     "addresses"
                 ],
                 "description": "read the specified Address",
@@ -635,7 +635,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.v1alpha1.Address"
+                            "$ref": "#/definitions/io.enmasse.v1beta1.Address"
                         }
                     },
                     "401": {
@@ -648,7 +648,7 @@
             },
             "put": {
                 "tags": [
-                    "enmasse_v1alpha1",
+                    "enmasse_v1beta1",
                     "addresses"
                 ],
                 "description": "replace the specified Address",
@@ -669,7 +669,7 @@
                         "name": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.v1alpha1.Address"
+                            "$ref": "#/definitions/io.enmasse.v1beta1.Address"
                         }
                     }
                 ],
@@ -677,13 +677,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.v1alpha1.Address"
+                            "$ref": "#/definitions/io.enmasse.v1beta1.Address"
                         }
                     },
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.v1alpha1.Address"
+                            "$ref": "#/definitions/io.enmasse.v1beta1.Address"
                         }
                     },
                     "401": {
@@ -693,7 +693,7 @@
             },
             "delete": {
                 "tags": [
-                    "enmasse_v1alpha1",
+                    "enmasse_v1beta1",
                     "addresses"
                 ],
                 "description": "delete an Address",
@@ -736,10 +736,10 @@
                 }
             ]
         },
-        "/apis/user.enmasse.io/v1alpha1/namespaces/{namespace}/messagingusers": {
+        "/apis/user.enmasse.io/v1beta1/namespaces/{namespace}/messagingusers": {
           "get": {
             "tags": [
-                    "enmasse_v1alpha1",
+                    "enmasse_v1beta1",
                     "auth",
                     "user"
                 ],
@@ -761,7 +761,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.user.v1alpha1.MessagingUserList"
+                            "$ref": "#/definitions/io.enmasse.user.v1beta1.MessagingUserList"
                         }
                     },
                     "401": {
@@ -771,7 +771,7 @@
             },
             "post": {
                 "tags": [
-                    "enmasse_v1alpha1",
+                    "enmasse_v1beta1",
                     "auth",
                     "user"
                 ],
@@ -789,7 +789,7 @@
                         "name": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.user.v1alpha1.MessagingUser"
+                            "$ref": "#/definitions/io.enmasse.user.v1beta1.MessagingUser"
                         }
                     }
                 ],
@@ -797,13 +797,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.user.v1alpha1.MessagingUser"
+                            "$ref": "#/definitions/io.enmasse.user.v1beta1.MessagingUser"
                         }
                     },
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.user.v1alpha1.MessagingUser"
+                            "$ref": "#/definitions/io.enmasse.user.v1beta1.MessagingUser"
                         }
                     },
                     "401": {
@@ -822,10 +822,10 @@
                 }
             ]
         },
-        "/apis/user.enmasse.io/v1alpha1/namespaces/{namespace}/messagingusers/{name}": {
+        "/apis/user.enmasse.io/v1beta1/namespaces/{namespace}/messagingusers/{name}": {
             "get": {
                 "tags": [
-                    "enmasse_v1alpha1",
+                    "enmasse_v1beta1",
                     "auth",
                     "user"
                 ],
@@ -850,7 +850,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.user.v1alpha1.MessagingUser"
+                            "$ref": "#/definitions/io.enmasse.user.v1beta1.MessagingUser"
                         }
                     },
                     "401": {
@@ -863,7 +863,7 @@
             },
             "put": {
                 "tags": [
-                    "enmasse_v1alpha1",
+                    "enmasse_v1beta1",
                     "auth",
                     "user"
                 ],
@@ -885,7 +885,7 @@
                         "name": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.user.v1alpha1.MessagingUser"
+                            "$ref": "#/definitions/io.enmasse.user.v1beta1.MessagingUser"
                         }
                     }
                 ],
@@ -893,13 +893,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.user.v1alpha1.MessagingUser"
+                            "$ref": "#/definitions/io.enmasse.user.v1beta1.MessagingUser"
                         }
                     },
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.user.v1alpha1.MessagingUser"
+                            "$ref": "#/definitions/io.enmasse.user.v1beta1.MessagingUser"
                         }
                     },
                     "401": {
@@ -909,7 +909,7 @@
             },
             "delete": {
                 "tags": [
-                    "enmasse_v1alpha1",
+                    "enmasse_v1beta1",
                     "auth",
                     "user"
                 ],
@@ -953,10 +953,10 @@
                 }
             ]
         },
-        "/apis/admin.enmasse.io/v1alpha1/namespaces/{namespace}/addressspaceplans": {
+        "/apis/admin.enmasse.io/v1beta1/namespaces/{namespace}/addressspaceplans": {
           "get": {
             "tags": [
-                    "enmasse_v1alpha1",
+                    "enmasse_v1beta1",
                     "admin",
                     "addressspaceplan"
                 ],
@@ -978,7 +978,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.admin.v1alpha1.AddressSpacePlanList"
+                            "$ref": "#/definitions/io.enmasse.admin.v1beta1.AddressSpacePlanList"
                         }
                     },
                     "401": {
@@ -988,7 +988,7 @@
             },
             "post": {
                 "tags": [
-                    "enmasse_v1alpha1",
+                    "enmasse_v1beta1",
                     "admin",
                     "addressspaceplan"
                 ],
@@ -1006,7 +1006,7 @@
                         "name": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.admin.v1alpha1.AddressSpacePlan"
+                            "$ref": "#/definitions/io.enmasse.admin.v1beta1.AddressSpacePlan"
                         }
                     }
                 ],
@@ -1014,13 +1014,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.admin.v1alpha1.AddressSpacePlan"
+                            "$ref": "#/definitions/io.enmasse.admin.v1beta1.AddressSpacePlan"
                         }
                     },
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.admin.v1alpha1.AddressSpacePlan"
+                            "$ref": "#/definitions/io.enmasse.admin.v1beta1.AddressSpacePlan"
                         }
                     },
                     "401": {
@@ -1039,10 +1039,10 @@
                 }
             ]
         },
-        "/apis/admin.enmasse.io/v1alpha1/namespaces/{namespace}/addressspaceplans/{name}": {
+        "/apis/admin.enmasse.io/v1beta1/namespaces/{namespace}/addressspaceplans/{name}": {
             "get": {
                 "tags": [
-                    "enmasse_v1alpha1",
+                    "enmasse_v1beta1",
                     "admin",
                     "addressspaceplan"
                 ],
@@ -1067,7 +1067,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.admin.v1alpha1.AddressSpacePlan"
+                            "$ref": "#/definitions/io.enmasse.admin.v1beta1.AddressSpacePlan"
                         }
                     },
                     "401": {
@@ -1080,7 +1080,7 @@
             },
             "put": {
                 "tags": [
-                    "enmasse_v1alpha1",
+                    "enmasse_v1beta1",
                     "admin",
                     "addressspaceplan"
                 ],
@@ -1102,7 +1102,7 @@
                         "name": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.admin.v1alpha1.AddressSpacePlan"
+                            "$ref": "#/definitions/io.enmasse.admin.v1beta1.AddressSpacePlan"
                         }
                     }
                 ],
@@ -1110,13 +1110,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.admin.v1alpha1.AddressSpacePlan"
+                            "$ref": "#/definitions/io.enmasse.admin.v1beta1.AddressSpacePlan"
                         }
                     },
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/io.enmasse.admin.v1alpha1.AddressSpacePlan"
+                            "$ref": "#/definitions/io.enmasse.admin.v1beta1.AddressSpacePlan"
                         }
                     },
                     "401": {
@@ -1126,7 +1126,7 @@
             },
             "delete": {
                 "tags": [
-                    "enmasse_v1alpha1",
+                    "enmasse_v1beta1",
                     "admin",
                     "addressspaceplan"
                 ],
@@ -1172,7 +1172,7 @@
         }
     },
     "definitions": {
-        "io.enmasse.v1alpha1.AddressSpace": {
+        "io.enmasse.v1beta1.AddressSpace": {
             "type": "object",
             "required": [
                 "apiVersion",
@@ -1184,7 +1184,7 @@
                 "apiVersion": {
                     "type": "string",
                     "enum": [
-                        "enmasse.io/v1alpha1"
+                        "enmasse.io/v1beta1"
                     ]
                 },
                 "kind": {
@@ -1197,14 +1197,14 @@
                     "$ref": "#/definitions/ObjectMeta"
                 },
                 "spec": {
-                    "$ref": "#/definitions/io.enmasse.v1alpha1.AddressSpaceSpec"
+                    "$ref": "#/definitions/io.enmasse.v1beta1.AddressSpaceSpec"
                 },
                 "status": {
-                    "$ref": "#/definitions/io.enmasse.v1alpha1.AddressSpaceStatus"
+                    "$ref": "#/definitions/io.enmasse.v1beta1.AddressSpaceStatus"
                 }
             }
         },
-        "io.enmasse.v1alpha1.AddressSpaceSpec": {
+        "io.enmasse.v1beta1.AddressSpaceSpec": {
             "type": "object",
             "required": [
                 "type",
@@ -1212,7 +1212,7 @@
             ],
             "properties": {
                 "type": {
-                    "$ref": "#/definitions/io.enmasse.v1alpha1.AddressSpaceType"
+                    "$ref": "#/definitions/io.enmasse.v1beta1.AddressSpaceType"
                 },
                 "plan": {
                     "type": "string"
@@ -1314,7 +1314,7 @@
                 }
             }
         },
-        "io.enmasse.v1alpha1.AddressSpaceStatus": {
+        "io.enmasse.v1beta1.AddressSpaceStatus": {
             "type": "object",
             "properties": {
                 "isReady": {
@@ -1376,7 +1376,7 @@
                 }
             }
         },
-        "io.enmasse.v1alpha1.AddressSpaceList": {
+        "io.enmasse.v1beta1.AddressSpaceList": {
             "type": "object",
             "required": [
                 "apiVersion",
@@ -1386,9 +1386,9 @@
             "properties": {
                 "apiVersion": {
                     "type": "string",
-                    "default": "enmasse.io/v1alpha1",
+                    "default": "enmasse.io/v1beta1",
                     "enum": [
-                        "enmasse.io/v1alpha1"
+                        "enmasse.io/v1beta1"
                     ]
                 },
                 "kind": {
@@ -1400,12 +1400,12 @@
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/io.enmasse.v1alpha1.AddressSpace"
+                        "$ref": "#/definitions/io.enmasse.v1beta1.AddressSpace"
                     }
                 }
             }
         },
-        "io.enmasse.v1alpha1.Address": {
+        "io.enmasse.v1beta1.Address": {
             "type": "object",
             "required": [
                 "apiVersion",
@@ -1417,7 +1417,7 @@
                 "apiVersion": {
                     "type": "string",
                     "enum": [
-                        "enmasse.io/v1alpha1"
+                        "enmasse.io/v1beta1"
                     ]
                 },
                 "kind": {
@@ -1430,14 +1430,14 @@
                     "$ref": "#/definitions/ObjectMeta"
                 },
                 "spec": {
-                    "$ref": "#/definitions/io.enmasse.v1alpha1.AddressSpec"
+                    "$ref": "#/definitions/io.enmasse.v1beta1.AddressSpec"
                 },
                 "status": {
-                    "$ref": "#/definitions/io.enmasse.v1alpha1.AddressStatus"
+                    "$ref": "#/definitions/io.enmasse.v1beta1.AddressStatus"
                 }
             }
         },
-        "io.enmasse.v1alpha1.AddressSpec": {
+        "io.enmasse.v1beta1.AddressSpec": {
             "type": "object",
             "required": [
                 "address",
@@ -1446,7 +1446,7 @@
             ],
             "properties": {
                 "type": {
-                    "$ref": "#/definitions/io.enmasse.v1alpha1.AddressType"
+                    "$ref": "#/definitions/io.enmasse.v1beta1.AddressType"
                 },
                 "plan": {
                     "type": "string"
@@ -1456,7 +1456,7 @@
                 }
             }
         },
-        "io.enmasse.v1alpha1.AddressStatus": {
+        "io.enmasse.v1beta1.AddressStatus": {
             "type": "object",
             "properties": {
                 "isReady": {
@@ -1480,7 +1480,7 @@
                 }
             }
         },
-        "io.enmasse.v1alpha1.AddressList": {
+        "io.enmasse.v1beta1.AddressList": {
             "type": "object",
             "required": [
                 "apiVersion",
@@ -1490,9 +1490,9 @@
             "properties": {
                 "apiVersion": {
                     "type": "string",
-                    "default": "enmasse.io/v1alpha1",
+                    "default": "enmasse.io/v1beta1",
                     "enum": [
-                        "enmasse.io/v1alpha1"
+                        "enmasse.io/v1beta1"
                     ]
                 },
                 "kind": {
@@ -1504,12 +1504,12 @@
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/io.enmasse.v1alpha1.Address"
+                        "$ref": "#/definitions/io.enmasse.v1beta1.Address"
                     }
                 }
             }
         },
-        "io.enmasse.user.v1alpha1.MessagingUser": {
+        "io.enmasse.user.v1beta1.MessagingUser": {
             "type": "object",
             "required": [
                 "apiVersion",
@@ -1521,7 +1521,7 @@
                 "apiVersion": {
                     "type": "string",
                     "enum": [
-                        "user.enmasse.io/v1alpha1"
+                        "user.enmasse.io/v1beta1"
                     ]
                 },
                 "kind": {
@@ -1534,11 +1534,11 @@
                     "$ref": "#/definitions/ObjectMeta"
                 },
                 "spec": {
-                    "$ref": "#/definitions/io.enmasse.user.v1alpha1.UserSpec"
+                    "$ref": "#/definitions/io.enmasse.user.v1beta1.UserSpec"
                 }
             }
         },
-        "io.enmasse.user.v1alpha1.UserSpec": {
+        "io.enmasse.user.v1beta1.UserSpec": {
             "type": "object",
             "required": [
                 "username"
@@ -1610,7 +1610,7 @@
                 }
             }
         },
-        "io.enmasse.user.v1alpha1.MessagingUserList": {
+        "io.enmasse.user.v1beta1.MessagingUserList": {
             "type": "object",
             "required": [
                 "apiVersion",
@@ -1621,7 +1621,7 @@
                 "apiVersion": {
                     "type": "string",
                     "enum": [
-                        "user.enmasse.io/v1alpha1"
+                        "user.enmasse.io/v1beta1"
                     ]
                 },
                 "kind": {
@@ -1633,7 +1633,7 @@
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/io.enmasse.user.v1alpha1.MessagingUser"
+                        "$ref": "#/definitions/io.enmasse.user.v1beta1.MessagingUser"
                     }
                 }
             }
@@ -1663,7 +1663,7 @@
                 }
             }
         },
-        "io.enmasse.v1alpha1.AddressSpaceType": {
+        "io.enmasse.v1beta1.AddressSpaceType": {
             "type": "string",
             "description": "AddressSpaceType is the type of address space (standard, brokered). Each type supports different types of addresses and semantics for those types.",
             "enum": [
@@ -1671,7 +1671,7 @@
                 "brokered"
             ]
         },
-        "io.enmasse.v1alpha1.AddressType": {
+        "io.enmasse.v1beta1.AddressType": {
             "type": "string",
             "description": "Type of address (queue, topic, ...). Each address type support different kinds of messaging semantics.",
             "enum": [
@@ -1681,7 +1681,7 @@
                 "multicast"
             ]
         },
-        "io.enmasse.admin.v1alpha1.BrokeredInfraConfig": {
+        "io.enmasse.admin.v1beta1.BrokeredInfraConfig": {
             "type": "object",
             "required": [
                 "apiVersion",
@@ -1693,7 +1693,7 @@
                 "apiVersion": {
                     "type": "string",
                     "enum": [
-                        "admin.enmasse.io/v1alpha1"
+                        "admin.enmasse.io/v1beta1"
                     ]
                 },
                 "kind": {
@@ -1706,11 +1706,11 @@
                     "$ref": "#/definitions/ObjectMeta"
                 },
                 "spec": {
-                    "$ref": "#/definitions/io.enmasse.admin.v1alpha1.BrokeredInfraConfigSpec"
+                    "$ref": "#/definitions/io.enmasse.admin.v1beta1.BrokeredInfraConfigSpec"
                 }
             }
         },
-        "io.enmasse.admin.v1alpha1.BrokeredInfraConfigSpec": {
+        "io.enmasse.admin.v1beta1.BrokeredInfraConfigSpec": {
             "type": "object",
             "required": [
                 "version"
@@ -1737,14 +1737,14 @@
                     }
                 },
                 "admin": {
-                    "$ref": "#/definitions/io.enmasse.admin.v1alpha1.BrokeredInfraConfigSpecAdmin"
+                    "$ref": "#/definitions/io.enmasse.admin.v1beta1.BrokeredInfraConfigSpecAdmin"
                 },
                 "broker": {
-                    "$ref": "#/definitions/io.enmasse.admin.v1alpha1.BrokeredInfraConfigSpecBroker"
+                    "$ref": "#/definitions/io.enmasse.admin.v1beta1.BrokeredInfraConfigSpecBroker"
                 }
             }
         },
-        "io.enmasse.admin.v1alpha1.BrokeredInfraConfigSpecAdmin": {
+        "io.enmasse.admin.v1beta1.BrokeredInfraConfigSpecAdmin": {
             "type": "object",
             "properties": {
                 "resources": {
@@ -1757,7 +1757,7 @@
                 }
             }
         },
-        "io.enmasse.admin.v1alpha1.BrokeredInfraConfigSpecBroker": {
+        "io.enmasse.admin.v1beta1.BrokeredInfraConfigSpecBroker": {
             "type": "object",
             "properties": {
                 "resources": {
@@ -1787,7 +1787,7 @@
                 }
             }
         },
-        "io.enmasse.admin.v1alpha1.BrokeredInfraConfigList": {
+        "io.enmasse.admin.v1beta1.BrokeredInfraConfigList": {
             "type": "object",
             "required": [
                 "apiVersion",
@@ -1798,7 +1798,7 @@
                 "apiVersion": {
                     "type": "string",
                     "enum": [
-                        "admin.enmasse.io/v1alpha1"
+                        "admin.enmasse.io/v1beta1"
                     ]
                 },
                 "kind": {
@@ -1810,12 +1810,12 @@
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/io.enmasse.admin.v1alpha1.BrokeredInfraConfig"
+                        "$ref": "#/definitions/io.enmasse.admin.v1beta1.BrokeredInfraConfig"
                     }
                 }
             }
         },
-        "io.enmasse.admin.v1alpha1.StandardInfraConfig": {
+        "io.enmasse.admin.v1beta1.StandardInfraConfig": {
             "type": "object",
             "required": [
                 "apiVersion",
@@ -1827,7 +1827,7 @@
                 "apiVersion": {
                     "type": "string",
                     "enum": [
-                        "admin.enmasse.io/v1alpha1"
+                        "admin.enmasse.io/v1beta1"
                     ]
                 },
                 "kind": {
@@ -1840,11 +1840,11 @@
                     "$ref": "#/definitions/ObjectMeta"
                 },
                 "spec": {
-                    "$ref": "#/definitions/io.enmasse.admin.v1alpha1.StandardInfraConfigSpec"
+                    "$ref": "#/definitions/io.enmasse.admin.v1beta1.StandardInfraConfigSpec"
                 }
             }
         },
-        "io.enmasse.admin.v1alpha1.StandardInfraConfigSpec": {
+        "io.enmasse.admin.v1beta1.StandardInfraConfigSpec": {
             "type": "object",
             "required": [
                 "version"
@@ -1871,17 +1871,17 @@
                     }
                 },
                 "admin": {
-                    "$ref": "#/definitions/io.enmasse.admin.v1alpha1.StandardInfraConfigSpecAdmin"
+                    "$ref": "#/definitions/io.enmasse.admin.v1beta1.StandardInfraConfigSpecAdmin"
                 },
                 "broker": {
-                    "$ref": "#/definitions/io.enmasse.admin.v1alpha1.StandardInfraConfigSpecBroker"
+                    "$ref": "#/definitions/io.enmasse.admin.v1beta1.StandardInfraConfigSpecBroker"
                 },
                 "router": {
-                    "$ref": "#/definitions/io.enmasse.admin.v1alpha1.StandardInfraConfigSpecRouter"
+                    "$ref": "#/definitions/io.enmasse.admin.v1beta1.StandardInfraConfigSpecRouter"
                 }
             }
         },
-        "io.enmasse.admin.v1alpha1.StandardInfraConfigSpecAdmin": {
+        "io.enmasse.admin.v1beta1.StandardInfraConfigSpecAdmin": {
             "type": "object",
             "properties": {
                 "resources": {
@@ -1894,7 +1894,7 @@
                 }
             }
         },
-        "io.enmasse.admin.v1alpha1.StandardInfraConfigSpecBroker": {
+        "io.enmasse.admin.v1beta1.StandardInfraConfigSpecBroker": {
             "type": "object",
             "properties": {
                 "resources": {
@@ -1924,7 +1924,7 @@
                 }
             }
         },
-        "io.enmasse.admin.v1alpha1.StandardInfraConfigSpecRouter": {
+        "io.enmasse.admin.v1beta1.StandardInfraConfigSpecRouter": {
             "type": "object",
             "properties": {
                 "resources": {
@@ -1943,7 +1943,7 @@
                 }
             }
         },
-        "io.enmasse.admin.v1alpha1.StandardInfraConfigList": {
+        "io.enmasse.admin.v1beta1.StandardInfraConfigList": {
             "type": "object",
             "required": [
                 "apiVersion",
@@ -1954,7 +1954,7 @@
                 "apiVersion": {
                     "type": "string",
                     "enum": [
-                        "admin.enmasse.io/v1alpha1"
+                        "admin.enmasse.io/v1beta1"
                     ]
                 },
                 "kind": {
@@ -1966,12 +1966,12 @@
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/io.enmasse.admin.v1alpha1.StandardInfraConfig"
+                        "$ref": "#/definitions/io.enmasse.admin.v1beta1.StandardInfraConfig"
                     }
                 }
             }
         },
-        "io.enmasse.admin.v1alpha1.AddressSpacePlan": {
+        "io.enmasse.admin.v1beta1.AddressSpacePlan": {
             "type": "object",
             "required": [
                 "apiVersion",
@@ -1988,7 +1988,7 @@
                 "apiVersion": {
                     "type": "string",
                     "enum": [
-                        "admin.enmasse.io/v1alpha1"
+                        "admin.enmasse.io/v1beta1"
                     ]
                 },
                 "kind": {
@@ -2044,7 +2044,7 @@
                 }
             }
         },
-        "io.enmasse.admin.v1alpha1.AddressSpacePlanList": {
+        "io.enmasse.admin.v1beta1.AddressSpacePlanList": {
             "type": "object",
             "required": [
                 "apiVersion",
@@ -2055,7 +2055,7 @@
                 "apiVersion": {
                     "type": "string",
                     "enum": [
-                        "admin.enmasse.io/v1alpha1"
+                        "admin.enmasse.io/v1beta1"
                     ]
                 },
                 "kind": {
@@ -2067,12 +2067,12 @@
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/io.enmasse.admin.v1alpha1.AddressSpacePlan"
+                        "$ref": "#/definitions/io.enmasse.admin.v1beta1.AddressSpacePlan"
                     }
                 }
             }
         },
-        "io.enmasse.admin.v1alpha1.AddressPlan": {
+        "io.enmasse.admin.v1beta1.AddressPlan": {
             "type": "object",
             "required": [
                 "apiVersion",
@@ -2089,7 +2089,7 @@
                 "apiVersion": {
                     "type": "string",
                     "enum": [
-                        "admin.enmasse.io/v1alpha1"
+                        "admin.enmasse.io/v1beta1"
                     ]
                 },
                 "kind": {
@@ -2139,7 +2139,7 @@
                 }
             }
         },
-        "io.enmasse.admin.v1alpha1.AddressPlanList": {
+        "io.enmasse.admin.v1beta1.AddressPlanList": {
             "type": "object",
             "required": [
                 "apiVersion",
@@ -2150,7 +2150,7 @@
                 "apiVersion": {
                     "type": "string",
                     "enum": [
-                        "admin.enmasse.io/v1alpha1"
+                        "admin.enmasse.io/v1beta1"
                     ]
                 },
                 "kind": {
@@ -2162,7 +2162,7 @@
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/io.enmasse.admin.v1alpha1.AddressPlan"
+                        "$ref": "#/definitions/io.enmasse.admin.v1beta1.AddressPlan"
                     }
                 }
             }

--- a/api-server/src/test/java/io/enmasse/api/server/HTTPServerTest.java
+++ b/api-server/src/test/java/io/enmasse/api/server/HTTPServerTest.java
@@ -43,16 +43,16 @@ import static org.mockito.Mockito.when;
 public class HTTPServerTest {
 
     private Vertx vertx;
-    private TestAddressSpaceApi instanceApi;
+    private TestAddressSpaceApi addressSpaceApi;
     private AddressSpace addressSpace;
 
     @BeforeEach
     public void setup(VertxTestContext context) throws InterruptedException {
         vertx = Vertx.vertx();
-        instanceApi = new TestAddressSpaceApi();
+        addressSpaceApi = new TestAddressSpaceApi();
         String addressSpaceName = "myinstance";
         addressSpace = createAddressSpace(addressSpaceName);
-        instanceApi.createAddressSpace(addressSpace);
+        addressSpaceApi.createAddressSpace(addressSpace);
 
         AuthApi authApi = mock(AuthApi.class);
         when(authApi.getNamespace()).thenReturn("controller");
@@ -84,7 +84,7 @@ public class HTTPServerTest {
         ApiServerOptions options = new ApiServerOptions();
         options.setVersion("1.0");
         options.setCertDir("/doesnotexist");
-        vertx.deployVerticle(new HTTPServer(instanceApi, new TestSchemaProvider(), authApi, userApi, new Metrics(), options, null, null, Clock.systemUTC()), context.succeeding(arg -> context.completeNow()));
+        vertx.deployVerticle(new HTTPServer(addressSpaceApi, new TestSchemaProvider(), authApi, userApi, new Metrics(), options, null, null, Clock.systemUTC()), context.succeeding(arg -> context.completeNow()));
     }
 
     @AfterEach
@@ -107,8 +107,17 @@ public class HTTPServerTest {
     }
 
     @Test
-    public void testAddressingApi(VertxTestContext context) throws InterruptedException {
-        instanceApi.withAddressSpace(addressSpace).createAddress(
+    public void testAddressingApiV1Alpha1(VertxTestContext context) throws InterruptedException {
+        testAddressApi(context, "v1alpha1");
+    }
+
+    @Test
+    public void testAddressingApiV1Beta1(VertxTestContext context) throws InterruptedException {
+        testAddressApi(context, "v1beta1");
+    }
+
+    private void testAddressApi(VertxTestContext context, String apiVersion) throws InterruptedException {
+        addressSpaceApi.withAddressSpace(addressSpace).createAddress(
                 new Address.Builder()
                         .setAddressSpace("myinstance")
                         .setName("myinstance.addr1")
@@ -121,7 +130,7 @@ public class HTTPServerTest {
         HttpClient client = vertx.createHttpClient();
         try {
             {
-                HttpClientRequest r1 = client.get(8080, "localhost", "/apis/enmasse.io/v1beta1/namespaces/ns/addressspaces/myinstance/addresses", response -> {
+                HttpClientRequest r1 = client.get(8080, "localhost", "/apis/enmasse.io/" + apiVersion + "/namespaces/ns/addressspaces/myinstance/addresses", response -> {
                     context.verify(() -> assertEquals(200, response.statusCode()));
                     response.bodyHandler(buffer -> {
                         JsonObject data = buffer.toJsonObject();
@@ -137,7 +146,7 @@ public class HTTPServerTest {
                 context.awaitCompletion(60, TimeUnit.SECONDS);
             }
             {
-                HttpClientRequest r2 = client.get(8080, "localhost", "/apis/enmasse.io/v1beta1/namespaces/ns/addresses/myinstance.addr1", response -> {
+                HttpClientRequest r2 = client.get(8080, "localhost", "/apis/enmasse.io/" + apiVersion + "/namespaces/ns/addresses/myinstance.addr1", response -> {
                     response.bodyHandler(buffer -> {
                         JsonObject data = buffer.toJsonObject();
                         context.verify(() -> {
@@ -152,7 +161,7 @@ public class HTTPServerTest {
                 context.awaitCompletion(60, TimeUnit.SECONDS);
             }
             {
-                HttpClientRequest r3 = client.post(8080, "localhost", "/apis/enmasse.io/v1beta1/namespaces/ns/addressspaces/myinstance/addresses", response -> {
+                HttpClientRequest r3 = client.post(8080, "localhost", "/apis/enmasse.io/" + apiVersion + "/namespaces/ns/addressspaces/myinstance/addresses", response -> {
                     response.bodyHandler(buffer -> {
                         context.verify(() -> assertEquals(201, response.statusCode()));
                         context.completeNow();
@@ -160,11 +169,11 @@ public class HTTPServerTest {
                 });
                 r3.putHeader("Content-Type", "application/json");
                 putAuthzToken(r3);
-                r3.end("{\"apiVersion\":\"enmasse.io/v1beta1\",\"kind\":\"AddressList\",\"items\":[{\"metadata\":{\"name\":\"a4\"},\"spec\":{\"address\":\"a4\",\"type\":\"queue\",\"plan\":\"plan1\"}}]}");
+                r3.end("{\"apiVersion\":\"enmasse.io/" + apiVersion + "\",\"kind\":\"AddressList\",\"items\":[{\"metadata\":{\"name\":\"a4\"},\"spec\":{\"address\":\"a4\",\"type\":\"queue\",\"plan\":\"plan1\"}}]}");
                 context.awaitCompletion(60, TimeUnit.SECONDS);
             }
             {
-                HttpClientRequest r4 = client.get(8080, "localhost", "/apis/enmasse.io/v1beta1/namespaces/ns/addressspaces/myinstance/addresses?address=addR1", response -> {
+                HttpClientRequest r4 = client.get(8080, "localhost", "/apis/enmasse.io/" + apiVersion + "/namespaces/ns/addressspaces/myinstance/addresses?address=addR1", response -> {
                     response.bodyHandler(buffer -> {
                         JsonObject data = buffer.toJsonObject();
                         System.out.println(data.toString());
@@ -190,11 +199,20 @@ public class HTTPServerTest {
     }
 
     @Test
-    public void testApiResources(VertxTestContext context) throws InterruptedException {
+    public void testApiResourcesV1Alpha1(VertxTestContext context) throws InterruptedException {
+        testApiResources(context, "v1alpha1");
+    }
+
+    @Test
+    public void testApiResourcesV1Beta1(VertxTestContext context) throws InterruptedException {
+        testApiResources(context, "v1beta1");
+    }
+
+    private void testApiResources(VertxTestContext context, String apiVersion) throws InterruptedException {
         HttpClient client = vertx.createHttpClient();
         try {
             {
-                HttpClientRequest rootReq = client.get(8080, "localhost", "/apis/enmasse.io/v1beta1", response -> {
+                HttpClientRequest rootReq = client.get(8080, "localhost", "/apis/enmasse.io/" + apiVersion, response -> {
                     context.verify(() -> assertEquals(200, response.statusCode()));
                     response.bodyHandler(buffer -> {
                         JsonObject data = buffer.toJsonObject();
@@ -209,7 +227,7 @@ public class HTTPServerTest {
                 context.awaitCompletion(60, TimeUnit.SECONDS);
             }
             {
-                HttpClientRequest rootReq = client.get(8080, "localhost", "/apis/user.enmasse.io/v1beta1", response -> {
+                HttpClientRequest rootReq = client.get(8080, "localhost", "/apis/user.enmasse.io/" + apiVersion, response -> {
                     context.verify(() -> assertEquals(200, response.statusCode()));
                     response.bodyHandler(buffer -> {
                         JsonObject data = buffer.toJsonObject();
@@ -229,11 +247,20 @@ public class HTTPServerTest {
     }
 
     @Test
-    public void testSchemaApi(VertxTestContext context) throws InterruptedException {
+    public void testSchemaApiV1Alpha1(VertxTestContext context) throws InterruptedException {
+        testSchemaApi(context, "v1alpha1");
+    }
+
+    @Test
+    public void testSchemaApiV1Beta1(VertxTestContext context) throws InterruptedException {
+        testSchemaApi(context, "v1beta1");
+    }
+
+    private void testSchemaApi(VertxTestContext context, String apiVersion) throws InterruptedException {
         HttpClient client = vertx.createHttpClient();
         try {
             {
-                HttpClientRequest request = client.get(8080, "localhost", "/apis/enmasse.io/v1beta1/namespaces/myinstance/addressspaceschemas", response -> {
+                HttpClientRequest request = client.get(8080, "localhost", "/apis/enmasse.io/" + apiVersion + "/namespaces/myinstance/addressspaceschemas", response -> {
                     context.verify(() -> assertEquals(200, response.statusCode()));
                     response.bodyHandler(buffer -> {
                         JsonObject data = buffer.toJsonObject();
@@ -255,11 +282,20 @@ public class HTTPServerTest {
     }
 
     @Test
-    public void testUserApi(VertxTestContext context) throws Exception {
+    public void testUserApiV1Alpha1(VertxTestContext context) throws Exception {
+        testUserApi(context, "v1alpha1");
+    }
+
+    @Test
+    public void testUserApiV1Beta1(VertxTestContext context) throws Exception {
+        testUserApi(context, "v1beta1");
+    }
+
+    private void testUserApi(VertxTestContext context, String apiVersion) throws Exception {
         HttpClient client = vertx.createHttpClient();
         try {
             {
-                HttpClientRequest r1 = client.get(8080, "localhost", "/apis/user.enmasse.io/v1beta1/namespaces/ns/messagingusers", response -> {
+                HttpClientRequest r1 = client.get(8080, "localhost", "/apis/user.enmasse.io/" + apiVersion + "/namespaces/ns/messagingusers", response -> {
                     context.verify(() -> assertEquals(200, response.statusCode()));
                     response.bodyHandler(buffer -> {
                         JsonObject data = buffer.toJsonObject();
@@ -279,52 +315,83 @@ public class HTTPServerTest {
         }
     }
 
-    /*
     @Test
-    public void testInstanceApi() throws InterruptedException {
-        Instance instance = new Instance.Builder(AddressSpaceId.withId("myinstance"))
-                .messagingHost(Optional.of("messaging.example.com"))
-                .build();
-        addressSpaceApi.createAddressSpace(instance);
+    public void testAddressSpaceApiV1Alpha1(VertxTestContext context) throws InterruptedException {
+        testAddressSpaceApi(context, "v1alpha1");
+    }
+
+    @Test
+    public void testAddressSpaceApiV1Beta1(VertxTestContext context) throws InterruptedException {
+        testAddressSpaceApi(context, "v1beta1");
+    }
+
+    private void testAddressSpaceApi(VertxTestContext context, String apiVersion) throws InterruptedException {
 
         HttpClient client = vertx.createHttpClient();
         try {
             {
-                final CountDownLatch latch = new CountDownLatch(1);
-                client.getNow(8080, "localhost", "/v3/addressspace", response -> {
+                HttpClientRequest r1 = client.get(8080, "localhost", "/apis/enmasse.io/" + apiVersion + "/namespaces/ns/addressspaces", response -> {
+                    context.verify(() -> assertEquals(200, response.statusCode()));
                     response.bodyHandler(buffer -> {
                         JsonObject data = buffer.toJsonObject();
-                        assertTrue(data.containsKey("kind"));
-                        assertThat(data.getString("kind"), is("InstanceList"));
-                        assertTrue(data.containsKey("items"));
-                        JsonArray items = data.getJsonArray("items");
-                        assertThat(items.size(), is(1));
-                        assertThat(items.getJsonObject(0).getJsonObject("spec").getString("messagingHost"), is("messaging.example.com"));
-                        latch.countDown();
+                        context.verify(() -> {
+                            assertTrue(data.containsKey("items"));
+                            assertEquals("myinstance", data.getJsonArray("items").getJsonObject(0).getJsonObject("metadata").getString("name"));
+                        });
+                        context.completeNow();
                     });
                 });
-                assertTrue(latch.await(1, TimeUnit.MINUTES));
+                putAuthzToken(r1);
+                r1.end();
+                context.awaitCompletion(60, TimeUnit.SECONDS);
             }
-
             {
-                final CountDownLatch latch = new CountDownLatch(1);
-                client.getNow(8080, "localhost", "/v3/addressspace/myinstance", response -> {
+                HttpClientRequest r2 = client.get(8080, "localhost", "/apis/enmasse.io/" + apiVersion + "/namespaces/ns/addressspaces/myinstance", response -> {
                     response.bodyHandler(buffer -> {
                         JsonObject data = buffer.toJsonObject();
-                        assertTrue(data.containsKey("metadata"));
-                        assertThat(data.getJsonObject("metadata").getString("name"), is("myinstance"));
-                        assertThat(data.getString("kind"), is("Instance"));
-                        assertThat(data.getJsonObject("spec").getString("messagingHost"), is("messaging.example.com"));
-                        latch.countDown();
+                        context.verify(() -> {
+                            assertTrue(data.containsKey("metadata"));
+                            assertEquals("myinstance", data.getJsonObject("metadata").getString("name"));
+                        });
+                        context.completeNow();
                     });
                 });
-                assertTrue(latch.await(1, TimeUnit.MINUTES));
+                putAuthzToken(r2);
+                r2.end();
+                context.awaitCompletion(60, TimeUnit.SECONDS);
+            }
+            {
+                HttpClientRequest r3 = client.post(8080, "localhost", "/apis/enmasse.io/" + apiVersion + "/namespaces/ns/addressspaces", response -> {
+                    response.bodyHandler(buffer -> {
+                        context.verify(() -> assertEquals(201, response.statusCode()));
+                        context.completeNow();
+                    });
+                });
+                r3.putHeader("Content-Type", "application/json");
+                putAuthzToken(r3);
+                r3.end("{\"apiVersion\":\"enmasse.io/" + apiVersion + "\",\"kind\":\"AddressSpace\",\"metadata\":{\"name\":\"a4\"},\"spec\":{\"type\":\"standard\",\"plan\":\"plan1\"}}");
+                context.awaitCompletion(60, TimeUnit.SECONDS);
+            }
+            {
+                HttpClientRequest r4 = client.get(8080, "localhost", "/apis/enmasse.io/" + apiVersion + "/namespaces/ns/addressspaces/a4", response -> {
+                    response.bodyHandler(buffer -> {
+                        JsonObject data = buffer.toJsonObject();
+                        System.out.println(data.toString());
+                        context.verify(() -> {
+                            assertTrue(data.containsKey("metadata"));
+                            assertEquals("plan1", data.getJsonObject("spec").getString("plan"));
+                        });
+                        context.completeNow();
+                    });
+                });
+                putAuthzToken(r4);
+                r4.end();
+                context.awaitCompletion(60, TimeUnit.SECONDS);
             }
         } finally {
             client.close();
         }
     }
-    */
 
     @Test
     public void testOpenApiSpec(VertxTestContext context) throws InterruptedException {

--- a/api-server/src/test/java/io/enmasse/api/server/HTTPServerTest.java
+++ b/api-server/src/test/java/io/enmasse/api/server/HTTPServerTest.java
@@ -121,7 +121,7 @@ public class HTTPServerTest {
         HttpClient client = vertx.createHttpClient();
         try {
             {
-                HttpClientRequest r1 = client.get(8080, "localhost", "/apis/enmasse.io/v1alpha1/namespaces/ns/addressspaces/myinstance/addresses", response -> {
+                HttpClientRequest r1 = client.get(8080, "localhost", "/apis/enmasse.io/v1beta1/namespaces/ns/addressspaces/myinstance/addresses", response -> {
                     context.verify(() -> assertEquals(200, response.statusCode()));
                     response.bodyHandler(buffer -> {
                         JsonObject data = buffer.toJsonObject();
@@ -137,7 +137,7 @@ public class HTTPServerTest {
                 context.awaitCompletion(60, TimeUnit.SECONDS);
             }
             {
-                HttpClientRequest r2 = client.get(8080, "localhost", "/apis/enmasse.io/v1alpha1/namespaces/ns/addresses/myinstance.addr1", response -> {
+                HttpClientRequest r2 = client.get(8080, "localhost", "/apis/enmasse.io/v1beta1/namespaces/ns/addresses/myinstance.addr1", response -> {
                     response.bodyHandler(buffer -> {
                         JsonObject data = buffer.toJsonObject();
                         context.verify(() -> {
@@ -152,7 +152,7 @@ public class HTTPServerTest {
                 context.awaitCompletion(60, TimeUnit.SECONDS);
             }
             {
-                HttpClientRequest r3 = client.post(8080, "localhost", "/apis/enmasse.io/v1alpha1/namespaces/ns/addressspaces/myinstance/addresses", response -> {
+                HttpClientRequest r3 = client.post(8080, "localhost", "/apis/enmasse.io/v1beta1/namespaces/ns/addressspaces/myinstance/addresses", response -> {
                     response.bodyHandler(buffer -> {
                         context.verify(() -> assertEquals(201, response.statusCode()));
                         context.completeNow();
@@ -160,11 +160,11 @@ public class HTTPServerTest {
                 });
                 r3.putHeader("Content-Type", "application/json");
                 putAuthzToken(r3);
-                r3.end("{\"apiVersion\":\"enmasse.io/v1alpha1\",\"kind\":\"AddressList\",\"items\":[{\"metadata\":{\"name\":\"a4\"},\"spec\":{\"address\":\"a4\",\"type\":\"queue\",\"plan\":\"plan1\"}}]}");
+                r3.end("{\"apiVersion\":\"enmasse.io/v1beta1\",\"kind\":\"AddressList\",\"items\":[{\"metadata\":{\"name\":\"a4\"},\"spec\":{\"address\":\"a4\",\"type\":\"queue\",\"plan\":\"plan1\"}}]}");
                 context.awaitCompletion(60, TimeUnit.SECONDS);
             }
             {
-                HttpClientRequest r4 = client.get(8080, "localhost", "/apis/enmasse.io/v1alpha1/namespaces/ns/addressspaces/myinstance/addresses?address=addR1", response -> {
+                HttpClientRequest r4 = client.get(8080, "localhost", "/apis/enmasse.io/v1beta1/namespaces/ns/addressspaces/myinstance/addresses?address=addR1", response -> {
                     response.bodyHandler(buffer -> {
                         JsonObject data = buffer.toJsonObject();
                         System.out.println(data.toString());
@@ -194,7 +194,7 @@ public class HTTPServerTest {
         HttpClient client = vertx.createHttpClient();
         try {
             {
-                HttpClientRequest rootReq = client.get(8080, "localhost", "/apis/enmasse.io/v1alpha1", response -> {
+                HttpClientRequest rootReq = client.get(8080, "localhost", "/apis/enmasse.io/v1beta1", response -> {
                     context.verify(() -> assertEquals(200, response.statusCode()));
                     response.bodyHandler(buffer -> {
                         JsonObject data = buffer.toJsonObject();
@@ -209,7 +209,7 @@ public class HTTPServerTest {
                 context.awaitCompletion(60, TimeUnit.SECONDS);
             }
             {
-                HttpClientRequest rootReq = client.get(8080, "localhost", "/apis/user.enmasse.io/v1alpha1", response -> {
+                HttpClientRequest rootReq = client.get(8080, "localhost", "/apis/user.enmasse.io/v1beta1", response -> {
                     context.verify(() -> assertEquals(200, response.statusCode()));
                     response.bodyHandler(buffer -> {
                         JsonObject data = buffer.toJsonObject();
@@ -233,7 +233,7 @@ public class HTTPServerTest {
         HttpClient client = vertx.createHttpClient();
         try {
             {
-                HttpClientRequest request = client.get(8080, "localhost", "/apis/enmasse.io/v1alpha1/namespaces/myinstance/addressspaceschemas", response -> {
+                HttpClientRequest request = client.get(8080, "localhost", "/apis/enmasse.io/v1beta1/namespaces/myinstance/addressspaceschemas", response -> {
                     context.verify(() -> assertEquals(200, response.statusCode()));
                     response.bodyHandler(buffer -> {
                         JsonObject data = buffer.toJsonObject();
@@ -259,7 +259,7 @@ public class HTTPServerTest {
         HttpClient client = vertx.createHttpClient();
         try {
             {
-                HttpClientRequest r1 = client.get(8080, "localhost", "/apis/user.enmasse.io/v1alpha1/namespaces/ns/messagingusers", response -> {
+                HttpClientRequest r1 = client.get(8080, "localhost", "/apis/user.enmasse.io/v1beta1/namespaces/ns/messagingusers", response -> {
                     context.verify(() -> assertEquals(200, response.statusCode()));
                     response.bodyHandler(buffer -> {
                         JsonObject data = buffer.toJsonObject();

--- a/documentation/common/address-example1.yaml
+++ b/documentation/common/address-example1.yaml
@@ -1,4 +1,4 @@
-apiVersion: enmasse.io/v1alpha1
+apiVersion: enmasse.io/v1beta1
 kind: Address
 metadata:
     name: myspace.myqueue <1>

--- a/documentation/common/address-space-example1.yaml
+++ b/documentation/common/address-space-example1.yaml
@@ -1,4 +1,4 @@
-apiVersion: enmasse.io/v1alpha1
+apiVersion: enmasse.io/v1beta1
 kind: AddressSpace
 metadata:
   name: myspace

--- a/documentation/common/address-space-example2.yaml
+++ b/documentation/common/address-space-example2.yaml
@@ -1,4 +1,4 @@
-apiVersion: enmasse.io/v1alpha1
+apiVersion: enmasse.io/v1beta1
 kind: AddressSpace
 metadata:
   name: myspace

--- a/documentation/common/address-space-output-example1.yaml
+++ b/documentation/common/address-space-output-example1.yaml
@@ -1,4 +1,4 @@
-apiVersion: enmasse.io/v1alpha1
+apiVersion: enmasse.io/v1beta1
 kind: AddressSpace
 metadata:
   name: myspace

--- a/documentation/common/brokered-infra-config-example.yaml
+++ b/documentation/common/brokered-infra-config-example.yaml
@@ -1,4 +1,4 @@
-apiVersion: admin.enmasse.io/v1alpha1
+apiVersion: admin.enmasse.io/v1beta1
 kind: BrokeredInfraConfig
 metadata:
   name: brokered-infra-config-example

--- a/documentation/common/restapi-reference.adoc
+++ b/documentation/common/restapi-reference.adoc
@@ -39,7 +39,7 @@ __URL__ : http://enmasse.io
 == Paths
 
 [[_createadminenmassev1alpha1namespacedaddressspaceplan]]
-=== POST /apis/admin.enmasse.io/v1alpha1/namespaces/{namespace}/addressspaceplans
+=== POST /apis/admin.enmasse.io/v1beta1/namespaces/{namespace}/addressspaceplans
 
 ==== Description
 create an AddressSpacePlan
@@ -53,7 +53,7 @@ create an AddressSpacePlan
 |**Path**|**namespace** +
 __required__|object name and auth scope, such as for teams and projects|string
 |**Body**|**body** +
-__required__||<<_io_enmasse_admin_v1alpha1_addressspaceplan,io.enmasse.admin.v1alpha1.AddressSpacePlan>>
+__required__||<<_io_enmasse_admin_v1beta1_addressspaceplan,io.enmasse.admin.v1beta1.AddressSpacePlan>>
 |===
 
 
@@ -62,8 +62,8 @@ __required__||<<_io_enmasse_admin_v1alpha1_addressspaceplan,io.enmasse.admin.v1a
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
-|**200**|OK|<<_io_enmasse_admin_v1alpha1_addressspaceplan,io.enmasse.admin.v1alpha1.AddressSpacePlan>>
-|**201**|Created|<<_io_enmasse_admin_v1alpha1_addressspaceplan,io.enmasse.admin.v1alpha1.AddressSpacePlan>>
+|**200**|OK|<<_io_enmasse_admin_v1beta1_addressspaceplan,io.enmasse.admin.v1beta1.AddressSpacePlan>>
+|**201**|Created|<<_io_enmasse_admin_v1beta1_addressspaceplan,io.enmasse.admin.v1beta1.AddressSpacePlan>>
 |**401**|Unauthorized|No Content
 |===
 
@@ -82,11 +82,11 @@ __required__||<<_io_enmasse_admin_v1alpha1_addressspaceplan,io.enmasse.admin.v1a
 
 * addressspaceplan
 * admin
-* enmasse_v1alpha1
+* enmasse_v1beta1
 
 
 [[_listadminenmassev1alpha1namespacedaddresspaceplan]]
-=== GET /apis/admin.enmasse.io/v1alpha1/namespaces/{namespace}/addressspaceplans
+=== GET /apis/admin.enmasse.io/v1beta1/namespaces/{namespace}/addressspaceplans
 
 ==== Description
 list objects of kind AddressSpacePlan
@@ -109,7 +109,7 @@ __optional__|A selector to restrict the list of returned objects by their labels
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
-|**200**|OK|<<_io_enmasse_admin_v1alpha1_addressspaceplanlist,io.enmasse.admin.v1alpha1.AddressSpacePlanList>>
+|**200**|OK|<<_io_enmasse_admin_v1beta1_addressspaceplanlist,io.enmasse.admin.v1beta1.AddressSpacePlanList>>
 |**401**|Unauthorized|No Content
 |===
 
@@ -123,11 +123,11 @@ __optional__|A selector to restrict the list of returned objects by their labels
 
 * addressspaceplan
 * admin
-* enmasse_v1alpha1
+* enmasse_v1beta1
 
 
 [[_readadminenmassev1alpha1namespacedaddressspaceplan]]
-=== GET /apis/admin.enmasse.io/v1alpha1/namespaces/{namespace}/addressspaceplans/{name}
+=== GET /apis/admin.enmasse.io/v1beta1/namespaces/{namespace}/addressspaceplans/{name}
 
 ==== Description
 read the specified AddressSpacePlan
@@ -150,7 +150,7 @@ __required__|object name and auth scope, such as for teams and projects|string
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
-|**200**|OK|<<_io_enmasse_admin_v1alpha1_addressspaceplan,io.enmasse.admin.v1alpha1.AddressSpacePlan>>
+|**200**|OK|<<_io_enmasse_admin_v1beta1_addressspaceplan,io.enmasse.admin.v1beta1.AddressSpacePlan>>
 |**401**|Unauthorized|No Content
 |**404**|Not found|No Content
 |===
@@ -170,11 +170,11 @@ __required__|object name and auth scope, such as for teams and projects|string
 
 * addressspaceplan
 * admin
-* enmasse_v1alpha1
+* enmasse_v1beta1
 
 
 [[_replaceadminenmassev1alpha1namespacedaddressspaceplan]]
-=== PUT /apis/admin.enmasse.io/v1alpha1/namespaces/{namespace}/addressspaceplans/{name}
+=== PUT /apis/admin.enmasse.io/v1beta1/namespaces/{namespace}/addressspaceplans/{name}
 
 ==== Description
 replace the specified AddressSpacePlan
@@ -190,7 +190,7 @@ __required__|Name of AddressSpacePlan to replace.|string
 |**Path**|**namespace** +
 __required__|object name and auth scope, such as for teams and projects|string
 |**Body**|**body** +
-__required__||<<_io_enmasse_admin_v1alpha1_addressspaceplan,io.enmasse.admin.v1alpha1.AddressSpacePlan>>
+__required__||<<_io_enmasse_admin_v1beta1_addressspaceplan,io.enmasse.admin.v1beta1.AddressSpacePlan>>
 |===
 
 
@@ -199,8 +199,8 @@ __required__||<<_io_enmasse_admin_v1alpha1_addressspaceplan,io.enmasse.admin.v1a
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
-|**200**|OK|<<_io_enmasse_admin_v1alpha1_addressspaceplan,io.enmasse.admin.v1alpha1.AddressSpacePlan>>
-|**201**|Created|<<_io_enmasse_admin_v1alpha1_addressspaceplan,io.enmasse.admin.v1alpha1.AddressSpacePlan>>
+|**200**|OK|<<_io_enmasse_admin_v1beta1_addressspaceplan,io.enmasse.admin.v1beta1.AddressSpacePlan>>
+|**201**|Created|<<_io_enmasse_admin_v1beta1_addressspaceplan,io.enmasse.admin.v1beta1.AddressSpacePlan>>
 |**401**|Unauthorized|No Content
 |===
 
@@ -214,11 +214,11 @@ __required__||<<_io_enmasse_admin_v1alpha1_addressspaceplan,io.enmasse.admin.v1a
 
 * addressspaceplan
 * admin
-* enmasse_v1alpha1
+* enmasse_v1beta1
 
 
 [[_deleteadminenmassev1alpha1namespacedaddressspaceplan]]
-=== DELETE /apis/admin.enmasse.io/v1alpha1/namespaces/{namespace}/addressspaceplans/{name}
+=== DELETE /apis/admin.enmasse.io/v1beta1/namespaces/{namespace}/addressspaceplans/{name}
 
 ==== Description
 delete an AddressSpacePlan
@@ -256,11 +256,11 @@ __required__|object name and auth scope, such as for teams and projects|string
 
 * addressspaceplan
 * admin
-* enmasse_v1alpha1
+* enmasse_v1beta1
 
 
 [[_createenmassev1alpha1namespacedaddress]]
-=== POST /apis/enmasse.io/v1alpha1/namespaces/{namespace}/addresses
+=== POST /apis/enmasse.io/v1beta1/namespaces/{namespace}/addresses
 
 ==== Description
 create an Address
@@ -274,7 +274,7 @@ create an Address
 |**Path**|**namespace** +
 __required__|object name and auth scope, such as for teams and projects|string
 |**Body**|**body** +
-__required__||<<_io_enmasse_v1alpha1_address,io.enmasse.v1alpha1.Address>>
+__required__||<<_io_enmasse_v1beta1_address,io.enmasse.v1beta1.Address>>
 |===
 
 
@@ -283,8 +283,8 @@ __required__||<<_io_enmasse_v1alpha1_address,io.enmasse.v1alpha1.Address>>
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
-|**200**|OK|<<_io_enmasse_v1alpha1_address,io.enmasse.v1alpha1.Address>>
-|**201**|Created|<<_io_enmasse_v1alpha1_address,io.enmasse.v1alpha1.Address>>
+|**200**|OK|<<_io_enmasse_v1beta1_address,io.enmasse.v1beta1.Address>>
+|**201**|Created|<<_io_enmasse_v1beta1_address,io.enmasse.v1beta1.Address>>
 |**401**|Unauthorized|No Content
 |===
 
@@ -302,11 +302,11 @@ __required__||<<_io_enmasse_v1alpha1_address,io.enmasse.v1alpha1.Address>>
 ==== Tags
 
 * addresses
-* enmasse_v1alpha1
+* enmasse_v1beta1
 
 
 [[_listenmassev1alpha1namespacedaddress]]
-=== GET /apis/enmasse.io/v1alpha1/namespaces/{namespace}/addresses
+=== GET /apis/enmasse.io/v1beta1/namespaces/{namespace}/addresses
 
 ==== Description
 list objects of kind Address
@@ -329,7 +329,7 @@ __optional__|A selector to restrict the list of returned objects by their labels
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
-|**200**|OK|<<_io_enmasse_v1alpha1_addresslist,io.enmasse.v1alpha1.AddressList>>
+|**200**|OK|<<_io_enmasse_v1beta1_addresslist,io.enmasse.v1beta1.AddressList>>
 |**401**|Unauthorized|No Content
 |===
 
@@ -342,11 +342,11 @@ __optional__|A selector to restrict the list of returned objects by their labels
 ==== Tags
 
 * addresses
-* enmasse_v1alpha1
+* enmasse_v1beta1
 
 
 [[_readenmassev1alpha1namespacedaddress]]
-=== GET /apis/enmasse.io/v1alpha1/namespaces/{namespace}/addresses/{name}
+=== GET /apis/enmasse.io/v1beta1/namespaces/{namespace}/addresses/{name}
 
 ==== Description
 read the specified Address
@@ -369,7 +369,7 @@ __required__|object name and auth scope, such as for teams and projects|string
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
-|**200**|OK|<<_io_enmasse_v1alpha1_address,io.enmasse.v1alpha1.Address>>
+|**200**|OK|<<_io_enmasse_v1beta1_address,io.enmasse.v1beta1.Address>>
 |**401**|Unauthorized|No Content
 |**404**|Not found|No Content
 |===
@@ -388,11 +388,11 @@ __required__|object name and auth scope, such as for teams and projects|string
 ==== Tags
 
 * addresses
-* enmasse_v1alpha1
+* enmasse_v1beta1
 
 
 [[_replaceenmassev1alpha1namespacedaddress]]
-=== PUT /apis/enmasse.io/v1alpha1/namespaces/{namespace}/addresses/{name}
+=== PUT /apis/enmasse.io/v1beta1/namespaces/{namespace}/addresses/{name}
 
 ==== Description
 replace the specified Address
@@ -408,7 +408,7 @@ __required__|Name of Address to replace|string
 |**Path**|**namespace** +
 __required__|object name and auth scope, such as for teams and projects|string
 |**Body**|**body** +
-__required__||<<_io_enmasse_v1alpha1_address,io.enmasse.v1alpha1.Address>>
+__required__||<<_io_enmasse_v1beta1_address,io.enmasse.v1beta1.Address>>
 |===
 
 
@@ -417,8 +417,8 @@ __required__||<<_io_enmasse_v1alpha1_address,io.enmasse.v1alpha1.Address>>
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
-|**200**|OK|<<_io_enmasse_v1alpha1_address,io.enmasse.v1alpha1.Address>>
-|**201**|Created|<<_io_enmasse_v1alpha1_address,io.enmasse.v1alpha1.Address>>
+|**200**|OK|<<_io_enmasse_v1beta1_address,io.enmasse.v1beta1.Address>>
+|**201**|Created|<<_io_enmasse_v1beta1_address,io.enmasse.v1beta1.Address>>
 |**401**|Unauthorized|No Content
 |===
 
@@ -431,11 +431,11 @@ __required__||<<_io_enmasse_v1alpha1_address,io.enmasse.v1alpha1.Address>>
 ==== Tags
 
 * addresses
-* enmasse_v1alpha1
+* enmasse_v1beta1
 
 
 [[_deleteenmassev1alpha1namespacedaddress]]
-=== DELETE /apis/enmasse.io/v1alpha1/namespaces/{namespace}/addresses/{name}
+=== DELETE /apis/enmasse.io/v1beta1/namespaces/{namespace}/addresses/{name}
 
 ==== Description
 delete an Address
@@ -472,11 +472,11 @@ __required__|object name and auth scope, such as for teams and projects|string
 ==== Tags
 
 * addresses
-* enmasse_v1alpha1
+* enmasse_v1beta1
 
 
 [[_createenmassev1alpha1namespacedaddressspace]]
-=== POST /apis/enmasse.io/v1alpha1/namespaces/{namespace}/addressspaces
+=== POST /apis/enmasse.io/v1beta1/namespaces/{namespace}/addressspaces
 
 ==== Description
 create an AddressSpace
@@ -490,7 +490,7 @@ create an AddressSpace
 |**Path**|**namespace** +
 __required__|object name and auth scope, such as for teams and projects|string
 |**Body**|**body** +
-__required__||<<_io_enmasse_v1alpha1_addressspace,io.enmasse.v1alpha1.AddressSpace>>
+__required__||<<_io_enmasse_v1beta1_addressspace,io.enmasse.v1beta1.AddressSpace>>
 |===
 
 
@@ -499,8 +499,8 @@ __required__||<<_io_enmasse_v1alpha1_addressspace,io.enmasse.v1alpha1.AddressSpa
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
-|**200**|OK|<<_io_enmasse_v1alpha1_addressspace,io.enmasse.v1alpha1.AddressSpace>>
-|**201**|Created|<<_io_enmasse_v1alpha1_addressspace,io.enmasse.v1alpha1.AddressSpace>>
+|**200**|OK|<<_io_enmasse_v1beta1_addressspace,io.enmasse.v1beta1.AddressSpace>>
+|**201**|Created|<<_io_enmasse_v1beta1_addressspace,io.enmasse.v1beta1.AddressSpace>>
 |**401**|Unauthorized|No Content
 |===
 
@@ -518,11 +518,11 @@ __required__||<<_io_enmasse_v1alpha1_addressspace,io.enmasse.v1alpha1.AddressSpa
 ==== Tags
 
 * addressspaces
-* enmasse_v1alpha1
+* enmasse_v1beta1
 
 
 [[_listenmassev1alpha1namespacedaddressspace]]
-=== GET /apis/enmasse.io/v1alpha1/namespaces/{namespace}/addressspaces
+=== GET /apis/enmasse.io/v1beta1/namespaces/{namespace}/addressspaces
 
 ==== Description
 list objects of kind AddressSpace
@@ -545,7 +545,7 @@ __optional__|A selector to restrict the list of returned objects by their labels
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
-|**200**|OK|<<_io_enmasse_v1alpha1_addressspacelist,io.enmasse.v1alpha1.AddressSpaceList>>
+|**200**|OK|<<_io_enmasse_v1beta1_addressspacelist,io.enmasse.v1beta1.AddressSpaceList>>
 |**401**|Unauthorized|No Content
 |===
 
@@ -558,11 +558,11 @@ __optional__|A selector to restrict the list of returned objects by their labels
 ==== Tags
 
 * addressspaces
-* enmasse_v1alpha1
+* enmasse_v1beta1
 
 
 [[_createenmassev1alpha1addressspaceaddresses]]
-=== POST /apis/enmasse.io/v1alpha1/namespaces/{namespace}/addressspaces/{addressSpace}/addresses
+=== POST /apis/enmasse.io/v1beta1/namespaces/{namespace}/addressspaces/{addressSpace}/addresses
 
 ==== Description
 create Addresses in an AddressSpace
@@ -578,7 +578,7 @@ __required__|Name of AddressSpace|string
 |**Path**|**namespace** +
 __required__|object name and auth scope, such as for teams and projects|string
 |**Body**|**body** +
-__required__|AddressList object|<<_io_enmasse_v1alpha1_addresslist,io.enmasse.v1alpha1.AddressList>>
+__required__|AddressList object|<<_io_enmasse_v1beta1_addresslist,io.enmasse.v1beta1.AddressList>>
 |===
 
 
@@ -606,11 +606,11 @@ __required__|AddressList object|<<_io_enmasse_v1alpha1_addresslist,io.enmasse.v1
 ==== Tags
 
 * addressspace_addresses
-* enmasse_v1alpha1
+* enmasse_v1beta1
 
 
 [[_listenmassev1alpha1namespacedaddressspaceaddress]]
-=== GET /apis/enmasse.io/v1alpha1/namespaces/{namespace}/addressspaces/{addressSpace}/addresses
+=== GET /apis/enmasse.io/v1beta1/namespaces/{namespace}/addressspaces/{addressSpace}/addresses
 
 ==== Description
 list objects of kind Address in AddressSpace
@@ -633,7 +633,7 @@ __required__|object name and auth scope, such as for teams and projects|string
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
-|**200**|OK|<<_io_enmasse_v1alpha1_addresslist,io.enmasse.v1alpha1.AddressList>>
+|**200**|OK|<<_io_enmasse_v1beta1_addresslist,io.enmasse.v1beta1.AddressList>>
 |**401**|Unauthorized|No Content
 |**404**|Not found|No Content
 |===
@@ -647,11 +647,11 @@ __required__|object name and auth scope, such as for teams and projects|string
 ==== Tags
 
 * addressspace_addresses
-* enmasse_v1alpha1
+* enmasse_v1beta1
 
 
 [[_readenmassev1alpha1namespacedaddressspaceaddress]]
-=== GET /apis/enmasse.io/v1alpha1/namespaces/{namespace}/addressspaces/{addressSpace}/addresses/{address}
+=== GET /apis/enmasse.io/v1beta1/namespaces/{namespace}/addressspaces/{addressSpace}/addresses/{address}
 
 ==== Description
 read the specified Address in AddressSpace
@@ -676,7 +676,7 @@ __required__|object name and auth scope, such as for teams and projects|string
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
-|**200**|OK|<<_io_enmasse_v1alpha1_address,io.enmasse.v1alpha1.Address>>
+|**200**|OK|<<_io_enmasse_v1beta1_address,io.enmasse.v1beta1.Address>>
 |**401**|Unauthorized|No Content
 |**404**|Not found|No Content
 |===
@@ -690,11 +690,11 @@ __required__|object name and auth scope, such as for teams and projects|string
 ==== Tags
 
 * addressspace_addresses
-* enmasse_v1alpha1
+* enmasse_v1beta1
 
 
 [[_replaceenmassev1alpha1namespacedaddressspaceaddress]]
-=== PUT /apis/enmasse.io/v1alpha1/namespaces/{namespace}/addressspaces/{addressSpace}/addresses/{address}
+=== PUT /apis/enmasse.io/v1beta1/namespaces/{namespace}/addressspaces/{addressSpace}/addresses/{address}
 
 ==== Description
 replace Address in an AddressSpace
@@ -712,7 +712,7 @@ __required__|Name of AddressSpace|string
 |**Path**|**namespace** +
 __required__|object name and auth scope, such as for teams and projects|string
 |**Body**|**body** +
-__required__|Address object|<<_io_enmasse_v1alpha1_address,io.enmasse.v1alpha1.Address>>
+__required__|Address object|<<_io_enmasse_v1beta1_address,io.enmasse.v1beta1.Address>>
 |===
 
 
@@ -721,8 +721,8 @@ __required__|Address object|<<_io_enmasse_v1alpha1_address,io.enmasse.v1alpha1.A
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
-|**200**|OK|<<_io_enmasse_v1alpha1_address,io.enmasse.v1alpha1.Address>>
-|**201**|Created|<<_io_enmasse_v1alpha1_address,io.enmasse.v1alpha1.Address>>
+|**200**|OK|<<_io_enmasse_v1beta1_address,io.enmasse.v1beta1.Address>>
+|**201**|Created|<<_io_enmasse_v1beta1_address,io.enmasse.v1beta1.Address>>
 |**401**|Unauthorized|No Content
 |**404**|Not found|No Content
 |===
@@ -741,11 +741,11 @@ __required__|Address object|<<_io_enmasse_v1alpha1_address,io.enmasse.v1alpha1.A
 ==== Tags
 
 * addressspace_addresses
-* enmasse_v1alpha1
+* enmasse_v1beta1
 
 
 [[_deleteenmassev1alpha1namespacedaddressspaceaddress]]
-=== DELETE /apis/enmasse.io/v1alpha1/namespaces/{namespace}/addressspaces/{addressSpace}/addresses/{address}
+=== DELETE /apis/enmasse.io/v1beta1/namespaces/{namespace}/addressspaces/{addressSpace}/addresses/{address}
 
 ==== Description
 delete an Address in AddressSpace
@@ -784,11 +784,11 @@ __required__|object name and auth scope, such as for teams and projects|string
 ==== Tags
 
 * addressspace_addresses
-* enmasse_v1alpha1
+* enmasse_v1beta1
 
 
 [[_readenmassev1alpha1namespacedaddressspace]]
-=== GET /apis/enmasse.io/v1alpha1/namespaces/{namespace}/addressspaces/{name}
+=== GET /apis/enmasse.io/v1beta1/namespaces/{namespace}/addressspaces/{name}
 
 ==== Description
 read the specified AddressSpace
@@ -811,7 +811,7 @@ __required__|object name and auth scope, such as for teams and projects|string
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
-|**200**|OK|<<_io_enmasse_v1alpha1_addressspace,io.enmasse.v1alpha1.AddressSpace>>
+|**200**|OK|<<_io_enmasse_v1beta1_addressspace,io.enmasse.v1beta1.AddressSpace>>
 |**401**|Unauthorized|No Content
 |**404**|Not found|No Content
 |===
@@ -830,11 +830,11 @@ __required__|object name and auth scope, such as for teams and projects|string
 ==== Tags
 
 * addressspaces
-* enmasse_v1alpha1
+* enmasse_v1beta1
 
 
 [[_replaceenmassev1alpha1namespacedaddressspace]]
-=== PUT /apis/enmasse.io/v1alpha1/namespaces/{namespace}/addressspaces/{name}
+=== PUT /apis/enmasse.io/v1beta1/namespaces/{namespace}/addressspaces/{name}
 
 ==== Description
 replace the specified AddressSpace
@@ -850,7 +850,7 @@ __required__|Name of AddressSpace to replace|string
 |**Path**|**namespace** +
 __required__|object name and auth scope, such as for teams and projects|string
 |**Body**|**body** +
-__required__||<<_io_enmasse_v1alpha1_addressspace,io.enmasse.v1alpha1.AddressSpace>>
+__required__||<<_io_enmasse_v1beta1_addressspace,io.enmasse.v1beta1.AddressSpace>>
 |===
 
 
@@ -859,8 +859,8 @@ __required__||<<_io_enmasse_v1alpha1_addressspace,io.enmasse.v1alpha1.AddressSpa
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
-|**200**|OK|<<_io_enmasse_v1alpha1_addressspace,io.enmasse.v1alpha1.AddressSpace>>
-|**201**|Created|<<_io_enmasse_v1alpha1_addressspace,io.enmasse.v1alpha1.AddressSpace>>
+|**200**|OK|<<_io_enmasse_v1beta1_addressspace,io.enmasse.v1beta1.AddressSpace>>
+|**201**|Created|<<_io_enmasse_v1beta1_addressspace,io.enmasse.v1beta1.AddressSpace>>
 |**401**|Unauthorized|No Content
 |===
 
@@ -873,11 +873,11 @@ __required__||<<_io_enmasse_v1alpha1_addressspace,io.enmasse.v1alpha1.AddressSpa
 ==== Tags
 
 * addressspaces
-* enmasse_v1alpha1
+* enmasse_v1beta1
 
 
 [[_deleteenmassev1alpha1namespacedaddressspace]]
-=== DELETE /apis/enmasse.io/v1alpha1/namespaces/{namespace}/addressspaces/{name}
+=== DELETE /apis/enmasse.io/v1beta1/namespaces/{namespace}/addressspaces/{name}
 
 ==== Description
 delete an AddressSpace
@@ -914,11 +914,11 @@ __required__|object name and auth scope, such as for teams and projects|string
 ==== Tags
 
 * addressspaces
-* enmasse_v1alpha1
+* enmasse_v1beta1
 
 
 [[_createauthenmassev1alpha1namespacedmessaginguser]]
-=== POST /apis/user.enmasse.io/v1alpha1/namespaces/{namespace}/messagingusers
+=== POST /apis/user.enmasse.io/v1beta1/namespaces/{namespace}/messagingusers
 
 ==== Description
 create a MessagingUser
@@ -932,7 +932,7 @@ create a MessagingUser
 |**Path**|**namespace** +
 __required__|object name and auth scope, such as for teams and projects|string
 |**Body**|**body** +
-__required__||<<_io_enmasse_user_v1alpha1_messaginguser,io.enmasse.user.v1alpha1.MessagingUser>>
+__required__||<<_io_enmasse_user_v1beta1_messaginguser,io.enmasse.user.v1beta1.MessagingUser>>
 |===
 
 
@@ -941,8 +941,8 @@ __required__||<<_io_enmasse_user_v1alpha1_messaginguser,io.enmasse.user.v1alpha1
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
-|**200**|OK|<<_io_enmasse_user_v1alpha1_messaginguser,io.enmasse.user.v1alpha1.MessagingUser>>
-|**201**|Created|<<_io_enmasse_user_v1alpha1_messaginguser,io.enmasse.user.v1alpha1.MessagingUser>>
+|**200**|OK|<<_io_enmasse_user_v1beta1_messaginguser,io.enmasse.user.v1beta1.MessagingUser>>
+|**201**|Created|<<_io_enmasse_user_v1beta1_messaginguser,io.enmasse.user.v1beta1.MessagingUser>>
 |**401**|Unauthorized|No Content
 |===
 
@@ -960,12 +960,12 @@ __required__||<<_io_enmasse_user_v1alpha1_messaginguser,io.enmasse.user.v1alpha1
 ==== Tags
 
 * auth
-* enmasse_v1alpha1
+* enmasse_v1beta1
 * user
 
 
 [[_listauthenmassev1alpha1namespacedmessaginguser]]
-=== GET /apis/user.enmasse.io/v1alpha1/namespaces/{namespace}/messagingusers
+=== GET /apis/user.enmasse.io/v1beta1/namespaces/{namespace}/messagingusers
 
 ==== Description
 list objects of kind MessagingUser
@@ -988,7 +988,7 @@ __optional__|A selector to restrict the list of returned objects by their labels
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
-|**200**|OK|<<_io_enmasse_user_v1alpha1_messaginguserlist,io.enmasse.user.v1alpha1.MessagingUserList>>
+|**200**|OK|<<_io_enmasse_user_v1beta1_messaginguserlist,io.enmasse.user.v1beta1.MessagingUserList>>
 |**401**|Unauthorized|No Content
 |===
 
@@ -1001,12 +1001,12 @@ __optional__|A selector to restrict the list of returned objects by their labels
 ==== Tags
 
 * auth
-* enmasse_v1alpha1
+* enmasse_v1beta1
 * user
 
 
 [[_readauthenmassev1alpha1namespacedmessaginguser]]
-=== GET /apis/user.enmasse.io/v1alpha1/namespaces/{namespace}/messagingusers/{name}
+=== GET /apis/user.enmasse.io/v1beta1/namespaces/{namespace}/messagingusers/{name}
 
 ==== Description
 read the specified MessagingUser
@@ -1029,7 +1029,7 @@ __required__|object name and auth scope, such as for teams and projects|string
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
-|**200**|OK|<<_io_enmasse_user_v1alpha1_messaginguser,io.enmasse.user.v1alpha1.MessagingUser>>
+|**200**|OK|<<_io_enmasse_user_v1beta1_messaginguser,io.enmasse.user.v1beta1.MessagingUser>>
 |**401**|Unauthorized|No Content
 |**404**|Not found|No Content
 |===
@@ -1048,12 +1048,12 @@ __required__|object name and auth scope, such as for teams and projects|string
 ==== Tags
 
 * auth
-* enmasse_v1alpha1
+* enmasse_v1beta1
 * user
 
 
 [[_replaceauthenmassev1alpha1namespacedmessaginguser]]
-=== PUT /apis/user.enmasse.io/v1alpha1/namespaces/{namespace}/messagingusers/{name}
+=== PUT /apis/user.enmasse.io/v1beta1/namespaces/{namespace}/messagingusers/{name}
 
 ==== Description
 replace the specified MessagingUser
@@ -1069,7 +1069,7 @@ __required__|Name of MessagingUser to replace. Must include addressSpace and dot
 |**Path**|**namespace** +
 __required__|object name and auth scope, such as for teams and projects|string
 |**Body**|**body** +
-__required__||<<_io_enmasse_user_v1alpha1_messaginguser,io.enmasse.user.v1alpha1.MessagingUser>>
+__required__||<<_io_enmasse_user_v1beta1_messaginguser,io.enmasse.user.v1beta1.MessagingUser>>
 |===
 
 
@@ -1078,8 +1078,8 @@ __required__||<<_io_enmasse_user_v1alpha1_messaginguser,io.enmasse.user.v1alpha1
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
-|**200**|OK|<<_io_enmasse_user_v1alpha1_messaginguser,io.enmasse.user.v1alpha1.MessagingUser>>
-|**201**|Created|<<_io_enmasse_user_v1alpha1_messaginguser,io.enmasse.user.v1alpha1.MessagingUser>>
+|**200**|OK|<<_io_enmasse_user_v1beta1_messaginguser,io.enmasse.user.v1beta1.MessagingUser>>
+|**201**|Created|<<_io_enmasse_user_v1beta1_messaginguser,io.enmasse.user.v1beta1.MessagingUser>>
 |**401**|Unauthorized|No Content
 |===
 
@@ -1092,12 +1092,12 @@ __required__||<<_io_enmasse_user_v1alpha1_messaginguser,io.enmasse.user.v1alpha1
 ==== Tags
 
 * auth
-* enmasse_v1alpha1
+* enmasse_v1beta1
 * user
 
 
 [[_deleteauthenmassev1alpha1namespacedmessaginguser]]
-=== DELETE /apis/user.enmasse.io/v1alpha1/namespaces/{namespace}/messagingusers/{name}
+=== DELETE /apis/user.enmasse.io/v1beta1/namespaces/{namespace}/messagingusers/{name}
 
 ==== Description
 delete a MessagingUser
@@ -1134,7 +1134,7 @@ __required__|object name and auth scope, such as for teams and projects|string
 ==== Tags
 
 * auth
-* enmasse_v1alpha1
+* enmasse_v1beta1
 * user
 
 
@@ -1171,8 +1171,8 @@ __optional__|Suggested HTTP return code for this status, 0 if not set.|integer (
 |===
 
 
-[[_io_enmasse_admin_v1alpha1_addressplan]]
-=== io.enmasse.admin.v1alpha1.AddressPlan
+[[_io_enmasse_admin_v1beta1_addressplan]]
+=== io.enmasse.admin.v1beta1.AddressPlan
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -1180,7 +1180,7 @@ __optional__|Suggested HTTP return code for this status, 0 if not set.|integer (
 |**addressType** +
 __required__|string
 |**apiVersion** +
-__required__|enum (admin.enmasse.io/v1alpha1)
+__required__|enum (admin.enmasse.io/v1beta1)
 |**displayName** +
 __required__|string
 |**displayOrder** +
@@ -1192,14 +1192,14 @@ __optional__|string
 |**metadata** +
 __required__|<<_objectmeta,ObjectMeta>>
 |**requiredResources** +
-__required__|< <<_io_enmasse_admin_v1alpha1_addressplan_requiredresources,requiredResources>> > array
+__required__|< <<_io_enmasse_admin_v1beta1_addressplan_requiredresources,requiredResources>> > array
 |**shortDescription** +
 __required__|string
 |**uuid** +
 __required__|string
 |===
 
-[[_io_enmasse_admin_v1alpha1_addressplan_requiredresources]]
+[[_io_enmasse_admin_v1beta1_addressplan_requiredresources]]
 **requiredResources**
 
 [options="header", cols=".^3a,.^4a"]
@@ -1212,23 +1212,23 @@ __required__|string
 |===
 
 
-[[_io_enmasse_admin_v1alpha1_addressplanlist]]
-=== io.enmasse.admin.v1alpha1.AddressPlanList
+[[_io_enmasse_admin_v1beta1_addressplanlist]]
+=== io.enmasse.admin.v1beta1.AddressPlanList
 
 [options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**apiVersion** +
-__required__|enum (admin.enmasse.io/v1alpha1)
+__required__|enum (admin.enmasse.io/v1beta1)
 |**items** +
-__required__|< <<_io_enmasse_admin_v1alpha1_addressplan,io.enmasse.admin.v1alpha1.AddressPlan>> > array
+__required__|< <<_io_enmasse_admin_v1beta1_addressplan,io.enmasse.admin.v1beta1.AddressPlan>> > array
 |**kind** +
 __required__|enum (AddressPlanList)
 |===
 
 
-[[_io_enmasse_admin_v1alpha1_addressspaceplan]]
-=== io.enmasse.admin.v1alpha1.AddressSpacePlan
+[[_io_enmasse_admin_v1beta1_addressspaceplan]]
+=== io.enmasse.admin.v1beta1.AddressSpacePlan
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -1238,7 +1238,7 @@ __optional__|< string > array
 |**addressSpaceType** +
 __required__|string
 |**apiVersion** +
-__required__|enum (admin.enmasse.io/v1alpha1)
+__required__|enum (admin.enmasse.io/v1beta1)
 |**displayName** +
 __required__|string
 |**displayOrder** +
@@ -1250,14 +1250,14 @@ __optional__|string
 |**metadata** +
 __required__|<<_objectmeta,ObjectMeta>>
 |**resources** +
-__required__|< <<_io_enmasse_admin_v1alpha1_addressspaceplan_resources,resources>> > array
+__required__|< <<_io_enmasse_admin_v1beta1_addressspaceplan_resources,resources>> > array
 |**shortDescription** +
 __required__|string
 |**uuid** +
 __required__|string
 |===
 
-[[_io_enmasse_admin_v1alpha1_addressspaceplan_resources]]
+[[_io_enmasse_admin_v1beta1_addressspaceplan_resources]]
 **resources**
 
 [options="header", cols=".^3a,.^4a"]
@@ -1270,70 +1270,70 @@ __required__|string
 |===
 
 
-[[_io_enmasse_admin_v1alpha1_addressspaceplanlist]]
-=== io.enmasse.admin.v1alpha1.AddressSpacePlanList
+[[_io_enmasse_admin_v1beta1_addressspaceplanlist]]
+=== io.enmasse.admin.v1beta1.AddressSpacePlanList
 
 [options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**apiVersion** +
-__required__|enum (admin.enmasse.io/v1alpha1)
+__required__|enum (admin.enmasse.io/v1beta1)
 |**items** +
-__required__|< <<_io_enmasse_admin_v1alpha1_addressspaceplan,io.enmasse.admin.v1alpha1.AddressSpacePlan>> > array
+__required__|< <<_io_enmasse_admin_v1beta1_addressspaceplan,io.enmasse.admin.v1beta1.AddressSpacePlan>> > array
 |**kind** +
 __required__|enum (AddressSpacePlanList)
 |===
 
 
-[[_io_enmasse_admin_v1alpha1_brokeredinfraconfig]]
-=== io.enmasse.admin.v1alpha1.BrokeredInfraConfig
+[[_io_enmasse_admin_v1beta1_brokeredinfraconfig]]
+=== io.enmasse.admin.v1beta1.BrokeredInfraConfig
 
 [options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**apiVersion** +
-__required__|enum (admin.enmasse.io/v1alpha1)
+__required__|enum (admin.enmasse.io/v1beta1)
 |**kind** +
 __required__|enum (BrokeredInfraConfig)
 |**metadata** +
 __required__|<<_objectmeta,ObjectMeta>>
 |**spec** +
-__required__|<<_io_enmasse_admin_v1alpha1_brokeredinfraconfigspec,io.enmasse.admin.v1alpha1.BrokeredInfraConfigSpec>>
+__required__|<<_io_enmasse_admin_v1beta1_brokeredinfraconfigspec,io.enmasse.admin.v1beta1.BrokeredInfraConfigSpec>>
 |===
 
 
-[[_io_enmasse_admin_v1alpha1_brokeredinfraconfiglist]]
-=== io.enmasse.admin.v1alpha1.BrokeredInfraConfigList
+[[_io_enmasse_admin_v1beta1_brokeredinfraconfiglist]]
+=== io.enmasse.admin.v1beta1.BrokeredInfraConfigList
 
 [options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**apiVersion** +
-__required__|enum (admin.enmasse.io/v1alpha1)
+__required__|enum (admin.enmasse.io/v1beta1)
 |**items** +
-__required__|< <<_io_enmasse_admin_v1alpha1_brokeredinfraconfig,io.enmasse.admin.v1alpha1.BrokeredInfraConfig>> > array
+__required__|< <<_io_enmasse_admin_v1beta1_brokeredinfraconfig,io.enmasse.admin.v1beta1.BrokeredInfraConfig>> > array
 |**kind** +
 __required__|enum (BrokeredInfraConfigList)
 |===
 
 
-[[_io_enmasse_admin_v1alpha1_brokeredinfraconfigspec]]
-=== io.enmasse.admin.v1alpha1.BrokeredInfraConfigSpec
+[[_io_enmasse_admin_v1beta1_brokeredinfraconfigspec]]
+=== io.enmasse.admin.v1beta1.BrokeredInfraConfigSpec
 
 [options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**admin** +
-__optional__|<<_io_enmasse_admin_v1alpha1_brokeredinfraconfigspecadmin,io.enmasse.admin.v1alpha1.BrokeredInfraConfigSpecAdmin>>
+__optional__|<<_io_enmasse_admin_v1beta1_brokeredinfraconfigspecadmin,io.enmasse.admin.v1beta1.BrokeredInfraConfigSpecAdmin>>
 |**broker** +
-__optional__|<<_io_enmasse_admin_v1alpha1_brokeredinfraconfigspecbroker,io.enmasse.admin.v1alpha1.BrokeredInfraConfigSpecBroker>>
+__optional__|<<_io_enmasse_admin_v1beta1_brokeredinfraconfigspecbroker,io.enmasse.admin.v1beta1.BrokeredInfraConfigSpecBroker>>
 |**networkPolicy** +
-__optional__|<<_io_enmasse_admin_v1alpha1_brokeredinfraconfigspec_networkpolicy,networkPolicy>>
+__optional__|<<_io_enmasse_admin_v1beta1_brokeredinfraconfigspec_networkpolicy,networkPolicy>>
 |**version** +
 __required__|string
 |===
 
-[[_io_enmasse_admin_v1alpha1_brokeredinfraconfigspec_networkpolicy]]
+[[_io_enmasse_admin_v1beta1_brokeredinfraconfigspec_networkpolicy]]
 **networkPolicy**
 
 [options="header", cols=".^3a,.^4a"]
@@ -1346,17 +1346,17 @@ __optional__|< <<_io_k8s_api_networking_v1_networkpolicyingressrule,io.k8s.api.n
 |===
 
 
-[[_io_enmasse_admin_v1alpha1_brokeredinfraconfigspecadmin]]
-=== io.enmasse.admin.v1alpha1.BrokeredInfraConfigSpecAdmin
+[[_io_enmasse_admin_v1beta1_brokeredinfraconfigspecadmin]]
+=== io.enmasse.admin.v1beta1.BrokeredInfraConfigSpecAdmin
 
 [options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**resources** +
-__optional__|<<_io_enmasse_admin_v1alpha1_brokeredinfraconfigspecadmin_resources,resources>>
+__optional__|<<_io_enmasse_admin_v1beta1_brokeredinfraconfigspecadmin_resources,resources>>
 |===
 
-[[_io_enmasse_admin_v1alpha1_brokeredinfraconfigspecadmin_resources]]
+[[_io_enmasse_admin_v1beta1_brokeredinfraconfigspecadmin_resources]]
 **resources**
 
 [options="header", cols=".^3a,.^4a"]
@@ -1367,8 +1367,8 @@ __optional__|string
 |===
 
 
-[[_io_enmasse_admin_v1alpha1_brokeredinfraconfigspecbroker]]
-=== io.enmasse.admin.v1alpha1.BrokeredInfraConfigSpecBroker
+[[_io_enmasse_admin_v1beta1_brokeredinfraconfigspecbroker]]
+=== io.enmasse.admin.v1beta1.BrokeredInfraConfigSpecBroker
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -1376,14 +1376,14 @@ __optional__|string
 |**addressFullPolicy** +
 __optional__|enum (PAGE, BLOCK, FAIL)
 |**resources** +
-__optional__|<<_io_enmasse_admin_v1alpha1_brokeredinfraconfigspecbroker_resources,resources>>
+__optional__|<<_io_enmasse_admin_v1beta1_brokeredinfraconfigspecbroker_resources,resources>>
 |**storageClassName** +
 __optional__|string
 |**updatePersistentVolumeClaim** +
 __optional__|boolean
 |===
 
-[[_io_enmasse_admin_v1alpha1_brokeredinfraconfigspecbroker_resources]]
+[[_io_enmasse_admin_v1beta1_brokeredinfraconfigspecbroker_resources]]
 **resources**
 
 [options="header", cols=".^3a,.^4a"]
@@ -1396,57 +1396,57 @@ __optional__|string
 |===
 
 
-[[_io_enmasse_admin_v1alpha1_standardinfraconfig]]
-=== io.enmasse.admin.v1alpha1.StandardInfraConfig
+[[_io_enmasse_admin_v1beta1_standardinfraconfig]]
+=== io.enmasse.admin.v1beta1.StandardInfraConfig
 
 [options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**apiVersion** +
-__required__|enum (admin.enmasse.io/v1alpha1)
+__required__|enum (admin.enmasse.io/v1beta1)
 |**kind** +
 __required__|enum (StandardInfraConfig)
 |**metadata** +
 __required__|<<_objectmeta,ObjectMeta>>
 |**spec** +
-__required__|<<_io_enmasse_admin_v1alpha1_standardinfraconfigspec,io.enmasse.admin.v1alpha1.StandardInfraConfigSpec>>
+__required__|<<_io_enmasse_admin_v1beta1_standardinfraconfigspec,io.enmasse.admin.v1beta1.StandardInfraConfigSpec>>
 |===
 
 
-[[_io_enmasse_admin_v1alpha1_standardinfraconfiglist]]
-=== io.enmasse.admin.v1alpha1.StandardInfraConfigList
+[[_io_enmasse_admin_v1beta1_standardinfraconfiglist]]
+=== io.enmasse.admin.v1beta1.StandardInfraConfigList
 
 [options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**apiVersion** +
-__required__|enum (admin.enmasse.io/v1alpha1)
+__required__|enum (admin.enmasse.io/v1beta1)
 |**items** +
-__required__|< <<_io_enmasse_admin_v1alpha1_standardinfraconfig,io.enmasse.admin.v1alpha1.StandardInfraConfig>> > array
+__required__|< <<_io_enmasse_admin_v1beta1_standardinfraconfig,io.enmasse.admin.v1beta1.StandardInfraConfig>> > array
 |**kind** +
 __required__|enum (StandardInfraConfigList)
 |===
 
 
-[[_io_enmasse_admin_v1alpha1_standardinfraconfigspec]]
-=== io.enmasse.admin.v1alpha1.StandardInfraConfigSpec
+[[_io_enmasse_admin_v1beta1_standardinfraconfigspec]]
+=== io.enmasse.admin.v1beta1.StandardInfraConfigSpec
 
 [options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**admin** +
-__optional__|<<_io_enmasse_admin_v1alpha1_standardinfraconfigspecadmin,io.enmasse.admin.v1alpha1.StandardInfraConfigSpecAdmin>>
+__optional__|<<_io_enmasse_admin_v1beta1_standardinfraconfigspecadmin,io.enmasse.admin.v1beta1.StandardInfraConfigSpecAdmin>>
 |**broker** +
-__optional__|<<_io_enmasse_admin_v1alpha1_standardinfraconfigspecbroker,io.enmasse.admin.v1alpha1.StandardInfraConfigSpecBroker>>
+__optional__|<<_io_enmasse_admin_v1beta1_standardinfraconfigspecbroker,io.enmasse.admin.v1beta1.StandardInfraConfigSpecBroker>>
 |**networkPolicy** +
-__optional__|<<_io_enmasse_admin_v1alpha1_standardinfraconfigspec_networkpolicy,networkPolicy>>
+__optional__|<<_io_enmasse_admin_v1beta1_standardinfraconfigspec_networkpolicy,networkPolicy>>
 |**router** +
-__optional__|<<_io_enmasse_admin_v1alpha1_standardinfraconfigspecrouter,io.enmasse.admin.v1alpha1.StandardInfraConfigSpecRouter>>
+__optional__|<<_io_enmasse_admin_v1beta1_standardinfraconfigspecrouter,io.enmasse.admin.v1beta1.StandardInfraConfigSpecRouter>>
 |**version** +
 __required__|string
 |===
 
-[[_io_enmasse_admin_v1alpha1_standardinfraconfigspec_networkpolicy]]
+[[_io_enmasse_admin_v1beta1_standardinfraconfigspec_networkpolicy]]
 **networkPolicy**
 
 [options="header", cols=".^3a,.^4a"]
@@ -1459,17 +1459,17 @@ __optional__|< <<_io_k8s_api_networking_v1_networkpolicyingressrule,io.k8s.api.n
 |===
 
 
-[[_io_enmasse_admin_v1alpha1_standardinfraconfigspecadmin]]
-=== io.enmasse.admin.v1alpha1.StandardInfraConfigSpecAdmin
+[[_io_enmasse_admin_v1beta1_standardinfraconfigspecadmin]]
+=== io.enmasse.admin.v1beta1.StandardInfraConfigSpecAdmin
 
 [options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**resources** +
-__optional__|<<_io_enmasse_admin_v1alpha1_standardinfraconfigspecadmin_resources,resources>>
+__optional__|<<_io_enmasse_admin_v1beta1_standardinfraconfigspecadmin_resources,resources>>
 |===
 
-[[_io_enmasse_admin_v1alpha1_standardinfraconfigspecadmin_resources]]
+[[_io_enmasse_admin_v1beta1_standardinfraconfigspecadmin_resources]]
 **resources**
 
 [options="header", cols=".^3a,.^4a"]
@@ -1480,8 +1480,8 @@ __optional__|string
 |===
 
 
-[[_io_enmasse_admin_v1alpha1_standardinfraconfigspecbroker]]
-=== io.enmasse.admin.v1alpha1.StandardInfraConfigSpecBroker
+[[_io_enmasse_admin_v1beta1_standardinfraconfigspecbroker]]
+=== io.enmasse.admin.v1beta1.StandardInfraConfigSpecBroker
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -1489,14 +1489,14 @@ __optional__|string
 |**addressFullPolicy** +
 __optional__|enum (PAGE, BLOCK, FAIL)
 |**resources** +
-__optional__|<<_io_enmasse_admin_v1alpha1_standardinfraconfigspecbroker_resources,resources>>
+__optional__|<<_io_enmasse_admin_v1beta1_standardinfraconfigspecbroker_resources,resources>>
 |**storageClassName** +
 __optional__|string
 |**updatePersistentVolumeClaim** +
 __optional__|boolean
 |===
 
-[[_io_enmasse_admin_v1alpha1_standardinfraconfigspecbroker_resources]]
+[[_io_enmasse_admin_v1beta1_standardinfraconfigspecbroker_resources]]
 **resources**
 
 [options="header", cols=".^3a,.^4a"]
@@ -1509,8 +1509,8 @@ __optional__|string
 |===
 
 
-[[_io_enmasse_admin_v1alpha1_standardinfraconfigspecrouter]]
-=== io.enmasse.admin.v1alpha1.StandardInfraConfigSpecRouter
+[[_io_enmasse_admin_v1beta1_standardinfraconfigspecrouter]]
+=== io.enmasse.admin.v1beta1.StandardInfraConfigSpecRouter
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -1520,10 +1520,10 @@ __optional__|integer
 |**minReplicas** +
 __optional__|integer
 |**resources** +
-__optional__|<<_io_enmasse_admin_v1alpha1_standardinfraconfigspecrouter_resources,resources>>
+__optional__|<<_io_enmasse_admin_v1beta1_standardinfraconfigspecrouter_resources,resources>>
 |===
 
-[[_io_enmasse_admin_v1alpha1_standardinfraconfigspecrouter_resources]]
+[[_io_enmasse_admin_v1beta1_standardinfraconfigspecrouter_resources]]
 **resources**
 
 [options="header", cols=".^3a,.^4a"]
@@ -1534,53 +1534,53 @@ __optional__|string
 |===
 
 
-[[_io_enmasse_user_v1alpha1_messaginguser]]
-=== io.enmasse.user.v1alpha1.MessagingUser
+[[_io_enmasse_user_v1beta1_messaginguser]]
+=== io.enmasse.user.v1beta1.MessagingUser
 
 [options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**apiVersion** +
-__required__|enum (user.enmasse.io/v1alpha1)
+__required__|enum (user.enmasse.io/v1beta1)
 |**kind** +
 __required__|enum (MessagingUser)
 |**metadata** +
 __required__|<<_objectmeta,ObjectMeta>>
 |**spec** +
-__required__|<<_io_enmasse_user_v1alpha1_userspec,io.enmasse.user.v1alpha1.UserSpec>>
+__required__|<<_io_enmasse_user_v1beta1_userspec,io.enmasse.user.v1beta1.UserSpec>>
 |===
 
 
-[[_io_enmasse_user_v1alpha1_messaginguserlist]]
-=== io.enmasse.user.v1alpha1.MessagingUserList
+[[_io_enmasse_user_v1beta1_messaginguserlist]]
+=== io.enmasse.user.v1beta1.MessagingUserList
 
 [options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**apiVersion** +
-__required__|enum (user.enmasse.io/v1alpha1)
+__required__|enum (user.enmasse.io/v1beta1)
 |**items** +
-__required__|< <<_io_enmasse_user_v1alpha1_messaginguser,io.enmasse.user.v1alpha1.MessagingUser>> > array
+__required__|< <<_io_enmasse_user_v1beta1_messaginguser,io.enmasse.user.v1beta1.MessagingUser>> > array
 |**kind** +
 __required__|enum (MessagingUserList)
 |===
 
 
-[[_io_enmasse_user_v1alpha1_userspec]]
-=== io.enmasse.user.v1alpha1.UserSpec
+[[_io_enmasse_user_v1beta1_userspec]]
+=== io.enmasse.user.v1beta1.UserSpec
 
 [options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**authentication** +
-__optional__|<<_io_enmasse_user_v1alpha1_userspec_authentication,authentication>>
+__optional__|<<_io_enmasse_user_v1beta1_userspec_authentication,authentication>>
 |**authorization** +
-__optional__|< <<_io_enmasse_user_v1alpha1_userspec_authorization,authorization>> > array
+__optional__|< <<_io_enmasse_user_v1beta1_userspec_authorization,authorization>> > array
 |**username** +
 __required__|string
 |===
 
-[[_io_enmasse_user_v1alpha1_userspec_authentication]]
+[[_io_enmasse_user_v1beta1_userspec_authentication]]
 **authentication**
 
 [options="header", cols=".^3a,.^11a,.^4a"]
@@ -1598,7 +1598,7 @@ __optional__|Name of provider to use for federated identity when 'federated' typ
 __required__||enum (password, federated)
 |===
 
-[[_io_enmasse_user_v1alpha1_userspec_authorization]]
+[[_io_enmasse_user_v1beta1_userspec_authorization]]
 **authorization**
 
 [options="header", cols=".^3a,.^4a"]
@@ -1611,93 +1611,93 @@ __required__|< enum (send, receive, view, manage) > array
 |===
 
 
-[[_io_enmasse_v1alpha1_address]]
-=== io.enmasse.v1alpha1.Address
+[[_io_enmasse_v1beta1_address]]
+=== io.enmasse.v1beta1.Address
 
 [options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**apiVersion** +
-__required__|enum (enmasse.io/v1alpha1)
+__required__|enum (enmasse.io/v1beta1)
 |**kind** +
 __required__|enum (Address)
 |**metadata** +
 __required__|<<_objectmeta,ObjectMeta>>
 |**spec** +
-__required__|<<_io_enmasse_v1alpha1_addressspec,io.enmasse.v1alpha1.AddressSpec>>
+__required__|<<_io_enmasse_v1beta1_addressspec,io.enmasse.v1beta1.AddressSpec>>
 |**status** +
-__optional__|<<_io_enmasse_v1alpha1_addressstatus,io.enmasse.v1alpha1.AddressStatus>>
+__optional__|<<_io_enmasse_v1beta1_addressstatus,io.enmasse.v1beta1.AddressStatus>>
 |===
 
 
-[[_io_enmasse_v1alpha1_addresslist]]
-=== io.enmasse.v1alpha1.AddressList
+[[_io_enmasse_v1beta1_addresslist]]
+=== io.enmasse.v1beta1.AddressList
 
 [options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**apiVersion** +
-__required__|**Default** : `"enmasse.io/v1alpha1"`|enum (enmasse.io/v1alpha1)
+__required__|**Default** : `"enmasse.io/v1beta1"`|enum (enmasse.io/v1beta1)
 |**items** +
-__required__||< <<_io_enmasse_v1alpha1_address,io.enmasse.v1alpha1.Address>> > array
+__required__||< <<_io_enmasse_v1beta1_address,io.enmasse.v1beta1.Address>> > array
 |**kind** +
 __required__||enum (AddressList)
 |===
 
 
-[[_io_enmasse_v1alpha1_addressspace]]
-=== io.enmasse.v1alpha1.AddressSpace
+[[_io_enmasse_v1beta1_addressspace]]
+=== io.enmasse.v1beta1.AddressSpace
 
 [options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**apiVersion** +
-__required__|enum (enmasse.io/v1alpha1)
+__required__|enum (enmasse.io/v1beta1)
 |**kind** +
 __required__|enum (AddressSpace)
 |**metadata** +
 __required__|<<_objectmeta,ObjectMeta>>
 |**spec** +
-__required__|<<_io_enmasse_v1alpha1_addressspacespec,io.enmasse.v1alpha1.AddressSpaceSpec>>
+__required__|<<_io_enmasse_v1beta1_addressspacespec,io.enmasse.v1beta1.AddressSpaceSpec>>
 |**status** +
-__optional__|<<_io_enmasse_v1alpha1_addressspacestatus,io.enmasse.v1alpha1.AddressSpaceStatus>>
+__optional__|<<_io_enmasse_v1beta1_addressspacestatus,io.enmasse.v1beta1.AddressSpaceStatus>>
 |===
 
 
-[[_io_enmasse_v1alpha1_addressspacelist]]
-=== io.enmasse.v1alpha1.AddressSpaceList
+[[_io_enmasse_v1beta1_addressspacelist]]
+=== io.enmasse.v1beta1.AddressSpaceList
 
 [options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
 |**apiVersion** +
-__required__|**Default** : `"enmasse.io/v1alpha1"`|enum (enmasse.io/v1alpha1)
+__required__|**Default** : `"enmasse.io/v1beta1"`|enum (enmasse.io/v1beta1)
 |**items** +
-__required__||< <<_io_enmasse_v1alpha1_addressspace,io.enmasse.v1alpha1.AddressSpace>> > array
+__required__||< <<_io_enmasse_v1beta1_addressspace,io.enmasse.v1beta1.AddressSpace>> > array
 |**kind** +
 __required__||enum (AddressSpaceList)
 |===
 
 
-[[_io_enmasse_v1alpha1_addressspacespec]]
-=== io.enmasse.v1alpha1.AddressSpaceSpec
+[[_io_enmasse_v1beta1_addressspacespec]]
+=== io.enmasse.v1beta1.AddressSpaceSpec
 
 [options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**authenticationService** +
-__optional__|<<_io_enmasse_v1alpha1_addressspacespec_authenticationservice,authenticationService>>
+__optional__|<<_io_enmasse_v1beta1_addressspacespec_authenticationservice,authenticationService>>
 |**endpoints** +
-__optional__|< <<_io_enmasse_v1alpha1_addressspacespec_endpoints,endpoints>> > array
+__optional__|< <<_io_enmasse_v1beta1_addressspacespec_endpoints,endpoints>> > array
 |**networkPolicy** +
-__optional__|<<_io_enmasse_v1alpha1_addressspacespec_networkpolicy,networkPolicy>>
+__optional__|<<_io_enmasse_v1beta1_addressspacespec_networkpolicy,networkPolicy>>
 |**plan** +
 __required__|string
 |**type** +
-__required__|<<_io_enmasse_v1alpha1_addressspacetype,io.enmasse.v1alpha1.AddressSpaceType>>
+__required__|<<_io_enmasse_v1beta1_addressspacetype,io.enmasse.v1beta1.AddressSpaceType>>
 |===
 
-[[_io_enmasse_v1alpha1_addressspacespec_authenticationservice]]
+[[_io_enmasse_v1beta1_addressspacespec_authenticationservice]]
 **authenticationService**
 
 [options="header", cols=".^3a,.^4a"]
@@ -1709,23 +1709,23 @@ __optional__|object
 __optional__|string
 |===
 
-[[_io_enmasse_v1alpha1_addressspacespec_endpoints]]
+[[_io_enmasse_v1beta1_addressspacespec_endpoints]]
 **endpoints**
 
 [options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**cert** +
-__optional__|<<_io_enmasse_v1alpha1_addressspacespec_cert,cert>>
+__optional__|<<_io_enmasse_v1beta1_addressspacespec_cert,cert>>
 |**expose** +
-__optional__|<<_io_enmasse_v1alpha1_addressspacespec_expose,expose>>
+__optional__|<<_io_enmasse_v1beta1_addressspacespec_expose,expose>>
 |**name** +
 __optional__|string
 |**service** +
 __optional__|string
 |===
 
-[[_io_enmasse_v1alpha1_addressspacespec_cert]]
+[[_io_enmasse_v1beta1_addressspacespec_cert]]
 **cert**
 
 [options="header", cols=".^3a,.^4a"]
@@ -1741,7 +1741,7 @@ __optional__|string
 __optional__|string
 |===
 
-[[_io_enmasse_v1alpha1_addressspacespec_expose]]
+[[_io_enmasse_v1beta1_addressspacespec_expose]]
 **expose**
 
 [options="header", cols=".^3a,.^4a"]
@@ -1763,7 +1763,7 @@ __optional__|string
 __optional__|enum (route, loadbalancer)
 |===
 
-[[_io_enmasse_v1alpha1_addressspacespec_networkpolicy]]
+[[_io_enmasse_v1beta1_addressspacespec_networkpolicy]]
 **networkPolicy**
 
 [options="header", cols=".^3a,.^4a"]
@@ -1776,21 +1776,21 @@ __optional__|< <<_io_k8s_api_networking_v1_networkpolicyingressrule,io.k8s.api.n
 |===
 
 
-[[_io_enmasse_v1alpha1_addressspacestatus]]
-=== io.enmasse.v1alpha1.AddressSpaceStatus
+[[_io_enmasse_v1beta1_addressspacestatus]]
+=== io.enmasse.v1beta1.AddressSpaceStatus
 
 [options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
 |**endpointStatuses** +
-__optional__|< <<_io_enmasse_v1alpha1_addressspacestatus_endpointstatuses,endpointStatuses>> > array
+__optional__|< <<_io_enmasse_v1beta1_addressspacestatus_endpointstatuses,endpointStatuses>> > array
 |**isReady** +
 __optional__|boolean
 |**messages** +
 __optional__|< string > array
 |===
 
-[[_io_enmasse_v1alpha1_addressspacestatus_endpointstatuses]]
+[[_io_enmasse_v1beta1_addressspacestatus_endpointstatuses]]
 **endpointStatuses**
 
 [options="header", cols=".^3a,.^4a"]
@@ -1801,16 +1801,16 @@ __optional__|string
 |**externalHost** +
 __optional__|string
 |**externalPorts** +
-__optional__|< <<_io_enmasse_v1alpha1_addressspacestatus_externalports,externalPorts>> > array
+__optional__|< <<_io_enmasse_v1beta1_addressspacestatus_externalports,externalPorts>> > array
 |**name** +
 __optional__|string
 |**serviceHost** +
 __optional__|string
 |**servicePorts** +
-__optional__|< <<_io_enmasse_v1alpha1_addressspacestatus_serviceports,servicePorts>> > array
+__optional__|< <<_io_enmasse_v1beta1_addressspacestatus_serviceports,servicePorts>> > array
 |===
 
-[[_io_enmasse_v1alpha1_addressspacestatus_externalports]]
+[[_io_enmasse_v1beta1_addressspacestatus_externalports]]
 **externalPorts**
 
 [options="header", cols=".^3a,.^4a"]
@@ -1822,7 +1822,7 @@ __optional__|string
 __optional__|integer
 |===
 
-[[_io_enmasse_v1alpha1_addressspacestatus_serviceports]]
+[[_io_enmasse_v1beta1_addressspacestatus_serviceports]]
 **servicePorts**
 
 [options="header", cols=".^3a,.^4a"]
@@ -1835,15 +1835,15 @@ __optional__|integer
 |===
 
 
-[[_io_enmasse_v1alpha1_addressspacetype]]
-=== io.enmasse.v1alpha1.AddressSpaceType
+[[_io_enmasse_v1beta1_addressspacetype]]
+=== io.enmasse.v1beta1.AddressSpaceType
 AddressSpaceType is the type of address space (standard, brokered). Each type supports different types of addresses and semantics for those types.
 
 __Type__ : enum (standard, brokered)
 
 
-[[_io_enmasse_v1alpha1_addressspec]]
-=== io.enmasse.v1alpha1.AddressSpec
+[[_io_enmasse_v1beta1_addressspec]]
+=== io.enmasse.v1beta1.AddressSpec
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -1853,12 +1853,12 @@ __required__|string
 |**plan** +
 __required__|string
 |**type** +
-__required__|<<_io_enmasse_v1alpha1_addresstype,io.enmasse.v1alpha1.AddressType>>
+__required__|<<_io_enmasse_v1beta1_addresstype,io.enmasse.v1beta1.AddressType>>
 |===
 
 
-[[_io_enmasse_v1alpha1_addressstatus]]
-=== io.enmasse.v1alpha1.AddressStatus
+[[_io_enmasse_v1beta1_addressstatus]]
+=== io.enmasse.v1beta1.AddressStatus
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -1872,8 +1872,8 @@ __optional__|enum (Pending, Configuring, Active, Failed, Terminating)
 |===
 
 
-[[_io_enmasse_v1alpha1_addresstype]]
-=== io.enmasse.v1alpha1.AddressType
+[[_io_enmasse_v1beta1_addresstype]]
+=== io.enmasse.v1beta1.AddressType
 Type of address (queue, topic, …). Each address type support different kinds of messaging semantics.
 
 __Type__ : enum (queue, topic, anycast, multicast)

--- a/documentation/common/restrictive-plan.yaml
+++ b/documentation/common/restrictive-plan.yaml
@@ -1,4 +1,4 @@
-apiVersion: admin.enmasse.io/v1alpha1
+apiVersion: admin.enmasse.io/v1beta1
 kind: AddressSpacePlan
 metadata:
   name: restrictive-plan

--- a/documentation/common/small-anycast-plan.yaml
+++ b/documentation/common/small-anycast-plan.yaml
@@ -1,4 +1,4 @@
-apiVersion: admin.enmasse.io/v1alpha1
+apiVersion: admin.enmasse.io/v1beta1
 kind: AddressPlan
 metadata:
   name: small-anycast

--- a/documentation/common/small-queue-plan.yaml
+++ b/documentation/common/small-queue-plan.yaml
@@ -1,4 +1,4 @@
-apiVersion: admin.enmasse.io/v1alpha1
+apiVersion: admin.enmasse.io/v1beta1
 kind: AddressPlan
 metadata:
   name: small-queue

--- a/documentation/common/standard-address-space.yaml
+++ b/documentation/common/standard-address-space.yaml
@@ -1,4 +1,4 @@
-apiVersion: enmasse.io/v1alpha1
+apiVersion: enmasse.io/v1beta1
 kind: AddressSpace
 metadata:
   name: myspace

--- a/documentation/common/standard-addresses.yaml
+++ b/documentation/common/standard-addresses.yaml
@@ -1,4 +1,4 @@
-apiVersion: enmasse.io/v1alpha1
+apiVersion: enmasse.io/v1beta1
 kind: AddressList
 items:
 - metadata:

--- a/documentation/common/standard-infra-config-example.yaml
+++ b/documentation/common/standard-infra-config-example.yaml
@@ -1,4 +1,4 @@
-apiVersion: admin.enmasse.io/v1alpha1
+apiVersion: admin.enmasse.io/v1beta1
 kind: StandardInfraConfig
 metadata:
   name: myconfig

--- a/documentation/common/standard-small-queue.yaml
+++ b/documentation/common/standard-small-queue.yaml
@@ -1,4 +1,4 @@
-apiVersion: enmasse.io/v1alpha1
+apiVersion: enmasse.io/v1beta1
 kind: Address
 metadata:
     name: myspace.myqueue

--- a/documentation/common/user-example1.yaml
+++ b/documentation/common/user-example1.yaml
@@ -1,4 +1,4 @@
-apiVersion: user.enmasse.io/v1alpha1
+apiVersion: user.enmasse.io/v1beta1
 kind: MessagingUser
 metadata:
   name: myspace.user1

--- a/documentation/design_docs/design/user-resource.adoc
+++ b/documentation/design_docs/design/user-resource.adoc
@@ -15,24 +15,24 @@ A new api group 'user.enmasse.io' will be created. It will support the following
 
 To create a user (oc create -f user1.yaml):
 ```
-POST /apis/user.enmasse.io/v1alpha1/namespaces/myproject/messagingusers
+POST /apis/user.enmasse.io/v1beta1/namespaces/myproject/messagingusers
 ```
 
 To read a user (oc get myspace.user1):
 ```
-GET /apis/user.enmasse.io/v1alpha1/namespaces/myproject/messagingusers/myspace.user1
+GET /apis/user.enmasse.io/v1beta1/namespaces/myproject/messagingusers/myspace.user1
 ```
 
 To update a user (oc replace -f user1.yaml):
 
 ```
-PUT /apis/user.enmasse.io/v1alpha1/namespaces/myproject/messagingusers/myspace.user1
+PUT /apis/user.enmasse.io/v1beta1/namespaces/myproject/messagingusers/myspace.user1
 ```
 
 To remove a user (oc delete enmasse-user myspace.user1)
 
 ```
-DELETE /apis/user.enmasse.io/v1alpha1/namespaces/myproject/messagingusers/myspace.user1
+DELETE /apis/user.enmasse.io/v1beta1/namespaces/myproject/messagingusers/myspace.user1
 ```
 
 In the same way as addresses, users are scoped by namespace _and_ address space and resource names
@@ -45,7 +45,7 @@ using secrets or other mechanisms. To start with, users can not be modified (i.e
 changed).
 
 ```
-apiVersion: user.enmasse.io/v1alpha1
+apiVersion: user.enmasse.io/v1beta1
 kind: MessagingUser
 metadata:
     name: myspace.user1
@@ -64,7 +64,7 @@ supported. In the first instance, federated users can only be used for console a
 reflected in user documentation).
 
 ```
-apiVersion: user.enmasse.io/v1alpha1
+apiVersion: user.enmasse.io/v1beta1
 kind: MessagingUser 
 metadata:
     name: myspace.user2

--- a/documentation/design_docs/servicecatalog/README.adoc
+++ b/documentation/design_docs/servicecatalog/README.adoc
@@ -70,7 +70,7 @@ getting started] instructions to try out the queue
 * Create the service instance:
 ```
 cat <<EOF | oc create -f -
-apiVersion: servicecatalog.k8s.io/v1alpha1
+apiVersion: servicecatalog.k8s.io/v1beta1
 kind: Instance
 metadata:
   name: my-inmemory-queue
@@ -104,7 +104,7 @@ provisioned successfully"
 * Create the binding:
 ```
 cat <<EOF | oc create -f -
-apiVersion: servicecatalog.k8s.io/v1alpha1
+apiVersion: servicecatalog.k8s.io/v1beta1
 kind: Binding
 metadata:
   name: my-inmemory-queue-binding
@@ -115,7 +115,7 @@ spec:
 EOF
 ```
 * Verify the binding's status:
-* `oc get bindings.v1alpha1.servicecatalog.k8s.io -o yaml`
+* `oc get bindings.v1beta1.servicecatalog.k8s.io -o yaml`
 * The `status.conditions.message` property should show "Injected bind
 result"
 * Verify the secret has been created:
@@ -125,7 +125,7 @@ result"
 === Unbinding the queue
 
 * Delete the binding:
-* `oc delete bindings.v1alpha1.servicecatalog.k8s.io my-inmemory-queue-binding`
+* `oc delete bindings.v1beta1.servicecatalog.k8s.io my-inmemory-queue-binding`
 * Verify the secret has been deleted:
 * `oc get secrets`
 

--- a/documentation/modules/proc-create-address-restapi.adoc
+++ b/documentation/modules/proc-create-address-restapi.adoc
@@ -12,7 +12,7 @@
 [source,json,options="nowrap"]
 ----
 {
-  "apiVersion": "enmasse.io/v1alpha1",
+  "apiVersion": "enmasse.io/v1beta1",
   "kind": "Address",
   "metadata": {
       "addressSpace": "myspace"
@@ -30,7 +30,7 @@
 [source,bash,options="nowrap"]
 ----
 TOKEN=`oc whoami -t`
-curl -X POST -T address.json -H "content-type: application/json" -H "Authorization: Bearer $TOKEN" -k https://$(oc get route restapi -o jsonpath='{.spec.host}')/apis/enmasse.io/v1alpha1/namespaces/[:namespace]/addressspaces/myspace/addresses
+curl -X POST -T address.json -H "content-type: application/json" -H "Authorization: Bearer $TOKEN" -k https://$(oc get route restapi -o jsonpath='{.spec.host}')/apis/enmasse.io/v1beta1/namespaces/[:namespace]/addressspaces/myspace/addresses
 ----
 
 where `namespace` is the name of the address space.
@@ -43,7 +43,7 @@ where `namespace` is the name of the address space.
 +
 [source,bash,options="nowrap"]
 ----
-curl -k https://$(oc get route restapi -o jsonpath='{.spec.host}')/apis/enmasse.io/v1alpha1/namespaces/[:namespace]/addressspaces/myspace/addresses
+curl -k https://$(oc get route restapi -o jsonpath='{.spec.host}')/apis/enmasse.io/v1beta1/namespaces/[:namespace]/addressspaces/myspace/addresses
 ----
 +
 The addresses are ready to be used by messaging clients once the `status.isReady` field of each

--- a/documentation/modules/proc-create-address-space-restapi.adoc
+++ b/documentation/modules/proc-create-address-space-restapi.adoc
@@ -12,7 +12,7 @@
 [source,json,options="nowrap"]
 ----
 {
-    "apiVersion": "enmasse.io/v1alpha1",
+    "apiVersion": "enmasse.io/v1beta1",
     "kind": "AddressSpace",
     "metadata": {
         "name": "myspace"
@@ -29,7 +29,7 @@
 [source,options="nowrap"]
 ----
 TOKEN=`oc whoami -t`
-curl -X POST -T space.json -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" -k https://$(oc get route restapi -o jsonpath='{.spec.host}')/apis/enmasse.io/v1alpha1/namespaces/[:namespace]/addressspaces
+curl -X POST -T space.json -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" -k https://$(oc get route restapi -o jsonpath='{.spec.host}')/apis/enmasse.io/v1beta1/namespaces/[:namespace]/addressspaces
 ----
 +
 This command creates the infrastructure required for that address space. Replace `namespace` with the
@@ -46,7 +46,7 @@ various components.
 [source,options="nowrap"]
 ----
 TOKEN=`oc whoami -t`
-curl -k -H "Authorization: Bearer $TOKEN" https://$(oc get route restapi -o jsonpath='{.spec.host}')/apis/enmasse.io/v1alpha1/namespaces/[:namespace]/addressspaces/myspace
+curl -k -H "Authorization: Bearer $TOKEN" https://$(oc get route restapi -o jsonpath='{.spec.host}')/apis/enmasse.io/v1beta1/namespaces/[:namespace]/addressspaces/myspace
 ----
 +
 You can consider the address space to be ready to use when `status.isReady` is `true` in the returned JSON

--- a/k8s-api/src/main/java/io/enmasse/k8s/api/ConfigMapAddressApi.java
+++ b/k8s-api/src/main/java/io/enmasse/k8s/api/ConfigMapAddressApi.java
@@ -73,7 +73,7 @@ public class ConfigMapAddressApi implements AddressApi, ListerWatcher<ConfigMap,
             }
 
             if (address.getSelfLink() == null) {
-                builder.setSelfLink("/apis/enmasse.io/v1alpha1/namespaces/" + address.getNamespace() + "/addressspaces/" + address.getAddressSpace());
+                builder.setSelfLink("/apis/enmasse.io/v1beta1/namespaces/" + address.getNamespace() + "/addressspaces/" + address.getAddressSpace());
             }
             return builder.build();
         } catch (IOException e) {

--- a/k8s-api/src/main/java/io/enmasse/k8s/api/ConfigMapAddressSpaceApi.java
+++ b/k8s-api/src/main/java/io/enmasse/k8s/api/ConfigMapAddressSpaceApi.java
@@ -184,7 +184,7 @@ public class ConfigMapAddressSpaceApi implements AddressSpaceApi, ListerWatcher<
             }
 
             if (addressSpace.getSelfLink() == null) {
-                builder.setSelfLink("/apis/enmasse.io/v1alpha1/namespaces/" + addressSpace.getNamespace() + "/addressspaces/" + addressSpace.getName());
+                builder.setSelfLink("/apis/enmasse.io/v1beta1/namespaces/" + addressSpace.getNamespace() + "/addressspaces/" + addressSpace.getName());
             }
 
             return builder.build();

--- a/keycloak-user-api/src/main/java/io/enmasse/user/keycloak/KeycloakUserApi.java
+++ b/keycloak-user-api/src/main/java/io/enmasse/user/keycloak/KeycloakUserApi.java
@@ -511,7 +511,7 @@ public class KeycloakUserApi implements UserApi {
                 .withMetadata(new ObjectMetaBuilder()
                         .withName(name)
                         .withNamespace(namespace)
-                        .withSelfLink("/apis/user.enmasse.io/v1alpha1/namespaces/" + namespace + "/messagingusers/" + name)
+                        .withSelfLink("/apis/user.enmasse.io/v1beta1/namespaces/" + namespace + "/messagingusers/" + name)
                         .withCreationTimestamp(userRep.getAttributes().get("creationTimestamp").get(0))
                         .build())
                 .withSpec(new UserSpecBuilder()

--- a/systemtests/scripts/test_func.sh
+++ b/systemtests/scripts/test_func.sh
@@ -122,7 +122,7 @@ function create_address_space() {
     else
         URL="https://$(oc get route -o jsonpath='{.spec.host}' restapi)"
     fi
-    curl -k -X POST -H "content-type: application/json" --data-binary @${ADDRESS_SPACE_DEF} -H "Authorization: Bearer ${TOKEN}" ${URL}/apis/enmasse.io/v1alpha1/namespaces/${NAMESPACE}/addressspaces
+    curl -k -X POST -H "content-type: application/json" --data-binary @${ADDRESS_SPACE_DEF} -H "Authorization: Bearer ${TOKEN}" ${URL}/apis/enmasse.io/v1beta1/namespaces/${NAMESPACE}/addressspaces
     wait_until_up 2 ${NAMESPACE}-${ADDRESS_SPACE_NAME} || return 1
 }
 
@@ -140,9 +140,9 @@ function create_address() {
         URL="https://$(oc get route -o jsonpath='{.spec.host}' restapi)"
     fi
 
-    PAYLOAD="{\"apiVersion\": \"enmasse.io/v1alpha1\", \"kind\": \"AddressList\", \"metadata\": { \"name\": \"${ADDRESS_SPACE}.${NAME}\"}, \"spec\": {\"address\": \"${ADDRESS}\", \"type\": \"${TYPE}\", \"plan\": \"${PLAN}\"}}"
+    PAYLOAD="{\"apiVersion\": \"enmasse.io/v1beta1\", \"kind\": \"AddressList\", \"metadata\": { \"name\": \"${ADDRESS_SPACE}.${NAME}\"}, \"spec\": {\"address\": \"${ADDRESS}\", \"type\": \"${TYPE}\", \"plan\": \"${PLAN}\"}}"
     TOKEN=$(oc whoami -t)
-    curl -k -X POST -H "content-type: application/json" -d "${PAYLOAD}" -H "Authorization: Bearer ${TOKEN}" ${URL}/apis/enmasse.io/v1alpha1/namespaces/${NAMESPACE}/addresses
+    curl -k -X POST -H "content-type: application/json" -d "${PAYLOAD}" -H "Authorization: Bearer ${TOKEN}" ${URL}/apis/enmasse.io/v1beta1/namespaces/${NAMESPACE}/addresses
 }
 
 function create_user() {

--- a/systemtests/src/main/java/io/enmasse/systemtest/User.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/User.java
@@ -129,14 +129,14 @@ public class User {
 
     public JsonObject toCRDJson(String addressSpace) {
         JsonObject config = this.toJson(addressSpace);
-        config.put("apiVersion", "user.enmasse.io/v1alpha1");
+        config.put("apiVersion", "user.enmasse.io/v1beta1");
         config.put("kind", "MessagingUser");
         return config;
     }
 
     public JsonObject toCRDJson(String addressSpace, String federatedUserIp) {
         JsonObject config = this.toJson(addressSpace, username, federatedUserIp);
-        config.put("apiVersion", "user.enmasse.io/v1alpha1");
+        config.put("apiVersion", "user.enmasse.io/v1beta1");
         config.put("kind", "MessagingUser");
         return config;
     }

--- a/systemtests/src/main/java/io/enmasse/systemtest/apiclients/AddressApiClient.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/apiclients/AddressApiClient.java
@@ -34,27 +34,27 @@ public class AddressApiClient extends ApiClient {
     private final String addressResourcePath;
 
     public AddressApiClient(Kubernetes kubernetes) throws MalformedURLException {
-        super(kubernetes, kubernetes::getRestEndpoint, "enmasse.io/v1alpha1");
-        this.schemaPath = String.format("/apis/enmasse.io/v1alpha1/namespaces/%s/addressspaceschemas", kubernetes.getNamespace());
-        this.addressSpacesPath = String.format("/apis/enmasse.io/v1alpha1/namespaces/%s/addressspaces", kubernetes.getNamespace());
-        this.addressNestedPathPattern = String.format("/apis/enmasse.io/v1alpha1/namespaces/%s/addressspaces", kubernetes.getNamespace()) + "/%s/addresses";
-        this.addressResourcePath = String.format("/apis/enmasse.io/v1alpha1/namespaces/%s/addresses", kubernetes.getNamespace());
+        super(kubernetes, kubernetes::getRestEndpoint, "enmasse.io/v1beta1");
+        this.schemaPath = String.format("/apis/enmasse.io/v1beta1/namespaces/%s/addressspaceschemas", kubernetes.getNamespace());
+        this.addressSpacesPath = String.format("/apis/enmasse.io/v1beta1/namespaces/%s/addressspaces", kubernetes.getNamespace());
+        this.addressNestedPathPattern = String.format("/apis/enmasse.io/v1beta1/namespaces/%s/addressspaces", kubernetes.getNamespace()) + "/%s/addresses";
+        this.addressResourcePath = String.format("/apis/enmasse.io/v1beta1/namespaces/%s/addresses", kubernetes.getNamespace());
     }
 
     public AddressApiClient(Kubernetes kubernetes, String namespace) throws MalformedURLException {
-        super(kubernetes, kubernetes::getRestEndpoint, "enmasse.io/v1alpha1");
-        this.schemaPath = String.format("/apis/enmasse.io/v1alpha1/namespaces/%s/addressspaceschemas", kubernetes.getNamespace());
-        this.addressSpacesPath = String.format("/apis/enmasse.io/v1alpha1/namespaces/%s/addressspaces", namespace);
-        this.addressNestedPathPattern = String.format("/apis/enmasse.io/v1alpha1/namespaces/%s/addressspaces", namespace) + "/%s/addresses";
-        this.addressResourcePath = String.format("/apis/enmasse.io/v1alpha1/namespaces/%s/addresses", namespace);
+        super(kubernetes, kubernetes::getRestEndpoint, "enmasse.io/v1beta1");
+        this.schemaPath = String.format("/apis/enmasse.io/v1beta1/namespaces/%s/addressspaceschemas", kubernetes.getNamespace());
+        this.addressSpacesPath = String.format("/apis/enmasse.io/v1beta1/namespaces/%s/addressspaces", namespace);
+        this.addressNestedPathPattern = String.format("/apis/enmasse.io/v1beta1/namespaces/%s/addressspaces", namespace) + "/%s/addresses";
+        this.addressResourcePath = String.format("/apis/enmasse.io/v1beta1/namespaces/%s/addresses", namespace);
     }
 
     public AddressApiClient(Kubernetes kubernetes, String namespace, String token) throws MalformedURLException {
-        super(kubernetes, kubernetes::getRestEndpoint, "enmasse.io/v1alpha1", token);
-        this.schemaPath = String.format("/apis/enmasse.io/v1alpha1/namespaces/%s/addressspaceschemas", kubernetes.getNamespace());
-        this.addressSpacesPath = String.format("/apis/enmasse.io/v1alpha1/namespaces/%s/addressspaces", namespace);
-        this.addressNestedPathPattern = String.format("/apis/enmasse.io/v1alpha1/namespaces/%s/addressspaces", namespace) + "/%s/addresses";
-        this.addressResourcePath = String.format("/apis/enmasse.io/v1alpha1/namespaces/%s/addresses", namespace);
+        super(kubernetes, kubernetes::getRestEndpoint, "enmasse.io/v1beta1", token);
+        this.schemaPath = String.format("/apis/enmasse.io/v1beta1/namespaces/%s/addressspaceschemas", kubernetes.getNamespace());
+        this.addressSpacesPath = String.format("/apis/enmasse.io/v1beta1/namespaces/%s/addressspaces", namespace);
+        this.addressNestedPathPattern = String.format("/apis/enmasse.io/v1beta1/namespaces/%s/addressspaces", namespace) + "/%s/addresses";
+        this.addressResourcePath = String.format("/apis/enmasse.io/v1beta1/namespaces/%s/addresses", namespace);
     }
 
     public void close() {

--- a/systemtests/src/main/java/io/enmasse/systemtest/apiclients/AdminApiClient.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/apiclients/AdminApiClient.java
@@ -18,9 +18,9 @@ public class AdminApiClient extends ApiClient {
     private final String addressPlansPath;
 
     public AdminApiClient(Kubernetes kubernetes) {
-        super(kubernetes, kubernetes::getMasterEndpoint, "admin.enmasse.io/v1alpha1");
-        this.addressSpacePlansPath = String.format("/apis/admin.enmasse.io/v1alpha1/namespaces/%s/addressspaceplans", kubernetes.getNamespace());
-        this.addressPlansPath = String.format("/apis/admin.enmasse.io/v1alpha1/namespaces/%s/addressplans", kubernetes.getNamespace());
+        super(kubernetes, kubernetes::getMasterEndpoint, "admin.enmasse.io/v1beta1");
+        this.addressSpacePlansPath = String.format("/apis/admin.enmasse.io/v1beta1/namespaces/%s/addressspaceplans", kubernetes.getNamespace());
+        this.addressPlansPath = String.format("/apis/admin.enmasse.io/v1beta1/namespaces/%s/addressplans", kubernetes.getNamespace());
     }
 
     public void close() {

--- a/systemtests/src/main/java/io/enmasse/systemtest/apiclients/UserApiClient.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/apiclients/UserApiClient.java
@@ -30,13 +30,13 @@ public class UserApiClient extends ApiClient {
     private final String userPath;
 
     public UserApiClient(Kubernetes kubernetes) throws MalformedURLException {
-        super(kubernetes, kubernetes::getRestEndpoint, "user.enmasse.io/v1alpha1");
-        this.userPath = String.format("/apis/user.enmasse.io/v1alpha1/namespaces/%s/messagingusers", kubernetes.getNamespace());
+        super(kubernetes, kubernetes::getRestEndpoint, "user.enmasse.io/v1beta1");
+        this.userPath = String.format("/apis/user.enmasse.io/v1beta1/namespaces/%s/messagingusers", kubernetes.getNamespace());
     }
 
     public UserApiClient(Kubernetes kubernetes, String namespace) throws MalformedURLException {
-        super(kubernetes, kubernetes::getRestEndpoint, "user.enmasse.io/v1alpha1");
-        this.userPath = String.format("/apis/user.enmasse.io/v1alpha1/namespaces/%s/messagingusers", namespace);
+        super(kubernetes, kubernetes::getRestEndpoint, "user.enmasse.io/v1beta1");
+        this.userPath = String.format("/apis/user.enmasse.io/v1beta1/namespaces/%s/messagingusers", namespace);
     }
 
     public JsonObject getUser(String addressSpace, String userName) throws Exception {

--- a/systemtests/src/main/java/io/enmasse/systemtest/resources/AddressPlan.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/resources/AddressPlan.java
@@ -46,7 +46,7 @@ public class AddressPlan {
 
     public JsonObject toJson() {
         JsonObject config = new JsonObject();
-        config.put("apiVersion", "admin.enmasse.io/v1alpha1");
+        config.put("apiVersion", "admin.enmasse.io/v1beta1");
         config.put("kind", "AddressPlan");
 
         JsonObject definitionMetadata = new JsonObject(); // <metadata>

--- a/systemtests/src/main/java/io/enmasse/systemtest/resources/AddressSpacePlan.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/resources/AddressSpacePlan.java
@@ -59,7 +59,7 @@ public class AddressSpacePlan {
     public JsonObject toJson() {
         //definition
         JsonObject config = new JsonObject();
-        config.put("apiVersion", "admin.enmasse.io/v1alpha1");
+        config.put("apiVersion", "admin.enmasse.io/v1beta1");
         config.put("kind", "AddressSpacePlan");
 
         JsonObject definitionMetadata = new JsonObject(); // <metadata>

--- a/templates/address-space-controller/010-CustomResourceDefinition-address-plan.yaml
+++ b/templates/address-space-controller/010-CustomResourceDefinition-address-plan.yaml
@@ -6,13 +6,20 @@ metadata:
     app: enmasse
 spec:
   group: admin.enmasse.io
-  version: v1alpha1
+  version: v1beta1
   scope: Namespaced
   names:
     kind: AddressPlan
     listKind: AddressPlanList
     singular: addressplan
     plural: addressplans
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+    - name: v1alpha1
+      served: true
+      storage: false
   validation:
     openAPIV3Schema:
       properties:

--- a/templates/address-space-controller/010-CustomResourceDefinition-address-space-plan.yaml
+++ b/templates/address-space-controller/010-CustomResourceDefinition-address-space-plan.yaml
@@ -6,13 +6,20 @@ metadata:
     app: enmasse
 spec:
   group: admin.enmasse.io
-  version: v1alpha1
+  version: v1beta1
   scope: Namespaced
   names:
     kind: AddressSpacePlan
     listKind: AddressSpacePlanList
     singular: addressspaceplan
     plural: addressspaceplans
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+    - name: v1alpha1
+      served: true
+      storage: false
   validation:
     openAPIV3Schema:
       properties:

--- a/templates/address-space-controller/010-CustomResourceDefinition-brokered-infra-config.yaml
+++ b/templates/address-space-controller/010-CustomResourceDefinition-brokered-infra-config.yaml
@@ -6,13 +6,20 @@ metadata:
     app: enmasse
 spec:
   group: admin.enmasse.io
-  version: v1alpha1
+  version: v1beta1
   scope: Namespaced
   names:
     kind: BrokeredInfraConfig
     listKind: BrokeredInfraConfigList
     singular: brokeredinfraconfig
     plural: brokeredinfraconfigs
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+    - name: v1alpha1
+      served: true
+      storage: false
   validation:
     openAPIV3Schema:
       properties:

--- a/templates/address-space-controller/010-CustomResourceDefinition-standard-infra-config.yaml
+++ b/templates/address-space-controller/010-CustomResourceDefinition-standard-infra-config.yaml
@@ -6,13 +6,20 @@ metadata:
     app: enmasse
 spec:
   group: admin.enmasse.io
-  version: v1alpha1
+  version: v1beta1
   scope: Namespaced
   names:
     kind: StandardInfraConfig
     listKind: StandardInfraConfigList
     singular: standardinfraconfig
     plural: standardinfraconfigs
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+    - name: v1alpha1
+      served: true
+      storage: false
   validation:
     openAPIV3Schema:
       properties:

--- a/templates/api-service/050-ApiService-api-service.yaml
+++ b/templates/api-service/050-ApiService-api-service.yaml
@@ -3,7 +3,7 @@ kind: APIService
 metadata:
   labels:
     app: enmasse
-  name: v1alpha1.enmasse.io
+  name: v1beta1.enmasse.io
 spec:
   group: enmasse.io
   groupPriorityMinimum: 1000
@@ -11,5 +11,5 @@ spec:
   service:
     name: api-server
     namespace: ${NAMESPACE}
-  version: v1alpha1
+  version: v1beta1
   versionPriority: 15

--- a/templates/api-service/050-ApiService-user-api-service.yaml
+++ b/templates/api-service/050-ApiService-user-api-service.yaml
@@ -3,7 +3,7 @@ kind: APIService
 metadata:
   labels:
     app: enmasse
-  name: v1alpha1.user.enmasse.io
+  name: v1beta1.user.enmasse.io
 spec:
   group: user.enmasse.io
   groupPriorityMinimum: 1000
@@ -11,5 +11,5 @@ spec:
   service:
     name: api-server
     namespace: ${NAMESPACE}
-  version: v1alpha1
+  version: v1beta1
   versionPriority: 15


### PR DESCRIPTION
This updates the API version of all EnMasse resources to use v1beta1. The v1alpha1 version will still be supported for all resources, but it will default to v1beta1.