### PR TITLE
Fix quota calculation

### DIFF
--- a/address-space-controller/src/main/java/io/enmasse/controller/CreateController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/CreateController.java
@@ -170,7 +170,10 @@ public class CreateController implements Controller {
 
     private boolean checkExceedsQuota(AddressSpaceType addressSpaceType, AddressSpacePlan plan, AddressSpace addressSpace) {
         AddressApi addressApi = addressSpaceApi.withAddressSpace(addressSpace);
-        Set<Address> addresses = addressApi.listAddressesWithLabels(addressSpace.getNamespace(), Collections.singletonMap(LabelKeys.ADDRESS_SPACE, addressSpace.getName()));
+        Set<Address> addresses = addressApi.listAddresses(addressSpace.getNamespace()).stream()
+                .filter(address -> addressSpace.getName().equals(address.getAddressSpace()))
+                .collect(Collectors.toSet());
+
         Map<String, Double> quota = new HashMap<>();
         Map<String, Double> usage = new HashMap<>();
         for (ResourceAllowance allowance : plan.getResources()) {

--- a/address-space-controller/src/test/java/io/enmasse/controller/CreateControllerTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/CreateControllerTest.java
@@ -4,8 +4,13 @@
  */
 package io.enmasse.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.enmasse.address.model.Address;
 import io.enmasse.address.model.AddressSpace;
+import io.enmasse.config.AnnotationKeys;
+import io.enmasse.config.LabelKeys;
 import io.enmasse.controller.common.Kubernetes;
+import io.enmasse.k8s.api.AddressApi;
 import io.enmasse.k8s.api.EventLogger;
 import io.enmasse.k8s.api.SchemaProvider;
 import io.enmasse.k8s.api.TestAddressSpaceApi;
@@ -19,10 +24,12 @@ import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 public class CreateControllerTest {
+    private static final ObjectMapper mapper = new ObjectMapper();
 
     @Test
     public void testAddressSpaceCreate() throws Exception {
@@ -55,5 +62,60 @@ public class CreateControllerTest {
         verify(kubernetes).create(resourceCaptor.capture());
         KubernetesList value = resourceCaptor.getValue();
         assertThat(value.getItems().size(), is(1));
+    }
+
+    @Test
+    public void testPlanUpdateNotAccepted() throws Exception {
+        Kubernetes kubernetes = mock(Kubernetes.class);
+        when(kubernetes.getNamespace()).thenReturn("otherspace");
+        SchemaProvider testSchema = new TestSchemaProvider();
+
+        AddressSpace addressSpace = new AddressSpace.Builder()
+                .setName("myspace")
+                .putAnnotation(AnnotationKeys.APPLIED_PLAN, "plan1")
+                .setUid(UUID.randomUUID().toString())
+                .putAnnotation(AnnotationKeys.APPLIED_INFRA_CONFIG,
+                        mapper.writeValueAsString(testSchema.getSchema().findAddressSpaceType("type1").get().getInfraConfigs().get(0)))
+                .setNamespace("mynamespace")
+                .setType("type1")
+                .setPlan("myplan")
+                .build();
+
+
+        TestAddressSpaceApi addressSpaceApi = new TestAddressSpaceApi();
+        addressSpaceApi.createAddressSpace(addressSpace);
+
+        AddressApi addressApi = addressSpaceApi.withAddressSpace(addressSpace);
+
+        Address address = new Address.Builder()
+                .setAddressSpace(addressSpace.getName())
+                .setName("myspace.q1")
+                .setNamespace("mynamespace")
+                .setAddress("q1")
+                .setType("queue")
+                .setPlan("plan1")
+                .build();
+
+        Address address2 = new Address.Builder()
+                .setAddressSpace(addressSpace.getName())
+                .setName("myspace.q2")
+                .setNamespace("mynamespace")
+                .setAddress("q2")
+                .setType("queue")
+                .setPlan("plan1")
+                .build();
+
+        addressApi.createAddress(address);
+        addressApi.createAddress(address2);
+
+        EventLogger eventLogger = mock(EventLogger.class);
+        when(kubernetes.existsAddressSpace(eq(addressSpace))).thenReturn(true);
+
+        CreateController createController = new CreateController(kubernetes, testSchema, null, eventLogger, null, "1.0", addressSpaceApi);
+
+        addressSpace = createController.handle(addressSpace);
+
+        assertThat(addressSpace.getStatus().getMessages().size(), is(1));
+        assertTrue(addressSpace.getStatus().getMessages().iterator().next().contains("quota exceeded for resource broker"));
     }
 }


### PR DESCRIPTION
* Filter addresses client side for now, performance will be "impacted" if > 1 address space exists within the same namespace as it will retrieve addresses for all address spaces within the namespace. We should consider adding labels to addresses and migrate to use those after version + 1.
* Add unit test for quota check.