### PR TITLE
Replace the correct gc parameter

### DIFF
--- a/artemis/utils/bin/launch.sh
+++ b/artemis/utils/bin/launch.sh
@@ -16,7 +16,7 @@ JAVA_OPTS="${JAVA_OPTS} -Djava.net.preferIPv4Stack=true"
 JAVA_OPTS="$(adjust_java_options ${JAVA_OPTS})"
 #GC Option conflicts with the one already configured.
 
-JAVA_OPTS=$(echo $JAVA_OPTS | sed -e "s/-XX:+UseParallelGC/ /")
+JAVA_OPTS=$(echo $JAVA_OPTS | sed -e "s/-XX:+UseParallelOldGC/ /")
 
 # Parameters are
 # - instance directory


### PR DESCRIPTION
I think this could fix the master build, but upgrade may still not work.

I'm really starting to be in favor of just dropping all scripts from artemis/ and using startup scripts exclusively from broker-plugin.