### PR TITLE
Remove jackson-module-jsonschema-from-api-server and api-common.

### DIFF
--- a/api-common/pom.xml
+++ b/api-common/pom.xml
@@ -65,11 +65,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.module</groupId>
-      <artifactId>jackson-module-jsonSchema</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jackson2-provider</artifactId>
       <scope>compile</scope>

--- a/api-server/pom.xml
+++ b/api-server/pom.xml
@@ -59,11 +59,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.module</groupId>
-      <artifactId>jackson-module-jsonSchema</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jackson2-provider</artifactId>
       <scope>compile</scope>


### PR DESCRIPTION
The dependency seems to be unused.  Dependency is used in service-broker, this remains, although its usage could easily be eliminated.