### PR TITLE
Bump Vertx/Netty/Qpid Proton-J dependencies

### DIFF
--- a/broker-plugin/sasl-delegation/pom.xml
+++ b/broker-plugin/sasl-delegation/pom.xml
@@ -95,6 +95,11 @@
         <scope>test</scope>
     </dependency>
     <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler</artifactId>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <fabric8.kubernetes-client.version>4.0.4</fabric8.kubernetes-client.version>
         <fabric8.kubernetes-model.version>3.0.2</fabric8.kubernetes-model.version>
         <sundrio.version>0.7.1</sundrio.version>
-        <vertx.version>3.5.3</vertx.version>
+        <vertx.version>3.6.2</vertx.version>
         <slf4j.version>1.7.21</slf4j.version>
         <log4j.version>1.2.17</log4j.version>
         <jackson-annotations.version>2.9.6</jackson-annotations.version>
@@ -62,12 +62,12 @@
         <artemis.version>2.6.3</artemis.version>
         <ngwebdriver.version>1.1.4</ngwebdriver.version>
         <paho.version>1.2.0</paho.version>
-        <netty.version>4.1.25.Final</netty.version>
+        <netty.version>4.1.30.Final</netty.version>
         <keycloak.version>3.4.3.Final</keycloak.version>
         <jboss.logging.version>3.3.0.Final</jboss.logging.version>
         <jboss.logging.processor.version>2.1.0.Final</jboss.logging.processor.version>
-        <protonj.version>0.27.3</protonj.version>
-        <qpidjms.version>0.34.0</qpidjms.version>
+        <protonj.version>0.31.0</protonj.version>
+        <qpidjms.version>0.40.0</qpidjms.version>
         <selenium.version>3.14.0</selenium.version>
         <gson.version>2.8.2</gson.version>
         <jacoco.version>0.7.9</jacoco.version>


### PR DESCRIPTION
* Vertx (3.5.3 -> 3.6.2)
* Netty (4.1.25.Final -> 4.1.30.Final)
* Qpid Proton-J (0.27.3 -> 0.34.0) versions
Also Qpid JMS test dependency (0.31.0 -> 0.40.0)