### PR TITLE
Separate external jars from broker-plugin.jar

### DIFF
--- a/broker-plugin/Dockerfile
+++ b/broker-plugin/Dockerfile
@@ -7,6 +7,8 @@ ARG commit
 ENV ARTEMIS_HOME=/opt/apache-artemis PATH=$ARTEMIS_HOME/bin:$PATH VERSION=${version} COMMIT=${commit}
 
 ADD ./build/broker-plugin-${version}-dist.tar.gz /
+ADD ./tcnative/target/lib/netty-tcnative-boringssl-static-2.0.7.Final.jar /opt/broker-plugin/lib/
+ADD ./jmx_exporter/target/lib/jmx_prometheus_javaagent-0.1.0.jar /opt/broker-plugin/jmx_exporter/
 
 RUN chgrp -R 0 /opt/broker-plugin && \
     chmod -R g=u /opt/broker-plugin

--- a/broker-plugin/Makefile
+++ b/broker-plugin/Makefile
@@ -13,14 +13,6 @@ build_tar:
 	mkdir -p $(ARTIFACT_BASE)/opt
 
 	tar xvf plugin/target/plugin-$(VERSION)-dist.tar.gz -C $(ARTIFACT_BASE)
-	
-	# Prometheus support
-	mkdir -p $(ARTEMIS_PLUGIN_HOME)/jmx_exporter
-	cp -f jmx_exporter/target/lib/jmx_prometheus_javaagent-0.1.0.jar $(ARTEMIS_PLUGIN_HOME)/jmx_exporter/
-
-	# Tcnative SSL
-	cp -f tcnative/target/lib/netty-tcnative-boringssl-static-2.0.7.Final.jar $(ARTEMIS_PLUGIN_HOME)/lib
-
 	tar -czf build/broker-plugin-$(VERSION)-dist.tar.gz -C $(ARTIFACT_BASE) .
 
 package: build_tar


### PR DESCRIPTION
Have Dockerfile include the following directly, to keep them out of broker-plugin.jar:
- netty-tcnative-boringssl-static-2.0.7.Final.jar
- jmx_prometheus_javaagent-0.1.0.jar

Signed-off-by: Vanessa <vbusch@redhat.com>