### PR TITLE
Switch build to openjdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ cache:
   directories:
   - "$HOME/.m2"
 jdk:
-- oraclejdk8
+- openjdk8
 python:
 - "2.7.14"
 before_install:


### PR DESCRIPTION
It looks like Oracle JDK 8 is already gone when using the Xenial image at travis, so I would suggest to use OpenJDK instead. Even for the current build.