### PR TITLE
Speed up travis build by skipping initial "mvn install"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ python:
 before_install:
 - sudo pip install requests[security] ansible
 - gem install asciidoctor
+install: true # would only call "mvn install", which doesn't help us at this point
 script:
 - "./.travis/setup-kubernetes.sh 'systemtests' ${OPENSHIFT} ${MINIKUBE} ${KUBECTL}"
 - "./.travis/build.sh"


### PR DESCRIPTION
This gives me a "boost" of about two minutes … 

… but I think it makes things more clear in the logs.