### PR TITLE
Bump CVE detection tool dependency-check-maven-plugin from 3.3.2 to 4.0.2.

### DIFF
--- a/.owasp/project-suppressions.xml
+++ b/.owasp/project-suppressions.xml
@@ -19,4 +19,24 @@
         <cpe>cpe:/a:user_project:user</cpe>
         <cpe>cpe:/a:keycloak:keycloak</cpe>
     </suppress>
+
+    <suppress>
+        <notes>EnMasse's own module amqp-connector is being misidentified as Apache ActiveMQ.</notes>
+        <gav regex="true">^io\.enmasse:amqp-connector:.*$</gav>
+        <cpe>cpe:/a:apache:activemq</cpe>
+        <cpe>cpe:/a:apache:activemq_artemis</cpe>
+    </suppress>
+
+    <suppress>
+        <notes>netty-tcnative-boringssl-static is being identified as core Netty itself and spuriously flagging CVE-2015-2156 and CVE-2014-3488</notes>
+        <gav regex="true">^io\.netty:netty-tcnative-boringssl-static.*:.*$</gav>
+        <cve>CVE-2014-3488</cve>
+        <cve>CVE-2015-2156</cve>
+    </suppress>
+
+    <suppress>
+        <notes>com.github.fge:json-patch is not /a:json-patch_project:json-patch</notes>
+        <gav regex="true">^com\.github\.fge:json-patch:.*$</gav>
+        <cpe>cpe:/a:json-patch_project:json-patch</cpe>
+    </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
         <netty-tcnative-boringssl-static.version>2.0.7.Final</netty-tcnative-boringssl-static.version>
         <security-versions-plugin.version>1.0.6</security-versions-plugin.version>
-        <dependency-check-maven-plugin.version>3.3.2</dependency-check-maven-plugin.version>
+        <dependency-check-maven-plugin.version>4.0.2</dependency-check-maven-plugin.version>
         <maven-xml-plugin.version>1.0.2</maven-xml-plugin.version>
 
         <license-report-stylesheet>${maven.multiModuleProjectDirectory}/licenses.xsl</license-report-stylesheet>


### PR DESCRIPTION
Also update suppressions for misidentified products.