### PR TITLE
Fix for upgradeTests for version 0.26

### DIFF
--- a/address-space-controller/src/main/java/io/enmasse/controller/CreateController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/CreateController.java
@@ -127,7 +127,7 @@ public class CreateController implements Controller {
             addressSpace.putAnnotation(AnnotationKeys.APPLIED_PLAN, addressSpace.getSpec().getPlan());
         } else if (currentInfraConfig == null || !currentInfraConfig.equals(desiredInfraConfig)) {
 
-            if (version.equals(desiredInfraConfig.getVersion())) {
+            if (version.equals(desiredInfraConfig.getVersion()) || doMajorMinorVersionsMatch(desiredInfraConfig.getVersion())) {
                 if (checkExceedsQuota(addressSpaceType, addressSpacePlan, addressSpace)) {
                     return addressSpace;
                 }
@@ -165,6 +165,15 @@ public class CreateController implements Controller {
 
         return addressSpace;
     }
+
+    //Can be removed after release 0.27
+    //In release 0.26, version of desired config = 0.26.0 controller version = 0.26
+    boolean doMajorMinorVersionsMatch(String desiredInfraConfigVersion) {
+		return desiredInfraConfigVersion != null
+				&& (desiredInfraConfigVersion.equals(version)
+				|| desiredInfraConfigVersion.startsWith(version+".")
+				&& desiredInfraConfigVersion.length() == version.length()+2);
+	}
 
     private boolean checkExceedsQuota(AddressSpaceType addressSpaceType, AddressSpacePlan plan, AddressSpace addressSpace) {
         AddressApi addressApi = addressSpaceApi.withAddressSpace(addressSpace);

--- a/address-space-controller/src/test/java/io/enmasse/controller/CreateControllerTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/CreateControllerTest.java
@@ -7,6 +7,7 @@ package io.enmasse.controller;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -154,5 +155,24 @@ public class CreateControllerTest {
 
         assertThat(addressSpace.getStatus().getMessages().size(), is(1));
         assertTrue(addressSpace.getStatus().getMessages().iterator().next().contains("quota exceeded for resource broker"));
+    }
+
+    @Test
+    public void testDoMajorMinorVersionsMatch() {
+        CreateController controller = new CreateController(null, null, null, null, null, "0.26", null);
+
+        assertTrue(controller.doMajorMinorVersionsMatch("0.26.0"));
+        assertTrue(controller.doMajorMinorVersionsMatch("0.26"));
+        assertTrue(controller.doMajorMinorVersionsMatch("0.26.1"));
+        assertFalse(controller.doMajorMinorVersionsMatch("0.26-SNAPSHOT"));
+        assertFalse(controller.doMajorMinorVersionsMatch("0.27"));
+        assertFalse(controller.doMajorMinorVersionsMatch("0.27.0"));
+
+        controller = new CreateController(null, null, null, null, null, "0.27-SNAPSHOT", null);
+
+        assertTrue(controller.doMajorMinorVersionsMatch("0.27-SNAPSHOT"));
+        assertFalse(controller.doMajorMinorVersionsMatch("0.26-SNAPSHOT"));
+        assertFalse(controller.doMajorMinorVersionsMatch("0.27"));
+        assertFalse(controller.doMajorMinorVersionsMatch("0.27.0"));
     }
 }


### PR DESCRIPTION
Version 0.26 has been released with controller version 0.26, not matching infra config version 0.26.0.  

This fix will allow the upgrade to happen as long as the major & minor versions match.
It is only required until after version 0.27 is released.  PR #2295 ensures version numbers match in future releases.

Signed-off-by: Vanessa <vbusch@redhat.com>