### PR TITLE
Fix the PlanTest failing due to missing endpoint

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/TimeoutBudget.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/TimeoutBudget.java
@@ -1,9 +1,10 @@
 /*
- * Copyright 2018, EnMasse authors.
+ * Copyright 2018-2019, EnMasse authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.enmasse.systemtest;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -33,5 +34,14 @@ public class TimeoutBudget {
 
     public boolean timeoutExpired() {
         return timeLeft() < 0;
+    }
+
+    public static TimeoutBudget ofDuration(final Duration duration) {
+        final long ms = duration.toMillis();
+        if (ms < 0) {
+            return new TimeoutBudget(duration.toNanos(), TimeUnit.NANOSECONDS);
+        } else {
+            return new TimeoutBudget(ms, TimeUnit.MILLISECONDS);
+        }
     }
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/TestBaseWithShared.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/TestBaseWithShared.java
@@ -12,7 +12,6 @@ import io.enmasse.systemtest.mqtt.MqttClientFactory;
 import org.apache.qpid.proton.message.Message;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.slf4j.Logger;
 


### PR DESCRIPTION
This change waits after the update of the address space that the
resource version changes, only after that does it make sense to wait
to wait for the readiness of the address space.

What happened was that the update came, and immediately it was checked
that the address space is ready, which succeeded, but for the old state.
Then the test progressed, but actually ran into an "unready" address
space.