### PR TITLE
Remove group wildcards special to brokered address space

### DIFF
--- a/broker-plugin/sasl-delegation/src/main/java/io/enmasse/artemis/sasl_delegation/SaslDelegatingLogin.java
+++ b/broker-plugin/sasl-delegation/src/main/java/io/enmasse/artemis/sasl_delegation/SaslDelegatingLogin.java
@@ -32,6 +32,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.Principal;
 import java.util.*;
 import java.util.function.BooleanSupplier;
+import java.util.stream.Collectors;
 import javax.naming.InvalidNameException;
 import javax.naming.ldap.LdapName;
 import javax.net.ssl.SSLContext;
@@ -352,7 +353,9 @@ public class SaslDelegatingLogin implements LoginModule {
             roles.addAll(defaultRolesAuthenticated);
 
             if (remoteProperties.get(Symbol.valueOf(GROUPS)) instanceof List) {
-                List<String> groups = (List<String>) remoteProperties.get(Symbol.valueOf(GROUPS));
+                List<String> groups = ((List<String>) ((List) remoteProperties.get(Symbol.valueOf(GROUPS)))).stream()
+                        .map(grp -> grp.replace('*', '#'))
+                        .collect(Collectors.toList());
                 groups.retainAll(SPECIAL_AUTHZ_GROUPS);
                 roles.addAll(groups);
             }
@@ -364,7 +367,7 @@ public class SaslDelegatingLogin implements LoginModule {
                 List<String> groups = new ArrayList<>();
                 for(Map.Entry<String, String[]> entry : authz.entrySet()) {
                     for(String permission : entry.getValue()) {
-                        groups.add(permission + "_" + entry.getKey());
+                        groups.add(permission + "_" + entry.getKey().replace('*', '#'));
                     }
                 }
                 roles.addAll(groups);

--- a/broker-plugin/sasl-delegation/src/main/java/io/enmasse/artemis/sasl_delegation/SaslDelegatingLogin.java
+++ b/broker-plugin/sasl-delegation/src/main/java/io/enmasse/artemis/sasl_delegation/SaslDelegatingLogin.java
@@ -353,11 +353,12 @@ public class SaslDelegatingLogin implements LoginModule {
             roles.addAll(defaultRolesAuthenticated);
 
             if (remoteProperties.get(Symbol.valueOf(GROUPS)) instanceof List) {
-                List<String> groups = ((List<String>) ((List) remoteProperties.get(Symbol.valueOf(GROUPS)))).stream()
-                        .map(grp -> grp.replace('*', '#'))
-                        .collect(Collectors.toList());
+                List<String> groups = new ArrayList<>(((List<String>) ((List) remoteProperties.get(Symbol.valueOf(GROUPS)))));
                 groups.retainAll(SPECIAL_AUTHZ_GROUPS);
                 roles.addAll(groups);
+                for (String group : groups) {
+                    roles.add(group + "_#");
+                }
             }
         }
 

--- a/keycloak-user-api/src/main/java/io/enmasse/user/keycloak/KeycloakUserApi.java
+++ b/keycloak-user-api/src/main/java/io/enmasse/user/keycloak/KeycloakUserApi.java
@@ -16,15 +16,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -578,8 +570,8 @@ public class KeycloakUserApi implements UserApi {
 
     static User buildUser(UserRepresentation userRep, List<GroupRepresentation> groupReps) {
         log.debug("Creating user from user representation id {}, name {} part of groups {}", userRep.getId(), userRep.getUsername(), userRep.getGroups());
-        Map<String, Set<Operation>> operationsByAddress = new HashMap<>();
-        Set<Operation> globalOperations = new HashSet<>();
+        Map<String, Set<Operation>> operationsByAddress = new LinkedHashMap<>();
+        Set<Operation> globalOperations = new LinkedHashSet<>();
         for (GroupRepresentation groupRep : groupReps) {
             log.debug("Checking group id {} name {}", groupRep.getId(), groupRep.getName());
             if (groupRep.getName().startsWith("manage")) {
@@ -590,15 +582,15 @@ public class KeycloakUserApi implements UserApi {
                 String[] parts = groupRep.getName().split("_");
                 Operation operation = Operation.valueOf(parts[0]);
                 String address = decodePart(parts[1]);
-                operationsByAddress.computeIfAbsent(address, k -> new HashSet<>())
+                operationsByAddress.computeIfAbsent(address, k -> new LinkedHashSet<>())
                         .add(operation);
             }
         }
 
-        Map<Set<Operation>, Set<String>> operations = new HashMap<>();
+        Map<Set<Operation>, Set<String>> operations = new LinkedHashMap<>();
         for (Map.Entry<String, Set<Operation>> byAddressEntry : operationsByAddress.entrySet()) {
             if (!operations.containsKey(byAddressEntry.getValue())) {
-                operations.put(byAddressEntry.getValue(), new HashSet<>());
+                operations.put(byAddressEntry.getValue(), new LinkedHashSet<>());
             }
             operations.get(byAddressEntry.getValue()).add(byAddressEntry.getKey());
         }

--- a/keycloak-user-api/src/main/java/io/enmasse/user/keycloak/KeycloakUserApi.java
+++ b/keycloak-user-api/src/main/java/io/enmasse/user/keycloak/KeycloakUserApi.java
@@ -325,7 +325,7 @@ public class KeycloakUserApi implements UserApi {
     /**
      * Create the set of desired groups.
      *
-     * @param user The user to create the groups for.
+     * @param authorization The authorization rule list to create the groups for.
      * @return A set of groups.
      */
     static Set<String> createDesiredGroupsSet(final List<UserAuthorization> authorization) {
@@ -338,11 +338,9 @@ public class KeycloakUserApi implements UserApi {
 
                 switch (operation) {
                     case manage:
-                        desiredGroups.add("manage_#");
                         desiredGroups.add("manage");
                         break;
                     case view:
-                        desiredGroups.add("monitor_#");
                         desiredGroups.add("monitor");
                         break;
                     default:
@@ -351,8 +349,6 @@ public class KeycloakUserApi implements UserApi {
                                 String groupName = operation.name() + "_" + encodePart(address);
                                 // normal name
                                 desiredGroups.add(groupName);
-                                // brokered name ( the set will remove duplicates for us)
-                                desiredGroups.add(groupName.replace("*", "#"));
                             }
                         }
                         break;

--- a/keycloak-user-api/src/test/java/io/enmasse/user/keycloak/KeycloakUserApiTest.java
+++ b/keycloak-user-api/src/test/java/io/enmasse/user/keycloak/KeycloakUserApiTest.java
@@ -264,7 +264,7 @@ public class KeycloakUserApiTest {
 
         final Set<String> result = KeycloakUserApi.createDesiredGroupsSet(auth);
 
-        assertGroups(result, "manage", "manage_#");
+        assertGroups(result, "manage");
     }
 
     @Test
@@ -280,7 +280,7 @@ public class KeycloakUserApiTest {
 
         assertGroups(result,
                 "recv_foo%2Fbar", "send_foo%2Fbar", "recv_bar%2Fbaz%2F%23", "send_bar%2Fbaz%2F%23",
-                "monitor", "monitor_#", "manage", "manage_#");
+                "monitor", "manage");
     }
 
     @Test
@@ -303,7 +303,7 @@ public class KeycloakUserApiTest {
 
         final Set<String> result = KeycloakUserApi.createDesiredGroupsSet(auth);
 
-        assertGroups(result, "manage", "manage_#");
+        assertGroups(result, "manage");
     }
 
     /**


### PR DESCRIPTION
The broker sasl plugin has been updated to handle the same wildcard
syntax as the dispatch router.