### PR TITLE
use generic command executor for minikube commands

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/Minikube.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/Minikube.java
@@ -20,7 +20,7 @@ public class Minikube extends Kubernetes {
 
     private static String runCommand(String... cmd) {
         try {
-            Executor executor = new Executor();
+            Executor executor = new Executor(false);
             int returnCode = executor.execute(Arrays.asList(cmd), 10000);
             if(returnCode == 0) {
                 return executor.getStdOut();
@@ -32,23 +32,12 @@ public class Minikube extends Kubernetes {
         }
     }
 
-    private static String removeQuotes(String value) {
-        String cleaned = value;
-        if(value.startsWith("\"")) {
-            cleaned = cleaned.substring(1);
-        }
-        if(value.endsWith("\"")) {
-            cleaned = cleaned.substring(0, cleaned.length()-1);
-        }
-        return cleaned;
-    }
-
     private String getIp(String namespace, String serviceName) {
-        return removeQuotes(runCommand("minikube", "service", "-n", namespace, "--format", "{{.IP}}", serviceName));
+        return runCommand("minikube", "service", "-n", namespace, "--format", "{{.IP}}", serviceName);
     }
 
     private String getPort(String namespace, String serviceName) {
-        return removeQuotes(runCommand("minikube", "service", "-n", namespace, "--format", "{{.Port}}", serviceName));
+        return runCommand("minikube", "service", "-n", namespace, "--format", "{{.Port}}", serviceName);
     }
 
     @Override

--- a/systemtests/src/main/java/io/enmasse/systemtest/executor/Executor.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/executor/Executor.java
@@ -29,11 +29,11 @@ public class Executor {
     private boolean appendLineSeparator;
 
     public Executor() {
-        appendLineSeparator = true;
+        this.appendLineSeparator = true;
     }
 
     public Executor(Path logPath) {
-        appendLineSeparator = true;
+        this.appendLineSeparator = true;
         this.logPath = logPath;
     }
 

--- a/systemtests/src/main/java/io/enmasse/systemtest/executor/Executor.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/executor/Executor.java
@@ -26,12 +26,19 @@ public class Executor {
     private StreamGobbler stdOutReader;
     private StreamGobbler stdErrReader;
     private Path logPath;
+    private boolean appendLineSeparator;
 
     public Executor() {
+        this(true);
     }
 
     public Executor(Path logPath) {
+        this();
         this.logPath = logPath;
+    }
+
+    public Executor(boolean appendLineSeparator) {
+        this.appendLineSeparator = appendLineSeparator;
     }
 
     /**
@@ -205,7 +212,10 @@ public class Executor {
                 try {
                     log.info("Reading stream {}", is);
                     while (scanner.hasNextLine()) {
-                        data.append(scanner.nextLine()).append(System.getProperty("line.separator"));
+                        data.append(scanner.nextLine());
+                        if(appendLineSeparator) {
+                            data.append(System.getProperty("line.separator"));
+                        }
                     }
                     scanner.close();
                     return data.toString();

--- a/systemtests/src/main/java/io/enmasse/systemtest/executor/Executor.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/executor/Executor.java
@@ -29,11 +29,11 @@ public class Executor {
     private boolean appendLineSeparator;
 
     public Executor() {
-        this(true);
+        appendLineSeparator = true;
     }
 
     public Executor(Path logPath) {
-        this();
+        appendLineSeparator = true;
         this.logPath = logPath;
     }
 

--- a/systemtests/src/main/java/io/enmasse/systemtest/executor/Executor.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/executor/Executor.java
@@ -204,7 +204,6 @@ public class Executor {
                 Scanner scanner = new Scanner(is);
                 try {
                     log.info("Reading stream {}", is);
-                    String line;
                     while (scanner.hasNextLine()) {
                         data.append(scanner.nextLine()).append(System.getProperty("line.separator"));
                     }


### PR DESCRIPTION
We have 2 commands for minikube so there is no need to create CmdClient for minikube so I just replaced the usage of Process and ProcessBuilder with our Executor for commands.