### PR TITLE
Split the travis build and run a second build, validating S2I

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,34 +23,52 @@ python:
   - "2.7.14"
 go:
   - "1.10.x"
-before_install:
-  - sudo pip install requests[security] ansible
-  - gem install asciidoctor
-  - sudo pip install requests[security] ansible
-  - sudo add-apt-repository -y ppa:masterminds/glide && sudo apt-get update
-  - sudo apt-get install -y glide
-  - gem install asciidoctor
-  - gimme 1.10.5
-  - source ~/.gimme/envs/go1.10.5.env
-  - go version
-install: true # would only call "mvn install", which doesn't help us at this point
-before_script:
-  - pwd
-  - export GOPATH="$HOME/gopath"
-  - env | sort
-  - mkdir -p "$GOPATH/src/github.com/enmasseproject/enmasse"
-  - cp -a "$TRAVIS_BUILD_DIR" "$GOPATH/src/github.com/enmasseproject/"
-  - cd "$GOPATH/src/github.com/enmasseproject/enmasse"
-  - ./hack/verify-codegen.sh
-script:
-  - "./.travis/setup-kubernetes.sh 'systemtests' ${OPENSHIFT} ${MINIKUBE} ${KUBECTL}"
-  - "./.travis/build.sh"
-after_failure:
-  - "./.travis/upload-artifacts.sh false"
-after_success:
-  - "./.travis/push.sh"
-  - "./.travis/upload-artifacts.sh true"
-  - "./.travis/trigger-docs.sh"
+jobs:
+  include:
+    - stage: build
+      before_install:
+        - sudo pip install requests[security] ansible
+        - gem install asciidoctor
+        - sudo pip install requests[security] ansible
+        - sudo add-apt-repository -y ppa:masterminds/glide && sudo apt-get update
+        - sudo apt-get install -y glide
+        - gem install asciidoctor
+        - gimme 1.10.5
+        - source ~/.gimme/envs/go1.10.5.env
+        - go version
+      install: true # would only call "mvn install", which doesn't help us at this point
+      before_script:
+        - pwd
+        - export GOPATH="$HOME/gopath"
+        - env | sort
+        - mkdir -p "$GOPATH/src/github.com/enmasseproject/enmasse"
+        - cp -a "$TRAVIS_BUILD_DIR" "$GOPATH/src/github.com/enmasseproject/"
+        - cd "$GOPATH/src/github.com/enmasseproject/enmasse"
+        - ./hack/verify-codegen.sh
+      script:
+        - "./.travis/setup-kubernetes.sh 'systemtests' ${OPENSHIFT} ${MINIKUBE} ${KUBECTL}"
+        - "./.travis/build.sh"
+      after_failure:
+        - "./.travis/upload-artifacts.sh false"
+      after_success:
+        - "./.travis/push.sh"
+        - "./.travis/upload-artifacts.sh true"
+        - "./.travis/trigger-docs.sh"
+      deploy:
+        - provider: releases
+          skip_cleanup: true
+          api_key:
+            secure: HepZcALZznJ9XL1gumw4EqtG2doiWX+dEdUy0Qug+DcFM6mTb7m61YIrYmiw0h2FCqzozsSjlDjKfBLUgnUalj6f6LZCQKqThh04VKQoBmDJbUoOX7nSiaGeV9SJ18zeG8MrIkoHriJVGnfKUTL870RSQGzRvCXOUyQdx9gy/kfFFM4R9eUN8XOH/nMdmMhtoqwlhfjcY8T0qeKlCISqFCXlan+uIV7KERVSiiBdK4L4fsA5VB8Dd3SUHKe2zpcntowsBXfGI9wemWe++FysZ4Wsg+bBohiZ11A2xeHWCpswosvUHl8OcRyQDK5RqLsphdhTcFxaKvuyXl8v0eecg4ktdHkVQ0EbEauTtd/19lDa4oNpv/Thm3ElKpM77xq4gf0CLW/QNCO6OSQ9zPKughyaH3b/lseLWvVxYEKsPanRdYCZO0PjVOUGtbUpPRxP5CkNDEkW7mpfbK0IgxAemGy0mcTnSWFKQOgdB9iyiZA+lrHdrF9pc1rj5QPbDE8e7mn7FoosPsZuwGjZAb/7lBdZ4aerUXHHsBoyRrVEMvj1qABv9UJtokgo3rBoY/JGdHX9Rq9gsVVQeLLFir5EIFlsTXoaj4z+NvwC5ODklNdBoQvkXYzZ6z9OYsCGDjl09rFi7AbMXCM7nLeKzUv3XQbuEr9iHHpkWhKO8gc8hNw=
+          file: templates/build/enmasse-${TRAVIS_TAG}.tgz
+          on:
+            tags: true
+            repo: EnMasseProject/enmasse
+    - before_install:
+        - curl -L https://github.com/openshift/source-to-image/releases/download/v1.1.13/source-to-image-v1.1.13-b54d75d3-linux-amd64.tar.gz --output s2i.tar.gz
+        - tar xzf s2i.tar.gz
+      install: true
+      script:
+        - ./s2i build . fabric8/s2i-java:3.0-java11 tenant-service -e MAVEN_ARGS_APPEND="-pl io.enmasse:tenant-service --also-make" -e ARTIFACT_DIR="iot/tenant-service/target"
 env:
   global:
     - BRANCH=${TRAVIS_BRANCH}
@@ -65,12 +83,3 @@ env:
     - secure: TY6XV1K2zRxpCy64V9tOSt9gTXvhJEX6ZTtxFG8wid5n/V+ubwF5J79mgvEO4NIS98Jr/rOHFqUO2gwlFg0NvpAMoDjdF5rXqznAlPtYSW7xNsBRN0Ry6epHKZZ6xa8EIfdeqgciYD1tjUZXjq0ZOh3hV1GZ15rOr/AYlzrMRwKP7uMluaTZjIgCMLbNFXlzPNVChtfY8mR+cP4SrZXPlhbxmGjI6MksKtHjdz6EN+5avz9TdjxPlOC29ePddyF/QuhArDHop0hAavcDiAYe9BCaMthkiXKeDGIOVFZNetbv0WsdtVSiDu4cDElT7vNLwypwN6QAAFuNZlHDbYfNFd8F6uoj1IDFNMxquP0vOn0Jdd1/HFT2uW94CIRFv+r2oAsNCBd6A1Kfdk8uGuKqBHja5InNtGN5Iw9r5pNDtcUgUZKOZ7O4R50OwC7XVi11xgCzihiyMRX2ogdIKgGkbVwh63fiKsvKUv/2IDRpcw0klVPCz+sRIkaRfxCxVAcYQf93McXfbN/eWjH1qgM7WHpLazk2hi1mmHw7mWvS3MAZ9zNXDNurQw1qXHmecfcxkKG/vu1NQNbGZUoViiG+LKOv7XtWpjxHrvrw2ejt8wYWC51Zv/Jxo4qAZEckZLj9XBCgvONaefBru7LX9VHENGMPP0fxEzI+lJZLQUmUC0g=
     - secure: WF0i7xDmu6WQnnijAuRj0QqsLK+lWhdL0tolR3Yn+GyZGJmkZq/jzpzZWcE/uJe5YRwXolwS1cxuPFY/wGl5PPQN6blSp2MJVGVfBx92x/Vleqw4XkQbWXhDUIyGP5Uc/Yx7jO19a93LjbVcpZOzR6/nnChZfNCLm1CHM5KCS/rV3KHF6T14V2u+x2G6Lg264qVvmtOeGr/IrBVjWiXj+9aEvY+hzw2dvTe6Wk6KBjGe8DMDjdWI1mxtRuqFlW69YLOYBcEKj6h2s7dT9ZeS7Z6+n9Zj+OfJpURxlr/+K64csdpHqajiR0hswSVlDJANmNBdMm5b1eIelbTfrCwdEqLNKgUr7+ihjlKWOEerI2Jrpeu4Sxt2EWrFeJNklsqJve0N6+ZS47MDWiTGB2oWadtUbXc+Uko84vrYbS4anOtvR8JX14dGuZl0l0Wdl7uIxhM0dg14bBYhea/R3d38CrJ43+672UQ5WLYeKn31UeAFFdSpAhRqE+j94Ue3GpQrRA6phadMYpxJCQ8yfRrLAcTchRpD9IE+QwBGehR8AZ4CU63iXq+lrlZjAfRLHw0j7XSxfgoyVm/UGqfmg95EhYER8d8RurNY9ctXVRYaJOC9jlRVZWhPULtVK1+jklbi+8kw8ZUeuoj2ggplxAYCZjFwPCwNqhyqP43IfsdpYio=
     - secure: jZacd85V6d2N/8NM5YjnbCtGuyeYRj5avzQjlKmVskIon9WdKr2/QhAOJc2UxGPLR2WVT3m2+JxmjidlL25FnA3PKGb8hRCCpBmIBFq2VwKhT8U1sEr1DfV3zZlQyxbp7tkiMKJ2cj+3aLBbmGieRr6AshDEMmXuXNN3k3tVCMns/G+pW7Pz82jQwJqmiOpdp4DgyiRXVQEPDxf5XJT4jYt1/KjMx8N6Vob5TqraGYPHTKQiufIebhS+MfFxo0Kpc7izYoBVNC547N8VY4Ra0A0hRyatx/hNiN5QzYHIds2TUHuy3Bin3KJ88qy7Q0zWUNndNg+sNc6FKkyqSw+alDq/cTOje5xpTFnatvS0f4gj42vsHceFhwrIj6O0CbUilWpVYY7wTO+G5JHXop/Q9T74UpJax6mrft++vlr7ahBk5kT+7I4Sph1X4eKWHFkzORfiS8Y8D9mLNGFXnW3OrvZNPdehBvEvshxBkTKVyZyP4DfIQKLfdzn29GQeYhZFipypR88jS5mqG7BZhEQuWjstiOBOi+8yo8B47uMpLPLhKjYgZuirJXem0GS959EqqygQApnLqHqoz+v0027wze4OBc8WmhAmRNRAaXluzsBar7aGWe7Sd6scn7nLl+YVTLkXtNDkoFWQVksr+5f/HUbcYilabAFLtPhLL8Hq35M=
-deploy:
-  - provider: releases
-    skip_cleanup: true
-    api_key:
-      secure: HepZcALZznJ9XL1gumw4EqtG2doiWX+dEdUy0Qug+DcFM6mTb7m61YIrYmiw0h2FCqzozsSjlDjKfBLUgnUalj6f6LZCQKqThh04VKQoBmDJbUoOX7nSiaGeV9SJ18zeG8MrIkoHriJVGnfKUTL870RSQGzRvCXOUyQdx9gy/kfFFM4R9eUN8XOH/nMdmMhtoqwlhfjcY8T0qeKlCISqFCXlan+uIV7KERVSiiBdK4L4fsA5VB8Dd3SUHKe2zpcntowsBXfGI9wemWe++FysZ4Wsg+bBohiZ11A2xeHWCpswosvUHl8OcRyQDK5RqLsphdhTcFxaKvuyXl8v0eecg4ktdHkVQ0EbEauTtd/19lDa4oNpv/Thm3ElKpM77xq4gf0CLW/QNCO6OSQ9zPKughyaH3b/lseLWvVxYEKsPanRdYCZO0PjVOUGtbUpPRxP5CkNDEkW7mpfbK0IgxAemGy0mcTnSWFKQOgdB9iyiZA+lrHdrF9pc1rj5QPbDE8e7mn7FoosPsZuwGjZAb/7lBdZ4aerUXHHsBoyRrVEMvj1qABv9UJtokgo3rBoY/JGdHX9Rq9gsVVQeLLFir5EIFlsTXoaj4z+NvwC5ODklNdBoQvkXYzZ6z9OYsCGDjl09rFi7AbMXCM7nLeKzUv3XQbuEr9iHHpkWhKO8gc8hNw=
-    file: templates/build/enmasse-${TRAVIS_TAG}.tgz
-    on:
-      tags: true
-      repo: EnMasseProject/enmasse

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ jobs:
         - tar xzf s2i.tar.gz
       install: true
       script:
-        - ./s2i build . fabric8/s2i-java:3.0-java11 tenant-service -e MAVEN_ARGS_APPEND="-pl io.enmasse:tenant-service --also-make" -e ARTIFACT_DIR="iot/tenant-service/target"
+        - ./s2i build . fabric8/s2i-java:3.0-java8 tenant-service -e MAVEN_ARGS_APPEND="-pl io.enmasse:tenant-service --also-make" -e ARTIFACT_DIR="iot/tenant-service/target"
 env:
   global:
     - BRANCH=${TRAVIS_BRANCH}


### PR DESCRIPTION
Split up the travis build into two jobs, running in parallel.

The first job is the existing configuration, and the second job runs the S2I builder to ensure "buildability" on the sources.

The job split is done in order to reduce the chance to run into the 50 minute job limit of travis.