### PR TITLE
Upgrade jackson-databind from 2.9.6 to 2.9.8.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,11 +46,11 @@
         <slf4j.version>1.7.21</slf4j.version>
         <logback.version>1.0.13</logback.version>
         <hibernate.validator.version>6.0.10.Final</hibernate.validator.version>
-        <jackson-annotations.version>2.9.6</jackson-annotations.version>
-        <jackson-core.version>2.9.6</jackson-core.version>
-        <jackson-databind.version>2.9.6</jackson-databind.version>
-        <jackson-module-jsonSchema.version>2.9.6</jackson-module-jsonSchema.version>
-        <jackson-module-jaxb-annotations.version>2.9.6</jackson-module-jaxb-annotations.version>
+        <jackson-annotations.version>2.9.8</jackson-annotations.version>
+        <jackson-core.version>2.9.8</jackson-core.version>
+        <jackson-databind.version>2.9.8</jackson-databind.version>
+        <jackson-module-jsonSchema.version>2.9.8</jackson-module-jsonSchema.version>
+        <jackson-module-jaxb-annotations.version>2.9.8</jackson-module-jaxb-annotations.version>
         <javax.validation.version>2.0.1.Final</javax.validation.version>
         <jboss.el.api.version>1.0.13.Final</jboss.el.api.version>
         <json-patch.version>1.9</json-patch.version>


### PR DESCRIPTION
Upgrade other librariee in Jackson suite to the same version.

Note: jackson-databind 2.9.6 was vulnerable to the following CVE (all deserialisation vulnerabilities).  It is not actually believed that versions of EnMasse that included jackson-databind 2.9.6 were vulnerable, this is because additional libraries were required to exploit the vulnerability (such as Apache Axis), which are not included.

CVE-2018-14718
CVE-2018-14719
CVE-2018-14720
CVE-2018-14721
CVE-2018-19360
CVE-2018-19361
CVE-2018-19362