### PR TITLE
Keycloak plugin: Exclude transitive provided openshift-restclient-java

### DIFF
--- a/keycloak-plugin/sasl-plugin/pom.xml
+++ b/keycloak-plugin/sasl-plugin/pom.xml
@@ -106,6 +106,10 @@
           <groupId>com.google.zxing</groupId>
           <artifactId>javase</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.openshift</groupId>
+          <artifactId>openshift-restclient-java</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 


### PR DESCRIPTION
In order to silence spurious report of CVE-2018-11771 during CVE scan.  No functional change - openshift-restclient-java was a provided dependency and not shipped.