### PR TITLE
Bump Selenium from 3.14.0 to 3.141.59 to avoid test dependency vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <jboss.logging.processor.version>2.1.0.Final</jboss.logging.processor.version>
         <protonj.version>0.31.0</protonj.version>
         <qpidjms.version>0.40.0</qpidjms.version>
-        <selenium.version>3.14.0</selenium.version>
+        <selenium.version>3.141.59</selenium.version>
         <gson.version>2.8.2</gson.version>
         <jacoco.version>0.7.9</jacoco.version>
         <node.version>v10.15.3</node.version>


### PR DESCRIPTION
in selenium-firefox-driver.  No production functional change.

@enmasse-ci run tests testcase=*ConsoleTest
