### PR TITLE
Fix duplicate install, and drop installation of glide

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,7 @@ jobs:
   include:
     - stage: build
       before_install:
-        - sudo pip install requests[security] ansible
-        - gem install asciidoctor
-        - sudo pip install requests[security] ansible
-        - sudo add-apt-repository -y ppa:masterminds/glide && sudo apt-get update
-        - sudo apt-get install -y glide
+        - pip install --user requests[security] ansible
         - gem install asciidoctor
         - gimme 1.10.5
         - source ~/.gimme/envs/go1.10.5.env


### PR DESCRIPTION
It looks like a merge issue, a duplicate installation of asciidoctor.
We also don't need glide on the travis build, as we only rely on the
vendor folder.