### PR TITLE
Also show human readable timestamp

### DIFF
--- a/systemtests/scripts/wait_until_up.sh
+++ b/systemtests/scripts/wait_until_up.sh
@@ -56,7 +56,7 @@ function waitingContainersReady {
 TIMEOUT=600
 NOW=$(date +%s)
 END=$(($NOW + $TIMEOUT))
-info "Waiting until ${END}"
+info "Waiting until ${END} ($(date -d @${END}))"
 while true
 do
     NOW=$(date +%s)


### PR DESCRIPTION
Shows the time until the system tests for for the pods to come up, but in a human readable form