### PR TITLE
Upgrade fixes

### DIFF
--- a/address-space-controller/src/main/java/io/enmasse/controller/TemplateInfraResourceFactory.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/TemplateInfraResourceFactory.java
@@ -45,6 +45,10 @@ public class TemplateInfraResourceFactory implements InfraResourceFactory {
         AuthenticationService authService = authenticationServiceRegistry.findAuthenticationService(addressSpace.getSpec().getAuthenticationService())
                 .orElseThrow(() -> new IllegalArgumentException("Unable to find authentication service " + addressSpace.getSpec().getAuthenticationService()));
 
+        if (authService.getStatus() == null) {
+            throw new IllegalArgumentException("Authentication service '" + authService.getMetadata().getName() + "' is not yet deployed");
+        }
+
 
         Optional<String> kcIdpHint = getKcIdpHint(infraConfig, addressSpace, authService);
 

--- a/pkg/util/install/utils.go
+++ b/pkg/util/install/utils.go
@@ -37,7 +37,9 @@ func ApplyDefaultLabels(meta *v1.ObjectMeta, component string, name string) {
 func ApplyServiceDefaults(service *corev1.Service, component string, name string) {
 
 	ApplyDefaultLabels(&service.ObjectMeta, component, name)
-	service.Spec.Selector = CreateDefaultLabels(nil, component, name)
+	if service.Spec.Selector == nil {
+		service.Spec.Selector = CreateDefaultLabels(nil, component, name)
+	}
 
 }
 
@@ -46,8 +48,10 @@ func ApplyDeploymentDefaults(deployment *appsv1.Deployment, component string, na
 
 	ApplyDefaultLabels(&deployment.ObjectMeta, component, name)
 
-	deployment.Spec.Selector = &v1.LabelSelector{
-		MatchLabels: CreateDefaultLabels(nil, component, name),
+	if deployment.Spec.Selector == nil {
+		deployment.Spec.Selector = &v1.LabelSelector{
+			MatchLabels: CreateDefaultLabels(nil, component, name),
+		}
 	}
 
 	deployment.Spec.Template.ObjectMeta.Labels = CreateDefaultLabels(deployment.Spec.Template.ObjectMeta.Labels, component, name)

--- a/pkg/util/install/utils.go
+++ b/pkg/util/install/utils.go
@@ -37,7 +37,7 @@ func ApplyDefaultLabels(meta *v1.ObjectMeta, component string, name string) {
 func ApplyServiceDefaults(service *corev1.Service, component string, name string) {
 
 	ApplyDefaultLabels(&service.ObjectMeta, component, name)
-	if service.Spec.Selector == nil {
+	if service.CreationTimestamp.IsZero() {
 		service.Spec.Selector = CreateDefaultLabels(nil, component, name)
 	}
 
@@ -48,7 +48,7 @@ func ApplyDeploymentDefaults(deployment *appsv1.Deployment, component string, na
 
 	ApplyDefaultLabels(&deployment.ObjectMeta, component, name)
 
-	if deployment.Spec.Selector == nil {
+	if deployment.CreationTimestamp.IsZero() {
 		deployment.Spec.Selector = &v1.LabelSelector{
 			MatchLabels: CreateDefaultLabels(nil, component, name),
 		}

--- a/templates/enmasse-operator/020-Role-enmasse-operator.yaml
+++ b/templates/enmasse-operator/020-Role-enmasse-operator.yaml
@@ -7,10 +7,10 @@ metadata:
 rules:
   - apiGroups: [ "apps" ]
     resources: [ "deployments" ]
-    verbs: [ "get", "list", "watch", "update", "create", "patch" ]
+    verbs: [ "get", "list", "watch", "update", "create", "patch", "delete" ]
   - apiGroups: [ "" ]
     resources: [ "configmaps", "secrets", "persistentvolumeclaims", "services" ]
-    verbs: [ "get", "list", "watch", "update", "create", "patch" ]
+    verbs: [ "get", "list", "watch", "update", "create", "patch", "delete" ]
   - apiGroups: [ "", "route.openshift.io" ]
     resources: [ "routes", "routes/custom-host", "routes/status"]
     verbs: [ "create", "update", "patch", "get", "list", "watch", "delete" ]


### PR DESCRIPTION
@ctron Wdyt about not reassigning the label selector if it is already set? If you try to the label selectors, the Kubernetes API will complain about it being immutable, so this prevents an upgrade where labels change to work for instance.

@k-wall Various fixes to handle upgrades, deleting keycloak-controller, better error handling in address space controller