### PR TITLE
Use cross compile options when linking Go executables destined for images

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -5,6 +5,9 @@ MOCHA_FILE      ?= build/test-results/test/TEST-$(PROJECT_NAME).xml
 SKIP_TESTS      ?= false
 UNAME_S := $(shell uname -s)
 LN=ln
+BUILD_GOOS=linux
+BUILD_GOARCH=amd64
+
 
 ifeq ($(UNAME_S),Darwin)
 	LN = gln

--- a/enmasse-controller-manager/Makefile
+++ b/enmasse-controller-manager/Makefile
@@ -3,7 +3,7 @@ include ../Makefile.common
 CMD=enmasse-controller-manager
 
 build/$(CMD):
-	cd $(GOPRJ)/cmd/$(@F) && go build -o $(abspath $@) .
+	cd $(GOPRJ)/cmd/$(@F) && GOOS=$(BUILD_GOOS) GOARCH=$(BUILD_GOARCH) go build -o $(abspath $@) .
 
 build: build/operatorImageMap.yaml build/$(CMD)
 

--- a/iot/iot-gc/Makefile
+++ b/iot/iot-gc/Makefile
@@ -3,7 +3,7 @@ include ../../Makefile.common
 CMD=iot-gc
 
 build/$(CMD):
-	cd $(GOPRJ)/cmd/$(@F) && go build -o $(abspath $@) .
+	cd $(GOPRJ)/cmd/$(@F) && GOOS=$(BUILD_GOOS) GOARCH=$(BUILD_GOARCH) go build -o $(abspath $@) .
 
 build: build/$(CMD)
 

--- a/iot/qdr-proxy-configurator/Makefile
+++ b/iot/qdr-proxy-configurator/Makefile
@@ -3,7 +3,7 @@ include ../../Makefile.common
 CMD=qdr-proxy-configurator
 
 build/$(CMD):
-	cd $(GOPRJ)/cmd/$(@F) && go build -o $(abspath $@) .
+	cd $(GOPRJ)/cmd/$(@F) && GOOS=$(BUILD_GOOS) GOARCH=$(BUILD_GOARCH) go build -o $(abspath $@) .
 
 build: build/$(CMD)
 


### PR DESCRIPTION
Ensures that when building EnMasse on platforms such as Mac OS X, the executables created run in the containers that target linux/amd64.