### PR TITLE
Bump vertx 3.6.2 to 3.6.3 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <fabric8.kubernetes-client.version>4.1.3</fabric8.kubernetes-client.version>
         <sundrio.version>0.16.4</sundrio.version>
-        <vertx.version>3.6.2</vertx.version>
+        <vertx.version>3.6.3</vertx.version>
         <slf4j.version>1.7.21</slf4j.version>
         <logback.version>1.0.13</logback.version>
         <hibernate.validator.version>6.0.10.Final</hibernate.validator.version>


### PR DESCRIPTION
Synchs with the vertx version already already used by the IoT modules.