### PR TITLE
Add actual plan to address status

### DIFF
--- a/api-model/src/main/java/io/enmasse/address/model/AddressPlanStatus.java
+++ b/api-model/src/main/java/io/enmasse/address/model/AddressPlanStatus.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.address.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.enmasse.admin.model.AddressPlan;
+import io.enmasse.admin.model.v1.AbstractWithAdditionalProperties;
+import io.fabric8.kubernetes.api.model.Doneable;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import io.sundr.builder.annotations.Inline;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = "io.fabric8.kubernetes.api.builder",
+        refs= {@BuildableReference(AbstractWithAdditionalProperties.class)},
+        inline = @Inline(
+                type = Doneable.class,
+                prefix = "Doneable",
+                value = "done"
+        )
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AddressPlanStatus extends AbstractWithAdditionalProperties {
+    private String name;
+    private Map<String, Double> resources;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Map<String, Double> getResources() {
+        return resources;
+    }
+
+    public void setResources(Map<String, Double> resources) {
+        this.resources = new HashMap<>(resources);
+    }
+
+    @Override
+    public String toString() {
+        return "AddressPlanStatus{" +
+                "name='" + name + '\'' +
+                ", resources=" + resources +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AddressPlanStatus that = (AddressPlanStatus) o;
+        return Objects.equals(name, that.name) &&
+                Objects.equals(resources, that.resources);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, resources);
+    }
+
+    public static AddressPlanStatus fromAddressPlan(AddressPlan addressPlan) {
+        AddressPlanStatus planStatus = new AddressPlanStatus();
+        planStatus.setName(addressPlan.getMetadata().getName());
+        planStatus.setResources(addressPlan.getResources());
+        return planStatus;
+    }
+}

--- a/api-model/src/main/java/io/enmasse/address/model/AddressResolver.java
+++ b/api-model/src/main/java/io/enmasse/address/model/AddressResolver.java
@@ -24,13 +24,22 @@ public class AddressResolver {
         return getType(address).findAddressPlan(address.getSpec().getPlan());
     }
 
+    public AddressPlan getDesiredPlan(Address address) {
+        return getType(address)
+                .findAddressPlan(address.getSpec().getPlan()).orElseThrow(() -> new UnresolvedAddressException("Unknown address plan " + address.getSpec().getPlan() + " for address type " + address.getSpec().getType()));
+    }
+
     public AddressPlan getPlan(AddressType addressType, String plan) {
         return addressType.findAddressPlan(plan).orElseThrow(() -> new UnresolvedAddressException("Unknown address plan " + plan + " for address type " + addressType.getName()));
     }
 
     public AddressPlan getPlan(AddressType addressType, Address address) {
-        return addressType.findAddressPlan(address.getAnnotation(AnnotationKeys.APPLIED_PLAN))
-                .orElse(addressType.findAddressPlan(address.getSpec().getPlan()).orElseThrow(() -> new UnresolvedAddressException("Unknown address plan " + address.getSpec().getPlan() + " for address type " + address.getSpec().getType())));
+        Optional<AddressPlan> found = Optional.empty();
+        if (address.getStatus().getPlanStatus() != null) {
+            found = addressType.findAddressPlan(address.getStatus().getPlanStatus().getName());
+        }
+        return found.orElse(addressType.findAddressPlan(address.getAnnotation(AnnotationKeys.APPLIED_PLAN))
+                .orElse(addressType.findAddressPlan(address.getSpec().getPlan()).orElseThrow(() -> new UnresolvedAddressException("Unknown address plan " + address.getSpec().getPlan() + " for address type " + address.getSpec().getType()))));
     }
 
     public AddressType getType(Address address) {

--- a/api-model/src/main/java/io/enmasse/address/model/AddressSpaceStatus.java
+++ b/api-model/src/main/java/io/enmasse/address/model/AddressSpaceStatus.java
@@ -113,7 +113,6 @@ public class AddressSpaceStatus {
         return Objects.hash(ready, endpointStatuses, messages);
     }
 
-
     @Override
     public String toString() {
         return new StringBuilder()

--- a/api-model/src/main/java/io/enmasse/address/model/Status.java
+++ b/api-model/src/main/java/io/enmasse/address/model/Status.java
@@ -11,6 +11,7 @@ import javax.validation.Valid;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import io.enmasse.admin.model.v1.AbstractWithAdditionalProperties;
 import io.enmasse.common.model.AbstractHasMetadata;
 import io.fabric8.kubernetes.api.model.Doneable;
 import io.sundr.builder.annotations.Buildable;
@@ -24,7 +25,7 @@ import io.sundr.builder.annotations.Inline;
         editableEnabled = false,
         generateBuilderPackage = false,
         builderPackage = "io.fabric8.kubernetes.api.builder",
-        refs= {@BuildableReference(AbstractHasMetadata.class)},
+        refs= {@BuildableReference(AbstractWithAdditionalProperties.class)},
         inline = @Inline(
                 type = Doneable.class,
                 prefix = "Doneable",
@@ -32,13 +33,14 @@ import io.sundr.builder.annotations.Inline;
                 )
         )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class Status {
+public class Status extends AbstractWithAdditionalProperties {
 
     @JsonProperty("isReady")
     private boolean ready = false;
     private Phase phase = Phase.Pending;
     private List<String> messages = new ArrayList<>();
     private List<@Valid BrokerStatus> brokerStatuses = new ArrayList<>();
+    private AddressPlanStatus planStatus;
 
     public Status() {
     }
@@ -117,12 +119,13 @@ public class Status {
         return ready == status.ready &&
                 phase == status.phase &&
                 Objects.equals(messages, status.messages) &&
-                Objects.equals(brokerStatuses, status.brokerStatuses);
+                Objects.equals(brokerStatuses, status.brokerStatuses) &&
+                Objects.equals(planStatus, status.planStatus);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(ready, phase, messages, brokerStatuses);
+        return Objects.hash(ready, phase, messages, brokerStatuses, planStatus);
     }
 
 
@@ -133,11 +136,20 @@ public class Status {
                 .append(",").append("phase=").append(phase)
                 .append(",").append("messages=").append(messages)
                 .append(",").append("brokerStatuses=").append(brokerStatuses)
+                .append(",").append("planStatus=").append(planStatus)
                 .append("}")
                 .toString();
     }
 
     public void addAllBrokerStatuses(List<BrokerStatus> toAdd) {
         brokerStatuses.addAll(toAdd);
+    }
+
+    public AddressPlanStatus getPlanStatus() {
+        return planStatus;
+    }
+
+    public void setPlanStatus(AddressPlanStatus planStatus) {
+        this.planStatus = planStatus;
     }
 }

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/AddressController.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/AddressController.java
@@ -121,7 +121,7 @@ public class AddressController implements Watcher<Address> {
 
         long calculatedUsage = System.nanoTime();
         Set<Address> pendingAddresses = filterBy(addressSet, address -> address.getStatus().getPhase().equals(Pending) ||
-                    AddressProvisioner.hasPlansChanged(address));
+                    AddressProvisioner.hasPlansChanged(addressResolver, address));
 
         Map<String, Map<String, UsageInfo>> neededMap = provisioner.checkQuota(usageMap, pendingAddresses, addressSet);
 

--- a/standard-controller/src/test/java/io/enmasse/controller/standard/AddressControllerTest.java
+++ b/standard-controller/src/test/java/io/enmasse/controller/standard/AddressControllerTest.java
@@ -5,12 +5,7 @@
 
 package io.enmasse.controller.standard;
 
-import io.enmasse.address.model.Address;
-import io.enmasse.address.model.AddressBuilder;
-import io.enmasse.address.model.BrokerState;
-import io.enmasse.address.model.BrokerStatus;
-import io.enmasse.address.model.Phase;
-import io.enmasse.address.model.Status;
+import io.enmasse.address.model.*;
 import io.enmasse.config.AnnotationKeys;
 import io.enmasse.k8s.api.AddressApi;
 import io.enmasse.k8s.api.EventLogger;
@@ -41,6 +36,7 @@ public class AddressControllerTest {
     private BrokerSetGenerator mockGenerator;
     private int id = 0;
     private BrokerIdGenerator idGenerator = () -> String.valueOf(id++);
+    private StandardControllerSchema standardControllerSchema = new StandardControllerSchema();
 
     @BeforeEach
     public void setUp() throws IOException {
@@ -50,7 +46,6 @@ public class AddressControllerTest {
         mockApi = mock(AddressApi.class);
         mockClient = mock(OpenShiftClient.class);
         EventLogger eventLogger = mock(EventLogger.class);
-        StandardControllerSchema standardControllerSchema = new StandardControllerSchema();
         when(mockHelper.getRouterCluster()).thenReturn(new RouterCluster("qdrouterd", 1, null));
         StandardControllerOptions options = new StandardControllerOptions();
         options.setAddressSpace("me1");
@@ -83,6 +78,10 @@ public class AddressControllerTest {
                 .withNewStatus()
                 .withReady(true)
                 .withPhase(Phase.Active)
+                .withPlanStatus(AddressPlanStatus.fromAddressPlan(standardControllerSchema.getType().findAddressType("queue").get().findAddressPlan("small-queue").get()))
+                .editOrNewPlanStatus()
+                .withName("small-queue")
+                .endPlanStatus()
                 .endStatus()
 
                 .build();
@@ -106,6 +105,8 @@ public class AddressControllerTest {
                 .withNewStatus()
                 .withReady(false)
                 .withPhase(Phase.Terminating)
+                .withPlanStatus(AddressPlanStatus.fromAddressPlan(standardControllerSchema.getType().findAddressType("queue").get().findAddressPlan("small-queue").get()))
+
                 .endStatus()
 
                 .build();

--- a/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
@@ -318,7 +318,7 @@ public class TestUtils {
         boolean isReady = false;
         JsonObject annotations = address.getJsonObject("metadata").getJsonObject("annotations");
         if (annotations != null) {
-            String appliedPlan = annotations.getString("enmasse.io/applied-plan");
+            String appliedPlan = address.getJsonObject("status").getJsonObject("planStatus").getString("name");
             String actualPlan = address.getJsonObject("spec").getString("plan");
             isReady = actualPlan.equals(appliedPlan);
         }


### PR DESCRIPTION
Storing plan name and assumed credits in status allows the
standard-controller to detect if the credits of a plan was changed, and
perform the necessary migration.