### PR TITLE
enforce python2 to avoid errors when default is python3

### DIFF
--- a/doc-utils/parse.py
+++ b/doc-utils/parse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 __license__ = """
 Licensed to the Apache Software Foundation (ASF) under one


### PR DESCRIPTION
When python3 is set as default python executable the build fails because this script use some py2 syntax.
This ensure the script is ran with the appropriate python version. 