### PR TITLE
Split docker build from default target

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -71,6 +71,13 @@ pipeline {
                 }
             }
         }
+        stage('build docker image') {
+            steps {
+                withCredentials([string(credentialsId: 'docker-registry-host', variable: 'DOCKER_REGISTRY')]) {
+                    sh 'TAG=$BUILD_TAG make docker_build'
+                }
+            }
+        }
         stage('push docker image') {
             steps {
                 withCredentials([string(credentialsId: 'docker-registry-host', variable: 'DOCKER_REGISTRY'), usernamePassword(credentialsId: 'docker-registry-credentials', passwordVariable: 'DOCKER_PASS', usernameVariable: 'DOCKER_USER')]) {

--- a/.jenkins/jenkins-functions.groovy
+++ b/.jenkins/jenkins-functions.groovy
@@ -72,7 +72,7 @@ def waitUntilAgentReady() {
 
 def buildEnmasse() {
     sh 'make'
-    sh 'make docker_tag'
+    sh 'make docker_build docker_tag'
 }
 
 def postAction(String coresDir, String artifactDir) {

--- a/.travis/build-only.sh
+++ b/.travis/build-only.sh
@@ -10,5 +10,6 @@ export DOCKER_REGISTRY="localhost:5000"
 # We do a slim build and drop all output to shrink the console output
 
 make SKIP_TESTS=true > /dev/null
+make docker_build > /dev/null
 make -j 4 docker_tag docker_push > /dev/null
 make -C templates > /dev/null

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -23,7 +23,7 @@ make clean
 
 time make
 
-make docu_html
+time make docker_build
 
 echo "Tagging Docker Images"
 if use_external_registry

--- a/HACKING.md
+++ b/HACKING.md
@@ -43,11 +43,15 @@ Create a new directory and set the `GOPATH` environment variable:
 
 *Note*: Make sure docker daemon is in running state.
 
-#### Full build, run unit tests and build docker images:
+#### Full build, run unit tests
 
     make
 
 This can be run at the top level or within each module. You can also run the 'build', 'test', and 'package' targets individually.
+
+#### Building docker images
+
+    make docker_build
 
 #### Full build and pushing docker images to a registry
 

--- a/Makefile
+++ b/Makefile
@@ -43,18 +43,15 @@ ifneq ($(strip $(PROJECT_DISPLAY_NAME)),)
 	MAVEN_ARGS+="-Dapplication.display.name=$(PROJECT_DISPLAY_NAME)"
 endif
 
-all: build_java build_go docker_build templates
+all: build_java build_go templates
 
 templates: docu_html
 	$(MAKE) -C templates
 
 deploy: build_java build_go
 	$(IMAGE_ENV) mvn -Prelease deploy $(MAVEN_ARGS)
-	for mod in $(GO_DIRS); do \
-		make -C $$mod deploy; \
-	done
 
-build_java:
+build_java: build_go
 	$(IMAGE_ENV) mvn package -q -B $(MAVEN_ARGS)
 
 build_go: $(GO_DIRS) test_go
@@ -89,6 +86,7 @@ coverage_go:
 
 buildpush:
 	$(MAKE)
+	$(MAKE) docker_build
 	$(MAKE) docker_tag
 	$(MAKE) docker_push
 
@@ -107,8 +105,6 @@ template_clean:
 
 clean: clean_java clean_go docu_htmlclean template_clean
 	rm -rf build
-
-docker_build: build_java build_go
 
 coverage: java_coverage
 	$(MAKE) FULL_BUILD=$(FULL_BUILD) -C $@ coverage

--- a/Makefile.common
+++ b/Makefile.common
@@ -13,7 +13,7 @@ ifeq ($(UNAME_S),Darwin)
 	LN = gln
 endif
 
-all: init build test package docker_build
+all: init build test package
 
 init:
 	mkdir -p build
@@ -31,11 +31,11 @@ buildpush:
 
 docker_build: package
 	if [ -f Dockerfile ]; then $(DOCKER) build $(DOCKER_BUILD_ARGS) --build-arg maven_version=$(MAVEN_VERSION) --build-arg version=$(VERSION) --build-arg commit=$(COMMIT) -t $(PROJECT_PREFIX)-$(PROJECT_NAME):$(VERSION) . ; fi
-	if [ -f Dockerfile ]; then docker images | grep $(PROJECT_PREFIX); fi
+	if [ -f Dockerfile ]; then $(DOCKER) images | grep $(PROJECT_PREFIX); fi
 
 docker_tag:
 	if [ -f Dockerfile ]; then $(DOCKER) tag $(PROJECT_PREFIX)-$(PROJECT_NAME):$(VERSION) $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(TAG) ; fi
-	if [ -f Dockerfile ]; then docker images | grep $(PROJECT_PREFIX); fi
+	if [ -f Dockerfile ]; then $(DOCKER) images | grep $(PROJECT_PREFIX); fi
 
 docker_push:
 	if [ -f Dockerfile ] ; \

--- a/iot/pom.xml
+++ b/iot/pom.xml
@@ -30,6 +30,8 @@
     <module>iot-http-adapter</module>
     <module>iot-mqtt-adapter</module>
     <module>iot-tenant-service</module>
+    <module>iot-gc</module>
+    <module>qdr-proxy-configurator</module>
   </modules>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,7 @@
         <module>service-broker</module>
         <module>bundle</module>
         <module>iot</module>
+        <module>enmasse-controller-manager</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
* Require docker_build to be explicitly invoked
* Use podman on travis and parallelize build

This avoids a deadlock where Golang docker images depended on java build
to complete, and java build depended on golang build to complete. Make
docker_build a standalone target also allows for parallelizing
docker_build invocations, which should work well with non-daemon
container tools such as podman