### PR TITLE
Include the iot-application-base in iot/pom.xml list of submodules.

### DIFF
--- a/iot/pom.xml
+++ b/iot/pom.xml
@@ -25,6 +25,7 @@
   </properties>
 
   <modules>
+    <module>iot-application-base</module>
     <module>iot-auth-service</module>
     <module>iot-device-registry</module>
     <module>iot-http-adapter</module>


### PR DESCRIPTION
It omision was causing versions:set to omit its children