### PR TITLE
Add missing type for array

### DIFF
--- a/api-server/src/main/resources/swagger.json
+++ b/api-server/src/main/resources/swagger.json
@@ -2070,7 +2070,10 @@
                             "type": "object"
                         },
                         "tolerations": {
-                            "type": "array"
+                            "type": "array",
+                            "items": {
+                                "type": "object"
+                            }
                         },
                         "priorityClassName": {
                             "type": "string"


### PR DESCRIPTION
I've backported this to release-0.27. This causes kubectl error when creating resources on Kubernetes.