### PR TITLE
Perform liveness check on statically configured listener

### DIFF
--- a/address-space-controller/src/main/resources/templates/standard-space-infra.yaml
+++ b/address-space-controller/src/main/resources/templates/standard-space-infra.yaml
@@ -259,7 +259,7 @@ objects:
             initialDelaySeconds: 30
             httpGet:
               path: /healthz
-              port: http-liveness
+              port: local
               scheme: HTTP
           readinessProbe:
             initialDelaySeconds: 60
@@ -281,7 +281,7 @@ objects:
             name: amqps
             protocol: TCP
           - containerPort: 7777
-            name: http-liveness
+            name: local
             protocol: TCP
           - containerPort: 8080
             name: http

--- a/address-space-controller/src/main/resources/templates/standard-space-infra.yaml
+++ b/address-space-controller/src/main/resources/templates/standard-space-infra.yaml
@@ -81,6 +81,11 @@ objects:
         host: 127.0.0.1
         port: 7777
         authenticatePeer: no
+        http: true
+        metrics: false
+        healthz: true
+        websockets: false
+        httpRootDir: invalid
       }
 
       listener {
@@ -251,10 +256,10 @@ objects:
           image: ${env.ROUTER_IMAGE}
           imagePullPolicy: ${env.IMAGE_PULL_POLICY}
           livenessProbe:
-            initialDelaySeconds: 60
+            initialDelaySeconds: 30
             httpGet:
               path: /healthz
-              port: http
+              port: http-liveness
               scheme: HTTP
           readinessProbe:
             initialDelaySeconds: 60
@@ -274,6 +279,9 @@ objects:
             protocol: TCP
           - containerPort: 5671
             name: amqps
+            protocol: TCP
+          - containerPort: 7777
+            name: http-liveness
             protocol: TCP
           - containerPort: 8080
             name: http


### PR DESCRIPTION
This makes sure the router is not killed if it is not configured within
liveness probe interval. Only readiness check should check that
router is configured. This bug was introduced when switching to http
based probes.