### PR TITLE
Fix IoT system tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ go/
 # Documentation specific
 documentation/html
 scripts/swagger2markup.jar
+
+# Testing output
+artifacts/
+api-server-cert/

--- a/.travis/common.sh
+++ b/.travis/common.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+if [ "${PULL_REQUEST}" == "true" ]; then
+	export IMAGE_PULL_POLICY=IfNotPresent
+fi
+
 function use_external_registry() {
     if [[ "${BRANCH}" == "master" ]] || [[ "${BRANCH}" == "${VERSION}"* ]] && [[ "${PULL_REQUEST}" == "false" ]]
     then

--- a/.travis/test-iot.sh
+++ b/.travis/test-iot.sh
@@ -5,4 +5,4 @@ source ${CURDIR}/common.sh
 
 TAG=${TAG:-latest}
 
-DEPLOY_IOT=true ONLY_PULL_ONCE=true time ./systemtests/scripts/run_test_kubernetes.sh templates/build/enmasse-${TAG} "smoke-iot"
+DEPLOY_IOT=true time ./systemtests/scripts/run_test_kubernetes.sh templates/build/enmasse-${TAG} "smoke-iot"

--- a/.travis/test-iot.sh
+++ b/.travis/test-iot.sh
@@ -5,4 +5,4 @@ source ${CURDIR}/common.sh
 
 TAG=${TAG:-latest}
 
-DEPLOY_IOT=true time ./systemtests/scripts/run_test_kubernetes.sh templates/build/enmasse-${TAG} "smoke-iot"
+DEPLOY_IOT=true ONLY_PULL_ONCE=true time ./systemtests/scripts/run_test_kubernetes.sh templates/build/enmasse-${TAG} "smoke-iot"

--- a/systemtests/scripts/run_test_kubernetes.sh
+++ b/systemtests/scripts/run_test_kubernetes.sh
@@ -34,12 +34,6 @@ mkdir -p api-server-cert/
 openssl req -new -x509 -batch -nodes -days 11000 -subj "/O=io.enmasse/CN=api-server.${KUBERNETES_NAMESPACE}.svc.cluster.local" -out api-server-cert/tls.crt -keyout api-server-cert/tls.key
 kubectl create secret tls api-server-cert --cert=api-server-cert/tls.crt --key=api-server-cert/tls.key
 
-if [ "$ONLY_PULL_ONCE" = "true" ]; then
-	# disable loading images always when running on travis
-	# we don't get refresh images, so we can speed this up
-	sed -i "s/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g" ${ENMASSE_DIR}/install/*/*/*.yaml
-fi
-
 sed -i "s/enmasse-infra/${KUBERNETES_NAMESPACE}/" ${ENMASSE_DIR}/install/*/*/*.yaml
 kubectl ${KUBE_OPERATION} -f ${ENMASSE_DIR}/install/bundles/enmasse
 kubectl ${KUBE_OPERATION} -f ${ENMASSE_DIR}/install/components/example-plans

--- a/systemtests/src/main/java/io/enmasse/systemtest/cmdclients/CmdClient.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/cmdclients/CmdClient.java
@@ -10,12 +10,17 @@ import io.enmasse.systemtest.executor.ExecutionResultData;
 import io.enmasse.systemtest.executor.Executor;
 import org.slf4j.Logger;
 
+import java.util.Arrays;
 import java.util.List;
 
 public abstract class CmdClient {
     private static Logger log = CustomLogger.getLogger();
     protected static final Object lock = new Object();
     protected static final Environment env = Environment.getInstance();
+
+    protected static ExecutionResultData execute(int timeout, boolean logToOutput, String ...cmd) {
+        return execute(Arrays.asList(cmd),timeout, logToOutput);
+    }
 
     protected static ExecutionResultData execute(List<String> command, int timeout, boolean logToOutput) {
         try {

--- a/systemtests/src/main/java/io/enmasse/systemtest/cmdclients/KubeCMDClient.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/cmdclients/KubeCMDClient.java
@@ -261,6 +261,10 @@ public class KubeCMDClient extends CmdClient {
         return execute(ressourcesCmd, DEFAULT_SYNC_TIMEOUT, true);
     }
 
+    public static ExecutionResultData describePods(String namespace) {
+        return execute(DEFAULT_SYNC_TIMEOUT, true, "kubectl", "-n", namespace, "describe", "pods");
+    }
+
     public static ExecutionResultData createFromFile(String namespace, Path path) {
         Objects.requireNonNull(namespace);
         Objects.requireNonNull(path);

--- a/systemtests/src/main/java/io/enmasse/systemtest/cmdclients/KubeCMDClient.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/cmdclients/KubeCMDClient.java
@@ -6,6 +6,8 @@ package io.enmasse.systemtest.cmdclients;
 
 import io.enmasse.systemtest.CustomLogger;
 import io.enmasse.systemtest.executor.ExecutionResultData;
+import io.fabric8.kubernetes.api.model.Pod;
+
 import org.slf4j.Logger;
 
 import java.io.File;
@@ -106,6 +108,13 @@ public class KubeCMDClient extends CmdClient {
     public static ExecutionResultData getAddress(String namespace) {
         List<String> getCmd = getRessourcesCmd("get", "addresses", namespace, Optional.of("wide"));
         return execute(getCmd, DEFAULT_SYNC_TIMEOUT, true);
+    }
+
+    public static void dumpPodLogs (final Pod pod) {
+        // we cannot use --all-containers, since kubectl is too old
+        for ( var c : pod.getStatus().getContainerStatuses() ) {
+            execute(DEFAULT_SYNC_TIMEOUT, true, CMD, "logs", pod.getMetadata().getName(), "-c", c.getName());
+        }
     }
 
     /**

--- a/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
@@ -151,13 +151,26 @@ public class TestUtils {
      */
     private static int numReady(List<Pod> pods) {
         int numReady = 0;
+
         for (Pod pod : pods) {
-            if ("Running".equals(pod.getStatus().getPhase())) {
-                numReady++;
-            } else {
+            if (!"Running".equals(pod.getStatus().getPhase())) {
                 log.info("POD {} in status : {}", pod.getMetadata().getName(), pod.getStatus().getPhase());
+                continue;
             }
+
+            var nonReadyContainers = pod.getStatus().getContainerStatuses().stream()
+                .filter(cs -> !Boolean.TRUE.equals(cs.getReady()))
+                .map(ContainerStatus::getName)
+                .collect(Collectors.toList());
+
+            if ( !nonReadyContainers.isEmpty()) {
+                log.info("POD {} non-ready containers: [{}]", pod.getMetadata().getName(), String.join(", ", nonReadyContainers));
+                continue;
+            }
+
+            numReady++;
         }
+
         return numReady;
     }
 

--- a/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
@@ -36,6 +36,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 public class TestUtils {
     private static Logger log = CustomLogger.getLogger();
@@ -150,28 +151,31 @@ public class TestUtils {
      * @return
      */
     private static int numReady(List<Pod> pods) {
-        int numReady = 0;
+        return (int)pods.stream().filter(pod -> isPodReady(pod, true)).count();
+    }
 
-        for (Pod pod : pods) {
-            if (!"Running".equals(pod.getStatus().getPhase())) {
+    private static boolean isPodReady(final Pod pod, final boolean doLog) {
+
+        if (!"Running".equals(pod.getStatus().getPhase())) {
+            if (doLog) {
                 log.info("POD {} in status : {}", pod.getMetadata().getName(), pod.getStatus().getPhase());
-                continue;
             }
-
-            var nonReadyContainers = pod.getStatus().getContainerStatuses().stream()
-                .filter(cs -> !Boolean.TRUE.equals(cs.getReady()))
-                .map(ContainerStatus::getName)
-                .collect(Collectors.toList());
-
-            if ( !nonReadyContainers.isEmpty()) {
-                log.info("POD {} non-ready containers: [{}]", pod.getMetadata().getName(), String.join(", ", nonReadyContainers));
-                continue;
-            }
-
-            numReady++;
+            return false;
         }
 
-        return numReady;
+        var nonReadyContainers = pod.getStatus().getContainerStatuses().stream()
+            .filter(cs -> !Boolean.TRUE.equals(cs.getReady()))
+            .map(ContainerStatus::getName)
+            .collect(Collectors.toList());
+
+        if ( !nonReadyContainers.isEmpty()) {
+            if(doLog) {
+                log.info("POD {} non-ready containers: [{}]", pod.getMetadata().getName(), String.join(", ", nonReadyContainers));
+            }
+            return false;
+        }
+
+        return true;
     }
 
     /**
@@ -282,6 +286,17 @@ public class TestUtils {
                 .filter(pod -> pod.getStatus().getContainerStatuses().stream().allMatch(ContainerStatus::getReady)
                         && !pod.getMetadata().getName().startsWith(SystemtestsKubernetesApps.MESSAGING_CLIENTS))
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Get list of all non-ready pods
+     *
+     * @param kubernetes client for manipulation with kubernetes cluster
+     * @return
+     */
+    public static Stream<Pod> streamNonReadyPods(Kubernetes kubernetes, String namespace) {
+        return kubernetes.listPods(namespace).stream()
+                .filter(pod -> !isPodReady(pod, false));
     }
 
     public static List<Pod> listBrokerPods(Kubernetes kubernetes) {

--- a/systemtests/src/test/java/io/enmasse/systemtest/iot/SimpleK8sDeployTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/iot/SimpleK8sDeployTest.java
@@ -150,8 +150,13 @@ public class SimpleK8sDeployTest {
 
         final TimeoutBudget budget = TimeoutBudget.ofDuration(Duration.ofMinutes(5));
 
-        TestUtils.waitUntilCondition("IoT Config to deploy", () -> allDeploymentsPresent(), budget);
-        TestUtils.waitForNReplicas(this.client , EXPECTED_DEPLOYMENTS.length, IOT_LABELS, budget);
+        try {
+            TestUtils.waitUntilCondition("IoT Config to deploy", () -> allDeploymentsPresent(), budget);
+            TestUtils.waitForNReplicas(this.client , EXPECTED_DEPLOYMENTS.length, IOT_LABELS, budget);
+        } catch ( Exception e ) {
+            KubeCMDClient.describePods(NAMESPACE);
+            throw e;
+        }
     }
 
     private boolean allDeploymentsPresent () {

--- a/systemtests/src/test/java/io/enmasse/systemtest/iot/SimpleK8sDeployTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/iot/SimpleK8sDeployTest.java
@@ -64,17 +64,17 @@ public class SimpleK8sDeployTest {
         secrets.put("iot-tenant-service", "systemtests-iot-tenant-service-tls");
         secrets.put("iot-device-registry", "systemtests-iot-device-registry-tls");
 
-        var c64 = new ContainerConfigBuilder()
+        var r1 = new ContainerConfigBuilder()
                 .withNewResources().addToLimits("memory", new Quantity("64Mi")).endResources()
                 .build();
-        var c128 = new ContainerConfigBuilder()
-                .withNewResources().addToLimits("memory", new Quantity("128Mi")).endResources()
+        var r2 = new ContainerConfigBuilder()
+                .withNewResources().addToLimits("memory", new Quantity("256Mi")).endResources()
                 .build();
 
         var commonContainers = new CommonAdapterContainersBuilder()
-                .withNewAdapterLike(c128).endAdapter()
-                .withNewProxyLike(c64).endProxy()
-                .withNewProxyConfiguratorLike(c64).endProxyConfigurator()
+                .withNewAdapterLike(r2).endAdapter()
+                .withNewProxyLike(r1).endProxy()
+                .withNewProxyConfiguratorLike(r1).endProxyConfigurator()
                 .build();
 
         IoTConfig config = new IoTConfigBuilder()
@@ -109,20 +109,20 @@ public class SimpleK8sDeployTest {
                 .withNewServices()
 
                 .withNewAuthentication()
-                .withNewContainerLike(c128).endContainer()
+                .withNewContainerLike(r2).endContainer()
                 .endAuthentication()
 
                 .withNewTenant()
-                .withNewContainerLike(c128).endContainer()
+                .withNewContainerLike(r2).endContainer()
                 .endTenant()
 
                 .withNewCollector()
-                .withNewContainerLike(c64).endContainer()
+                .withNewContainerLike(r1).endContainer()
                 .endCollector()
 
                 .withNewDeviceRegistry()
                 .withNewFile()
-                .withNewContainerLike(c128).endContainer()
+                .withNewContainerLike(r2).endContainer()
                 .endFile()
                 .endDeviceRegistry()
 

--- a/systemtests/src/test/java/io/enmasse/systemtest/iot/SimpleK8sDeployTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/iot/SimpleK8sDeployTest.java
@@ -154,6 +154,7 @@ public class SimpleK8sDeployTest {
             TestUtils.waitUntilCondition("IoT Config to deploy", () -> allDeploymentsPresent(), budget);
             TestUtils.waitForNReplicas(this.client , EXPECTED_DEPLOYMENTS.length, IOT_LABELS, budget);
         } catch ( Exception e ) {
+            TestUtils.streamNonReadyPods(this.client, NAMESPACE).forEach(KubeCMDClient::dumpPodLogs);
             KubeCMDClient.describePods(NAMESPACE);
             throw e;
         }


### PR DESCRIPTION
So it turns out the system tests should have have worked. However the failure to detect "non-ready" containers in the `TestUtils` reported "OK" for the test, although the test was not ok.

The cause for the test to fail was that the hostnames in the plain k8s inter service certificates where generated with `enmasse-infra` instead of `enmasseci`, which is required for running on travis.