### PR TITLE
Trim the Maven reactor of superfluous modules when performing a single module Make build.

### DIFF
--- a/Makefile.java.mk
+++ b/Makefile.java.mk
@@ -1,4 +1,5 @@
 TOPDIR=$(dir $(lastword $(MAKEFILE_LIST)))
+MVNPROJ=$(shell realpath --relative-to="$(realpath $(TOPDIR))" "$(shell pwd)")
 include $(TOPDIR)/Makefile.common
 ifeq ($(SKIP_TESTS),true)
 MAVEN_ARGS="-DskipTests"
@@ -9,7 +10,7 @@ endif
 
 ifneq ($(FULL_BUILD),true)
 build:
-	cd $(TOPDIR); $(IMAGE_ENV) mvn clean install $(MAVEN_ARGS)
+	cd $(TOPDIR); $(IMAGE_ENV) mvn -pl $(MVNPROJ) -am clean install $(MAVEN_ARGS)
 
 test:
 ifeq ($(SKIP_TESTS),true)


### PR DESCRIPTION
For instance,

`make -C address-space-controller  SKIP_TESTS=true`

Now builds just:

```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO]
[INFO] EnMasse
[INFO] api-model
[INFO] metrics-api
[INFO] k8s-api
[INFO] keycloak-user-api
[INFO] k8s-api-testutil
[INFO] address-space-controller

```
rather than all the world.