### PR TITLE
fix maven build warning (duplicate dependency)

### DIFF
--- a/address-space-controller/pom.xml
+++ b/address-space-controller/pom.xml
@@ -34,11 +34,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-jackson2-provider</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>io.enmasse</groupId>
       <artifactId>k8s-api</artifactId>
       <scope>compile</scope>


### PR DESCRIPTION
Fixes build noise...  No functional change.

```
[WARNING]
[WARNING] Some problems were encountered while building the effective model for io.enmasse:address-space-controller:jar:0.27-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.jboss.resteasy:resteasy-jackson2-provider:jar -> duplicate declaration of version (?) @ io.enmasse:address-space-controller:[unknown-version], /Users/keith/go/src/github.com/enmasseproject/enmasse/address-space-controller/pom.xml, line 76, column 17
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```