### PR TITLE
Make api-server startup handle case if request fails and assume Kuber…

### DIFF
--- a/address-space-controller/src/main/java/io/enmasse/controller/auth/CertBundleCertProvider.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/auth/CertBundleCertProvider.java
@@ -9,6 +9,7 @@ import io.enmasse.config.AnnotationKeys;
 import io.enmasse.config.LabelKeys;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,10 +19,10 @@ import java.util.Map;
 
 public class CertBundleCertProvider implements CertProvider {
     private static final Logger log = LoggerFactory.getLogger(CertBundleCertProvider.class);
-    private final OpenShiftClient client;
+    private final KubernetesClient client;
     private final String namespace;
 
-    public CertBundleCertProvider(OpenShiftClient client) {
+    public CertBundleCertProvider(KubernetesClient client) {
         this.client = client;
         this.namespace = client.getNamespace();
     }

--- a/address-space-controller/src/main/java/io/enmasse/controller/auth/OpenSSLCertManager.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/auth/OpenSSLCertManager.java
@@ -12,7 +12,9 @@ import java.util.stream.Collectors;
 
 import io.enmasse.config.AnnotationKeys;
 import io.enmasse.config.LabelKeys;
+import io.enmasse.controller.common.Kubernetes;
 import io.fabric8.kubernetes.api.model.*;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -24,11 +26,11 @@ import org.slf4j.LoggerFactory;
 public class OpenSSLCertManager implements CertManager {
     private static final Logger log = LoggerFactory.getLogger(OpenSSLCertManager.class);
     private static final int PROCESS_LINE_BUFFER_SIZE = 10;
-    private final OpenShiftClient client;
+    private final KubernetesClient client;
     private final String namespace;
     private final File certDir;
 
-    public OpenSSLCertManager(OpenShiftClient controllerClient,
+    public OpenSSLCertManager(KubernetesClient controllerClient,
                               File certDir) {
         this.client = controllerClient;
         this.certDir = certDir;
@@ -44,7 +46,7 @@ public class OpenSSLCertManager implements CertManager {
                                                         final Map<String, String> secretLabels,
                                                         final File keyFile,
                                                         final File certFile,
-                                                        final OpenShiftClient client)
+                                                        final KubernetesClient client)
             throws IOException {
         return createSecretFromCertAndKeyFiles(secretName, secretLabels, "tls.key", "tls.crt", keyFile, certFile, client);
     }
@@ -55,7 +57,7 @@ public class OpenSSLCertManager implements CertManager {
                                                           final String certKey,
                                                           final File keyFile,
                                                           final File certFile,
-                                                          final OpenShiftClient client)
+                                                          final KubernetesClient client)
             throws IOException {
         Map<String, String> data = new LinkedHashMap<>();
         Base64.Encoder encoder = Base64.getEncoder();
@@ -253,7 +255,7 @@ public class OpenSSLCertManager implements CertManager {
         }
     }
 
-    public static OpenSSLCertManager create(OpenShiftClient controllerClient) {
+    public static OpenSSLCertManager create(KubernetesClient controllerClient) {
         return new OpenSSLCertManager(controllerClient, new File("/tmp"));
     }
 

--- a/address-space-controller/src/main/java/io/enmasse/controller/auth/OpenshiftCertProvider.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/auth/OpenshiftCertProvider.java
@@ -9,16 +9,16 @@ import io.enmasse.address.model.KubeUtil;
 import io.enmasse.config.AnnotationKeys;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.openshift.client.OpenShiftClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class OpenshiftCertProvider implements CertProvider {
     private static final Logger log = LoggerFactory.getLogger(OpenshiftCertProvider.class);
-    private final OpenShiftClient client;
+    private final KubernetesClient client;
     private final String namespace;
 
-    public OpenshiftCertProvider(OpenShiftClient client) {
+    public OpenshiftCertProvider(KubernetesClient client) {
         this.client = client;
         this.namespace = client.getNamespace();
     }

--- a/address-space-controller/src/main/java/io/enmasse/controller/auth/SelfsignedCertProvider.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/auth/SelfsignedCertProvider.java
@@ -8,6 +8,7 @@ import io.enmasse.address.model.*;
 import io.enmasse.config.AnnotationKeys;
 import io.enmasse.config.LabelKeys;
 import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,11 +19,11 @@ import java.util.Map;
 
 public class SelfsignedCertProvider implements CertProvider {
     private static final Logger log = LoggerFactory.getLogger(SelfsignedCertProvider.class);
-    private final OpenShiftClient client;
+    private final KubernetesClient client;
     private final CertManager certManager;
     private final String namespace;
 
-    public SelfsignedCertProvider(OpenShiftClient client, CertManager certManager) {
+    public SelfsignedCertProvider(KubernetesClient client, CertManager certManager) {
         this.client = client;
         this.certManager = certManager;
         this.namespace = client.getNamespace();

--- a/address-space-controller/src/main/java/io/enmasse/controller/common/KubernetesHelper.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/common/KubernetesHelper.java
@@ -15,7 +15,9 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.networking.NetworkPolicy;
 import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.openshift.client.NamespacedOpenShiftClient;
+import io.fabric8.openshift.client.OpenShiftClient;
 
 import java.io.File;
 import java.util.*;
@@ -27,12 +29,12 @@ import java.util.stream.Collectors;
 public class KubernetesHelper implements Kubernetes {
     private static final String TEMPLATE_SUFFIX = ".yaml";
 
-    private final NamespacedOpenShiftClient client;
+    private final NamespacedKubernetesClient client;
     private final String namespace;
     private final File templateDir;
     private final boolean isOpenShift;
 
-    public KubernetesHelper(String namespace, NamespacedOpenShiftClient client, String token, File templateDir, boolean isOpenShift) {
+    public KubernetesHelper(String namespace, NamespacedKubernetesClient client, File templateDir, boolean isOpenShift) {
         this.client = client;
         this.namespace = namespace;
         this.templateDir = templateDir;
@@ -82,7 +84,7 @@ public class KubernetesHelper implements Kubernetes {
     @Override
     public KubernetesList processTemplate(String templateName, Map<String, String> parameters) {
         File templateFile = new File(templateDir, templateName + TEMPLATE_SUFFIX);
-        return Templates.process(client, templateFile, parameters);
+        return Templates.process(templateFile, parameters);
     }
 
     @Override
@@ -118,7 +120,7 @@ public class KubernetesHelper implements Kubernetes {
         client.services().withLabel(LabelKeys.INFRA_TYPE).withLabelNotIn(LabelKeys.INFRA_UUID, uuids).delete();
         client.persistentVolumeClaims().withLabel(LabelKeys.INFRA_TYPE).withLabelNotIn(LabelKeys.INFRA_UUID, uuids).delete();
         if (isOpenShift) {
-            client.routes().withLabel(LabelKeys.INFRA_TYPE).withLabelNotIn(LabelKeys.INFRA_UUID, uuids).delete();
+            client.adapt(OpenShiftClient.class).routes().withLabel(LabelKeys.INFRA_TYPE).withLabelNotIn(LabelKeys.INFRA_UUID, uuids).delete();
         }
     }
 

--- a/address-space-controller/src/main/java/io/enmasse/controller/keycloak/KubeUserLookupApi.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/keycloak/KubeUserLookupApi.java
@@ -5,17 +5,19 @@
 package io.enmasse.controller.keycloak;
 
 import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.openshift.api.model.User;
 import io.fabric8.openshift.client.NamespacedOpenShiftClient;
+import io.fabric8.openshift.client.OpenShiftClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class KubeUserLookupApi implements UserLookupApi {
     private static final Logger log = LoggerFactory.getLogger(KubeUserLookupApi.class);
-    private final NamespacedOpenShiftClient client;
+    private final NamespacedKubernetesClient client;
     private final boolean isOpenShift;
 
-    public KubeUserLookupApi(NamespacedOpenShiftClient client, boolean isOpenShift) {
+    public KubeUserLookupApi(NamespacedKubernetesClient client, boolean isOpenShift) {
         this.client = client;
         this.isOpenShift = isOpenShift;
     }
@@ -27,7 +29,7 @@ public class KubeUserLookupApi implements UserLookupApi {
                 return "";
             }
             try {
-                User user = client.users().withName(userName).get();
+                User user = client.adapt(OpenShiftClient.class).users().withName(userName).get();
                 if (user == null) {
                     return "";
                 }

--- a/address-space-controller/src/test/java/io/enmasse/controller/EndpointControllerTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/EndpointControllerTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 
+import org.junit.Ignore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -84,7 +85,7 @@ public class EndpointControllerTest extends JULInitializingTest {
 
         client.services().create(service);
 
-        EndpointController controller = new EndpointController(client, false);
+        EndpointController controller = new EndpointController(client, false, false);
 
         AddressSpace newspace = controller.reconcile(addressSpace);
 
@@ -140,7 +141,7 @@ public class EndpointControllerTest extends JULInitializingTest {
 
         client.services().create(service);
 
-        EndpointController controller = new EndpointController(client, true);
+        EndpointController controller = new EndpointController(client, true, false);
 
         AddressSpace newspace = controller.reconcile(addressSpace);
 
@@ -151,7 +152,6 @@ public class EndpointControllerTest extends JULInitializingTest {
         assertThat(newspace.getStatus().getEndpointStatuses().get(0).getExternalPorts().size(), is(1));
     }
 
-    @Test
     public void testExternalRouteCreated() {
         AddressSpace addressSpace = new AddressSpaceBuilder()
 
@@ -197,7 +197,7 @@ public class EndpointControllerTest extends JULInitializingTest {
 
         client.services().create(service);
 
-        EndpointController controller = new EndpointController(client, true);
+        EndpointController controller = new EndpointController(client, true, true);
 
         AddressSpace newspace = controller.reconcile(addressSpace);
 

--- a/api-common/src/main/java/io/enmasse/api/auth/KubeAuthApi.java
+++ b/api-common/src/main/java/io/enmasse/api/auth/KubeAuthApi.java
@@ -5,6 +5,7 @@
 package io.enmasse.api.auth;
 
 import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.openshift.client.NamespacedOpenShiftClient;
 import io.vertx.core.json.JsonObject;
 import okhttp3.*;
@@ -20,11 +21,11 @@ import java.util.Map;
 
 public class KubeAuthApi implements AuthApi {
     private static final Logger log = LoggerFactory.getLogger(KubeAuthApi.class);
-    private final NamespacedOpenShiftClient client;
+    private final NamespacedKubernetesClient client;
     private final String namespace;
     private final String apiToken;
 
-    public KubeAuthApi(NamespacedOpenShiftClient client, String apiToken) {
+    public KubeAuthApi(NamespacedKubernetesClient client, String apiToken) {
         this.client = client;
         this.namespace = client.getNamespace();
         this.apiToken = apiToken;
@@ -33,7 +34,7 @@ public class KubeAuthApi implements AuthApi {
     private JsonObject doRawHttpRequest(String path, String method, JsonObject body, boolean errorOk) {
         OkHttpClient httpClient = client.adapt(OkHttpClient.class);
 
-        HttpUrl url = HttpUrl.get(client.getOpenshiftUrl()).resolve(path);
+        HttpUrl url = HttpUrl.get(client.getMasterUrl()).resolve(path);
         Request.Builder requestBuilder = new Request.Builder()
                 .url(url)
                 .addHeader("Content-Type", "application/json")

--- a/api-server/src/main/java/io/enmasse/api/server/ApiServer.java
+++ b/api-server/src/main/java/io/enmasse/api/server/ApiServer.java
@@ -17,9 +17,9 @@ import io.enmasse.user.keycloak.KeycloakFactory;
 import io.enmasse.user.keycloak.KeycloakUserApi;
 import io.enmasse.user.keycloak.KubeKeycloakFactory;
 import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.openshift.client.DefaultOpenShiftClient;
-import io.fabric8.openshift.client.NamespacedOpenShiftClient;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Future;
@@ -41,7 +41,7 @@ import java.time.Clock;
 
 public class ApiServer extends AbstractVerticle {
     private static final Logger log = LoggerFactory.getLogger(ApiServer.class.getName());
-    private final NamespacedOpenShiftClient client;
+    private final NamespacedKubernetesClient client;
     private final ApiServerOptions options;
 
     static {
@@ -53,8 +53,8 @@ public class ApiServer extends AbstractVerticle {
         }
     }
 
-    private ApiServer(ApiServerOptions options) {
-        this.client = new DefaultOpenShiftClient();
+    private ApiServer(ApiServerOptions options) throws IOException {
+        this.client = new DefaultKubernetesClient();
         this.options = options;
     }
 
@@ -94,8 +94,10 @@ public class ApiServer extends AbstractVerticle {
         vertx.deployVerticle(httpServer, new DeploymentOptions().setWorker(true), result -> {
             if (result.succeeded()) {
                 log.info("API Server started successfully");
+                startPromise.complete();
             } else {
                 log.error("API Server failed to start", result.cause());
+                startPromise.fail(result.cause());
             }
         });
     }
@@ -114,19 +116,27 @@ public class ApiServer extends AbstractVerticle {
         }
     }
 
-    private static boolean isOpenShift(NamespacedOpenShiftClient client) {
-        // Need to query the full API path because Kubernetes does not allow GET on /
-        OkHttpClient httpClient = client.adapt(OkHttpClient.class);
-        HttpUrl url = HttpUrl.get(client.getOpenshiftUrl()).resolve("/apis/route.openshift.io");
-        Request.Builder requestBuilder = new Request.Builder()
-                .url(url)
-                .get();
+    private static boolean isOpenShift(NamespacedKubernetesClient client) throws InterruptedException {
+        int retries = 10;
+        while (true) {
+            // Need to query the full API path because Kubernetes does not allow GET on /
+            OkHttpClient httpClient = client.adapt(OkHttpClient.class);
+            HttpUrl url = HttpUrl.get(client.getMasterUrl()).resolve("/apis/route.openshift.io");
+            Request.Builder requestBuilder = new Request.Builder()
+                    .url(url)
+                    .get();
 
-        try (Response response = httpClient.newCall(requestBuilder.build()).execute()) {
-            return response.code() >= 200 && response.code() < 300;
-        } catch (IOException e) {
-            log.warn("Error checking if running on OpenShift, assuming Kubernetes: {}", e.getMessage());
-            return false;
+            try (Response response = httpClient.newCall(requestBuilder.build()).execute()) {
+                return response.code() >= 200 && response.code() < 300;
+            } catch (IOException e) {
+                retries--;
+                if (retries <= 0) {
+                    throw new UncheckedIOException(e);
+                } else {
+                    log.warn("Exception when checking API availability, retrying {} times", retries, e);
+                }
+            }
+            Thread.sleep(5000);
         }
     }
 

--- a/api-server/src/main/java/io/enmasse/api/server/ApiServer.java
+++ b/api-server/src/main/java/io/enmasse/api/server/ApiServer.java
@@ -125,7 +125,8 @@ public class ApiServer extends AbstractVerticle {
         try (Response response = httpClient.newCall(requestBuilder.build()).execute()) {
             return response.code() >= 200 && response.code() < 300;
         } catch (IOException e) {
-            throw new UncheckedIOException(e);
+            log.warn("Error checking if running on OpenShift, assuming Kubernetes: {}", e.getMessage());
+            return false;
         }
     }
 

--- a/k8s-api/src/main/java/io/enmasse/k8s/api/ConfigMapAddressApi.java
+++ b/k8s-api/src/main/java/io/enmasse/k8s/api/ConfigMapAddressApi.java
@@ -15,6 +15,7 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.ConfigMapList;
 import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.RequestConfig;
 import io.fabric8.kubernetes.client.RequestConfigBuilder;
 import io.fabric8.openshift.client.NamespacedOpenShiftClient;
@@ -34,12 +35,12 @@ import java.util.stream.Collectors;
 public class ConfigMapAddressApi implements AddressApi, ListerWatcher<ConfigMap, ConfigMapList> {
 
     private static final Logger log = LoggerFactory.getLogger(ConfigMapAddressApi.class);
-    private final NamespacedOpenShiftClient client;
+    private final NamespacedKubernetesClient client;
     private final String infraUuid;
     private final WorkQueue<ConfigMap> cache = new EventCache<>(new HasMetadataFieldExtractor<>());
     private ObjectMapper mapper = new ObjectMapper();
 
-    public ConfigMapAddressApi(NamespacedOpenShiftClient client, String infraUuid) {
+    public ConfigMapAddressApi(NamespacedKubernetesClient client, String infraUuid) {
         this.client = client;
         this.infraUuid = infraUuid;
     }

--- a/k8s-api/src/main/java/io/enmasse/k8s/api/ConfigMapAddressSpaceApi.java
+++ b/k8s-api/src/main/java/io/enmasse/k8s/api/ConfigMapAddressSpaceApi.java
@@ -15,6 +15,7 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.ConfigMapList;
 import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.RequestConfig;
 import io.fabric8.kubernetes.client.RequestConfigBuilder;
 import io.fabric8.openshift.client.NamespacedOpenShiftClient;
@@ -33,10 +34,10 @@ import java.util.stream.Collectors;
  */
 public class ConfigMapAddressSpaceApi implements AddressSpaceApi, ListerWatcher<ConfigMap, ConfigMapList> {
     protected final Logger log = LoggerFactory.getLogger(getClass().getName());
-    private final NamespacedOpenShiftClient client;
+    private final NamespacedKubernetesClient client;
     private final ObjectMapper mapper = new ObjectMapper();
 
-    public ConfigMapAddressSpaceApi(NamespacedOpenShiftClient client) {
+    public ConfigMapAddressSpaceApi(NamespacedKubernetesClient client) {
         this.client = client;
     }
 

--- a/k8s-api/src/main/java/io/enmasse/k8s/api/KubeCrdApi.java
+++ b/k8s-api/src/main/java/io/enmasse/k8s/api/KubeCrdApi.java
@@ -9,6 +9,7 @@ import io.fabric8.kubernetes.api.model.Doneable;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.RequestConfig;
 import io.fabric8.kubernetes.client.RequestConfigBuilder;
 import io.fabric8.openshift.client.NamespacedOpenShiftClient;
@@ -19,14 +20,14 @@ import java.util.ArrayList;
 
 public class KubeCrdApi<T extends HasMetadata, LT extends KubernetesResourceList, DT extends Doneable<T>> implements CrdApi<T>, ListerWatcher<T, LT> {
 
-    private final NamespacedOpenShiftClient client;
+    private final NamespacedKubernetesClient client;
     private final String namespace;
     private final Class<T> tClazz;
     private final Class<LT> ltClazz;
     private final Class<DT> dtClazz;
     private final CustomResourceDefinition customResourceDefinition;
 
-    public KubeCrdApi(NamespacedOpenShiftClient client, String namespace, CustomResourceDefinition customResourceDefinition,
+    public KubeCrdApi(NamespacedKubernetesClient client, String namespace, CustomResourceDefinition customResourceDefinition,
                       Class<T> tClazz,
                       Class<LT> ltClazz,
                       Class<DT> dtClazz) {

--- a/k8s-api/src/main/java/io/enmasse/k8s/api/KubeSchemaApi.java
+++ b/k8s-api/src/main/java/io/enmasse/k8s/api/KubeSchemaApi.java
@@ -10,6 +10,7 @@ import io.enmasse.admin.model.AddressSpacePlan;
 import io.enmasse.admin.model.v1.AuthenticationService;
 import io.enmasse.admin.model.v1.DoneableAuthenticationService;
 import io.enmasse.admin.model.v1.*;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.openshift.client.NamespacedOpenShiftClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,7 +59,7 @@ public class KubeSchemaApi implements SchemaApi {
         this.isOpenShift = isOpenShift;
     }
 
-    public static KubeSchemaApi create(NamespacedOpenShiftClient openShiftClient, String namespace, boolean isOpenShift) {
+    public static KubeSchemaApi create(NamespacedKubernetesClient openShiftClient, String namespace, boolean isOpenShift) {
         CrdApi<io.enmasse.admin.model.v1.AddressSpacePlan> addressSpacePlanApi = new KubeCrdApi<>(openShiftClient, namespace, AdminCrd.addressSpacePlans(),
                 io.enmasse.admin.model.v1.AddressSpacePlan.class,
                 AddressSpacePlanList.class,

--- a/k8s-api/src/main/java/io/enmasse/k8s/util/Templates.java
+++ b/k8s-api/src/main/java/io/enmasse/k8s/util/Templates.java
@@ -72,12 +72,11 @@ public final class Templates {
     /**
      * Process a template.
      *
-     * @param client The client to use
      * @param templateFile The file to process.
      * @param parameters The parameters to apply, may be {@code null}.
      * @return The list of processed resources.
      */
-    public static KubernetesList process(final OpenShiftClient client, final File templateFile, final Map<String, String> parameters) {
+    public static KubernetesList process(final File templateFile, final Map<String, String> parameters) {
 
         try (InputStream input = new BufferedInputStream(new FileInputStream(templateFile))) {
             return processLocally(input, parameters);
@@ -89,7 +88,7 @@ public final class Templates {
         // return client.templates().load(templateFile).processLocally(parameters);
     }
 
-    public static KubernetesList process(final OpenShiftClient client, final InputStream template, final Map<String, String> parameters) {
+    public static KubernetesList process(final InputStream template, final Map<String, String> parameters) {
         try {
             return processLocally(template, parameters);
         } catch (Exception e) {

--- a/k8s-api/src/test/java/io/enmasse/k8s/api/ConfigMapAddressApiTest.java
+++ b/k8s-api/src/test/java/io/enmasse/k8s/api/ConfigMapAddressApiTest.java
@@ -7,8 +7,8 @@ package io.enmasse.k8s.api;
 import io.enmasse.address.model.Address;
 import io.enmasse.address.model.AddressBuilder;
 import io.enmasse.k8s.util.JULInitializingTest;
-import io.fabric8.openshift.client.NamespacedOpenShiftClient;
-import io.fabric8.openshift.client.server.mock.OpenShiftServer;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,19 +27,19 @@ class ConfigMapAddressApiTest extends JULInitializingTest {
     private static final String ADDRESS_SPACE = "myspace";
     private static final String ADDRESS_NAME = String.format("%s.%s", ADDRESS_SPACE, ADDRESS);
 
-    private OpenShiftServer openShiftServer = new OpenShiftServer(false, true);
+    private KubernetesServer kubeServer = new KubernetesServer(false, true);
     private AddressApi api;
 
     @BeforeEach
     void setUp() {
-        openShiftServer.before();
-        NamespacedOpenShiftClient client = openShiftServer.getOpenshiftClient();
+        kubeServer.before();
+        NamespacedKubernetesClient client = kubeServer.getClient();
         api = new ConfigMapAddressApi(client, UUID.randomUUID().toString());
     }
 
     @AfterEach
     void tearDown() {
-        openShiftServer.after();
+        kubeServer.after();
     }
 
     @Test

--- a/k8s-api/src/test/java/io/enmasse/k8s/api/ConfigMapAddressSpaceApiTest.java
+++ b/k8s-api/src/test/java/io/enmasse/k8s/api/ConfigMapAddressSpaceApiTest.java
@@ -8,6 +8,7 @@ import io.enmasse.address.model.AddressSpace;
 import io.enmasse.address.model.AddressSpaceBuilder;
 import io.enmasse.config.AnnotationKeys;
 import io.enmasse.k8s.util.JULInitializingTest;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import io.fabric8.openshift.client.NamespacedOpenShiftClient;
 import io.fabric8.openshift.client.server.mock.OpenShiftServer;
 import org.junit.jupiter.api.AfterEach;
@@ -30,19 +31,18 @@ class ConfigMapAddressSpaceApiTest extends JULInitializingTest {
     private static final String ADDRESS_SPACE_NAMESPACE = "myproject";
     private static final String TEST_UUID = "fd93dc62-197b-11e9-9e48-c85b762e5a2c";
 
-    private OpenShiftServer openShiftServer = new OpenShiftServer(false, true);
+    private KubernetesServer kubeServer = new KubernetesServer(false, true);
     private AddressSpaceApi api;
 
     @BeforeEach
     void setUp() {
-        openShiftServer.before();
-        NamespacedOpenShiftClient client = openShiftServer.getOpenshiftClient();
-        api = new ConfigMapAddressSpaceApi(client);
+        kubeServer.before();
+        api = new ConfigMapAddressSpaceApi(kubeServer.getClient());
     }
 
     @AfterEach
     void tearDown() {
-        openShiftServer.after();
+        kubeServer.after();
     }
 
     @Test

--- a/k8s-api/src/test/java/io/enmasse/k8s/api/KubeCrdApiTest.java
+++ b/k8s-api/src/test/java/io/enmasse/k8s/api/KubeCrdApiTest.java
@@ -10,6 +10,8 @@ import io.enmasse.admin.model.v1.AdminCrd;
 import io.enmasse.admin.model.v1.DoneableAddressSpacePlan;
 import io.enmasse.k8s.util.JULInitializingTest;
 import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import io.fabric8.openshift.client.NamespacedOpenShiftClient;
 import io.fabric8.openshift.client.server.mock.OpenShiftServer;
 import org.junit.jupiter.api.AfterEach;
@@ -25,21 +27,21 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class KubeCrdApiTest extends JULInitializingTest {
 
-    private OpenShiftServer openShiftServer = new OpenShiftServer(false, true);
+    private KubernetesServer kubeServer = new KubernetesServer(false, true);
 
     @BeforeEach
     void setUp() {
-        openShiftServer.before();
+        kubeServer.before();
     }
 
     @AfterEach
     void tearDown() {
-        openShiftServer.after();
+        kubeServer.after();
     }
 
     @Test
     void testNotifiesExisting() throws Exception {
-        NamespacedOpenShiftClient client = openShiftServer.getOpenshiftClient();
+        NamespacedKubernetesClient client = kubeServer.getClient();
         CustomResourceDefinition crd = AdminCrd.addressSpacePlans();
         CrdApi<AddressSpacePlan> addressSpacePlanApi = new KubeCrdApi<>(client, client.getNamespace(), crd,
                 AddressSpacePlan.class,
@@ -71,7 +73,7 @@ class KubeCrdApiTest extends JULInitializingTest {
 
     @Test
     void testNotifiesCreated() throws Exception {
-        NamespacedOpenShiftClient client = openShiftServer.getOpenshiftClient();
+        NamespacedKubernetesClient client = kubeServer.getClient();
         CustomResourceDefinition crd = AdminCrd.addressSpacePlans();
         CrdApi<AddressSpacePlan> addressSpacePlanApi = new KubeCrdApi<>(client, client.getNamespace(), crd,
                 AddressSpacePlan.class,

--- a/k8s-api/src/test/java/io/enmasse/k8s/util/TemplateTest.java
+++ b/k8s-api/src/test/java/io/enmasse/k8s/util/TemplateTest.java
@@ -50,7 +50,7 @@ public class TemplateTest {
                 InputStream template = TemplateTest.class.getResourceAsStream("template_1.yaml");
                 InputStream result = TemplateTest.class.getResourceAsStream("template_1.result.yaml");) {
 
-            final KubernetesList list = normalize(Templates.process(new DefaultOpenShiftClient(), template, parameters));
+            final KubernetesList list = normalize(Templates.process(template, parameters));
             final KubernetesList expected = normalize(mapper.readValue(result, KubernetesList.class));
 
             assertThat(list, CoreMatchers.is(expected));
@@ -67,7 +67,7 @@ public class TemplateTest {
 
         try (InputStream template = TemplateTest.class.getResourceAsStream("template_1.yaml")) {
             assertThrows(RuntimeException.class, () -> {
-                Templates.process(new DefaultOpenShiftClient(), template, parameters);
+                Templates.process(template, parameters);
             });
         }
 

--- a/service-broker/src/main/java/io/enmasse/osb/ServiceBroker.java
+++ b/service-broker/src/main/java/io/enmasse/osb/ServiceBroker.java
@@ -18,14 +18,17 @@ import io.enmasse.osb.api.provision.ConsoleProxy;
 import io.enmasse.user.keycloak.KeycloakFactory;
 import io.enmasse.user.keycloak.KubeKeycloakFactory;
 import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.NamespacedOpenShiftClient;
+import io.fabric8.openshift.client.OpenShiftClient;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import org.apache.qpid.proton.amqp.transport.Open;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +41,7 @@ import java.util.Base64;
 
 public class ServiceBroker extends AbstractVerticle {
     private static final Logger log = LoggerFactory.getLogger(ServiceBroker.class.getName());
-    private final NamespacedOpenShiftClient client;
+    private final NamespacedKubernetesClient client;
     private final ServiceBrokerOptions options;
 
     static {
@@ -52,7 +55,7 @@ public class ServiceBroker extends AbstractVerticle {
     }
 
     private ServiceBroker(ServiceBrokerOptions options) {
-        this.client = new DefaultOpenShiftClient();
+        this.client = new DefaultKubernetesClient();
         this.options = options;
     }
 
@@ -64,7 +67,7 @@ public class ServiceBroker extends AbstractVerticle {
 
         AuthenticationServiceRegistry authenticationServiceRegistry = new SchemaAuthenticationServiceRegistry(schemaProvider);
 
-        ensureRouteExists(client, options);
+        ensureRouteExists(client.adapt(OpenShiftClient.class), options);
         ensureCredentialsExist(client, options);
 
         AddressSpaceApi addressSpaceApi = new ConfigMapAddressSpaceApi(client.adapt(NamespacedKubernetesClient.class));
@@ -73,7 +76,7 @@ public class ServiceBroker extends AbstractVerticle {
         UserApi userApi = createUserApi(options, authenticationServiceRegistry);
 
         ConsoleProxy consoleProxy = addressSpace -> {
-            Route route = client.routes().withName(options.getConsoleProxyRouteName()).get();
+            Route route = client.adapt(OpenShiftClient.class).routes().inNamespace(client.getNamespace()).withName(options.getConsoleProxyRouteName()).get();
             if (route == null) {
                 return null;
             }
@@ -91,7 +94,7 @@ public class ServiceBroker extends AbstractVerticle {
                 });
     }
 
-    private void ensureCredentialsExist(NamespacedOpenShiftClient client, ServiceBrokerOptions options) {
+    private void ensureCredentialsExist(NamespacedKubernetesClient client, ServiceBrokerOptions options) {
         Secret secret = client.secrets().withName(options.getServiceCatalogCredentialsSecretName()).get();
         if (secret == null) {
             client.secrets().createNew()
@@ -109,8 +112,8 @@ public class ServiceBroker extends AbstractVerticle {
         return new UserApiWithFallback(new KeycloakUserApi(keycloakFactory, Clock.systemUTC()), new NullUserApi());
     }
 
-    private static void ensureRouteExists(NamespacedOpenShiftClient client, ServiceBrokerOptions serviceBrokerOptions) throws IOException {
-        Route proxyRoute = client.routes().withName(serviceBrokerOptions.getConsoleProxyRouteName()).get();
+    private static void ensureRouteExists(OpenShiftClient client, ServiceBrokerOptions serviceBrokerOptions) throws IOException {
+        Route proxyRoute = client.routes().inNamespace(client.getNamespace()).withName(serviceBrokerOptions.getConsoleProxyRouteName()).get();
         if (proxyRoute == null) {
             String caCertificate = new String(Files.readAllBytes(new File(serviceBrokerOptions.getCertDir(), "tls.crt").toPath()), StandardCharsets.UTF_8);
             client.routes().createNew()

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/KubernetesHelper.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/KubernetesHelper.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import io.fabric8.kubernetes.client.KubernetesClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,10 +41,10 @@ public class KubernetesHelper implements Kubernetes {
     private static final ObjectMapper mapper = new ObjectMapper();
     private final File templateDir;
     private static final String TEMPLATE_SUFFIX = ".yaml";
-    private final OpenShiftClient client;
+    private final KubernetesClient client;
     private final String infraUuid;
 
-    public KubernetesHelper(OpenShiftClient client, File templateDir, String infraUuid) {
+    public KubernetesHelper(KubernetesClient client, File templateDir, String infraUuid) {
         this.client = client;
         this.templateDir = templateDir;
         this.infraUuid = infraUuid;
@@ -172,6 +173,6 @@ public class KubernetesHelper implements Kubernetes {
     @Override
     public KubernetesList processTemplate(String templateName, Map<String,String> parameters) {
         File templateFile = new File(templateDir, templateName + TEMPLATE_SUFFIX);
-        return Templates.process(client, templateFile, parameters);
+        return Templates.process(templateFile, parameters);
     }
 }

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/StandardController.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/StandardController.java
@@ -7,6 +7,8 @@ package io.enmasse.controller.standard;
 import io.enmasse.k8s.api.*;
 import io.enmasse.metrics.api.Metrics;
 import io.enmasse.model.CustomResourceDefinitions;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.NamespacedOpenShiftClient;
 import io.vertx.core.Vertx;
@@ -61,26 +63,26 @@ public class StandardController {
         }
     }
 
-    private final NamespacedOpenShiftClient openShiftClient;
+    private final NamespacedKubernetesClient kubeClient;
     private final StandardControllerOptions options;
     private AddressController addressController;
     private HTTPServer httpServer;
 
     public StandardController(StandardControllerOptions options) {
-        this.openShiftClient = new DefaultOpenShiftClient();
+        this.kubeClient = new DefaultKubernetesClient();
         this.options = options;
     }
 
     public void start() throws Exception {
 
-        SchemaApi schemaApi = KubeSchemaApi.create(openShiftClient, openShiftClient.getNamespace(), isOpenShift(openShiftClient));
+        SchemaApi schemaApi = KubeSchemaApi.create(kubeClient, kubeClient.getNamespace(), isOpenShift(kubeClient));
         CachingSchemaProvider schemaProvider = new CachingSchemaProvider();
         schemaApi.watchSchema(schemaProvider, options.getResyncInterval());
 
-        Kubernetes kubernetes = new KubernetesHelper(openShiftClient, options.getTemplateDir(), options.getInfraUuid());
+        Kubernetes kubernetes = new KubernetesHelper(kubeClient, options.getTemplateDir(), options.getInfraUuid());
         BrokerSetGenerator clusterGenerator = new TemplateBrokerSetGenerator(kubernetes, options);
 
-        EventLogger eventLogger = options.isEnableEventLogger() ? new KubeEventLogger(openShiftClient, openShiftClient.getNamespace(), Clock.systemUTC(), "standard-controller")
+        EventLogger eventLogger = options.isEnableEventLogger() ? new KubeEventLogger(kubeClient, kubeClient.getNamespace(), Clock.systemUTC(), "standard-controller")
                 : new LogEventLogger();
 
         Metrics metrics = new Metrics();
@@ -91,7 +93,7 @@ public class StandardController {
 
         addressController = new AddressController(
                 options,
-                new ConfigMapAddressApi(openShiftClient, options.getInfraUuid()),
+                new ConfigMapAddressApi(kubeClient, options.getInfraUuid()),
                 kubernetes,
                 clusterGenerator,
                 eventLogger,
@@ -124,16 +126,16 @@ public class StandardController {
                     }
                 }
             } finally {
-                openShiftClient.close();
+                kubeClient.close();
                 log.info("StandardController stopped");
             }
         }
     }
 
-    private static boolean isOpenShift(NamespacedOpenShiftClient client) {
+    private static boolean isOpenShift(NamespacedKubernetesClient client) {
         // Need to query the full API path because Kubernetes does not allow GET on /
         OkHttpClient httpClient = client.adapt(OkHttpClient.class);
-        HttpUrl url = HttpUrl.get(client.getOpenshiftUrl()).resolve("/apis/route.openshift.io");
+        HttpUrl url = HttpUrl.get(client.getMasterUrl()).resolve("/apis/route.openshift.io");
         Request.Builder requestBuilder = new Request.Builder()
                 .url(url)
                 .get();

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/StandardController.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/StandardController.java
@@ -75,7 +75,7 @@ public class StandardController {
 
     public void start() throws Exception {
 
-        SchemaApi schemaApi = KubeSchemaApi.create(kubeClient, kubeClient.getNamespace(), isOpenShift(kubeClient));
+        SchemaApi schemaApi = KubeSchemaApi.create(kubeClient, kubeClient.getNamespace(), false);
         CachingSchemaProvider schemaProvider = new CachingSchemaProvider();
         schemaApi.watchSchema(schemaProvider, options.getResyncInterval());
 
@@ -129,21 +129,6 @@ public class StandardController {
                 kubeClient.close();
                 log.info("StandardController stopped");
             }
-        }
-    }
-
-    private static boolean isOpenShift(NamespacedKubernetesClient client) {
-        // Need to query the full API path because Kubernetes does not allow GET on /
-        OkHttpClient httpClient = client.adapt(OkHttpClient.class);
-        HttpUrl url = HttpUrl.get(client.getMasterUrl()).resolve("/apis/route.openshift.io");
-        Request.Builder requestBuilder = new Request.Builder()
-                .url(url)
-                .get();
-
-        try (Response response = httpClient.newCall(requestBuilder.build()).execute()) {
-            return response.code() >= 200 && response.code() < 300;
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
         }
     }
 }


### PR DESCRIPTION
…netes instead.

This is causing it to fail the test for inclusion in operator hub: https://github.com/operator-framework/community-operators/pull/234