### PR TITLE
Align the Java API with the Go API

### DIFF
--- a/api-model/src/main/java/io/enmasse/iot/model/v1/AddressConfig.java
+++ b/api-model/src/main/java/io/enmasse/iot/model/v1/AddressConfig.java
@@ -2,9 +2,8 @@
  * Copyright 2019, EnMasse authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.enmasse.iot.model.v1;
 
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+package io.enmasse.iot.model.v1;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -20,26 +19,22 @@ import io.sundr.builder.annotations.Inline;
                 type = Doneable.class,
                 prefix = "Doneable",
                 value = "done"))
-@JsonInclude(NON_NULL)
-public class ManagedDownstreamStrategy {
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AddressConfig {
 
-    private AddressSpaceConfig addressSpace;
-    private AddressesConfig addresses;
+    private String plan;
 
-    public AddressSpaceConfig getAddressSpace() {
-        return addressSpace;
+    public AddressConfig() {}
+
+    public AddressConfig(String plan) {
+        this.plan = plan;
     }
 
-    public void setAddressSpace(AddressSpaceConfig addressSpace) {
-        this.addressSpace = addressSpace;
+    public String getPlan() {
+        return plan;
     }
 
-    public AddressesConfig getAddresses() {
-        return addresses;
+    public void setPlan(String plan) {
+        this.plan = plan;
     }
-
-    public void setAddresses(AddressesConfig addresses) {
-        this.addresses = addresses;
-    }
-
 }

--- a/api-model/src/main/java/io/enmasse/iot/model/v1/AddressSpaceConfig.java
+++ b/api-model/src/main/java/io/enmasse/iot/model/v1/AddressSpaceConfig.java
@@ -4,8 +4,6 @@
  */
 package io.enmasse.iot.model.v1;
 
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import io.fabric8.kubernetes.api.model.Doneable;
@@ -20,26 +18,26 @@ import io.sundr.builder.annotations.Inline;
                 type = Doneable.class,
                 prefix = "Doneable",
                 value = "done"))
-@JsonInclude(NON_NULL)
-public class ManagedDownstreamStrategy {
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AddressSpaceConfig {
+    private String name;
+    private String plan;
 
-    private AddressSpaceConfig addressSpace;
-    private AddressesConfig addresses;
-
-    public AddressSpaceConfig getAddressSpace() {
-        return addressSpace;
+    public String getName() {
+        return name;
     }
 
-    public void setAddressSpace(AddressSpaceConfig addressSpace) {
-        this.addressSpace = addressSpace;
+    public void setName(String name) {
+        this.name = name;
     }
 
-    public AddressesConfig getAddresses() {
-        return addresses;
+    public String getPlan() {
+        return plan;
     }
 
-    public void setAddresses(AddressesConfig addresses) {
-        this.addresses = addresses;
+    public void setPlan(String plan) {
+        this.plan = plan;
     }
+
 
 }

--- a/api-model/src/main/java/io/enmasse/iot/model/v1/AddressesConfig.java
+++ b/api-model/src/main/java/io/enmasse/iot/model/v1/AddressesConfig.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.enmasse.iot.model.v1;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.fabric8.kubernetes.api.model.Doneable;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.Inline;
+
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = "io.fabric8.kubernetes.api.builder",
+        inline = @Inline(
+                type = Doneable.class,
+                prefix = "Doneable",
+                value = "done"))
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AddressesConfig {
+
+    private AddressConfig command;
+    private AddressConfig event;
+    private AddressConfig telemetry;
+
+    public AddressConfig getCommand() {
+        return command;
+    }
+
+    public void setCommand(AddressConfig command) {
+        this.command = command;
+    }
+
+    public AddressConfig getEvent() {
+        return event;
+    }
+
+    public void setEvent(AddressConfig event) {
+        this.event = event;
+    }
+
+    public AddressConfig getTelemetry() {
+        return telemetry;
+    }
+
+    public void setTelemetry(AddressConfig telemetry) {
+        this.telemetry = telemetry;
+    }
+
+}

--- a/api-model/src/main/java/io/enmasse/iot/model/v1/IoTConfigList.java
+++ b/api-model/src/main/java/io/enmasse/iot/model/v1/IoTConfigList.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2019, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.iot.model.v1;
+
+import io.enmasse.common.model.AbstractList;
+import io.enmasse.common.model.DefaultCustomResource;
+
+@DefaultCustomResource
+@SuppressWarnings("serial")
+public class IoTConfigList extends AbstractList<IoTConfig> {
+
+    public static final String KIND = "IoTConfigList";
+
+    public IoTConfigList() {
+        super(KIND, IoTCrd.API_VERSION);
+    }
+}

--- a/api-model/src/main/java/io/enmasse/iot/model/v1/IoTCrd.java
+++ b/api-model/src/main/java/io/enmasse/iot/model/v1/IoTCrd.java
@@ -15,9 +15,11 @@ public class IoTCrd {
     public static final String API_VERSION = GROUP + "/" + VERSION;
 
     private static final CustomResourceDefinition PROJECT_CRD;
+    private static final CustomResourceDefinition CONFIG_CRD;
 
     static {
         PROJECT_CRD = CustomResources.createCustomResource(GROUP, VERSION, IoTProject.KIND);
+        CONFIG_CRD = CustomResources.createCustomResource(GROUP, VERSION, IoTConfig.KIND);
     }
 
     public static void registerCustomCrds() {
@@ -28,6 +30,10 @@ public class IoTCrd {
 
     public static CustomResourceDefinition project() {
         return PROJECT_CRD;
+    }
+
+    public static CustomResourceDefinition config() {
+        return CONFIG_CRD;
     }
 
 }

--- a/api-model/src/test/java/io/enmasse/iot/model/v1/IoTProjectTest.java
+++ b/api-model/src/test/java/io/enmasse/iot/model/v1/IoTProjectTest.java
@@ -60,14 +60,16 @@ public class IoTProjectTest {
                 .withNewSpec()
                 .withNewDownstreamStrategy()
                 .withNewManagedStrategy()
-                .withAddressSpaceName("managed")
+                .withNewAddressSpace()
+                .withName("managed")
+                .endAddressSpace()
                 .endManagedStrategy()
                 .endDownstreamStrategy()
                 .endSpec()
                 .build();
 
         assertEquals("proj", project.getMetadata().getName());
-        assertEquals("managed", project.getSpec().getDownstreamStrategy().getManagedStrategy().getAddressSpaceName());
+        assertEquals("managed", project.getSpec().getDownstreamStrategy().getManagedStrategy().getAddressSpace().getName());
         assertNull(project.getSpec().getDownstreamStrategy().getExternalStrategy());
     }
 


### PR DESCRIPTION
It looks like the changes to the addressspace and address configuration are missing on the Java side. As is the `IoTConfigList`, which is required when working with the fabric8 client.