### PR TITLE
Don't fail deleting an item that is already gone

### DIFF
--- a/pkg/qdr/qdmanage_test.go
+++ b/pkg/qdr/qdmanage_test.go
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package qdr
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestNotFound(t *testing.T) {
+	var err error = &ResourceNotFoundError{}
+
+	if IsNotFound(err) != true {
+		t.Error("IsNotFound should return true")
+	}
+	if IsNotFound(fmt.Errorf("not found")) != false {
+		t.Error("IsNotFound should return false")
+	}
+	if IsNotFound(nil) != false {
+		t.Error("IsNotFound should return false")
+	}
+}


### PR DESCRIPTION
Currently when the configurator tries do delete an item, it may happen that the item is not there. In this case it currently fails to resync the configuration, as deleting returns "not found" as an error.