### PR TITLE
Add namespace parameter in service catalog

### DIFF
--- a/service-broker/src/main/java/io/enmasse/osb/HTTPServer.java
+++ b/service-broker/src/main/java/io/enmasse/osb/HTTPServer.java
@@ -77,7 +77,7 @@ public class HTTPServer extends AbstractVerticle {
         }
 
         deployment.getRegistry().addSingletonResource(new HttpHealthService());
-        deployment.getRegistry().addSingletonResource(new HttpConsoleService(authApi.getNamespace(), addressSpaceApi));
+        deployment.getRegistry().addSingletonResource(new HttpConsoleService(addressSpaceApi));
         deployment.getRegistry().addSingletonResource(new OSBCatalogService(addressSpaceApi, authApi, schemaProvider));
         deployment.getRegistry().addSingletonResource(new OSBProvisioningService(addressSpaceApi, authApi, schemaProvider, consoleProxy));
         deployment.getRegistry().addSingletonResource(new OSBBindingService(addressSpaceApi, authApi, schemaProvider, authenticationServiceRegistry, userApi));

--- a/service-broker/src/main/java/io/enmasse/osb/ServiceBroker.java
+++ b/service-broker/src/main/java/io/enmasse/osb/ServiceBroker.java
@@ -79,7 +79,7 @@ public class ServiceBroker extends AbstractVerticle {
             if (route == null) {
                 return null;
             }
-            return String.format("https://%s/console/%s", route.getSpec().getHost(), addressSpace.getMetadata().getName());
+            return String.format("https://%s/console/%s/%s", route.getSpec().getHost(), addressSpace.getMetadata().getNamespace(), addressSpace.getMetadata().getName());
         };
 
         vertx.deployVerticle(new HTTPServer(addressSpaceApi, schemaProvider, authApi, options.getCertDir(), options.getEnableRbac(), userApi, options.getListenPort(), consoleProxy, authenticationServiceRegistry),

--- a/service-broker/src/main/java/io/enmasse/osb/api/OSBServiceBase.java
+++ b/service-broker/src/main/java/io/enmasse/osb/api/OSBServiceBase.java
@@ -62,14 +62,14 @@ public abstract class OSBServiceBase {
 
 
     protected Optional<AddressSpace> findAddressSpaceByInstanceId(String serviceInstanceId) {
-        return addressSpaceApi.listAddressSpacesWithLabels(namespace, Collections.singletonMap(LabelKeys.SERVICE_INSTANCE_ID, serviceInstanceId)).stream().findAny();
+        return addressSpaceApi.listAllAddressSpacesWithLabels(Collections.singletonMap(LabelKeys.SERVICE_INSTANCE_ID, serviceInstanceId)).stream().findAny();
     }
 
-    protected Optional<AddressSpace> findAddressSpaceByName(String name) {
+    protected Optional<AddressSpace> findAddressSpace(String name, String namespace) {
         return addressSpaceApi.listAddressSpaces(namespace).stream().filter(a -> a.getMetadata().getName().equals(name)).findAny();
     }
 
-    protected AddressSpace createAddressSpace(String instanceId, String name, String type, String plan, String userId, String userName) throws Exception {
+    protected AddressSpace createAddressSpace(String instanceId, String name, String namespace, String type, String plan, String userId, String userName) throws Exception {
         AuthenticationService authService = new AuthenticationServiceBuilder()
                 .withType(AuthenticationServiceType.STANDARD)
                 .withDetails(Collections.emptyMap())
@@ -77,6 +77,7 @@ public abstract class OSBServiceBase {
         AddressSpace addressSpace = new AddressSpaceBuilder()
                 .withNewMetadata()
                 .withName(name)
+                .withNamespace(namespace)
                 .addToAnnotations(AnnotationKeys.CREATED_BY, userName)
                 .addToAnnotations(AnnotationKeys.CREATED_BY_UID, userId)
                 .addToLabels(LabelKeys.SERVICE_INSTANCE_ID, instanceId)

--- a/service-broker/src/main/java/io/enmasse/osb/api/OSBServiceBase.java
+++ b/service-broker/src/main/java/io/enmasse/osb/api/OSBServiceBase.java
@@ -88,6 +88,10 @@ public abstract class OSBServiceBase {
                 .withPlan(plan)
                 .withAuthenticationService(authService)
                 .endSpec()
+                .editOrNewStatus()
+                .withReady(false)
+                .withPhase(Phase.Pending)
+                .endStatus()
 
                 .build();
         addressSpace = setDefaults(addressSpace, namespace);

--- a/service-broker/src/main/java/io/enmasse/osb/api/OSBServiceBase.java
+++ b/service-broker/src/main/java/io/enmasse/osb/api/OSBServiceBase.java
@@ -6,10 +6,7 @@ package io.enmasse.osb.api;
 
 import java.util.*;
 
-import io.enmasse.address.model.AuthenticationService;
-import io.enmasse.address.model.AuthenticationServiceBuilder;
-import io.enmasse.address.model.AuthenticationServiceType;
-import io.enmasse.address.model.KubeUtil;
+import io.enmasse.address.model.*;
 import io.enmasse.api.auth.AuthApi;
 import io.enmasse.api.auth.RbacSecurityContext;
 import io.enmasse.api.auth.ResourceVerb;
@@ -18,8 +15,6 @@ import io.enmasse.k8s.api.SchemaProvider;
 import io.enmasse.api.common.UuidGenerator;
 import io.enmasse.config.AnnotationKeys;
 import io.enmasse.config.LabelKeys;
-import io.enmasse.address.model.AddressSpace;
-import io.enmasse.address.model.AddressSpaceBuilder;
 import io.enmasse.k8s.api.AddressSpaceApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/service-broker/src/main/java/io/enmasse/osb/api/ServiceMapping.java
+++ b/service-broker/src/main/java/io/enmasse/osb/api/ServiceMapping.java
@@ -147,7 +147,15 @@ public class ServiceMapping {
             instanceNameProperty.setMinLength(1);
             instanceNameProperty.setMaxLength(64);
             instanceNameProperty.setPattern("^[a-z][a-z0-9-]{0,63}$");
+
+            StringSchema instanceNamespaceProperty = new StringSchema();
+            instanceNamespaceProperty.setDescription("The namespace of the address space to create");
+            instanceNamespaceProperty.setRequired(true);
+            instanceNamespaceProperty.setMinLength(1);
+            instanceNamespaceProperty.setMaxLength(64);
+            instanceNamespaceProperty.setPattern("^[a-z][a-z0-9-]{0,63}$");
             serviceCreateParameters.putProperty("name", instanceNameProperty);
+            serviceCreateParameters.putProperty("namespace", instanceNamespaceProperty);
             InputParameters createParametersSchema = new InputParameters(serviceCreateParameters);
             InputParameters updateParametersSchema = null;
             ServiceInstanceSchema instanceSchema = new ServiceInstanceSchema(createParametersSchema, updateParametersSchema);

--- a/service-broker/src/main/java/io/enmasse/osb/api/bind/OSBBindingService.java
+++ b/service-broker/src/main/java/io/enmasse/osb/api/bind/OSBBindingService.java
@@ -182,8 +182,11 @@ public class OSBBindingService extends OSBServiceBase {
         log.info("Received unbind request for instance {}, binding {}", instanceId, bindingId);
         verifyAuthorized(securityContext, ResourceVerb.get);
 
-        AddressSpace addressSpace = findAddressSpaceByInstanceId(instanceId)
-            .orElseThrow(() -> Exceptions.notFoundException("Service instance " + instanceId + " does not exist"));
+        AddressSpace addressSpace = findAddressSpaceByInstanceId(instanceId).orElse(null);
+        if (addressSpace == null) {
+            return Response.status(Response.Status.GONE).build();
+
+        }
 
         try {
             String username = "user-" + bindingId;

--- a/service-broker/src/main/java/io/enmasse/osb/api/bind/OSBBindingService.java
+++ b/service-broker/src/main/java/io/enmasse/osb/api/bind/OSBBindingService.java
@@ -184,8 +184,7 @@ public class OSBBindingService extends OSBServiceBase {
 
         AddressSpace addressSpace = findAddressSpaceByInstanceId(instanceId).orElse(null);
         if (addressSpace == null) {
-            return Response.status(Response.Status.GONE).build();
-
+            return Response.status(Response.Status.GONE).entity("{}").build();
         }
 
         try {
@@ -194,7 +193,7 @@ public class OSBBindingService extends OSBServiceBase {
             if(deleteUser(addressSpace, username)) {
                 return Response.ok(new EmptyResponse()).build();
             } else {
-                return Response.status(Response.Status.GONE).build();
+                return Response.status(Response.Status.GONE).entity("{}").build();
             }
         } catch (Exception e) {
             throw new InternalServerErrorException("Exception interacting with auth service", e);

--- a/service-broker/src/main/java/io/enmasse/osb/api/console/HttpConsoleService.java
+++ b/service-broker/src/main/java/io/enmasse/osb/api/console/HttpConsoleService.java
@@ -19,18 +19,16 @@ import java.util.Optional;
 public class HttpConsoleService {
     public static final String BASE_URI = "/console";
     private final AddressSpaceApi addressSpaceApi;
-    private final String namespace;
 
-    public HttpConsoleService(String namespace, AddressSpaceApi addressSpaceApi) {
-        this.namespace = namespace;
+    public HttpConsoleService(AddressSpaceApi addressSpaceApi) {
         this.addressSpaceApi = addressSpaceApi;
     }
 
     @GET
     @Consumes({MediaType.APPLICATION_JSON})
     @Produces({MediaType.APPLICATION_JSON})
-    @Path("{addressSpace}")
-    public Response getConsole(@PathParam("addressSpace") String addressSpaceName) {
+    @Path("{namespace}/{addressSpace}")
+    public Response getConsole(@PathParam("namespace") String namespace, @PathParam("addressSpace") String addressSpaceName) {
         return addressSpaceApi.getAddressSpaceWithName(namespace, addressSpaceName)
                 .map(addressSpace -> getConsoleURL(addressSpace)
                         .map(uri -> Response.temporaryRedirect(uri).build())

--- a/service-broker/src/main/java/io/enmasse/osb/api/provision/OSBProvisioningService.java
+++ b/service-broker/src/main/java/io/enmasse/osb/api/provision/OSBProvisioningService.java
@@ -72,7 +72,7 @@ public class OSBProvisioningService extends OSBServiceBase {
         }
 
         String name = request.getParameter("name").orElse(service.getName() + "-" + shortenUuid(instanceId));
-        String namespace = request.getParameter("namespace").orElse(service.getName() + "-" + shortenUuid(instanceId));
+        String namespace = request.getParameter("namespace").orElseThrow(() -> Exceptions.badRequestException("Parameter namespace not set"));
         Optional<AddressSpace> existingAddressSpace = findAddressSpaceByInstanceId(instanceId);
 
         if (existingAddressSpace.isPresent()) {

--- a/service-broker/src/main/java/io/enmasse/osb/api/provision/OSBProvisioningService.java
+++ b/service-broker/src/main/java/io/enmasse/osb/api/provision/OSBProvisioningService.java
@@ -72,6 +72,7 @@ public class OSBProvisioningService extends OSBServiceBase {
         }
 
         String name = request.getParameter("name").orElse(service.getName() + "-" + shortenUuid(instanceId));
+        String namespace = request.getParameter("namespace").orElse(service.getName() + "-" + shortenUuid(instanceId));
         Optional<AddressSpace> existingAddressSpace = findAddressSpaceByInstanceId(instanceId);
 
         if (existingAddressSpace.isPresent()) {
@@ -86,11 +87,11 @@ public class OSBProvisioningService extends OSBServiceBase {
             throw Exceptions.conflictException("Service addressspace " + instanceId + " already exists");
         }
 
-        if(findAddressSpaceByName(name).isPresent()) {
-            throw Exceptions.conflictException("Service addressspace with name " + name + " already exists");
+        if(findAddressSpace(name, namespace).isPresent()) {
+            throw Exceptions.conflictException("Service addressspace with name " + name + " in namespace " + namespace + " already exists");
         }
         AddressSpaceType addressSpaceType = serviceMapping.getAddressSpaceTypeForService(service);
-        AddressSpace addressSpace = createAddressSpace(instanceId, name, addressSpaceType.getName(), service.getPlan(request.getPlanId()).get().getName(), userId, userName);
+        AddressSpace addressSpace = createAddressSpace(instanceId, name, namespace, addressSpaceType.getName(), service.getPlan(request.getPlanId()).get().getName(), userId, userName);
 
         String dashboardUrl = consoleProxy.getConsoleUrl(addressSpace);
 

--- a/service-broker/src/main/java/io/enmasse/osb/api/provision/OSBProvisioningService.java
+++ b/service-broker/src/main/java/io/enmasse/osb/api/provision/OSBProvisioningService.java
@@ -119,8 +119,10 @@ public class OSBProvisioningService extends OSBServiceBase {
         if (planId == null) {
             throw Exceptions.badRequestException("Missing plan_id parameter");
         }
-        AddressSpace addressSpace = findAddressSpaceByInstanceId(instanceId)
-                .orElseThrow(() -> Exceptions.goneException("Service addressspace " + instanceId + " is gone"));
+        AddressSpace addressSpace = findAddressSpaceByInstanceId(instanceId).orElse(null);
+        if (addressSpace == null) {
+            return Response.status(Response.Status.GONE).entity("{}").build();
+        }
         deleteAddressSpace(addressSpace);
         return Response.ok(new EmptyResponse()).build();
 

--- a/systemtests/src/main/java/io/enmasse/systemtest/ability/ExecutionListener.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/ability/ExecutionListener.java
@@ -57,8 +57,8 @@ public class ExecutionListener implements TestExecutionListener {
                     iotProjectClient.listAllIoTProjects().forEach(project -> {
                         log.info("iot project '{}' will be removed", project.getMetadata().getName());
                         String projectNamespace = project.getMetadata().getNamespace();
-                        try {
-                            IoTUtils.deleteIoTProjectAndWait(kube, new IoTProjectApiClient(kube, projectNamespace), project, new AddressApiClient(kube, projectNamespace));
+                        try (AddressApiClient addressApiClient = new AddressApiClient(kube, projectNamespace)) {
+                            IoTUtils.deleteIoTProjectAndWait(kube, new IoTProjectApiClient(kube, projectNamespace), project, addressApiClient);
                         } catch ( Exception e ) {
                             e.printStackTrace();
                         }

--- a/systemtests/src/main/java/io/enmasse/systemtest/apiclients/AddressApiClient.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/apiclients/AddressApiClient.java
@@ -401,7 +401,7 @@ public class AddressApiClient extends ApiClient {
     }
 
     private String getAddressPath(String addressSpace) {
-        return String.format(addressNestedPathPattern, addressSpace);
+        return String.format(addressNestedPathPattern, defaultNamespace, addressSpace);
     }
 
     public void deleteAddress(String addressSpace, Address destination, int expectedCode) throws Exception {

--- a/systemtests/src/main/java/io/enmasse/systemtest/apiclients/AddressApiClient.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/apiclients/AddressApiClient.java
@@ -61,12 +61,6 @@ public class AddressApiClient extends ApiClient {
     }
 
     @Override
-    public void close() {
-        client.close();
-        vertx.close();
-    }
-
-    @Override
     protected String apiClientName() {
         return "Address-Api";
     }

--- a/systemtests/src/main/java/io/enmasse/systemtest/apiclients/AddressApiClient.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/apiclients/AddressApiClient.java
@@ -39,35 +39,28 @@ public class AddressApiClient extends ApiClient {
     private final static String ADDRESS_PATH = "/apis/enmasse.io/" + CoreCrd.VERSION + "/addresses";
     private final static String ADDRESS_SPACE_PATH = "/apis/enmasse.io/" + CoreCrd.VERSION + "/addressspaces";
 
-    private final String schemaPath;
-    private final String addressSpacesPath;
-    private final String addressNestedPathPattern;
-    private final String addressResourcePath;
+    private final String schemaPathPattern = "/apis/enmasse.io/" + CoreCrd.VERSION + "/namespaces/%s/addressspaceschemas";
+    private final String addressSpacesPathPattern = "/apis/enmasse.io/" + CoreCrd.VERSION + "/namespaces/%s/addressspaces";
+    private final String addressNestedPathPattern = "/apis/enmasse.io/" + CoreCrd.VERSION + "/namespaces/%s/addressspaces/%s/addresses";
+    private final String addressResourcePathPattern = "/apis/enmasse.io/" + CoreCrd.VERSION + "/namespaces/%s/addresses";
+    private final String defaultNamespace;
 
     public AddressApiClient(Kubernetes kubernetes) throws MalformedURLException {
         super(kubernetes, kubernetes::getRestEndpoint, "enmasse.io/" + CoreCrd.VERSION);
-        this.schemaPath = String.format("/apis/enmasse.io/%s/namespaces/%s/addressspaceschemas", CoreCrd.VERSION, kubernetes.getNamespace());
-        this.addressSpacesPath = String.format("/apis/enmasse.io/%s/namespaces/%s/addressspaces", CoreCrd.VERSION, kubernetes.getNamespace());
-        this.addressNestedPathPattern = String.format("/apis/enmasse.io/%s/namespaces/%s/addressspaces", CoreCrd.VERSION, kubernetes.getNamespace()) + "/%s/addresses";
-        this.addressResourcePath = String.format("/apis/enmasse.io/%s/namespaces/%s/addresses", CoreCrd.VERSION, kubernetes.getNamespace());
+        this.defaultNamespace = kubernetes.getNamespace();
     }
 
     public AddressApiClient(Kubernetes kubernetes, String namespace) throws MalformedURLException {
         super(kubernetes, kubernetes::getRestEndpoint, "enmasse.io/" + CoreCrd.VERSION);
-        this.schemaPath = String.format("/apis/enmasse.io/%s/namespaces/%s/addressspaceschemas", CoreCrd.VERSION, kubernetes.getNamespace());
-        this.addressSpacesPath = String.format("/apis/enmasse.io/%s/namespaces/%s/addressspaces", CoreCrd.VERSION, namespace);
-        this.addressNestedPathPattern = String.format("/apis/enmasse.io/%s/namespaces/%s/addressspaces", CoreCrd.VERSION, namespace) + "/%s/addresses";
-        this.addressResourcePath = String.format("/apis/enmasse.io/%s/namespaces/%s/addresses", CoreCrd.VERSION, namespace);
+        this.defaultNamespace = namespace;
     }
 
     public AddressApiClient(Kubernetes kubernetes, String namespace, String token) throws MalformedURLException {
         super(kubernetes, kubernetes::getRestEndpoint, "enmasse.io/" + CoreCrd.VERSION, token);
-        this.schemaPath = String.format("/apis/enmasse.io/%s/namespaces/%s/addressspaceschemas", CoreCrd.VERSION, kubernetes.getNamespace());
-        this.addressSpacesPath = String.format("/apis/enmasse.io/%s/namespaces/%s/addressspaces", CoreCrd.VERSION, namespace);
-        this.addressNestedPathPattern = String.format("/apis/enmasse.io/%s/namespaces/%s/addressspaces", CoreCrd.VERSION, namespace) + "/%s/addresses";
-        this.addressResourcePath = String.format("/apis/enmasse.io/%s/namespaces/%s/addresses", CoreCrd.VERSION, namespace);
+        this.defaultNamespace = namespace;
     }
 
+    @Override
     public void close() {
         client.close();
         vertx.close();
@@ -75,7 +68,7 @@ public class AddressApiClient extends ApiClient {
 
     @Override
     protected String apiClientName() {
-        return "Address-controller";
+        return "Address-Api";
     }
 
     public void createAddressSpaceList(AddressSpace... addressSpaces) throws Exception {
@@ -86,6 +79,8 @@ public class AddressApiClient extends ApiClient {
 
     public void createAddressSpace(io.enmasse.address.model.AddressSpace addressSpace, int expectedCode) throws Exception {
         JsonObject config = AddressSpaceUtils.addressSpaceToJson(addressSpace);
+
+        String addressSpacesPath = String.format(addressSpacesPathPattern, defaultNamespace);
 
         log.info("POST-address-space: path {}; body {}", addressSpacesPath, config.toString());
         CompletableFuture<JsonObject> responsePromise = new CompletableFuture<>();
@@ -114,6 +109,7 @@ public class AddressApiClient extends ApiClient {
     }
 
     public void replaceAddressSpace(AddressSpace addressSpace, int expectedCode) throws Exception {
+        String addressSpacesPath = String.format(addressSpacesPathPattern, defaultNamespace);
         String path = addressSpacesPath + "/" + addressSpace.getMetadata().getName();
         JsonObject config = AddressSpaceUtils.addressSpaceToJson(addressSpace);
 
@@ -136,6 +132,7 @@ public class AddressApiClient extends ApiClient {
     }
 
     public void deleteAddressSpace(AddressSpace addressSpace, int expectedCode) throws Exception {
+        String addressSpacesPath = String.format(addressSpacesPathPattern, defaultNamespace);
         String path = addressSpacesPath + "/" + addressSpace.getMetadata().getName();
         log.info("DELETE-address-space: path '{}'", path);
         CompletableFuture<JsonObject> responsePromise = new CompletableFuture<>();
@@ -155,7 +152,7 @@ public class AddressApiClient extends ApiClient {
     }
 
     public void deleteAddressSpaces(int expectedCode) throws Exception {
-        String path = addressSpacesPath;
+        String path = String.format(addressSpacesPathPattern, defaultNamespace);
         log.info("DELETE-address-space: path '{}'", path);
         CompletableFuture<JsonObject> responsePromise = new CompletableFuture<>();
         doRequestNTimes(initRetry, () -> {
@@ -185,6 +182,11 @@ public class AddressApiClient extends ApiClient {
      * @throws InterruptedException
      */
     public JsonObject getAddressSpace(String name, int expectedCode) throws Exception {
+        return getAddressSpace(name, defaultNamespace, expectedCode);
+    }
+
+    public JsonObject getAddressSpace(String name, String namespace, int expectedCode) throws Exception {
+        String addressSpacesPath = String.format(addressSpacesPathPattern, namespace);
         String path = addressSpacesPath + "/" + name;
         log.info("GET-address-space: path '{}'", path);
         CompletableFuture<JsonObject> responsePromise = new CompletableFuture<>();
@@ -206,6 +208,10 @@ public class AddressApiClient extends ApiClient {
         return getAddressSpace(name, HTTP_OK);
     }
 
+    public JsonObject getAddressSpace(String name, String namespace) throws Exception {
+        return getAddressSpace(name, namespace, HTTP_OK);
+    }
+
     public Set<String> listAddressSpaces() throws Exception {
         JsonArray items = listAddressSpacesObjects().getJsonArray("items");
         Set<String> spaces = new HashSet<>();
@@ -218,6 +224,7 @@ public class AddressApiClient extends ApiClient {
     }
 
     public JsonObject listAddressSpacesObjects() throws Exception {
+        String addressSpacesPath = String.format(addressSpacesPathPattern, defaultNamespace);
         log.info("GET-address-spaces: path {}; endpoint {}; ", addressSpacesPath, endpoint.toString());
 
         CompletableFuture<JsonObject> response = new CompletableFuture<>();
@@ -353,6 +360,7 @@ public class AddressApiClient extends ApiClient {
      * @throws Exception
      */
     public JsonObject getSchema(int expectedCode) throws Exception {
+        String schemaPath = String.format(schemaPathPattern, defaultNamespace);
         log.info("GET-schema: path {}; ", schemaPath);
 
         return doRequestNTimes(initRetry, () -> {
@@ -525,6 +533,7 @@ public class AddressApiClient extends ApiClient {
     }
 
     public void createAddress(Address destination, int expectedCode) throws Exception {
+        String addressResourcePath = String.format(addressResourcePathPattern, defaultNamespace);
         JsonObject addressJson = AddressUtils.addressToJson(destination);
         log.info("POST-address: path {}; body: {}", addressResourcePath, addressJson.toString());
 

--- a/systemtests/src/main/java/io/enmasse/systemtest/apiclients/ApiClient.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/apiclients/ApiClient.java
@@ -31,7 +31,7 @@ import java.util.function.Supplier;
 import static java.net.HttpURLConnection.HTTP_CREATED;
 import static java.net.HttpURLConnection.HTTP_OK;
 
-public abstract class ApiClient {
+public abstract class ApiClient implements AutoCloseable {
     protected static Logger log = CustomLogger.getLogger();
     protected WebClient client;
     protected Kubernetes kubernetes;
@@ -65,6 +65,11 @@ public abstract class ApiClient {
     protected void reconnect() {
         this.client.close();
         connect();
+    }
+
+    public void close() {
+        this.client.close();
+        this.vertx.close();
     }
 
     protected void connect() {

--- a/systemtests/src/main/java/io/enmasse/systemtest/apiclients/ApiClient.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/apiclients/ApiClient.java
@@ -63,12 +63,17 @@ public abstract class ApiClient implements AutoCloseable {
     protected abstract String apiClientName();
 
     protected void reconnect() {
-        this.client.close();
+        if (client != null) {
+            this.client.close();
+        }
         connect();
     }
 
+    @Override
     public void close() {
-        this.client.close();
+        if (client != null) {
+            this.client.close();
+        }
         this.vertx.close();
     }
 

--- a/systemtests/src/main/java/io/enmasse/systemtest/selenium/page/ConsoleWebPage.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/selenium/page/ConsoleWebPage.java
@@ -674,7 +674,7 @@ public class ConsoleWebPage implements IWebPage {
         assertNotNull(items, String.format("Console failed, does not contain created address item : %s", destination));
 
         if (waitForReady)
-            AddressUtils.waitForDestinationsReady(new AddressApiClient(Kubernetes.getInstance(), destination.getMetadata().getNamespace()), defaultAddressSpace,
+            AddressUtils.waitForDestinationsReady(new AddressApiClient(Kubernetes.getInstance(), defaultAddressSpace.getMetadata().getNamespace()), defaultAddressSpace,
                     new TimeoutBudget(5, TimeUnit.MINUTES), destination);
     }
 

--- a/systemtests/src/main/java/io/enmasse/systemtest/selenium/page/ConsoleWebPage.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/selenium/page/ConsoleWebPage.java
@@ -35,29 +35,26 @@ public class ConsoleWebPage implements IWebPage {
     private static Logger log = CustomLogger.getLogger();
     private SeleniumProvider selenium;
     private String consoleRoute;
-    private AddressApiClient addressApiClient;
     private AddressSpace defaultAddressSpace;
     private ToolbarType toolbarType;
     private UserCredentials credentials;
     private GlobalConsolePage globalConsole;
 
-    public ConsoleWebPage(SeleniumProvider selenium, AddressApiClient addressApiClient, AddressSpace defaultAddressSpace) throws Exception {
+    public ConsoleWebPage(SeleniumProvider selenium, AddressSpace defaultAddressSpace) throws Exception {
         this.selenium = selenium;
-        this.addressApiClient = addressApiClient;
         this.defaultAddressSpace = defaultAddressSpace;
         this.globalConsole = new GlobalConsolePage(selenium, TestUtils.getGlobalConsoleRoute(), null);
     }
 
-    public ConsoleWebPage(SeleniumProvider selenium, AddressApiClient addressApiClient, AddressSpace defaultAddressSpace, UserCredentials credentials) throws Exception {
+    public ConsoleWebPage(SeleniumProvider selenium, AddressSpace defaultAddressSpace, UserCredentials credentials) throws Exception {
         this.selenium = selenium;
-        this.addressApiClient = addressApiClient;
         this.defaultAddressSpace = defaultAddressSpace;
         this.credentials = credentials;
         this.globalConsole = new GlobalConsolePage(selenium, TestUtils.getGlobalConsoleRoute(), credentials);
     }
 
-    public ConsoleWebPage(SeleniumProvider selenium, String consoleRoute, AddressApiClient addressApiClient, AddressSpace defaultAddressSpace, UserCredentials credentials) throws Exception {
-        this(selenium, addressApiClient, defaultAddressSpace);
+    public ConsoleWebPage(SeleniumProvider selenium, String consoleRoute, AddressSpace defaultAddressSpace, UserCredentials credentials) throws Exception {
+        this(selenium, defaultAddressSpace);
         this.consoleRoute = consoleRoute;
         this.credentials = credentials;
         this.globalConsole = new GlobalConsolePage(selenium, TestUtils.getGlobalConsoleRoute(), credentials);
@@ -677,7 +674,7 @@ public class ConsoleWebPage implements IWebPage {
         assertNotNull(items, String.format("Console failed, does not contain created address item : %s", destination));
 
         if (waitForReady)
-            AddressUtils.waitForDestinationsReady(addressApiClient, defaultAddressSpace,
+            AddressUtils.waitForDestinationsReady(new AddressApiClient(Kubernetes.getInstance(), destination.getMetadata().getNamespace()), defaultAddressSpace,
                     new TimeoutBudget(5, TimeUnit.MINUTES), destination);
     }
 

--- a/systemtests/src/main/java/io/enmasse/systemtest/selenium/page/GlobalConsolePage.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/selenium/page/GlobalConsolePage.java
@@ -175,7 +175,9 @@ public class GlobalConsolePage implements IWebPage {
         selenium.clickOnItem(getNextButton());
         selenium.clickOnItem(getFinishButton());
         selenium.waitUntilItemPresent(30, () -> getAddressSpaceItem(addressSpace));
-        AddressSpaceUtils.waitForAddressSpaceReady(new AddressApiClient(Kubernetes.getInstance(), addressSpace.getMetadata().getNamespace()), addressSpace);
+        try (AddressApiClient addressApiClient = new AddressApiClient(Kubernetes.getInstance(), addressSpace.getMetadata().getNamespace())) {
+            AddressSpaceUtils.waitForAddressSpaceReady(addressApiClient, addressSpace);
+        }
         selenium.refreshPage();
     }
 

--- a/systemtests/src/main/java/io/enmasse/systemtest/selenium/page/GlobalConsolePage.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/selenium/page/GlobalConsolePage.java
@@ -193,7 +193,7 @@ public class GlobalConsolePage implements IWebPage {
     public ConsoleWebPage openAddressSpaceConsolePage(AddressSpace addressSpace) throws Exception {
         AddressSpaceWebItem item = (AddressSpaceWebItem) selenium.waitUntilItemPresent(30, () -> getAddressSpaceItem(addressSpace));
         selenium.clickOnItem(item.getConsoleRoute());
-        ConsoleWebPage consolePage =  new ConsoleWebPage(selenium, new AddressApiClient(Kubernetes.getInstance()), addressSpace, credentials);
+        ConsoleWebPage consolePage = new ConsoleWebPage(selenium, addressSpace, credentials);
         consolePage.login();
         return consolePage;
     }

--- a/systemtests/src/main/java/io/enmasse/systemtest/selenium/page/OpenshiftWebPage.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/selenium/page/OpenshiftWebPage.java
@@ -234,9 +234,10 @@ public class OpenshiftWebPage implements IWebPage {
         selenium.clickOnItem(getAddToProjectDropDown(), "Add to project dropdown");
     }
 
-    public String provisionAddressSpaceViaSC(AddressSpace addressSpace, String projectName) throws Exception {
+    public String provisionAddressSpaceViaSC(AddressSpace addressSpace) throws Exception {
         log.info("Service for addressSpace {} will be provisioned", addressSpace);
         openOpenshiftPage();
+        String projectName = addressSpace.getMetadata().getNamespace();
         if (addressSpace.getSpec().getType().equals(AddressSpaceType.BROKERED.toString())) {
             createAddressSpaceBrokered(addressSpace.getMetadata().getName(), projectName);
         } else {
@@ -250,9 +251,7 @@ public class OpenshiftWebPage implements IWebPage {
         waitForRedirectToService();
         String serviceId = getProvisionedServiceItem().getId();
         waitUntilServiceIsReady();
-        try (AddressApiClient addressApiClient = new AddressApiClient(Kubernetes.getInstance(), projectName)) {
-            addressSpace = AddressSpaceUtils.getAddressSpaceObject(addressApiClient, addressSpace.getMetadata().getName());
-        }
+        addressSpace = AddressSpaceUtils.getAddressSpaceObject(addressApiClient, addressSpace.getMetadata().getName(), addressSpace.getMetadata().getNamespace());
         return serviceId;
     }
 
@@ -330,11 +329,11 @@ public class OpenshiftWebPage implements IWebPage {
         selenium.clickOnItem(selenium.getDriver().findElement(By.className("projects-view-all")), "Show all projects");
     }
 
-    public String createBinding(String projectName, String receiveAddress, String sendAddresses) throws Exception {
-        log.info("Binding in namespace {} will be created", projectName);
+    public String createBinding(AddressSpace addressSpace, String receiveAddress, String sendAddresses) throws Exception {
+        log.info("Binding in namespace {} will be created", addressSpace.getMetadata().getNamespace());
         openOpenshiftPage();
         clickOnShowAllProjects();
-        selenium.clickOnItem(getProjectListItem(projectName), projectName);
+        selenium.clickOnItem(getProjectListItem(addressSpace.getMetadata().getNamespace()), addressSpace.getMetadata().getNamespace());
         waitForRedirectToService();
         selenium.clickOnItem(getProvisionedServiceItem().getServiceActionCreateBinding(), "Create Binding");
         next();
@@ -351,7 +350,8 @@ public class OpenshiftWebPage implements IWebPage {
         return bindingId;
     }
 
-    public void removeBinding(String namespace, String bindingID) throws Exception {
+    public void removeBinding(AddressSpace addressSpace, String bindingID) throws Exception {
+        String namespace = addressSpace.getMetadata().getNamespace();
         log.info("Binding {} in namespace {} will be removed", bindingID, namespace);
         openOpenshiftPage();
         clickOnShowAllProjects();
@@ -364,9 +364,10 @@ public class OpenshiftWebPage implements IWebPage {
         selenium.clickOnItem(getModalWindow().findElement(By.className("btn-danger")));
     }
 
-    public BindingSecretData viewSecretOfBinding(String namespace, String bindingID) throws Exception {
+    public BindingSecretData viewSecretOfBinding(AddressSpace addressSpace, String bindingID) throws Exception {
         openOpenshiftPage();
         clickOnShowAllProjects();
+        String namespace = addressSpace.getMetadata().getNamespace();
         selenium.clickOnItem(getProjectListItem(namespace), namespace);
         waitForRedirectToService();
         ProvisionedServiceItem serviceItem = getProvisionedServiceItem();
@@ -379,10 +380,10 @@ public class OpenshiftWebPage implements IWebPage {
         return secretData;
     }
 
-    public ConsoleWebPage clickOnDashboard(String namespace, AddressSpace addressSpace) throws Exception {
+    public ConsoleWebPage clickOnDashboard(AddressSpace addressSpace) throws Exception {
         openOpenshiftPage();
         clickOnShowAllProjects();
-        selenium.clickOnItem(getProjectListItem(namespace), namespace);
+        selenium.clickOnItem(getProjectListItem(addressSpace.getMetadata().getNamespace()), addressSpace.getMetadata().getNamespace());
         waitForRedirectToService();
         ProvisionedServiceItem serviceItem = getProvisionedServiceItem();
         serviceItem.collapseServiceItem();

--- a/systemtests/src/main/java/io/enmasse/systemtest/selenium/page/OpenshiftWebPage.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/selenium/page/OpenshiftWebPage.java
@@ -6,7 +6,10 @@ package io.enmasse.systemtest.selenium.page;
 
 
 import io.enmasse.address.model.AddressSpace;
-import io.enmasse.systemtest.*;
+import io.enmasse.systemtest.AddressSpacePlans;
+import io.enmasse.systemtest.AddressSpaceType;
+import io.enmasse.systemtest.CustomLogger;
+import io.enmasse.systemtest.UserCredentials;
 import io.enmasse.systemtest.apiclients.AddressApiClient;
 import io.enmasse.systemtest.selenium.SeleniumProvider;
 import io.enmasse.systemtest.selenium.resources.BindingSecretData;
@@ -390,7 +393,7 @@ public class OpenshiftWebPage implements IWebPage {
         selenium.clickOnItem(serviceItem.getRedirectConsoleButton());
         Set<String> tabHandles = selenium.getDriver().getWindowHandles();
         selenium.getDriver().switchTo().window(tabHandles.toArray()[tabHandles.size() - 1].toString());
-        return new ConsoleWebPage(selenium, addressApiClient, addressSpace);
+        return new ConsoleWebPage(selenium, addressSpace);
     }
 
     @Override

--- a/systemtests/src/main/java/io/enmasse/systemtest/selenium/page/OpenshiftWebPage.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/selenium/page/OpenshiftWebPage.java
@@ -273,6 +273,8 @@ public class OpenshiftWebPage implements IWebPage {
         selectProjectInWizard(projectName);
         selenium.fillInputItem(getModalWindow().findElement(By.tagName("catalog-parameters")).findElement(By.id("name")),
                 name);
+        selenium.fillInputItem(getModalWindow().findElement(By.tagName("catalog-parameters")).findElement(By.id("namespace")),
+                projectName);
         next();
         next();
     }
@@ -285,6 +287,8 @@ public class OpenshiftWebPage implements IWebPage {
         selectProjectInWizard(projectName);
         selenium.fillInputItem(getModalWindow().findElement(By.tagName("catalog-parameters")).findElement(By.id("name")),
                 name);
+        selenium.fillInputItem(getModalWindow().findElement(By.tagName("catalog-parameters")).findElement(By.id("namespace")),
+                projectName);
         next();
         next();
     }

--- a/systemtests/src/main/java/io/enmasse/systemtest/selenium/page/OpenshiftWebPage.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/selenium/page/OpenshiftWebPage.java
@@ -6,10 +6,7 @@ package io.enmasse.systemtest.selenium.page;
 
 
 import io.enmasse.address.model.AddressSpace;
-import io.enmasse.systemtest.AddressSpacePlans;
-import io.enmasse.systemtest.AddressSpaceType;
-import io.enmasse.systemtest.CustomLogger;
-import io.enmasse.systemtest.UserCredentials;
+import io.enmasse.systemtest.*;
 import io.enmasse.systemtest.apiclients.AddressApiClient;
 import io.enmasse.systemtest.selenium.SeleniumProvider;
 import io.enmasse.systemtest.selenium.resources.BindingSecretData;
@@ -253,7 +250,9 @@ public class OpenshiftWebPage implements IWebPage {
         waitForRedirectToService();
         String serviceId = getProvisionedServiceItem().getId();
         waitUntilServiceIsReady();
-        addressSpace = AddressSpaceUtils.getAddressSpaceObject(addressApiClient, addressSpace.getMetadata().getName());
+        try (AddressApiClient addressApiClient = new AddressApiClient(Kubernetes.getInstance(), projectName)) {
+            addressSpace = AddressSpaceUtils.getAddressSpaceObject(addressApiClient, addressSpace.getMetadata().getName());
+        }
         return serviceId;
     }
 

--- a/systemtests/src/main/java/io/enmasse/systemtest/utils/AddressSpaceUtils.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/utils/AddressSpaceUtils.java
@@ -200,8 +200,20 @@ public class AddressSpaceUtils {
         return convertToAddressSpaceObject(addressSpaceJson).get(0);
     }
 
+    public static AddressSpace getAddressSpaceObject(AddressApiClient apiClient, String addressSpaceName, String namespace) throws Exception {
+        JsonObject addressSpaceJson = apiClient.getAddressSpace(addressSpaceName, namespace);
+        log.info("address space received {}", addressSpaceJson.toString());
+        return convertToAddressSpaceObject(addressSpaceJson).get(0);
+    }
+
     public static void syncAddressSpaceObject(AddressSpace addressSpace, AddressApiClient apiClient) throws Exception {
-        AddressSpace results = jsonToAdressSpace(apiClient.getAddressSpace(addressSpace.getMetadata().getName()));
+        JsonObject json = null;
+        if (addressSpace.getMetadata().getNamespace() != null) {
+            json = apiClient.getAddressSpace(addressSpace.getMetadata().getName(), addressSpace.getMetadata().getNamespace());
+        } else {
+            json = apiClient.getAddressSpace(addressSpace.getMetadata().getName());
+        }
+        AddressSpace results = jsonToAdressSpace(json);
         addressSpace.setSpec(results.getSpec());
         addressSpace.setMetadata(results.getMetadata());
         addressSpace.setStatus(results.getStatus());

--- a/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
@@ -471,15 +471,15 @@ public class TestUtils {
         kubernetes.replaceConfigMap(addrSpace.getMetadata().getNamespace(), destConfigMap);
     }
 
-    public static void deleteAddressSpaceCreatedBySC(Kubernetes kubernetes, AddressSpace addressSpace, String namespace, GlobalLogCollector logCollector) throws Exception {
+    public static void deleteAddressSpaceCreatedBySC(Kubernetes kubernetes, AddressSpace addressSpace, GlobalLogCollector logCollector) throws Exception {
         String operationID = TimeMeasuringSystem.startOperation(SystemtestsOperation.DELETE_ADDRESS_SPACE);
         logCollector.collectEvents();
         logCollector.collectApiServerJmapLog();
         logCollector.collectLogsTerminatedPods();
         logCollector.collectConfigMaps();
         logCollector.collectRouterState("deleteAddressSpaceCreatedBySC");
-        kubernetes.deleteNamespace(namespace);
-        waitForNamespaceDeleted(kubernetes, namespace);
+        kubernetes.deleteNamespace(addressSpace.getMetadata().getNamespace());
+        waitForNamespaceDeleted(kubernetes, addressSpace.getMetadata().getNamespace());
         AddressSpaceUtils.waitForAddressSpaceDeleted(kubernetes, addressSpace);
         TimeMeasuringSystem.stopOperation(operationID);
     }

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/TestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/TestBase.java
@@ -604,7 +604,7 @@ public abstract class TestBase implements ITestBase, ITestSeparator {
         try {
             SeleniumManagement.deployFirefoxApp();
             selenium = getFirefoxSeleniumProvider();
-            ConsoleWebPage console = new ConsoleWebPage(selenium, getConsoleRoute(addressSpace), addressApiClient, addressSpace, defaultCredentials);
+            ConsoleWebPage console = new ConsoleWebPage(selenium, getConsoleRoute(addressSpace), addressSpace, defaultCredentials);
             console.openWebConsolePage();
             console.openAddressesPageWebConsole();
 

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/TestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/TestBase.java
@@ -1022,8 +1022,8 @@ public abstract class TestBase implements ITestBase, ITestSeparator {
         log.info("{}MB {} message received", sizeInMB, mode == DeliveryMode.PERSISTENT ? "durable" : "non-durable");
     }
 
-    protected void deleteAddressSpaceCreatedBySC(String namespace, AddressSpace addressSpace) throws Exception {
-        TestUtils.deleteAddressSpaceCreatedBySC(kubernetes, addressSpace, namespace, logCollector);
+    protected void deleteAddressSpaceCreatedBySC(AddressSpace addressSpace) throws Exception {
+        TestUtils.deleteAddressSpaceCreatedBySC(kubernetes, addressSpace, logCollector);
     }
 
     protected List<Address> getAllStandardAddresses() {

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/web/WebConsolePlansTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/web/WebConsolePlansTest.java
@@ -96,7 +96,7 @@ public abstract class WebConsolePlansTest extends TestBase implements ISeleniumP
         createUser(consoleAddrSpace, user);
 
         //create addresses
-        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(consoleAddrSpace), addressApiClient, consoleAddrSpace, clusterUser);
+        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(consoleAddrSpace), consoleAddrSpace, clusterUser);
         consoleWebPage.openWebConsolePage();
         Address q1 = AddressUtils.createQueueAddressObject("new-queue-instance-1", consoleQueuePlan1.getMetadata().getName());
         Address t2 = AddressUtils.createTopicAddressObject("new-topic-instance-2", consoleTopicPlan2.getMetadata().getName());

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/web/WebConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/web/WebConsoleTest.java
@@ -69,7 +69,7 @@ public abstract class WebConsoleTest extends TestBaseWithShared implements ISele
     //============================================================================================
 
     protected void doTestCreateDeleteAddress(Address... destinations) throws Exception {
-        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), addressApiClient,
+        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), 
                 sharedAddressSpace, clusterUser);
         consoleWebPage.openWebConsolePage();
         for (Address dest : destinations) {
@@ -80,7 +80,7 @@ public abstract class WebConsoleTest extends TestBaseWithShared implements ISele
     }
 
     protected void doTestCreateDeleteDurableSubscription(Address... destinations) throws Exception {
-        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), addressApiClient,
+        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), 
                 sharedAddressSpace, clusterUser);
         consoleWebPage.openWebConsolePage();
         consoleWebPage.openAddressesPageWebConsole();
@@ -102,7 +102,7 @@ public abstract class WebConsoleTest extends TestBaseWithShared implements ISele
     }
 
     protected void doTestAddressStatus(Address destination) throws Exception {
-        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), addressApiClient,
+        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), 
                 sharedAddressSpace, clusterUser);
         consoleWebPage.openWebConsolePage();
         consoleWebPage.createAddressWebConsole(destination, false);
@@ -121,7 +121,7 @@ public abstract class WebConsoleTest extends TestBaseWithShared implements ISele
         int addressCount = 4;
         ArrayList<Address> addresses = generateQueueTopicList("via-web", IntStream.range(0, addressCount));
 
-        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), addressApiClient,
+        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), 
                 sharedAddressSpace, clusterUser);
         consoleWebPage.openWebConsolePage();
         consoleWebPage.createAddressesWebConsole(addresses.toArray(new Address[0]));
@@ -155,7 +155,7 @@ public abstract class WebConsoleTest extends TestBaseWithShared implements ISele
         int addressCount = 4;
         ArrayList<Address> addresses = generateQueueTopicList("via-web", IntStream.range(0, addressCount));
 
-        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), addressApiClient,
+        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), 
                 sharedAddressSpace, clusterUser);
         consoleWebPage.openWebConsolePage();
         consoleWebPage.createAddressesWebConsole(addresses.toArray(new Address[0]));
@@ -204,7 +204,7 @@ public abstract class WebConsoleTest extends TestBaseWithShared implements ISele
         Address destTopic = AddressUtils.createAddressObject(AddressType.TOPIC, testString + "topic",
                 getDefaultPlan(AddressType.TOPIC), Optional.empty());
 
-        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), addressApiClient,
+        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), 
                 sharedAddressSpace, clusterUser);
         consoleWebPage.openWebConsolePage();
         consoleWebPage.createAddressWebConsole(destQueue);
@@ -232,7 +232,7 @@ public abstract class WebConsoleTest extends TestBaseWithShared implements ISele
         int addressCount = 4;
         ArrayList<Address> addresses = generateQueueTopicList("via-web", IntStream.range(0, addressCount));
 
-        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), addressApiClient,
+        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), 
                 sharedAddressSpace, clusterUser);
         consoleWebPage.openWebConsolePage();
         consoleWebPage.createAddressesWebConsole(addresses.toArray(new Address[0]));
@@ -276,7 +276,7 @@ public abstract class WebConsoleTest extends TestBaseWithShared implements ISele
         int addressCount = 2;
         ArrayList<Address> addresses = generateQueueTopicList("via-web", IntStream.range(0, addressCount));
 
-        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), addressApiClient,
+        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), 
                 sharedAddressSpace, clusterUser);
         consoleWebPage.openWebConsolePage();
         consoleWebPage.createAddressesWebConsole(addresses.toArray(new Address[0]));
@@ -303,7 +303,7 @@ public abstract class WebConsoleTest extends TestBaseWithShared implements ISele
         int addressCount = 4;
         ArrayList<Address> addresses = generateQueueTopicList("via-web", IntStream.range(0, addressCount));
 
-        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), addressApiClient,
+        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), 
                 sharedAddressSpace, clusterUser);
         consoleWebPage.openWebConsolePage();
         consoleWebPage.createAddressesWebConsole(addresses.toArray(new Address[0]));
@@ -319,7 +319,7 @@ public abstract class WebConsoleTest extends TestBaseWithShared implements ISele
         int addressCount = 4;
         ArrayList<Address> addresses = generateQueueTopicList("via-web", IntStream.range(0, addressCount));
 
-        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), addressApiClient,
+        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), 
                 sharedAddressSpace, clusterUser);
         consoleWebPage.openWebConsolePage();
         consoleWebPage.createAddressesWebConsole(addresses.toArray(new Address[0]));
@@ -358,7 +358,7 @@ public abstract class WebConsoleTest extends TestBaseWithShared implements ISele
         int addressCount = 2;
         ArrayList<Address> addresses = generateQueueTopicList("via-web", IntStream.range(0, addressCount));
 
-        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), addressApiClient,
+        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), 
                 sharedAddressSpace, clusterUser);
         consoleWebPage.openWebConsolePage();
         consoleWebPage.createAddressesWebConsole(addresses.toArray(new Address[0]));
@@ -379,7 +379,7 @@ public abstract class WebConsoleTest extends TestBaseWithShared implements ISele
         int addressCount = 2;
         ArrayList<Address> addresses = generateQueueTopicList("via-web", IntStream.range(0, addressCount));
 
-        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), addressApiClient,
+        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), 
                 sharedAddressSpace, clusterUser);
         consoleWebPage.openWebConsolePage();
         consoleWebPage.createAddressesWebConsole(addresses.toArray(new Address[0]));
@@ -398,7 +398,7 @@ public abstract class WebConsoleTest extends TestBaseWithShared implements ISele
 
 
     protected void doTestFilterConnectionsByEncrypted() throws Exception {
-        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), addressApiClient,
+        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), 
                 sharedAddressSpace, clusterUser);
         consoleWebPage.openWebConsolePage();
         Address queue = AddressUtils.createQueueAddressObject("queue-via-web-connections-encrypted", getDefaultPlan(AddressType.QUEUE));
@@ -425,7 +425,7 @@ public abstract class WebConsoleTest extends TestBaseWithShared implements ISele
     }
 
     protected void doTestFilterConnectionsByUser() throws Exception {
-        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), addressApiClient,
+        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), 
                 sharedAddressSpace, clusterUser);
         consoleWebPage.openWebConsolePage();
         Address queue = AddressUtils.createQueueAddressObject("queue-via-web-connections-users", getDefaultPlan(AddressType.QUEUE));
@@ -478,7 +478,7 @@ public abstract class WebConsoleTest extends TestBaseWithShared implements ISele
     protected void doTestFilterConnectionsByHostname() throws Exception {
         int addressCount = 2;
         ArrayList<Address> addresses = generateQueueTopicList("via-web", IntStream.range(0, addressCount));
-        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), addressApiClient,
+        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), 
                 sharedAddressSpace, clusterUser);
         consoleWebPage.openWebConsolePage();
         consoleWebPage.createAddressesWebConsole(addresses.toArray(new Address[0]));
@@ -500,7 +500,7 @@ public abstract class WebConsoleTest extends TestBaseWithShared implements ISele
     protected void doTestSortConnectionsByHostname() throws Exception {
         int addressCount = 2;
         ArrayList<Address> addresses = generateQueueTopicList("via-web", IntStream.range(0, addressCount));
-        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), addressApiClient,
+        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), 
                 sharedAddressSpace, clusterUser);
         consoleWebPage.openWebConsolePage();
         consoleWebPage.createAddressesWebConsole(addresses.toArray(new Address[0]));
@@ -520,7 +520,7 @@ public abstract class WebConsoleTest extends TestBaseWithShared implements ISele
     protected void doTestFilterConnectionsByContainerId() throws Exception {
         int connectionCount = 5;
 
-        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), addressApiClient,
+        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), 
                 sharedAddressSpace, clusterUser);
         consoleWebPage.openWebConsolePage();
         Address dest = AddressUtils.createQueueAddressObject("queue-via-web", getDefaultPlan(AddressType.QUEUE));
@@ -545,7 +545,7 @@ public abstract class WebConsoleTest extends TestBaseWithShared implements ISele
     protected void doTestSortConnectionsByContainerId() throws Exception {
         int connectionCount = 5;
 
-        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), addressApiClient,
+        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), 
                 sharedAddressSpace, clusterUser);
         consoleWebPage.openWebConsolePage();
         Address dest = AddressUtils.createQueueAddressObject("queue-via-web", getDefaultPlan(AddressType.QUEUE));
@@ -567,7 +567,7 @@ public abstract class WebConsoleTest extends TestBaseWithShared implements ISele
 
     protected void doTestMessagesMetrics() throws Exception {
         int msgCount = 19;
-        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), addressApiClient,
+        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), 
                 sharedAddressSpace, clusterUser);
         consoleWebPage.openWebConsolePage();
         Address dest = AddressUtils.createQueueAddressObject("queue-via-web", getDefaultPlan(AddressType.QUEUE));
@@ -596,7 +596,7 @@ public abstract class WebConsoleTest extends TestBaseWithShared implements ISele
     protected void doTestClientsMetrics() throws Exception {
         int senderCount = 5;
         int receiverCount = 10;
-        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), addressApiClient,
+        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), 
                 sharedAddressSpace, clusterUser);
         consoleWebPage.openWebConsolePage();
         Address dest = AddressUtils.createQueueAddressObject("queue-via-web", getDefaultPlan(AddressType.QUEUE));
@@ -620,7 +620,7 @@ public abstract class WebConsoleTest extends TestBaseWithShared implements ISele
 
     protected void doTestCanOpenConsolePage(UserCredentials credentials) throws Exception {
         try {
-            consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), addressApiClient,
+            consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), 
                     sharedAddressSpace, credentials);
             consoleWebPage.openWebConsolePage();
             log.info(String.format("User %s successfully authenticated", credentials));
@@ -644,7 +644,7 @@ public abstract class WebConsoleTest extends TestBaseWithShared implements ISele
             testString = String.join("", Collections.nCopies(24, "10charHere"));
         }
 
-        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), addressApiClient,
+        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), 
                 sharedAddressSpace, clusterUser);
         consoleWebPage.openWebConsolePage();
 
@@ -677,7 +677,7 @@ public abstract class WebConsoleTest extends TestBaseWithShared implements ISele
         String testString = "addressname";
         Address destValid = AddressUtils.createQueueAddressObject(testString, getDefaultPlan(AddressType.QUEUE));
 
-        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), addressApiClient,
+        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), 
                 sharedAddressSpace, clusterUser);
         consoleWebPage.openWebConsolePage();
         consoleWebPage.openAddressesPageWebConsole();
@@ -696,7 +696,7 @@ public abstract class WebConsoleTest extends TestBaseWithShared implements ISele
     }
 
     protected void doTestCreateAddressWithSymbolsAt61stCharIndex(Address... destinations) throws Exception {
-        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), addressApiClient,
+        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), 
                 sharedAddressSpace, clusterUser);
         consoleWebPage.openWebConsolePage();
         consoleWebPage.openAddressesPageWebConsole();
@@ -715,7 +715,7 @@ public abstract class WebConsoleTest extends TestBaseWithShared implements ISele
         Address destTopic = AddressUtils.createAddressObject(AddressType.TOPIC, "test-addr-topic",
                 getDefaultPlan(AddressType.TOPIC), Optional.empty());
 
-        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), addressApiClient,
+        consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(sharedAddressSpace), 
                 sharedAddressSpace, clusterUser);
         consoleWebPage.openWebConsolePage();
         consoleWebPage.openAddressesPageWebConsole();

--- a/systemtests/src/test/java/io/enmasse/systemtest/common/api/ApiServerTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/common/api/ApiServerTest.java
@@ -202,7 +202,6 @@ public class ApiServerTest extends TestBase {
             ConsoleWebPage console = new ConsoleWebPage(
                     selenium,
                     getConsoleRoute(addressSpace),
-                    addressApiClient,
                     addressSpace,
                     luckyUser);
             console.openWebConsolePage();

--- a/systemtests/src/test/java/io/enmasse/systemtest/common/api/ApiServerTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/common/api/ApiServerTest.java
@@ -355,14 +355,14 @@ public class ApiServerTest extends TestBase {
         String namespace1 = "test-namespace-1";
         String namespace2 = "test-namespace-2";
 
+        AddressApiClient nameSpaceClient1 = new AddressApiClient(kubernetes, namespace1);
+        AddressApiClient nameSpaceClient2 = new AddressApiClient(kubernetes, namespace2);
+
         try {
             kubernetes.createNamespace(namespace1);
             kubernetes.createNamespace(namespace2);
 
             log.info("--------------- Address space part -------------------");
-
-            AddressApiClient nameSpaceClient1 = new AddressApiClient(kubernetes, namespace1);
-            AddressApiClient nameSpaceClient2 = new AddressApiClient(kubernetes, namespace2);
 
             AddressSpace brokered = AddressSpaceUtils.createAddressSpaceObject("brokered", namespace1, AddressSpaceType.BROKERED, AuthenticationServiceType.STANDARD);
             AddressSpace standard = AddressSpaceUtils.createAddressSpaceObject("standard", namespace2, AddressSpaceType.STANDARD, AddressSpacePlans.STANDARD_SMALL, AuthenticationServiceType.STANDARD);
@@ -402,6 +402,8 @@ public class ApiServerTest extends TestBase {
                             .stream().filter(user -> user.getSpec().getAuthentication().getType().equals(UserAuthenticationType.password)).collect(Collectors.toList()).size(),
                     is(2));
         } finally {
+            nameSpaceClient1.close();
+            nameSpaceClient2.close();
             kubernetes.deleteNamespace(namespace1);
             kubernetes.deleteNamespace(namespace2);
         }

--- a/systemtests/src/test/java/io/enmasse/systemtest/common/api/CustomResourceDefinitionAddressSpacesTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/common/api/CustomResourceDefinitionAddressSpacesTest.java
@@ -106,8 +106,7 @@ class CustomResourceDefinitionAddressSpacesTest extends TestBase {
     void testCreateAddressSpaceViaCmdNonAdminUser() throws Exception {
         String namespace = Credentials.namespace();
         UserCredentials user = Credentials.userCredentials();
-        try {
-            AddressApiClient apiClient = new AddressApiClient(kubernetes, namespace);
+        try (AddressApiClient apiClient = new AddressApiClient(kubernetes, namespace)) {
             AddressSpace brokered = AddressSpaceUtils.createAddressSpaceObject("crd-addressspaces-test-baz", AddressSpaceType.BROKERED, AuthenticationServiceType.STANDARD);
             JsonObject addressSpacePayloadJson = AddressSpaceUtils.addressSpaceToJson(brokered);
 
@@ -134,11 +133,10 @@ class CustomResourceDefinitionAddressSpacesTest extends TestBase {
     void testCliOutput() throws Exception {
         String namespace = "cli-output";
         UserCredentials user = new UserCredentials("pepan", "pepan");
-        try {
+        try (AddressApiClient apiClient = new AddressApiClient(kubernetes, namespace)) {
             //===========================
             // AddressSpace part
             //===========================
-            AddressApiClient apiClient = new AddressApiClient(kubernetes, namespace);
             AddressSpace brokered = AddressSpaceUtils.createAddressSpaceObject("crd-brokered", AddressSpaceType.BROKERED, AuthenticationServiceType.STANDARD);
             AddressSpace standard = AddressSpaceUtils.createAddressSpaceObject("crd-standard", AddressSpaceType.STANDARD, AddressSpacePlans.STANDARD_SMALL, AuthenticationServiceType.STANDARD);
 

--- a/systemtests/src/test/java/io/enmasse/systemtest/common/api/CustomResourceDefinitionAddressesTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/common/api/CustomResourceDefinitionAddressesTest.java
@@ -52,7 +52,7 @@ public class CustomResourceDefinitionAddressesTest extends TestBase implements I
         Address dest1 = AddressUtils.createTopicAddressObject("mytopic-agent", DestinationPlan.BROKERED_TOPIC);
         Address dest2 = AddressUtils.createTopicAddressObject("mytopic-api", DestinationPlan.BROKERED_TOPIC);
 
-        ConsoleWebPage consoleWeb = new ConsoleWebPage(selenium, getConsoleRoute(brokered), addressApiClient, brokered, clusterUser);
+        ConsoleWebPage consoleWeb = new ConsoleWebPage(selenium, getConsoleRoute(brokered), brokered, clusterUser);
         consoleWeb.openWebConsolePage();
         consoleWeb.openAddressesPageWebConsole();
         consoleWeb.createAddressWebConsole(dest1, false);
@@ -139,7 +139,7 @@ public class CustomResourceDefinitionAddressesTest extends TestBase implements I
                 String.format("Get all addresses should contains '%s'; but contains only: %s",
                         AddressUtils.generateAddressMetadataName(brokered.getMetadata().getName(), dest2), output));
 
-        ConsoleWebPage consoleWeb = new ConsoleWebPage(selenium, getConsoleRoute(brokered), addressApiClient, brokered, clusterUser);
+        ConsoleWebPage consoleWeb = new ConsoleWebPage(selenium, getConsoleRoute(brokered), brokered, clusterUser);
         consoleWeb.openWebConsolePage();
         consoleWeb.openAddressesPageWebConsole();
         consoleWeb.deleteAddressWebConsole(dest1);

--- a/systemtests/src/test/java/io/enmasse/systemtest/common/catalog/ServiceCatalogWebTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/common/catalog/ServiceCatalogWebTest.java
@@ -31,9 +31,9 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.slf4j.Logger;
 
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
@@ -47,11 +47,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ServiceCatalogWebTest extends TestBase implements ISeleniumProviderFirefox {
 
     private static Logger log = CustomLogger.getLogger();
-    private Map<String, AddressSpace> provisionedServices = new HashMap<>();
+    private List<AddressSpace> provisionedServices = new ArrayList<>();
     private UserCredentials ocTestUser = Credentials.userCredentials();
 
-    private String getUserProjectName(AddressSpace addressSpace) {
-        return String.format("%s-%s", "service", addressSpace.getMetadata().getName());
+    private String getUserProjectName(String name) {
+        return String.format("%s-%s", "service", name);
     }
 
     @BeforeEach
@@ -66,9 +66,9 @@ class ServiceCatalogWebTest extends TestBase implements ISeleniumProviderFirefox
     @AfterEach
     void tearDownWebConsoleTests() {
         if (!environment.skipCleanup()) {
-            provisionedServices.forEach((project, addressSpace) -> {
+            provisionedServices.forEach((addressSpace) -> {
                 try {
-                    deleteAddressSpaceCreatedBySC(project, addressSpace);
+                    deleteAddressSpaceCreatedBySC(addressSpace);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
@@ -82,42 +82,39 @@ class ServiceCatalogWebTest extends TestBase implements ISeleniumProviderFirefox
     @Test
     @DisabledIfEnvironmentVariable(named = useMinikubeEnv, matches = "true")
     void testProvisionAddressSpaceBrokered() throws Exception {
-        AddressSpace brokered = AddressSpaceUtils.createAddressSpaceObject("addr-space-brokered", AddressSpaceType.BROKERED);
-        String namespace = getUserProjectName(brokered);
-        provisionedServices.put(namespace, brokered);
+        AddressSpace brokered = AddressSpaceUtils.createAddressSpaceObject("addr-space-brokered", getUserProjectName("addr-space-brokered"), AddressSpaceType.BROKERED);
+        provisionedServices.add(brokered);
         OpenshiftWebPage ocPage = new OpenshiftWebPage(selenium, addressApiClient, getOCConsoleRoute(), ocTestUser);
         ocPage.openOpenshiftPage();
-        ocPage.provisionAddressSpaceViaSC(brokered, namespace);
-        ocPage.deprovisionAddressSpace(namespace);
+        ocPage.provisionAddressSpaceViaSC(brokered);
+        ocPage.deprovisionAddressSpace(brokered.getMetadata().getNamespace());
     }
 
     @Test
     @DisabledIfEnvironmentVariable(named = useMinikubeEnv, matches = "true")
     void testProvisionAddressSpaceStandard() throws Exception {
-        AddressSpace standard = AddressSpaceUtils.createAddressSpaceObject("addr-space-standard", AddressSpaceType.STANDARD, AddressSpacePlans.STANDARD_SMALL);
-        String namespace = getUserProjectName(standard);
-        provisionedServices.put(namespace, standard);
+        AddressSpace standard = AddressSpaceUtils.createAddressSpaceObject("addr-space-standard", getUserProjectName("addr-space-standard"), AddressSpaceType.STANDARD, AddressSpacePlans.STANDARD_SMALL);
+        provisionedServices.add(standard);
         OpenshiftWebPage ocPage = new OpenshiftWebPage(selenium, addressApiClient, getOCConsoleRoute(), ocTestUser);
         ocPage.openOpenshiftPage();
-        ocPage.provisionAddressSpaceViaSC(standard, namespace);
-        ocPage.deprovisionAddressSpace(namespace);
+        ocPage.provisionAddressSpaceViaSC(standard);
+        ocPage.deprovisionAddressSpace(standard.getMetadata().getNamespace());
     }
 
     @Test
     @DisabledIfEnvironmentVariable(named = useMinikubeEnv, matches = "true")
     void testCreateDeleteBindings() throws Exception {
-        AddressSpace brokered = AddressSpaceUtils.createAddressSpaceObject("test-binding-space", AddressSpaceType.BROKERED);
-        String namespace = getUserProjectName(brokered);
-        provisionedServices.put(namespace, brokered);
+        AddressSpace brokered = AddressSpaceUtils.createAddressSpaceObject("test-binding-space", getUserProjectName("test-binding-space"), AddressSpaceType.BROKERED);
+        provisionedServices.add(brokered);
         OpenshiftWebPage ocPage = new OpenshiftWebPage(selenium, addressApiClient, getOCConsoleRoute(), ocTestUser);
         ocPage.openOpenshiftPage();
-        ocPage.provisionAddressSpaceViaSC(brokered, namespace);
-        String binding1 = ocPage.createBinding(namespace, null, null);
-        String binding2 = ocPage.createBinding(namespace, "test_*", "pepa_*");
-        String binding3 = ocPage.createBinding(namespace, "test_address", "test_address");
-        ocPage.removeBinding(namespace, binding1);
-        ocPage.removeBinding(namespace, binding2);
-        ocPage.removeBinding(namespace, binding3);
+        ocPage.provisionAddressSpaceViaSC(brokered);
+        String binding1 = ocPage.createBinding(brokered, null, null);
+        String binding2 = ocPage.createBinding(brokered, "test_*", "pepa_*");
+        String binding3 = ocPage.createBinding(brokered, "test_address", "test_address");
+        ocPage.removeBinding(brokered, binding1);
+        ocPage.removeBinding(brokered, binding2);
+        ocPage.removeBinding(brokered, binding3);
     }
 
     @Test
@@ -125,21 +122,20 @@ class ServiceCatalogWebTest extends TestBase implements ISeleniumProviderFirefox
     void testCreateBindingCreateAddressSendReceive() throws Exception {
         Address queue = AddressUtils.createQueueAddressObject("test-queue", DestinationPlan.BROKERED_QUEUE);
         Address topic = AddressUtils.createTopicAddressObject("test-topic", DestinationPlan.BROKERED_TOPIC);
-        AddressSpace brokered = AddressSpaceUtils.createAddressSpaceObject("test-messaging-space", AddressSpaceType.BROKERED, AuthenticationServiceType.STANDARD);
-        String namespace = getUserProjectName(brokered);
-        provisionedServices.put(namespace, brokered);
+        AddressSpace brokered = AddressSpaceUtils.createAddressSpaceObject("test-messaging-space", getUserProjectName("test-messaging-space"), AddressSpaceType.BROKERED, AuthenticationServiceType.STANDARD);
+        provisionedServices.add(brokered);
         OpenshiftWebPage ocPage = new OpenshiftWebPage(selenium, addressApiClient, getOCConsoleRoute(), ocTestUser);
 
         ocPage.openOpenshiftPage();
-        ocPage.provisionAddressSpaceViaSC(brokered, namespace);
+        ocPage.provisionAddressSpaceViaSC(brokered);
         reloadAddressSpaceEndpoints(brokered);
 
-        String bindingID = ocPage.createBinding(namespace, null, null);
-        String restrictedAccesId = ocPage.createBinding(namespace, "noexists", "noexists");
-        BindingSecretData credentials = ocPage.viewSecretOfBinding(namespace, bindingID);
-        BindingSecretData restricted = ocPage.viewSecretOfBinding(namespace, restrictedAccesId);
+        String bindingID = ocPage.createBinding(brokered, null, null);
+        String restrictedAccesId = ocPage.createBinding(brokered, "noexists", "noexists");
+        BindingSecretData credentials = ocPage.viewSecretOfBinding(brokered, bindingID);
+        BindingSecretData restricted = ocPage.viewSecretOfBinding(brokered, restrictedAccesId);
 
-        ConsoleWebPage consolePage = ocPage.clickOnDashboard(namespace, brokered);
+        ConsoleWebPage consolePage = ocPage.clickOnDashboard(brokered);
         consolePage.login(ocTestUser);
         consolePage.createAddressWebConsole(queue, false);
         consolePage.createAddressWebConsole(topic, true);
@@ -148,7 +144,7 @@ class ServiceCatalogWebTest extends TestBase implements ISeleniumProviderFirefox
         assertCannotConnect(brokered, restricted.getCredentials(), Arrays.asList(queue, topic));
 
         log.info("Remove binding and check if client cannot connect");
-        ocPage.removeBinding(namespace, bindingID);
+        ocPage.removeBinding(brokered, bindingID);
         assertCannotConnect(brokered, credentials.getCredentials(), Arrays.asList(queue, topic));
     }
 
@@ -156,19 +152,18 @@ class ServiceCatalogWebTest extends TestBase implements ISeleniumProviderFirefox
     @DisabledIfEnvironmentVariable(named = useMinikubeEnv, matches = "true")
     void testSendMessageUsingBindingCert() throws Exception {
         Address queue = AddressUtils.createQueueAddressObject("test-queue", DestinationPlan.STANDARD_LARGE_QUEUE);
-        AddressSpace addressSpace = AddressSpaceUtils.createAddressSpaceObject("test-cert-space", AddressSpaceType.STANDARD);
-        String namespace = getUserProjectName(addressSpace);
-        provisionedServices.put(namespace, addressSpace);
+        AddressSpace addressSpace = AddressSpaceUtils.createAddressSpaceObject("test-cert-space", getUserProjectName("test-cert-space"), AddressSpaceType.STANDARD);
+        provisionedServices.add(addressSpace);
         OpenshiftWebPage ocPage = new OpenshiftWebPage(selenium, addressApiClient, getOCConsoleRoute(), ocTestUser);
 
         ocPage.openOpenshiftPage();
-        ocPage.provisionAddressSpaceViaSC(addressSpace, namespace);
+        ocPage.provisionAddressSpaceViaSC(addressSpace);
         reloadAddressSpaceEndpoints(addressSpace);
 
-        String bindingID = ocPage.createBinding(namespace, null, null);
-        BindingSecretData credentials = ocPage.viewSecretOfBinding(namespace, bindingID);
+        String bindingID = ocPage.createBinding(addressSpace, null, null);
+        BindingSecretData credentials = ocPage.viewSecretOfBinding(addressSpace, bindingID);
 
-        ConsoleWebPage consolePage = ocPage.clickOnDashboard(namespace, addressSpace);
+        ConsoleWebPage consolePage = ocPage.clickOnDashboard(addressSpace);
         consolePage.login(ocTestUser);
         consolePage.createAddressWebConsole(queue, true);
 
@@ -184,18 +179,17 @@ class ServiceCatalogWebTest extends TestBase implements ISeleniumProviderFirefox
     @Test
     @DisabledIfEnvironmentVariable(named = useMinikubeEnv, matches = "true")
     void testLoginWithOpensShiftCredentials() throws Exception {
-        AddressSpace brokeredSpace = AddressSpaceUtils.createAddressSpaceObject("login-via-oc-brokered", AddressSpaceType.BROKERED);
-        String namespace = getUserProjectName(brokeredSpace);
+        AddressSpace brokeredSpace = AddressSpaceUtils.createAddressSpaceObject("login-via-oc-brokered", getUserProjectName("login-via-oc-brokered"), AddressSpaceType.BROKERED);
 
         //provision via oc web ui and wait until ready
-        provisionedServices.put(namespace, brokeredSpace);
+        provisionedServices.add(brokeredSpace);
         OpenshiftWebPage ocPage = new OpenshiftWebPage(selenium, addressApiClient, getOCConsoleRoute(), ocTestUser);
         ocPage.openOpenshiftPage();
-        ocPage.provisionAddressSpaceViaSC(brokeredSpace, namespace);
+        ocPage.provisionAddressSpaceViaSC(brokeredSpace);
         reloadAddressSpaceEndpoints(brokeredSpace);
 
         //open console login web page and use OpenShift credentials for login
-        ConsoleWebPage consolePage = ocPage.clickOnDashboard(namespace, brokeredSpace);
+        ConsoleWebPage consolePage = ocPage.clickOnDashboard(brokeredSpace);
         consolePage.login(ocTestUser);
     }
 
@@ -203,25 +197,24 @@ class ServiceCatalogWebTest extends TestBase implements ISeleniumProviderFirefox
     @DisabledIfEnvironmentVariable(named = useMinikubeEnv, matches = "true")
     void testSendReceiveInsideCluster() throws Exception {
         Address queue = AddressUtils.createQueueAddressObject("test-queue", DestinationPlan.STANDARD_LARGE_QUEUE);
-        AddressSpace addressSpace = AddressSpaceUtils.createAddressSpaceObject("cluster-messaging-space", AddressSpaceType.STANDARD);
-        String namespace = getUserProjectName(addressSpace);
-        provisionedServices.put(namespace, addressSpace);
+        AddressSpace addressSpace = AddressSpaceUtils.createAddressSpaceObject("cluster-messaging-space", getUserProjectName("cluster-messaging-space"), AddressSpaceType.STANDARD);
+        provisionedServices.add(addressSpace);
         OpenshiftWebPage ocPage = new OpenshiftWebPage(selenium, addressApiClient, getOCConsoleRoute(), ocTestUser);
 
         ocPage.openOpenshiftPage();
-        ocPage.provisionAddressSpaceViaSC(addressSpace, namespace);
+        ocPage.provisionAddressSpaceViaSC(addressSpace);
         reloadAddressSpaceEndpoints(addressSpace);
 
-        String bindingID = ocPage.createBinding(namespace, null, null);
-        BindingSecretData credentials = ocPage.viewSecretOfBinding(namespace, bindingID);
+        String bindingID = ocPage.createBinding(addressSpace, null, null);
+        BindingSecretData credentials = ocPage.viewSecretOfBinding(addressSpace, bindingID);
 
-        ConsoleWebPage consolePage = ocPage.clickOnDashboard(namespace, addressSpace);
+        ConsoleWebPage consolePage = ocPage.clickOnDashboard(addressSpace);
         consolePage.login(ocTestUser);
         consolePage.createAddressWebConsole(queue, true);
 
         try {
-            SystemtestsKubernetesApps.deployMessagingClientApp(namespace, kubernetes);
-            MsgCliApiClient client = new MsgCliApiClient(kubernetes, SystemtestsKubernetesApps.getMessagingClientEndpoint(namespace, kubernetes));
+            SystemtestsKubernetesApps.deployMessagingClientApp(addressSpace.getMetadata().getNamespace(), kubernetes);
+            MsgCliApiClient client = new MsgCliApiClient(kubernetes, SystemtestsKubernetesApps.getMessagingClientEndpoint(addressSpace.getMetadata().getNamespace(), kubernetes));
 
             ProtonJMSClientSender msgClient = new ProtonJMSClientSender();
 
@@ -243,27 +236,25 @@ class ServiceCatalogWebTest extends TestBase implements ISeleniumProviderFirefox
             assertThat(String.format("Return code of receiver is not 0: %s", response.toString()),
                     response.getInteger("ecode"), is(0));
         } finally {
-            SystemtestsKubernetesApps.deleteMessagingClientApp(namespace, kubernetes);
+            SystemtestsKubernetesApps.deleteMessagingClientApp(addressSpace.getMetadata().getNamespace(), kubernetes);
         }
     }
 
     @Test
     void testConsoleErrorOnDeleteAddressSpace() throws Exception {
-        AddressSpace addressSpace = AddressSpaceUtils.createAddressSpaceObject("test-addr-space", AuthenticationServiceType.STANDARD);
+        AddressSpace addressSpace = AddressSpaceUtils.createAddressSpaceObject("test-addr-space", getUserProjectName("test-addr-space"), AuthenticationServiceType.STANDARD);
 
-        String namespace = getUserProjectName(addressSpace);
-
-        provisionedServices.put(namespace, addressSpace);
+        provisionedServices.add(addressSpace);
         OpenshiftWebPage ocPage = new OpenshiftWebPage(selenium, addressApiClient, getOCConsoleRoute(), ocTestUser);
         ocPage.openOpenshiftPage();
-        ocPage.provisionAddressSpaceViaSC(addressSpace, namespace);
+        ocPage.provisionAddressSpaceViaSC(addressSpace);
         reloadAddressSpaceEndpoints(addressSpace);
 
-        ConsoleWebPage consolePage = ocPage.clickOnDashboard(namespace, addressSpace);
+        ConsoleWebPage consolePage = ocPage.clickOnDashboard(addressSpace);
         consolePage.login(ocTestUser);
         consolePage.createAddressWebConsole(AddressUtils.createQueueAddressObject("test-queue-before", DestinationPlan.STANDARD_SMALL_QUEUE), true);
 
-        deleteAddressSpaceCreatedBySC(namespace, addressSpace);
+        deleteAddressSpaceCreatedBySC(addressSpace);
 
         WebElement errorLog = selenium.getWebElement(() ->
                 selenium.getDriver().findElement(By.id("peerLostErrorDialogLabel")));

--- a/systemtests/src/test/java/io/enmasse/systemtest/common/plans/PlansTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/common/plans/PlansTest.java
@@ -865,7 +865,7 @@ class PlansTest extends TestBase implements ISeleniumProviderChrome {
             }
         }
 
-        ConsoleWebPage page = new ConsoleWebPage(selenium, getConsoleRoute(addressSpace), addressApiClient, addressSpace, clusterUser);
+        ConsoleWebPage page = new ConsoleWebPage(selenium, getConsoleRoute(addressSpace), addressSpace, clusterUser);
         page.openWebConsolePage();
         page.openAddressesPageWebConsole();
 

--- a/systemtests/src/test/java/io/enmasse/systemtest/marathon/MarathonTestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/marathon/MarathonTestBase.java
@@ -312,7 +312,7 @@ abstract class MarathonTestBase extends TestBase {
         runTestInLoop(30, () -> {
             SeleniumProvider selenium = new SeleniumProvider();
             selenium.setupDriver(environment, kubernetes, TestUtils.getFirefoxDriver());
-            consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(addressSpace), addressApiClient, addressSpace, clusterUser);
+            consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(addressSpace), addressSpace, clusterUser);
             consoleWebPage.openWebConsolePage(user);
             try {
                 consoleWebPage.createAddressesWebConsole(addresses.toArray(new Address[0]));
@@ -322,7 +322,7 @@ abstract class MarathonTestBase extends TestBase {
                 selenium.tearDownDrivers();
             } catch (Exception ex) {
                 selenium.setupDriver(environment, kubernetes, TestUtils.getFirefoxDriver());
-                consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(addressSpace), addressApiClient, addressSpace, clusterUser);
+                consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(addressSpace), addressSpace, clusterUser);
                 consoleWebPage.openWebConsolePage(user);
                 throw new Exception(ex);
             }


### PR DESCRIPTION
Add namespace parameter when creating address space using service
catalog, as the user does not have permissions to the address space
stored in the global enmasse namespace

Fixes #2649