### PR TITLE
Correct cookie decoder error handling

### DIFF
--- a/agent/lib/auth_utils.js
+++ b/agent/lib/auth_utils.js
@@ -318,6 +318,8 @@ module.exports.auth_handler = function (authz, env, handler, auth_context, opens
                 } else {
                     log.debug("No access token found in SSO cookie");
                 }
+            } catch (e) {
+                log.debug("Failed to decode SSO cookie, probably wrong cookie key.", e);
             } finally {
                 next();
             }

--- a/agent/lib/cookie_decoder.js
+++ b/agent/lib/cookie_decoder.js
@@ -51,13 +51,7 @@ CookieDecoder.prototype.decode = function (oauthcookie_base64url) {
         throw Error(util.format("invalid number of fields (got %d expected 4)", cookie_chunks.length));
     }
     var access_token_ciphered = cookie_chunks[1];
-    var refresh_token_token_ciphered = cookie_chunks[3];
-
     session_state.access_token = this._do_decode(access_token_ciphered);
-    if (refresh_token_token_ciphered) {
-        session_state.refresh_token = this._do_decode(refresh_token_token_ciphered);
-    }
-
     return session_state;
 };
 


### PR DESCRIPTION
The intent was that if cookie decode fails for any reason, we fall back on the OAuth/OIDC.  The implemented logic was duff.

Also remove redundant refresh cookie handling on SSO path.