### PR TITLE
Bump logback from 1.0.13 to 1.2.3 to avoid report of CVE-2017-5929.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <sundrio.version>0.16.4</sundrio.version>
         <vertx.version>3.6.3</vertx.version>
         <slf4j.version>1.7.21</slf4j.version>
-        <logback.version>1.0.13</logback.version>
+        <logback.version>1.2.3</logback.version>
         <hibernate.validator.version>6.0.10.Final</hibernate.validator.version>
         <jackson-annotations.version>2.9.8</jackson-annotations.version>
         <jackson-core.version>2.9.8</jackson-core.version>


### PR DESCRIPTION
EnMasse does not make use of the SocketServer and ServerSocketReceiver feature affected by the CVE, so was probably not impacted.