### PR TITLE
Use AMQP only on 7777

### DIFF
--- a/address-space-controller/src/main/resources/templates/standard-space-infra.yaml
+++ b/address-space-controller/src/main/resources/templates/standard-space-infra.yaml
@@ -93,6 +93,12 @@ objects:
         host: 127.0.0.1
         port: 7777
         authenticatePeer: no
+      }
+
+      listener {
+        host: 127.0.0.1
+        port: 7770
+        authenticatePeer: no
         http: true
         metrics: false
         healthz: true
@@ -282,7 +288,7 @@ objects:
             initialDelaySeconds: 30
             httpGet:
               path: /healthz
-              port: local
+              port: local-http
               scheme: HTTP
           readinessProbe:
             initialDelaySeconds: 60
@@ -305,6 +311,9 @@ objects:
             protocol: TCP
           - containerPort: 7777
             name: local
+            protocol: TCP
+          - containerPort: 7770
+            name: local-http
             protocol: TCP
           - containerPort: 8080
             name: http


### PR DESCRIPTION
Moves http health check port to 7770 to allow qdmanage and qdstat to
work on 7777 as intended.