### PR TITLE
install connection event listeners before opening the connection

### DIFF
--- a/agent/www/shared/address_service.js
+++ b/agent/www/shared/address_service.js
@@ -165,7 +165,6 @@ function AddressService($http) {
     var ws = rhea.websocket_connect(WebSocket);
     var connectionDetails = ws("wss://" + location.hostname + ":" + location.port + "/websocket", ["binary", "AMQPWSB10"]);
     this.connection = rhea.create_connection({"connection_details": connectionDetails, "reconnect":15000, rejectUnauthorized:true});
-    this.connection.connect();
     this.connection.on('message', this.on_message.bind(this));
     this.connection.on('connection_open', function (context) {
         self.update_periodic_deltas_interval = setInterval(self.update_periodic_deltas.bind(self), 5000);
@@ -188,6 +187,7 @@ function AddressService($http) {
             self.callback("peer_disconnected");
         }
     });
+    this.connection.connect();
 
     this.sender = this.connection.open_sender({autosettle: false});
     this.sender.on("accepted", (context) => {


### PR DESCRIPTION
This change should fix an occasional test fail seen during system test runs.  It affects only the client (browser) side.  I theory is that the test failure is a race condition likely on slow hardware, where the server side manages to close the connection before the client's thread of control has had chance to install the connection listeners.