### PR TITLE
Bump maven-assembly-version to avoid suspected bundling issue with symlinks

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -47,6 +47,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-assembly-plugin</artifactId>
+                        <version>3.1.1</version>
                         <executions>
                             <execution>
                                 <id>make-src-assembly</id>


### PR DESCRIPTION
Change affects only the bundle module for now (no functional change).