### PR TITLE
Fix sporadically failing ServiceCatalogWebTest

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/TestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/TestBase.java
@@ -453,8 +453,12 @@ public abstract class TestBase implements ITestBase, ITestSeparator {
     }
 
     protected boolean userExist(AddressSpace addressSpace, String username) throws Exception {
+        return userExist(getUserApiClient(), addressSpace, username);
+    }
+
+    protected boolean userExist(UserApiClient client, AddressSpace addressSpace, String username) throws Exception {
         String id = String.format("%s.%s", addressSpace.getMetadata().getName(), username);
-        JsonObject response = getUserApiClient().getUserList(addressSpace.getMetadata().getName());
+        JsonObject response = client.getUserList(addressSpace.getMetadata().getName());
         log.info("User list for {}: {}", addressSpace.getMetadata().getName(), response.toString());
         JsonArray users = response.getJsonArray("items");
         for (Object user : users) {

--- a/systemtests/src/test/java/io/enmasse/systemtest/common/catalog/ServiceCatalogWebTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/common/catalog/ServiceCatalogWebTest.java
@@ -10,6 +10,7 @@ import io.enmasse.address.model.AuthenticationServiceType;
 import io.enmasse.systemtest.*;
 import io.enmasse.systemtest.amqp.AmqpClient;
 import io.enmasse.systemtest.apiclients.MsgCliApiClient;
+import io.enmasse.systemtest.apiclients.UserApiClient;
 import io.enmasse.systemtest.bases.TestBase;
 import io.enmasse.systemtest.common.Credentials;
 import io.enmasse.systemtest.messagingclients.ClientArgument;
@@ -145,6 +146,16 @@ class ServiceCatalogWebTest extends TestBase implements ISeleniumProviderFirefox
 
         log.info("Remove binding and check if client cannot connect");
         ocPage.removeBinding(brokered, bindingID);
+
+        try(UserApiClient clientApi = new UserApiClient(kubernetes, brokered.getMetadata().getNamespace())) {
+            long end = System.currentTimeMillis() + 30_000;
+            String username = credentials.getCredentials().getUsername();
+            while(userExist(clientApi, brokered, username) && end > System.currentTimeMillis()) {
+                Thread.sleep(5_000);
+                log.info("Still awaiting user {} to be removed.", username);
+            }
+        }
+
         assertCannotConnect(brokered, credentials.getCredentials(), Arrays.asList(queue, topic));
     }
 


### PR DESCRIPTION
Most likely cause for sporadic test failure is that the controller has not yet fully actioned the removal of the user.  Test now awaits the user to be gone before proceeding.