### PR TITLE
On Darwin changing 'base64 -w0' into 'base64 -b0'.

### DIFF
--- a/ansible/roles/monitoring-infrastructure/tasks/main.yml
+++ b/ansible/roles/monitoring-infrastructure/tasks/main.yml
@@ -5,6 +5,14 @@
 - name: Base64 encode Alertmanager config
   register: config
   shell: cat {{ playbook_dir }}/install/alertmanager/010-Config-alertmanager | base64 -w0
+  when: ansible_facts['os_family'] != "Darwin"
+
+- name: Base64 encode Alertmanager config
+  register: config
+  shell: cat {{ playbook_dir }}/install/alertmanager/010-Config-alertmanager | base64 -b0
+  when: ansible_facts['os_family'] == "Darwin"
+
+
 
 - name: Create Alertmanager config secret
   lineinfile:


### PR DESCRIPTION
On Darwin base64 has no option named '-w0' but uses the option '-b0'.

This PR checks if it is or is not on Darwin and uses the current base64 option according to the used platform.