### PR TITLE
Further console operator improvements

### DIFF
--- a/pkg/util/install/utils.go
+++ b/pkg/util/install/utils.go
@@ -382,6 +382,10 @@ func ApplyEnvSimple(container *corev1.Container, name string, value string) {
 }
 
 func ApplyEnvSecret(container *corev1.Container, name string, secretKey string, secretName string) {
+	ApplyEnvOptionalSecret(container, name, secretKey, secretName, nil)
+}
+
+func ApplyEnvOptionalSecret(container *corev1.Container, name string, secretKey string, secretName string, optional *bool) {
 	ApplyEnv(container, name, func(envvar *corev1.EnvVar) {
 		envvar.Value = ""
 		envvar.ValueFrom = &corev1.EnvVarSource{
@@ -390,6 +394,7 @@ func ApplyEnvSecret(container *corev1.Container, name string, secretKey string, 
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: secretName,
 				},
+				Optional: optional,
 			},
 		}
 	})


### PR DESCRIPTION
We saw a case in an OCP4 test environment where the sso-cookie secret didn't get automatically generated.  This changes the reconcile algorithm so that if that situation were to occur, the secret would get generated on the next pass.

Also changed the reconciler so that if it itself updates the consoleservice CR it suppresses the requeue to prevent a needless iteration (that usually resulted in errors in the logs). 
