### PR TITLE
Version between quotes in infra config example

### DIFF
--- a/documentation/modules/proc-applying-infra-config.adoc
+++ b/documentation/modules/proc-applying-infra-config.adoc
@@ -37,7 +37,7 @@ kind: StandardInfraConfig
 metadata:
   name: myconfig
 spec:
-  version: {EnMasseVersion}
+  version: "{EnMasseVersion}"
   admin:
     resources:
       memory: 256Mi


### PR DESCRIPTION
Changes the version field in one example of infraestructure configuration to be consistent with the rest of examples and just because it's the correct way.