### PR TITLE
Modified way of detecting if we are kubernetes

### DIFF
--- a/console/console-init/oauth-proxy/bin/init.sh
+++ b/console/console-init/oauth-proxy/bin/init.sh
@@ -51,3 +51,10 @@ do
       -e "s,\${OAUTH2_SCOPE},${OAUTH2_SCOPE},g" \
       -i ${c}
 done
+
+echo "window.env = {" > ${TARGET_DIR}/www/env.js
+echo "  OPENSHIFT_AVAILABLE:${OPENSHIFT_AVAILABLE}," >> ${TARGET_DIR}/www/env.js
+#if [ ! -z ${ITEM_REFRESH_RATE} ]; then
+#  echo "  ITEM_REFRESH_RATE:${ITEM_REFRESH_RATE}," >> ${TARGET_DIR}/www/env.js
+#fi
+echo "};" >> ${TARGET_DIR}/www/env.js

--- a/console/console-init/ui/src/components/MessagingInstances/MessagingInstance/Enmasse/CreateAddressSpace/Steps/Configuration/ConfigurationForm.test.js
+++ b/console/console-init/ui/src/components/MessagingInstances/MessagingInstance/Enmasse/CreateAddressSpace/Steps/Configuration/ConfigurationForm.test.js
@@ -19,6 +19,7 @@ describe('< Configuration Form />', () => {
   };
 
   beforeEach(() => {
+    window.env = {OPENSHIFT_AVAILABLE: 'true'};
     wrapper = shallow(<ConfigurationForm newInstance={newInstance} isValid={()=>{}}/>);
   });
 

--- a/console/console-init/ui/src/components/MessagingInstances/MessagingInstance/InstanceLoader.js
+++ b/console/console-init/ui/src/components/MessagingInstances/MessagingInstance/InstanceLoader.js
@@ -11,45 +11,42 @@ class InstanceLoader {
   };
 
   loadNamespaces() {
-    return axios.get('apis/project.openshift.io/v1/').then(() => {
+
+    if (window.env.OPENSHIFT_AVAILABLE) {
       return axios.get('apis/project.openshift.io/v1/projects')
-          .then(response => {
-            return this.translateNamespaces(response.data);
-          })
-          .catch(error => {
-              console.log('FAILED to load namespaces', error);
-              throw(error);
-            }
-          );
-      }
-    ).catch(() => {
+        .then(response => {
+          return this.translateNamespaces(response.data);
+        })
+        .catch(error => {
+            console.log('FAILED to load namespaces', error);
+            throw(error);
+          }
+        );
+    } else {
       console.log('Can not load namespaces in Kubernetes');
-      return new Promise((resolve, reject) =>
-        resolve([]));
-    });
+      return new Promise((resolve, reject) => resolve([]));
+    }
   }
 
   loadInstances() {
-    return axios.get('apis/project.openshift.io/v1/')
-      .then(() => {
-        return this.loadNamespaces().then(namespaces => {
-            let promises = [];
-            namespaces.forEach(namespace => {
-              promises.push(loadMessagingInstance(namespace));
-            });
-            return Promise.all(promises)
-              .then(values => {
-                return [].concat.apply([], values);
-              })
-              .catch(error => {
-                console.log('failed: ', error);
-                return error;
-              });
+    if (window.env.OPENSHIFT_AVAILABLE) {
+      return this.loadNamespaces().then(namespaces => {
+        let promises = [];
+        namespaces.forEach(namespace => {
+          promises.push(loadMessagingInstance(namespace));
+        });
+        return Promise.all(promises)
+          .then(values => {
+            return [].concat.apply([], values);
+          })
+          .catch(error => {
+            console.log('failed: ', error);
+            return error;
           });
-        })
-      .catch(() => {
-        return loadMessagingInstances();
       });
+    } else {
+      return loadMessagingInstances();
+    }
   }
 };
 

--- a/console/console-init/ui/src/index.html
+++ b/console/console-init/ui/src/index.html
@@ -6,6 +6,8 @@
   <title>Console</title>
   <meta id="appName" name="application-name" content="Console">
   <link rel="icon" type="image/png" href="./favicon.ico">
+
+  <script src="./env.js"></script>
 </head>
 
 <body>

--- a/pkg/controller/consoleservice/consoleservice_controller.go
+++ b/pkg/controller/consoleservice/consoleservice_controller.go
@@ -569,6 +569,8 @@ func applyDeployment(consoleservice *v1beta1.ConsoleService, deployment *appsv1.
 			return err
 		}
 
+		install.ApplyEnvSimple(container, "OPENSHIFT_AVAILABLE", strconv.FormatBool(util.IsOpenshift()))
+
 		if consoleservice.Spec.Scope != nil {
 			install.ApplyEnv(container, "OAUTH2_SCOPE", func(envvar *corev1.EnvVar) {
 				envvar.Value = *consoleservice.Spec.Scope


### PR DESCRIPTION
used variable to replaced calls to 'apis/project.openshift.io/v1/' to decide if openshift vs kubernetes.

Signed-off-by: Vanessa <vbusch@redhat.com>