### PR TITLE
Use ENMASSE_OPENSHIFT as a short-circuit to determine the presence of OpenShift

### DIFF
--- a/address-space-controller/pom.xml
+++ b/address-space-controller/pom.xml
@@ -20,6 +20,10 @@
     </dependency>
     <dependency>
       <groupId>io.enmasse</groupId>
+      <artifactId>api-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.enmasse</groupId>
       <artifactId>keycloak-user-api</artifactId>
       <scope>compile</scope>
     </dependency>

--- a/address-space-controller/src/main/java/io/enmasse/controller/AddressSpaceController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/AddressSpaceController.java
@@ -6,6 +6,7 @@
 package io.enmasse.controller;
 
 import io.enmasse.admin.model.v1.AuthenticationServiceType;
+import io.enmasse.api.common.OpenShift;
 import io.enmasse.controller.auth.*;
 import io.enmasse.controller.common.Kubernetes;
 import io.enmasse.controller.common.KubernetesHelper;
@@ -22,16 +23,10 @@ import io.enmasse.user.keycloak.KubeKeycloakFactory;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
-import okhttp3.HttpUrl;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.Map;
@@ -58,23 +53,8 @@ public class AddressSpaceController {
         this.options = options;
     }
 
-    private static boolean isOpenShift(NamespacedKubernetesClient client) {
-        // Need to query the full API path because Kubernetes does not allow GET on /
-        OkHttpClient httpClient = client.adapt(OkHttpClient.class);
-        HttpUrl url = HttpUrl.get(client.getMasterUrl()).resolve("/apis/route.openshift.io");
-        Request.Builder requestBuilder = new Request.Builder()
-                .url(url)
-                .get();
-
-        try (Response response = httpClient.newCall(requestBuilder.build()).execute()) {
-            return response.code() >= 200 && response.code() < 300;
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
-
     public void start() throws Exception {
-        boolean isOpenShift = isOpenShift(controllerClient);
+        boolean isOpenShift = OpenShift.isOpenShift(controllerClient);
         KubeSchemaApi schemaApi = KubeSchemaApi.create(controllerClient, controllerClient.getNamespace(), options.getVersion(), isOpenShift);
 
         log.info("AddressSpaceController starting with options: {}", options);

--- a/api-common/src/main/java/io/enmasse/api/common/OpenShift.java
+++ b/api-common/src/main/java/io/enmasse/api/common/OpenShift.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016-2019, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.enmasse.api.common;
+
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+public class OpenShift {
+    private static final Logger log = LoggerFactory.getLogger(OpenShift.class);
+    public static final String ENMASSE_OPENSHIFT = "ENMASSE_OPENSHIFT";
+
+    public static boolean isOpenShift(NamespacedKubernetesClient client) throws InterruptedException {
+        if (System.getenv().containsKey(ENMASSE_OPENSHIFT)) {
+            return Boolean.parseBoolean(System.getenv().get(ENMASSE_OPENSHIFT));
+        }
+        int retries = 10;
+        while (true) {
+            // Need to query the full API path because Kubernetes does not allow GET on /
+            OkHttpClient httpClient = client.adapt(OkHttpClient.class);
+            HttpUrl url = HttpUrl.get(client.getMasterUrl()).resolve("/apis/route.openshift.io");
+            Request.Builder requestBuilder = new Request.Builder()
+                    .url(url)
+                    .get();
+
+            try (Response response = httpClient.newCall(requestBuilder.build()).execute()) {
+                return response.code() >= 200 && response.code() < 300;
+            } catch (IOException e) {
+                retries--;
+                if (retries <= 0) {
+                    throw new UncheckedIOException(e);
+                } else {
+                    log.warn("Exception when checking API availability, retrying {} times", retries, e);
+                }
+            }
+            Thread.sleep(5000);
+        }
+    }
+
+}


### PR DESCRIPTION
The Go path already uses this environment variable so it seems reasonable for Java to do the same.