### PR TITLE
Fix #2759: Use RollingUpdate for console redeployments

### DIFF
--- a/pkg/controller/consoleservice/consoleservice_controller.go
+++ b/pkg/controller/consoleservice/consoleservice_controller.go
@@ -575,29 +575,39 @@ func applyDeployment(consoleservice *v1beta1.ConsoleService, deployment *appsv1.
 			install.ApplyEnv(container, "ITEM_REFRESH_RATE", func(envvar *corev1.EnvVar) {
 				envvar.Value = consoleservice.ObjectMeta.GetAnnotations()["enmasse.io/console-refresh-rate"]
 			})
+		} else {
+			install.RemoveEnv(container, "ITEM_REFRESH_RATE")
 		}
 
 		if consoleservice.Spec.Scope != nil {
 			install.ApplyEnv(container, "OAUTH2_SCOPE", func(envvar *corev1.EnvVar) {
 				envvar.Value = *consoleservice.Spec.Scope
 			})
+		} else {
+			install.RemoveEnv(container, "OAUTH2_SCOPE")
 		}
 
 		if consoleservice.Spec.DiscoveryMetadataURL != nil {
 			install.ApplyEnv(container, "DISCOVERY_METADATA_URL", func(envvar *corev1.EnvVar) {
 				envvar.Value = *consoleservice.Spec.DiscoveryMetadataURL
 			})
+		} else {
+			install.RemoveEnv(container, "DISCOVERY_METADATA_URL")
 		}
 
 		if consoleservice.Spec.SsoCookieDomain != nil {
 			install.ApplyEnv(container, "SSO_COOKIE_DOMAIN", func(envvar *corev1.EnvVar) {
 				envvar.Value = *consoleservice.Spec.SsoCookieDomain
 			})
+		} else {
+			install.RemoveEnv(container, "SSO_COOKIE_DOMAIN")
 		}
 
 		if consoleservice.Spec.SsoCookieSecret != nil {
 			b := true
 			install.ApplyEnvOptionalSecret(container, "SSO_COOKIE_SECRET", "cookie-secret", consoleservice.Spec.SsoCookieSecret.Name, &b)
+		} else {
+			install.RemoveEnv(container, "SSO_COOKIE_SECRET")
 		}
 
 		install.ApplyVolumeMountSimple(container, "apps", "/apps", false)
@@ -631,8 +641,24 @@ func applyDeployment(consoleservice *v1beta1.ConsoleService, deployment *appsv1.
 				Name:          "http",
 			}}
 
-			// Can't define a probe as HTTPD bound to loopback.  Perhaps have oauth-proxy's probes reach through
-			// HTTP and hit whoami?
+			probeHandler := corev1.Handler{
+				Exec: &corev1.ExecAction{
+					Command: []string{"bash",
+						"-c",
+						"curl --fail --show-error --silent " +
+							"--header \"X-Forwarded-Access-Token: $(< /var/run/secrets/kubernetes.io/serviceaccount/token)\" " +
+							"http://localhost:8080/apis/user.openshift.io/v1/users/~"},
+				},
+			}
+			container.LivenessProbe = &corev1.Probe{
+				InitialDelaySeconds: 120,
+				Handler:             probeHandler,
+			}
+
+			container.ReadinessProbe = &corev1.Probe{
+				InitialDelaySeconds: 60,
+				Handler:             probeHandler,
+			}
 
 			return nil
 		}); err != nil {
@@ -660,9 +686,6 @@ func applyDeployment(consoleservice *v1beta1.ConsoleService, deployment *appsv1.
 		}
 	}
 
-	deployment.Spec.Strategy = appsv1.DeploymentStrategy{
-		Type: appsv1.RecreateDeploymentStrategyType,
-	}
 	return nil
 }
 

--- a/pkg/util/install/utils.go
+++ b/pkg/util/install/utils.go
@@ -421,3 +421,16 @@ func ApplyTlsSecret(secret *corev1.Secret, key []byte, certificate []byte) {
 		"tls.crt": certificate,
 	}
 }
+
+func RemoveEnv(container *corev1.Container, name string) {
+	if container.Env == nil {
+		return
+	}
+
+	for i, e := range container.Env {
+		if e.Name == name {
+			container.Env = append(container.Env[:i], container.Env[i+1:]...)
+			break
+		}
+	}
+}


### PR DESCRIPTION
 and define HTTPD pod readiness/liveness probes.

The use of the `Recreate` strategy was unintentional.  I copied/pasted the code from elsewhere and didn't review sufficiently.