### PR TITLE
Turn off Artemis  audit logging (new in 2.7+) in default broker config

### DIFF
--- a/broker-plugin/plugin/src/main/resources/logging.properties
+++ b/broker-plugin/plugin/src/main/resources/logging.properties
@@ -17,7 +17,7 @@
 
 # Additional logger names to configure (root logger is always configured)
 # Root logger option
-loggers=org.eclipse.jetty,org.jboss.logging,org.apache.activemq.artemis.core.server,org.apache.activemq.artemis.utils,org.apache.activemq.artemis.journal,org.apache.activemq.artemis.jms.server,org.apache.activemq.artemis.integration.bootstrap
+loggers=org.eclipse.jetty,org.jboss.logging,org.apache.activemq.artemis.core.server,org.apache.activemq.artemis.utils,org.apache.activemq.artemis.journal,org.apache.activemq.artemis.jms.server,org.apache.activemq.artemis.integration.bootstrap,org.apache.activemq.audit.base,org.apache.activemq.audit.message
 
 # Root logger level
 logger.level=INFO
@@ -30,6 +30,15 @@ logger.org.apache.activemq.artemis.integration.bootstrap.level=INFO
 logger.org.eclipse.jetty.level=WARN
 # Root logger handlers
 logger.handlers=CONSOLE
+
+# to enable audit change the level to INFO
+logger.org.apache.activemq.audit.base.level=ERROR
+logger.org.apache.activemq.audit.base.handlers=CONSOLE
+logger.org.apache.activemq.audit.base.useParentHandlers=false
+
+logger.org.apache.activemq.audit.message.level=ERROR
+logger.org.apache.activemq.audit.message.handlers=CONSOLE
+logger.org.apache.activemq.audit.message.useParentHandlers=false
 
 # Console handler configuration
 handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler


### PR DESCRIPTION
The audit logging is quite noisy for the EnMasse use-case.