### PR TITLE
Validate router version alignment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ jobs:
   include:
   - stage: build
     before_install:
+    - ./.travis/find-qdrouterd-base-versions.sh
     - pip install --user requests[security] ansible
     - gem install asciidoctor
     - gimme 1.11.6

--- a/.travis/find-qdrouterd-base-versions.sh
+++ b/.travis/find-qdrouterd-base-versions.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+echo -n "Verify qdrouterd-base version alignment... "
+
+PATHSPEC='./* :!.travis/**'
+EXP='/qdrouterd-base:([^\\"]+)'
+
+NUM=$(git grep -E -h -e '/qdrouterd-base:([^\\"]+)' -- $PATHSPEC | cat - | sed -E 's/.*qdrouterd-base:(.*)/\1/g'  | sort -u | wc -l)
+
+test "$NUM" -eq 1 || {
+	echo "FAILED"
+	echo "Versions misaligned:" >&2
+	echo "========================================" >&2
+	git grep -E -e '/qdrouterd-base:([^\\"]+)' -- $PATHSPEC | cat -
+	echo "========================================" >&2
+	exit 1
+}
+
+echo "OK"

--- a/Makefile.env.mk
+++ b/Makefile.env.mk
@@ -40,7 +40,7 @@ ALERTMANAGER_IMAGE ?= prom/alertmanager:v0.15.2
 GRAFANA_IMAGE ?= grafana/grafana:5.3.1
 APPLICATION_MONITORING_OPERATOR_IMAGE ?= quay.io/integreatly/application-monitoring-operator:0.0.5
 KUBE_STATE_METRICS_IMAGE ?= quay.io/coreos/kube-state-metrics:v1.4.0
-QDROUTERD_BASE_IMAGE ?= enmasseproject/qdrouterd-base:1.6.0-rc1
+QDROUTERD_BASE_IMAGE ?= enmasseproject/qdrouterd-base:1.7.0
 BROKER_IMAGE ?= quay.io/enmasse/artemis-base:2.8.0
 
 CONTROLLER_MANAGER_IMAGE   ?= $(DOCKER_REGISTRY_PREFIX)$(DOCKER_ORG)/controller-manager:$(IMAGE_VERSION)


### PR DESCRIPTION
This adds a small check to travis to check if the qdrouter-base versions are aligned. Because currently aren't. Again.