### PR TITLE
Improve logging in QueueTest#testScaledown to help understand test failure

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/GlobalLogCollector.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/GlobalLogCollector.java
@@ -89,11 +89,12 @@ public class GlobalLogCollector {
         });
     }
 
-    public void collectLogsOfPodsByLabels(String namespace, Map<String, String> labels) {
+    public void collectLogsOfPodsByLabels(String namespace, String discriminator, Map<String, String> labels) {
         log.info("Store logs from all pods in namespace '{}' matching labels {}", namespace, labels);
         kubernetes.getLogsByLables(namespace, labels).forEach((podName, podLogs) -> {
             try {
-                Path podLog = resolveLogFile(namespace + "." + podName + ".log");
+                String filename = discriminator == null ? String.format("%s.%s.log", namespace, podName) : String.format("%s.%s.%s.log", namespace, discriminator, podName);
+                Path podLog = resolveLogFile(filename);
                 log.info("log of '{}' pod will be archived with path: '{}'", podName, podLog);
                 try (BufferedWriter bf = Files.newBufferedWriter(podLog)) {
                     bf.write(podLogs);

--- a/systemtests/src/test/java/io/enmasse/systemtest/common/certs/CertProviderTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/common/certs/CertProviderTest.java
@@ -268,7 +268,7 @@ class CertProviderTest extends TestBase {
         } finally {
             if (!testSucceeded) {
                 logCollector.collectLogsOfPodsByLabels(appNamespace,
-                        Collections.singletonMap("app", SystemtestsKubernetesApps.OPENSHIFT_CERT_VALIDATOR));
+                        null, Collections.singletonMap("app", SystemtestsKubernetesApps.OPENSHIFT_CERT_VALIDATOR));
             }
             SystemtestsKubernetesApps.deleteOpenshiftCertValidator(appNamespace, kubernetes);
         }


### PR DESCRIPTION
Currently, during the scale down tests, the logs corresponding to the brokers that are removed as the queue is scaled down are never captured.  This change captures the full set of broker log prior to each scale up/down to close that gap.