### PR TITLE
Test of multiple iotprojects

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/Kubernetes.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/Kubernetes.java
@@ -29,7 +29,6 @@ import io.fabric8.kubernetes.api.model.storage.StorageClass;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
-import io.fabric8.kubernetes.client.dsl.*;
 import io.fabric8.kubernetes.client.dsl.ExecListener;
 import io.fabric8.kubernetes.client.dsl.ExecWatch;
 import io.fabric8.kubernetes.client.dsl.LogWatch;
@@ -207,7 +206,7 @@ public abstract class Kubernetes {
 
     public MixedOperation<IoTProject, IoTProjectList, DoneableIoTProject, Resource<IoTProject, DoneableIoTProject>> getIoTProjectClient(String namespace) {
         if(namespace == null) {
-            return client.customResources(CoreCrd.addresseSpaces(), IoTProject.class, IoTProjectList.class, DoneableIoTProject.class);
+            return client.customResources(IoTCrd.project(), IoTProject.class, IoTProjectList.class, DoneableIoTProject.class);
         }else {
             return (MixedOperation<IoTProject, IoTProjectList, DoneableIoTProject, Resource<IoTProject, DoneableIoTProject>>) client.customResources(IoTCrd.project(), IoTProject.class, IoTProjectList.class, DoneableIoTProject.class).inNamespace(namespace);
         }

--- a/systemtests/src/main/java/io/enmasse/systemtest/iot/HttpAdapterClient.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/iot/HttpAdapterClient.java
@@ -37,9 +37,9 @@ public class HttpAdapterClient extends ApiClient {
 
     protected static Logger log = CustomLogger.getLogger();
 
-    public HttpAdapterClient(Kubernetes kubernetes, Endpoint endpoint, String username, String password) {
+    public HttpAdapterClient(Kubernetes kubernetes, Endpoint endpoint, String deviceAuthId, String tenantId, String password) {
         super(kubernetes, () -> endpoint, "");
-        this.authzString = getBasicAuth(username, password);
+        this.authzString = getBasicAuth(deviceAuthId + "@" + tenantId, password);
     }
 
     @Override
@@ -55,6 +55,7 @@ public class HttpAdapterClient extends ApiClient {
                 .setVerifyHost(false));
     }
 
+    @Override
     public void close () {
         this.client.close();
     }

--- a/systemtests/src/main/java/io/enmasse/systemtest/iot/IoTProjectTestContext.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/iot/IoTProjectTestContext.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2019, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.systemtest.iot;
+
+import org.eclipse.paho.client.mqttv3.IMqttClient;
+
+import io.enmasse.iot.model.v1.IoTProject;
+import io.enmasse.systemtest.amqp.AmqpClient;
+import io.enmasse.user.model.v1.User;
+
+public class IoTProjectTestContext {
+
+    private String namespace;
+    private IoTProject project;
+
+    private String deviceId;
+    private String deviceAuthId;
+    private String devicePassword;
+    private HttpAdapterClient httpAdapterClient;
+    private IMqttClient mqttAdapterClient;
+
+    private User amqpUser;
+    private AmqpClient amqpClient;
+
+    public IoTProjectTestContext(String namespace, IoTProject project) {
+        this.namespace = namespace;
+        this.project = project;
+    }
+
+    public String getDeviceId() {
+        return deviceId;
+    }
+
+    public void setDeviceId(String deviceId) {
+        this.deviceId = deviceId;
+    }
+
+    public String getDeviceAuthId() {
+        return deviceAuthId;
+    }
+
+    public void setDeviceAuthId(String deviceAuthId) {
+        this.deviceAuthId = deviceAuthId;
+    }
+
+    public String getDevicePassword() {
+        return devicePassword;
+    }
+
+    public void setDevicePassword(String devicePassword) {
+        this.devicePassword = devicePassword;
+    }
+
+    public HttpAdapterClient getHttpAdapterClient() {
+        return httpAdapterClient;
+    }
+
+    public void setHttpAdapterClient(HttpAdapterClient httpAdapterClient) {
+        this.httpAdapterClient = httpAdapterClient;
+    }
+
+    public IMqttClient getMqttAdapterClient() {
+        return mqttAdapterClient;
+    }
+
+    public void setMqttAdapterClient(IMqttClient mqttAdapterClient) {
+        this.mqttAdapterClient = mqttAdapterClient;
+    }
+
+    public User getAmqpUser() {
+        return amqpUser;
+    }
+
+    public void setAmqpUser(User amqpUser) {
+        this.amqpUser = amqpUser;
+    }
+
+    public AmqpClient getAmqpClient() {
+        return amqpClient;
+    }
+
+    public void setAmqpClient(AmqpClient amqpClient) {
+        this.amqpClient = amqpClient;
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    public IoTProject getProject() {
+        return project;
+    }
+
+}

--- a/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
@@ -32,6 +32,7 @@ import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.*;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
@@ -568,5 +569,21 @@ public class TestUtils {
 
     public static String getGlobalConsoleRoute() throws Exception {
         return Kubernetes.getInstance().getConsoleServiceClient().withName("console").get().getStatus().getUrl();
+    }
+
+    public static CompletableFuture<Void> runAsync(ThrowingCallable callable){
+        return CompletableFuture.runAsync(() -> {
+            try {
+                callable.call();
+            } catch ( Exception e ) {
+                log.error("Error running async test", e);
+                throw new RuntimeException(e);
+            }
+        }, e -> new Thread(e).start());
+    }
+
+    @FunctionalInterface
+    public static interface ThrowingCallable {
+        void call() throws Exception;
     }
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/IoTTestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/IoTTestBase.java
@@ -91,17 +91,6 @@ public abstract class IoTTestBase extends TestBase {
         return null;
     }
 
-    /**
-     * Get the Hono tenant name from the project configuration.
-     */
-    protected String tenantId() {
-        var project = getSharedIoTProject();
-        if (project == null) {
-            return null;
-        }
-        return String.format("%s.%s", project.getMetadata().getNamespace(), project.getMetadata().getName());
-    }
-
     protected void createIoTConfig(IoTConfig config) throws Exception {
         String operationID = TimeMeasuringSystem.startOperation(SystemtestsOperation.CREATE_IOT_CONFIG);
         var iotConfigApiClient = kubernetes.getIoTConfigClient();
@@ -140,7 +129,7 @@ public abstract class IoTTestBase extends TestBase {
         waitForFirstSuccess(adapterClient, MessageType.TELEMETRY);
     }
 
-    protected void waitForFirstSuccess(HttpAdapterClient adapterClient, MessageType type) throws Exception {
+    protected static void waitForFirstSuccess(HttpAdapterClient adapterClient, MessageType type) throws Exception {
         JsonObject json = new JsonObject(Map.of("a", "b"));
         String message = "First successful " + type.name().toLowerCase() + " message";
         TestUtils.waitUntilCondition(message, (phase) -> {
@@ -164,10 +153,14 @@ public abstract class IoTTestBase extends TestBase {
         log.info("First " + type.name().toLowerCase() + " message accepted");
     }
 
-    private void logResponseIfLastTryFailed(WaitPhase phase, HttpResponse<?> response, String warnMessage) {
-        if (phase == WaitPhase.LAST_TRY && response.statusCode() != HTTP_ACCEPTED) {
+    private static void logResponseIfLastTryFailed(WaitPhase phase, HttpResponse<?> response, String warnMessage) {
+        if(phase == WaitPhase.LAST_TRY && response.statusCode() != HTTP_ACCEPTED) {
             log.error("expected-code: {}, response-code: {}, body: {}, op: {}", HTTP_ACCEPTED, response.statusCode(), response.body(), warnMessage);
         }
+    }
+
+    public String tenantId(IoTProject project) {
+        return String.format("%s.%s", project.getMetadata().getNamespace(), project.getMetadata().getName());
     }
 
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/IoTTestBaseWithShared.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/IoTTestBaseWithShared.java
@@ -11,7 +11,6 @@ import io.enmasse.iot.model.v1.IoTProject;
 import io.enmasse.systemtest.CertBundle;
 import io.enmasse.systemtest.CustomLogger;
 import io.enmasse.systemtest.Endpoint;
-import io.enmasse.systemtest.Environment;
 import io.enmasse.systemtest.SystemtestsKubernetesApps;
 import io.enmasse.systemtest.UserCredentials;
 import io.enmasse.systemtest.amqp.AmqpClientFactory;
@@ -82,7 +81,7 @@ public abstract class IoTTestBaseWithShared extends IoTTestBase {
     }
 
     public AddressSpace getAddressSpace() {
-        return getAddressSpace(this.addressSpace);
+        return getAddressSpace(this.iotProjectNamespace, this.addressSpace);
     }
 
     /**
@@ -90,7 +89,7 @@ public abstract class IoTTestBaseWithShared extends IoTTestBase {
      */
     private AmqpClientFactory createAmqpClientFactory() throws Exception {
 
-        createOrUpdateUser(this.addressSpace, this.credentials);
+        createOrUpdateUser(getAddressSpace(this.iotProjectNamespace, this.addressSpace), this.credentials);
         return new AmqpClientFactory(getAddressSpace(this.iotProjectNamespace, this.addressSpace), this.credentials);
 
     }
@@ -140,6 +139,17 @@ public abstract class IoTTestBaseWithShared extends IoTTestBase {
     @Override
     public IoTProject getSharedIoTProject() {
         return sharedProject;
+    }
+
+    /**
+     * Get the Hono tenant name from the project configuration.
+     */
+    protected String tenantId() {
+        var project = getSharedIoTProject();
+        if (project == null) {
+            return null;
+        }
+        return tenantId(project);
     }
 
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/iot/MultipleProjectsTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/iot/MultipleProjectsTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2019, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.systemtest.iot;
+
+import java.net.HttpURLConnection;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.paho.client.mqttv3.IMqttClient;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import io.enmasse.address.model.AddressSpace;
+import io.enmasse.iot.model.v1.IoTConfig;
+import io.enmasse.iot.model.v1.IoTConfigBuilder;
+import io.enmasse.iot.model.v1.IoTProject;
+import io.enmasse.systemtest.CertBundle;
+import io.enmasse.systemtest.Endpoint;
+import io.enmasse.systemtest.TestTag;
+import io.enmasse.systemtest.TimeoutBudget;
+import io.enmasse.systemtest.UserCredentials;
+import io.enmasse.systemtest.WaitPhase;
+import io.enmasse.systemtest.ability.ITestBaseStandard;
+import io.enmasse.systemtest.amqp.AmqpClient;
+import io.enmasse.systemtest.bases.IoTTestBase;
+import io.enmasse.systemtest.iot.http.HttpAdapterTest;
+import io.enmasse.systemtest.iot.mqtt.MqttAdapterTest;
+import io.enmasse.systemtest.mqtt.MqttClientFactory;
+import io.enmasse.systemtest.utils.CertificateUtils;
+import io.enmasse.systemtest.utils.IoTUtils;
+import io.enmasse.systemtest.utils.TestUtils;
+import io.enmasse.user.model.v1.Operation;
+import io.enmasse.user.model.v1.User;
+import io.enmasse.user.model.v1.UserAuthenticationType;
+import io.enmasse.user.model.v1.UserAuthorizationBuilder;
+import io.enmasse.user.model.v1.UserBuilder;
+
+@Tag(TestTag.sharedIot)
+@Tag(TestTag.smoke)
+public class MultipleProjectsTest extends IoTTestBase implements ITestBaseStandard {
+
+    private DeviceRegistryClient registryClient;
+    private CredentialsRegistryClient credentialsClient;
+
+    private int numberOfProjects = 2;
+    private List<IoTProjectTestContext> projects = new ArrayList<>();
+
+    @BeforeEach
+    void initEnv() throws Exception {
+        CertBundle certBundle = CertificateUtils.createCertBundle();
+        IoTConfig iotConfig = new IoTConfigBuilder()
+                .withNewMetadata()
+                .withName("default")
+                .endMetadata()
+                .withNewSpec()
+                .withNewAdapters()
+                .withNewMqtt()
+                .withNewEndpoint()
+                .withNewKeyCertificateStrategy()
+                .withCertificate(ByteBuffer.wrap(certBundle.getCert().getBytes()))
+                .withKey(ByteBuffer.wrap(certBundle.getKey().getBytes()))
+                .endKeyCertificateStrategy()
+                .endEndpoint()
+                .endMqtt()
+                .endAdapters()
+                .endSpec()
+                .build();
+        createIoTConfig(iotConfig);
+
+        Endpoint deviceRegistryEndpoint = kubernetes.getExternalEndpoint("device-registry");
+        registryClient = new DeviceRegistryClient(kubernetes, deviceRegistryEndpoint);
+        credentialsClient = new CredentialsRegistryClient(kubernetes, deviceRegistryEndpoint);
+
+        for(int i=1; i<=numberOfProjects; i++) {
+            String projectName = String.format("project-%s", i);
+
+            if (!kubernetes.namespaceExists(projectName)) {
+                kubernetes.createNamespace(projectName);
+            }
+            IoTProject project = IoTUtils.getBasicIoTProjectObject(projectName, projectName, projectName);
+            createIoTProject(project);
+            IoTProjectTestContext ctx = new IoTProjectTestContext(projectName, project);
+
+            configureDeviceSide(ctx);
+
+            configureAmqpSide(ctx);
+
+            projects.add(ctx);
+        }
+    }
+
+    @AfterEach
+    void cleanEnv(ExtensionContext context) throws Exception {
+        if (context.getExecutionException().isPresent()) { //test failed
+            logCollector.collectHttpAdapterQdrProxyState();
+        }
+
+        for(IoTProjectTestContext ctx : projects) {
+            cleanDeviceSide(ctx);
+            cleanAmqpSide(ctx);
+        }
+
+    }
+
+    @Test
+    void testMultipleProjects() throws Exception {
+        CompletableFuture.allOf(projects.stream()
+                .map(ctx -> {
+                    return CompletableFuture.allOf(
+                            TestUtils.runAsync(() -> HttpAdapterTest.simpleHttpTelemetryTest(ctx.getAmqpClient(), tenantId(ctx.getProject()), ctx.getHttpAdapterClient())),
+                            TestUtils.runAsync(() -> HttpAdapterTest.simpleHttpEventTest(ctx.getAmqpClient(), tenantId(ctx.getProject()), ctx.getHttpAdapterClient())));
+                            //TODO add mqtt adapter tests when mqtt tests are enabled
+                })
+                .toArray(CompletableFuture[]::new)).get(5, TimeUnit.MINUTES);
+    }
+
+    private void configureAmqpSide(IoTProjectTestContext ctx) throws Exception {
+        AddressSpace addressSpace = getAddressSpace(ctx.getNamespace(), ctx.getProject().getSpec().getDownstreamStrategy().getManagedStrategy().getAddressSpace().getName());
+        User amqpUser = configureAmqpUser(ctx.getProject(), addressSpace);
+        ctx.setAmqpUser(amqpUser);
+        AmqpClient amqpClient = configureAmqpClient(addressSpace, amqpUser);
+        ctx.setAmqpClient(amqpClient);
+    }
+
+    private User configureAmqpUser(IoTProject project, AddressSpace addressSpace) {
+        String tenant = tenantId(project);
+
+        User amqpUser = new UserBuilder()
+
+                .withNewMetadata()
+                .withName(String.format("%s.%s", addressSpace.getMetadata().getName(), project.getMetadata().getName()))
+                .endMetadata()
+
+                .withNewSpec()
+                .withUsername(UUID.randomUUID().toString())
+                .withNewAuthentication()
+                .withPassword(Base64.getEncoder().encodeToString(UUID.randomUUID().toString().getBytes(StandardCharsets.UTF_8)))
+                .withType(UserAuthenticationType.password)
+                .endAuthentication()
+                .withAuthorization(Collections.singletonList(new UserAuthorizationBuilder()
+                        .withAddresses(IOT_ADDRESS_TELEMETRY + "/" + tenant,
+                                IOT_ADDRESS_TELEMETRY + "/" + tenant + "/*",
+                                IOT_ADDRESS_EVENT + "/" + tenant,
+                                IOT_ADDRESS_EVENT + "/" + tenant + "/*")
+                        .withOperations(Operation.recv)
+                        .build()))
+                .endSpec()
+                .build();
+        kubernetes.getUserClient(project.getMetadata().getNamespace()).create(amqpUser);
+
+        return amqpUser;
+    }
+
+    private AmqpClient configureAmqpClient(AddressSpace addressSpace, User user) throws Exception {
+        AmqpClient amqpClient = amqpClientFactory.createQueueClient(addressSpace);
+        amqpClient.getConnectOptions()
+            .setUsername(user.getSpec().getUsername())
+            .setPassword(new String(Base64.getDecoder().decode(user.getSpec().getAuthentication().getPassword())));
+        return amqpClient;
+    }
+
+    private void cleanAmqpSide(IoTProjectTestContext ctx) throws Exception {
+        ctx.getAmqpClient().close();
+        var userClient = kubernetes.getUserClient(ctx.getNamespace());
+        userClient.delete(userClient.withName(ctx.getAmqpUser().getMetadata().getName()).get());
+    }
+
+    private void configureDeviceSide(IoTProjectTestContext ctx) throws Exception {
+        String tenant = tenantId(ctx.getProject());
+        ctx.setDeviceId(UUID.randomUUID().toString());
+        ctx.setDeviceAuthId(UUID.randomUUID().toString());
+        ctx.setDevicePassword(UUID.randomUUID().toString());
+        registryClient.registerDevice(tenant, ctx.getDeviceId());
+        credentialsClient.addCredentials(tenant, ctx.getDeviceId(), ctx.getDeviceAuthId(), ctx.getDevicePassword());
+        Endpoint httpAdapterEndpoint = kubernetes.getExternalEndpoint("iot-http-adapter");
+        ctx.setHttpAdapterClient(new HttpAdapterClient(kubernetes, httpAdapterEndpoint, ctx.getDeviceAuthId(), tenant, ctx.getDevicePassword()));
+        MqttConnectOptions mqttOptions = new MqttConnectOptions();
+        mqttOptions.setAutomaticReconnect(true);
+        mqttOptions.setConnectionTimeout(60);
+        IMqttClient mqttAdapterClient = new MqttClientFactory(null, new UserCredentials(ctx.getDeviceAuthId() + "@" + tenant, ctx.getDevicePassword()))
+                .build()
+                .clientId(ctx.getDeviceId())
+                .endpoint(kubernetes.getExternalEndpoint("iot-mqtt-adapter"))
+                .mqttConnectionOptions(mqttOptions)
+                .create();
+        TestUtils.waitUntilCondition("Successfully connect to mqtt adapter", phase -> {
+            try {
+                mqttAdapterClient.connect();
+                return true;
+            } catch (MqttException mqttException) {
+                if (phase == WaitPhase.LAST_TRY) {
+                    log.error("Error waiting to connect mqtt adapter", mqttException);
+                }
+                return false;
+            }
+        }, new TimeoutBudget(1, TimeUnit.MINUTES));
+        log.info("Connection to mqtt adapter succeeded");
+        ctx.setMqttAdapterClient(mqttAdapterClient);
+    }
+
+    private void cleanDeviceSide(IoTProjectTestContext ctx) throws Exception {
+        String tenant = tenantId(ctx.getProject());
+        String deviceId = ctx.getDeviceId();
+        credentialsClient.deleteAllCredentials(tenant, deviceId);
+        credentialsClient.getCredentials(tenant, deviceId, HttpURLConnection.HTTP_NOT_FOUND);
+        registryClient.deleteDeviceRegistration(tenant, deviceId);
+        registryClient.getDeviceRegistration(tenant, deviceId, HttpURLConnection.HTTP_NOT_FOUND);
+        ctx.getHttpAdapterClient().close();
+        if (ctx.getMqttAdapterClient().isConnected()) {
+            ctx.getMqttAdapterClient().disconnect();
+            ctx.getMqttAdapterClient().close();
+        }
+    }
+
+}

--- a/systemtests/src/test/java/io/enmasse/systemtest/iot/control/CommandAndControlTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/iot/control/CommandAndControlTest.java
@@ -88,7 +88,7 @@ class CommandAndControlTest extends IoTTestBaseWithShared {
         this.deviceId = UUID.randomUUID().toString();
         this.authId = UUID.randomUUID().toString();
         this.password = UUID.randomUUID().toString();
-        this.httpClient = new HttpAdapterClient(kubernetes, this.httpAdapterEndpoint, this.authId + "@" + tenantId(), this.password);
+        this.httpClient = new HttpAdapterClient(kubernetes, this.httpAdapterEndpoint, this.authId,  tenantId(), this.password);
 
         // set up new random device
         this.registryClient.registerDevice(tenantId(), this.deviceId);

--- a/systemtests/src/test/java/io/enmasse/systemtest/iot/http/HttpAdapterTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/iot/http/HttpAdapterTest.java
@@ -50,7 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @Tag(sharedIot)
 public class HttpAdapterTest extends IoTTestBaseWithShared {
 
-    private Logger log = CustomLogger.getLogger();
+    private static final Logger log = CustomLogger.getLogger();
 
     private Endpoint deviceRegistryEndpoint;
     private DeviceRegistryClient registryClient;
@@ -95,7 +95,7 @@ public class HttpAdapterTest extends IoTTestBaseWithShared {
                 .setPassword(businessApplicationPassword);
 
         Endpoint httpAdapterEndpoint = kubernetes.getExternalEndpoint("iot-http-adapter");
-        adapterClient = new HttpAdapterClient(kubernetes, httpAdapterEndpoint, deviceAuthId + "@" + tenantId(), devicePassword);
+        adapterClient = new HttpAdapterClient(kubernetes, httpAdapterEndpoint, deviceAuthId, tenantId(), devicePassword);
 
     }
 
@@ -132,20 +132,23 @@ public class HttpAdapterTest extends IoTTestBaseWithShared {
 
     @Test
     public void batchTelemetryTest() throws Exception {
+        simpleHttpTelemetryTest(businessApplicationClient, tenantId(), adapterClient);
+    }
 
+    public static void simpleHttpTelemetryTest(AmqpClient amqpClient, String tenantId, HttpAdapterClient httpAdapterClient) throws Exception{
         int messagesToSend = 50;
 
         log.info("Connecting amqp consumer");
         AtomicInteger receivedMessagesCounter = new AtomicInteger(0);
-        Future<List<Message>> futureReceivedMessages = setUpMessagingConsumer(IOT_ADDRESS_TELEMETRY, receivedMessagesCounter, messagesToSend);
+        Future<List<Message>> futureReceivedMessages = setUpMessagingConsumer(amqpClient, IOT_ADDRESS_TELEMETRY, tenantId, receivedMessagesCounter, messagesToSend);
 
-        waitForFirstSuccess(adapterClient, MessageType.TELEMETRY);
+        waitForFirstSuccess(httpAdapterClient, MessageType.TELEMETRY);
 
         log.info("Sending telemetry messages");
         for (int i = 0; i < messagesToSend; i++) {
             JsonObject json = new JsonObject();
             json.put("i", i);
-            sendWithRetry(MessageType.TELEMETRY, json);
+            sendWithRetry(httpAdapterClient, MessageType.TELEMETRY, json);
         }
 
         try {
@@ -157,8 +160,8 @@ public class HttpAdapterTest extends IoTTestBaseWithShared {
             log.error("Timeout receiving telemetry, messages received: {} error:", receivedMessagesCounter.get(), e);
             throw e;
         }
-
     }
+
 
     @Test
     public void basicEventTest() throws Exception {
@@ -179,20 +182,24 @@ public class HttpAdapterTest extends IoTTestBaseWithShared {
 
     @Test
     public void batchEventTest() throws Exception {
+        simpleHttpEventTest(businessApplicationClient, tenantId(), adapterClient);
+    }
 
-        waitForFirstSuccess(adapterClient, MessageType.EVENT);
+    public static void simpleHttpEventTest(AmqpClient amqpClient, String tenantId, HttpAdapterClient httpAdapterClient) throws Exception{
+
+        waitForFirstSuccess(httpAdapterClient, MessageType.EVENT);
 
         int eventsToSend = 5;
         log.info("Sending events");
         for (int i = 0; i < eventsToSend; i++) {
             JsonObject json = new JsonObject();
             json.put("i", i);
-            sendWithRetry(MessageType.EVENT, json);
+            sendWithRetry(httpAdapterClient, MessageType.EVENT, json);
         }
 
         log.info("Consuming events in business application");
         AtomicInteger receivedMessagesCounter = new AtomicInteger(0);
-        Future<List<Message>> status = setUpMessagingConsumer(IOT_ADDRESS_EVENT, receivedMessagesCounter, eventsToSend);
+        Future<List<Message>> status = setUpMessagingConsumer(amqpClient, IOT_ADDRESS_EVENT, tenantId, receivedMessagesCounter, eventsToSend);
 
         try {
             log.info("Waiting to receive events");
@@ -206,9 +213,9 @@ public class HttpAdapterTest extends IoTTestBaseWithShared {
 
     }
 
-    private Future<List<Message>> setUpMessagingConsumer(String type, AtomicInteger receivedMessagesCounter, int expectedMessages) {
-        return businessApplicationClient.recvMessages(type + "/" + tenantId(), msg -> {
-            if (msg.getBody() instanceof Data) {
+    private static Future<List<Message>> setUpMessagingConsumer(AmqpClient amqpClient, String type, String tenantId, AtomicInteger receivedMessagesCounter, int expectedMessages) {
+        return amqpClient.recvMessages(type + "/" + tenantId, msg ->{
+            if(msg.getBody() instanceof Data) {
                 Binary value = ((Data) msg.getBody()).getValue();
                 JsonObject json = new JsonObject(Buffer.buffer(value.getArray()));
                 if (json.containsKey("i")) {
@@ -219,15 +226,15 @@ public class HttpAdapterTest extends IoTTestBaseWithShared {
         });
     }
 
-    private void sendWithRetry(MessageType messageType, JsonObject json) throws Exception, InterruptedException {
+    private static void sendWithRetry(HttpAdapterClient httpAdapterClient, MessageType messageType, JsonObject json) throws Exception, InterruptedException {
         if (messageType == MessageType.COMMAND_RESPONSE) {
             return;
         }
         var timeout = new TimeoutBudget(30, TimeUnit.SECONDS);
         var sendOk = false;
-        while (!timeout.timeoutExpired() && !sendOk) {
-            var response = messageType == MessageType.TELEMETRY ? adapterClient.sendTelemetry(json, Predicates.any()) : adapterClient.sendEvent(json, Predicates.any());
-            if (Predicates.notIn(HTTP_ACCEPTED, HTTP_UNAVAILABLE).test(response.statusCode())) {
+        while(!timeout.timeoutExpired() && !sendOk) {
+            var response = messageType == MessageType.TELEMETRY ? httpAdapterClient.sendTelemetry(json, Predicates.any()) : httpAdapterClient.sendEvent(json, Predicates.any());
+            if(Predicates.notIn(HTTP_ACCEPTED, HTTP_UNAVAILABLE).test(response.statusCode())) {
                 log.error("expected-code: {}, response-code: {}, body: {}, op: {}", HTTP_ACCEPTED, response.statusCode(), response.body(), "Error sending " + messageType.name().toLowerCase() + " data");
                 throw new RuntimeException("Status " + response.statusCode() + " body: " + (response.body() != null ? response.body().toString() : null));
             }

--- a/systemtests/src/test/java/io/enmasse/systemtest/iot/registry/DeviceRegistryTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/iot/registry/DeviceRegistryTest.java
@@ -167,7 +167,7 @@ class DeviceRegistryTest extends IoTTestBaseWithShared {
     }
 
     private void checkCredentials(String authId, String password, boolean authFail) throws Exception {
-        try (var httpAdapterClient = new HttpAdapterClient(kubernetes, httpAdapterEndpoint, authId + "@" + tenantId(), password)) {
+        try (var httpAdapterClient = new HttpAdapterClient(kubernetes, httpAdapterEndpoint, authId, tenantId(), password)) {
             JsonObject payload = new JsonObject(Map.of("data", "dummy"));
 
             var expectedResponse = authFail ? in(HTTP_UNAUTHORIZED): in(HTTP_UNAVAILABLE, HTTP_ACCEPTED);


### PR DESCRIPTION
Adds a few fixes for iot tests with the new usage of fabric8 clients in systemtests
Also adds new test MultipleProjectsTest which for now runs a simple workload over http-adapter of 2 iot projects concurrently.
The idea with this test and more similar tests to come is to verify the behaviour of the platform in a more real case because the iot infrastructure is shared between tenants