### PR TITLE
remove uneeded serializable in Infinispan Device Registry

### DIFF
--- a/iot/iot-device-registry-infinispan/src/main/java/io/enmasse/iot/registry/infinispan/CredentialsKey.java
+++ b/iot/iot-device-registry-infinispan/src/main/java/io/enmasse/iot/registry/infinispan/CredentialsKey.java
@@ -5,7 +5,6 @@
 
 package io.enmasse.iot.registry.infinispan;
 
-import java.io.Serializable;
 import java.util.Objects;
 import org.infinispan.protostream.annotations.ProtoDoc;
 import org.infinispan.protostream.annotations.ProtoField;
@@ -17,7 +16,7 @@ import org.infinispan.protostream.annotations.ProtoField;
  *  See {@link CacheCredentialService CacheCredentialService} class.
  */
 @ProtoDoc("@Indexed")
-public class CredentialsKey implements Serializable {
+public class CredentialsKey {
 
     private String tenantId;
     private String authId;

--- a/iot/iot-device-registry-infinispan/src/main/java/io/enmasse/iot/registry/infinispan/RegistrationKey.java
+++ b/iot/iot-device-registry-infinispan/src/main/java/io/enmasse/iot/registry/infinispan/RegistrationKey.java
@@ -5,7 +5,6 @@
 
 package io.enmasse.iot.registry.infinispan;
 
-import java.io.Serializable;
 import java.util.Objects;
 import org.infinispan.protostream.annotations.ProtoDoc;
 import org.infinispan.protostream.annotations.ProtoField;
@@ -17,9 +16,7 @@ import org.infinispan.protostream.annotations.ProtoField;
  *  See {@link CacheRegistrationService CacheRegistrationService} class.
  */
 @ProtoDoc("@Indexed")
-public class RegistrationKey implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class RegistrationKey {
 
     private String tenantId;
     private String deviceId;

--- a/iot/iot-device-registry-infinispan/src/main/java/io/enmasse/iot/registry/infinispan/RegistryCredentialObject.java
+++ b/iot/iot-device-registry-infinispan/src/main/java/io/enmasse/iot/registry/infinispan/RegistryCredentialObject.java
@@ -8,7 +8,6 @@ package io.enmasse.iot.registry.infinispan;
 import io.vertx.core.json.JsonObject;
 import org.eclipse.hono.util.CredentialsObject;
 
-import java.io.Serializable;
 import org.infinispan.protostream.annotations.ProtoDoc;
 import org.infinispan.protostream.annotations.ProtoField;
 
@@ -19,9 +18,7 @@ import org.infinispan.protostream.annotations.ProtoField;
  *  See {@link CacheTenantService CacheTenantService} class.
  */
 @ProtoDoc("@Indexed")
-public class RegistryCredentialObject implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class RegistryCredentialObject {
 
     private String tenantId;
     private String deviceId;

--- a/iot/iot-device-registry-infinispan/src/main/java/io/enmasse/iot/registry/infinispan/RegistryTenantObject.java
+++ b/iot/iot-device-registry-infinispan/src/main/java/io/enmasse/iot/registry/infinispan/RegistryTenantObject.java
@@ -8,7 +8,6 @@ package io.enmasse.iot.registry.infinispan;
 import io.vertx.core.json.JsonObject;
 import org.eclipse.hono.util.TenantObject;
 
-import java.io.Serializable;
 import org.infinispan.protostream.annotations.ProtoDoc;
 import org.infinispan.protostream.annotations.ProtoField;
 
@@ -19,9 +18,7 @@ import org.infinispan.protostream.annotations.ProtoField;
  *  See {@link CacheTenantService CacheTenantService} class.
  */
 @ProtoDoc("@Indexed")
-public class RegistryTenantObject implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class RegistryTenantObject {
 
     private String tenantId;
     private String trustedCa;


### PR DESCRIPTION
using the protostream annotations and unsing Infinispan's ProtoStreamMarashaller does the serialization work, there is no need to extend serializable.