### PR TITLE
Upgrade the address space, even if there is the version number is in the config

### DIFF
--- a/k8s-api/src/main/java/io/enmasse/k8s/api/KubeSchemaApi.java
+++ b/k8s-api/src/main/java/io/enmasse/k8s/api/KubeSchemaApi.java
@@ -342,13 +342,13 @@ public class KubeSchemaApi implements SchemaApi {
         }
 
         for (StandardInfraConfig standardInfraConfig : standardInfraConfigs) {
-            if (standardInfraConfig.getSpec() != null && standardInfraConfig.getSpec().getVersion() == null) {
+            if (standardInfraConfig.getSpec() != null) {
                 standardInfraConfig.getSpec().setVersion(defaultVersion);
             }
         }
 
         for (BrokeredInfraConfig brokeredInfraConfig : brokeredInfraConfigs) {
-            if (brokeredInfraConfig.getSpec() != null && brokeredInfraConfig.getSpec().getVersion() == null) {
+            if (brokeredInfraConfig.getSpec() != null) {
                 brokeredInfraConfig.getSpec().setVersion(defaultVersion);
             }
         }


### PR DESCRIPTION
Version 0.26 has a version number in InfraConfig..  And we should upgrade even if we see it.

Signed-off-by: Vanessa <vbusch@redhat.com>