### PR TITLE
Fix #2865: Ensure phase is set, even if it  is not already

### DIFF
--- a/address-space-controller/src/main/java/io/enmasse/controller/StatusController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/StatusController.java
@@ -43,15 +43,13 @@ public class StatusController implements Controller {
         checkComponentsReady(addressSpace);
         checkAuthServiceReady(addressSpace);
         checkExposedEndpoints(addressSpace);
-        if (addressSpace.getStatus().getPhase() != null) {
-            if (addressSpace.getStatus().isReady()) {
-                if (addressSpace.getSpec().getPlan().equals(addressSpace.getAnnotation(AnnotationKeys.APPLIED_PLAN))) {
-                    addressSpace.getStatus().setPhase(Phase.Active);
-                }
-            } else {
-                if (Phase.Active.equals(addressSpace.getStatus().getPhase())) {
-                    addressSpace.getStatus().setPhase(Phase.Failed);
-                }
+        if (addressSpace.getStatus().isReady()) {
+            if (addressSpace.getSpec().getPlan().equals(addressSpace.getAnnotation(AnnotationKeys.APPLIED_PLAN))) {
+                addressSpace.getStatus().setPhase(Phase.Active);
+            }
+        } else {
+            if (Phase.Active.equals(addressSpace.getStatus().getPhase())) {
+                addressSpace.getStatus().setPhase(Phase.Failed);
             }
         }
         return addressSpace;


### PR DESCRIPTION
Handles the upgrade case, where previously, phase would be left unset.