### PR TITLE
ExternalName field needs to be a FQDN

### DIFF
--- a/address-space-controller/src/main/java/io/enmasse/controller/ExportsController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/ExportsController.java
@@ -130,7 +130,7 @@ public class ExportsController implements Controller {
                 .endMetadata()
                 .editOrNewSpec()
                 .withType("ExternalName")
-                .withExternalName(endpointStatus.getServiceHost())
+                .withExternalName(endpointStatus.getServiceHost() + ".cluster.local")
                 .withPorts(ServiceHelper.toServicePortList(endpointStatus.getServicePorts()))
                 .endSpec()
                 .build();


### PR DESCRIPTION
ExternalName needs to be a FQDN in order to resolve.

#2877 