### PR TITLE
Issue 2876 don't garbage collect offline broker pods

### DIFF
--- a/standard-controller/src/main/java/io/enmasse/controller/standard/BrokerStatusCollector.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/BrokerStatusCollector.java
@@ -45,11 +45,11 @@ class BrokerStatusCollector {
                     totalMessageCount += queueMessageCount;
                 }
             } else {
-                log.info("Broker pod '{}' in cluster '{}' is not ready ({}), cannot get depth for queue '{}' at this time.",
+                throw new IllegalStateException(String.format("Broker pod '%s' in cluster '%s' is not ready (%s), cannot get depth for queue '%s' at this time.",
                         broker.getMetadata().getName(),
                         clusterId,
                         broker.getStatus(),
-                        queue);
+                        queue));
             }
         }
         log.info("Queue '{}' on cluster '{}' ({} replica(s)) has depth: {}", queue,  clusterId, pods.size(), totalMessageCount);


### PR DESCRIPTION
Issue #2876: the queue's original broker status was already going correctly into Migrating.   The issue was that check for a drained broker assumes that the broker *is drained* if it is not running (io.enmasse.controller.standard.BrokerStatusCollector#getQueueMessageCount) .  This is not safe.  During an upgrade the old broker is upgraded to the new image, so it does restart.

The controller was checking queue depth whilst the broker is down, and then prematurely deleting the broker. This lead to be the message loss.