### PR TITLE
Handle exceptions in lifecycle methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,9 +63,9 @@
         <commons-collections.version>3.2.2</commons-collections.version>
         <guava.version>25.0-jre</guava.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <junit.jupiter.version>5.4.2</junit.jupiter.version>
-        <junit.platform.runner.version>1.4.2</junit.platform.runner.version>
-        <junit.platform.launcher.version>1.4.2</junit.platform.launcher.version>
+        <junit.jupiter.version>5.5.0-RC1</junit.jupiter.version>
+        <junit.platform.runner.version>1.5.0-RC1</junit.platform.runner.version>
+        <junit.platform.launcher.version>1.5.0-RC1</junit.platform.launcher.version>
         <artemis.version>2.8.0</artemis.version>
         <ngwebdriver.version>1.1.4</ngwebdriver.version>
         <paho.version>1.2.0</paho.version>

--- a/systemtests/src/main/java/io/enmasse/systemtest/ability/TestWatcher.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/ability/TestWatcher.java
@@ -46,7 +46,7 @@ public class TestWatcher implements TestExecutionExceptionHandler, LifecycleMeth
                     for (Container c : containers) {
                         File filePath = new File(path.toString(), String.format("%s_%s.log", p.getMetadata().getName(), c.getName()));
                         try {
-                            Files.write(Paths.get(filePath.toString()), kube.getLog(p.getMetadata().getName(), c.getName()).getBytes());
+                            Files.write(filePath.toPath(), kube.getLog(p.getMetadata().getName(), c.getName()).getBytes());
                         } catch (IOException e) {
                             log.warn("Cannot write file {}", filePath.getName());
                         }
@@ -55,8 +55,8 @@ public class TestWatcher implements TestExecutionExceptionHandler, LifecycleMeth
                     log.warn("Cannot access logs from container: ", ex);
                 }
             }
-            Files.write(Paths.get(path.toString(), "describe.txt"), KubeCMDClient.describePods(kube.getInfraNamespace()).getStdOut().getBytes());
-            Files.write(Paths.get(path.toString(), "events.txt"), KubeCMDClient.getEvents(kube.getInfraNamespace()).getStdOut().getBytes());
+            Files.write(path.resolve("describe.txt"), KubeCMDClient.describePods(kube.getInfraNamespace()).getStdOut().getBytes());
+            Files.write(path.resolve("events.txt"), KubeCMDClient.getEvents(kube.getInfraNamespace()).getStdOut().getBytes());
             log.info("Pod logs and describe successfully stored into {}", path.toString());
         } catch (Exception ex) {
             log.warn("Cannot save pod logs and info: {}", ex.getMessage());


### PR DESCRIPTION
@ctron this allow us to hadle exceptions in before and after methods, so we can collect logs immediately when iot project or addressspace creation failed.