### PR TITLE
fix ansible monitoring-operator installation

### DIFF
--- a/ansible/roles/monitoring-operator/tasks/main.yml
+++ b/ansible/roles/monitoring-operator/tasks/main.yml
@@ -1,7 +1,4 @@
 ---
-- name: Deploy Kube-state-metrics
-  shell: oc apply -n {{ namespace }} -f {{ playbook_dir }}/install/kube-state-metrics
-
 - name: Create project namespace
   shell: oc new-project {{ monitoring_namespace }} --description="EnMasse Monitoring"
   register: namespace_exists
@@ -13,3 +10,13 @@
 
 - name: Deploy the Application Monitoring Operator
   shell: oc apply -n {{ monitoring_namespace }} -f {{ playbook_dir }}/install/monitoring-operator
+
+- name: ServiceMonitors crd is installed and kube-state-metrics can be installed
+  shell: oc get crd servicemonitors.monitoring.coreos.com
+  register: servicemonitors_crd
+  until: servicemonitors_crd.rc == 0
+  retries: 10
+  delay: 5
+
+- name: Deploy Kube-state-metrics
+  shell: oc apply -n {{ namespace }} -f {{ playbook_dir }}/install/kube-state-metrics


### PR DESCRIPTION
I found an error installing monitoring using ansible. The error was concretely when installing kube-state-metrics because it depends on `ServiceMonitors` crd which is installed by monitoring-operator which was installed after kube-state-metrics. So basically what I did to fix it is to move the installation of kube-state-metrics after monitoring-operator and wait until `ServiceMonitors` crd is available.

The command to try this would be like :
`ansible-playbook templates/build/enmasse-latest/ansible/playbooks/openshift/deploy_all.yml -i systemtests/ansible/inventory/systemtests.inventory --extra-vars "{\"namespace\": \"enmasse-infra\", \"monitoring_namespace\": \"enmasse-monitoring\", \"monitoring_operator\": \"true\", \"monitoring\": \"true\" }"`