### PR TITLE
Fix #2855: Respect custom routes when building oauth redirects

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/standard/web/FirefoxWebConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/standard/web/FirefoxWebConsoleTest.java
@@ -301,7 +301,6 @@ public class FirefoxWebConsoleTest extends WebConsoleTest implements ITestBaseSt
     }
 
     @Test
-    @Disabled("issue 2855")
     void testOpenConsoleCustomRoute() throws Exception {
         doTestOpenConsoleCustomRoute();
     }


### PR DESCRIPTION
I needed to switch from watching the routes to watching the configmaps backing the addressspaces.  My preference would have been to watch to address spaces directly, but this is currently not possible as our API server does not yet have that ability.