### PR TITLE
Upd OLM csv

### DIFF
--- a/templates/csv/enmasse.clusterserviceversion.yaml
+++ b/templates/csv/enmasse.clusterserviceversion.yaml
@@ -146,26 +146,10 @@ metadata:
           }
         },
         {
-          "apiVersion": "admin.enmasse.io/v1beta1",
-          "kind": "ConsoleService",
-          "metadata": {
-            "name": "console"
-          },
-          "spec": {}
-        },
-        {
           "apiVersion": "iot.enmasse.io/v1alpha1",
           "kind": "IoTConfig",
           "metadata": {
             "name": "default"
-          },
-          "spec": {}
-        },
-        {
-          "apiVersion": "enmasse.io/v1beta1",
-          "kind": "AddressSpaceSchema",
-          "metadata": {
-            "name": "undefined"
           },
           "spec": {}
         }
@@ -332,6 +316,9 @@ spec:
         - apiGroups: [ "", "route.openshift.io" ]
           resources: [ "routes", "routes/custom-host", "routes/status"]
           verbs: [ "create", "update", "patch", "get", "list", "watch", "delete" ]
+        - apiGroups: [ "apps.openshift.io" ]
+          resources: [ "deploymentconfigs"]
+          verbs: [  "get", "list", "watch" ]
         - apiGroups: [ "admin.enmasse.io" ]
           resources: [ "authenticationservices", "authenticationservices/finalizers", "consoleservices", "consoleservices/finalizers" ]
           verbs: [ "get", "list", "watch", "update", "create", "patch" ]

--- a/templates/csv/enmasse.clusterserviceversion.yaml
+++ b/templates/csv/enmasse.clusterserviceversion.yaml
@@ -146,10 +146,26 @@ metadata:
           }
         },
         {
+          "apiVersion": "admin.enmasse.io/v1beta1",
+          "kind": "ConsoleService",
+          "metadata": {
+            "name": "console"
+          },
+          "spec": {}
+        },
+        {
           "apiVersion": "iot.enmasse.io/v1alpha1",
           "kind": "IoTConfig",
           "metadata": {
             "name": "default"
+          },
+          "spec": {}
+        },
+        {
+          "apiVersion": "enmasse.io/v1beta1",
+          "kind": "AddressSpaceSchema",
+          "metadata": {
+            "name": "undefined"
           },
           "spec": {}
         }


### PR DESCRIPTION
Update the olm clusterserviceversion
- Fix missing role (relates to changes made in #2857 but not reflected here)
- remove consoleservice from the example.  the consoleservice operator spontaneously creates the CR, so creating it explicity is supefluous.
- remove addressspaceschema from example. you can't create these, standard and brokered are baked in