### PR TITLE
Mqtt tests in brokered addressspace

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/mqtt/MqttPublishTestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/mqtt/MqttPublishTestBase.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2019, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.systemtest.bases.mqtt;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.paho.client.mqttv3.IMqttClient;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.slf4j.Logger;
+
+import io.enmasse.address.model.Address;
+import io.enmasse.address.model.AddressBuilder;
+import io.enmasse.systemtest.AddressType;
+import io.enmasse.systemtest.CustomLogger;
+import io.enmasse.systemtest.bases.TestBaseWithShared;
+import io.enmasse.systemtest.mqtt.MqttClientFactory.Builder;
+import io.enmasse.systemtest.mqtt.MqttUtils;
+import io.enmasse.systemtest.utils.AddressUtils;
+
+public abstract class MqttPublishTestBase extends TestBaseWithShared {
+
+    private static final String MYTOPIC = "mytopic";
+    private static final Logger log = CustomLogger.getLogger();
+
+    public void testPublishQoS0() throws Exception {
+        List<MqttMessage> messages = Stream.generate(MqttMessage::new).limit(3).collect(Collectors.toList());
+        messages.forEach(m -> {
+            m.setPayload(UUID.randomUUID().toString().getBytes(StandardCharsets.UTF_8));
+            m.setQos(0);
+        });
+
+        this.publish(messages, 0);
+    }
+
+    public void testPublishQoS1() throws Exception {
+        List<MqttMessage> messages = Stream.generate(MqttMessage::new).limit(3).collect(Collectors.toList());
+        messages.forEach(m -> {
+            m.setPayload(UUID.randomUUID().toString().getBytes(StandardCharsets.UTF_8));
+            m.setQos(1);
+        });
+
+        this.publish(messages, 1);
+    }
+
+    public void testPublishQoS2() throws Exception {
+        List<MqttMessage> messages = Stream.generate(MqttMessage::new).limit(3).collect(Collectors.toList());
+        messages.forEach(m -> {
+            m.setPayload(UUID.randomUUID().toString().getBytes(StandardCharsets.UTF_8));
+            m.setQos(2);
+        });
+
+        this.publish(messages, 2);
+    }
+
+    public void testRetainedMessages() throws Exception {
+        Address topic = new AddressBuilder()
+                .withNewMetadata()
+                .withNamespace(sharedAddressSpace.getMetadata().getNamespace())
+                .withName(AddressUtils.generateAddressMetadataName(sharedAddressSpace, "test-topic1"))
+                .endMetadata()
+                .withNewSpec()
+                .withType("topic")
+                .withAddress("test-topic1")
+                .withPlan(topicPlan())
+                .endSpec()
+                .build();
+        setAddresses(topic);
+
+        MqttMessage retainedMessage = new MqttMessage();
+        retainedMessage.setQos(1);
+        retainedMessage.setPayload("retained-message".getBytes(StandardCharsets.UTF_8));
+        retainedMessage.setId(1);
+        retainedMessage.setRetained(true);
+
+        // send retained message to the topic
+        Builder publisherBuilder = mqttClientFactory.build();
+        customizeClient(publisherBuilder);
+        IMqttClient publisher = publisherBuilder.create();
+        publisher.connect();
+        publisher.publish(topic.getSpec().getAddress(), retainedMessage);
+        publisher.disconnect();
+
+        // each client which will subscribe to the topic should receive retained message!
+        Builder subscriberBuilder = mqttClientFactory.build();
+        customizeClient(subscriberBuilder);
+        IMqttClient subscriber = subscriberBuilder.create();
+        subscriber.connect();
+        CompletableFuture<MqttMessage> messageFuture = new CompletableFuture<>();
+        subscriber.subscribe(topic.getSpec().getAddress(), (topic1, message) -> messageFuture.complete(message));
+        MqttMessage receivedMessage = messageFuture.get(1, TimeUnit.MINUTES);
+        assertTrue(receivedMessage.isRetained(), "Retained message expected");
+
+        subscriber.disconnect();
+    }
+
+    private void publish(List<MqttMessage> messages, int subscriberQos) throws Exception {
+
+        Address dest = new AddressBuilder()
+                .withNewMetadata()
+                .withNamespace(sharedAddressSpace.getMetadata().getNamespace())
+                .withName(AddressUtils.generateAddressMetadataName(sharedAddressSpace, MYTOPIC))
+                .endMetadata()
+                .withNewSpec()
+                .withType("topic")
+                .withAddress(MYTOPIC)
+                .withPlan(topicPlan())
+                .endSpec()
+                .build();
+        setAddresses(dest);
+
+        MqttConnectOptions options = new MqttConnectOptions();
+        options.setConnectionTimeout(options.getConnectionTimeout() * 2);
+        options.setAutomaticReconnect(true);
+        Builder clientBuilder = mqttClientFactory.build().mqttConnectionOptions(options);
+        customizeClient(clientBuilder);
+        IMqttClient client = clientBuilder.create();
+
+        try {
+            log.info("Connecting");
+            client.connect();
+
+
+            List<CompletableFuture<MqttMessage>> receiveFutures = MqttUtils.subscribeAndReceiveMessages(client, dest.getSpec().getAddress(), messages.size(), subscriberQos);
+            List<CompletableFuture<Void>> publishFutures = MqttUtils.publish(client, dest.getSpec().getAddress(), messages);
+
+            int publishCount = MqttUtils.awaitAndReturnCode(publishFutures, 1, TimeUnit.MINUTES);
+            assertThat("Incorrect count of messages published",
+                    publishCount, is(messages.size()));
+
+            int receivedCount = MqttUtils.awaitAndReturnCode(receiveFutures, 1, TimeUnit.MINUTES);
+            assertThat("Incorrect count of messages received",
+                    receivedCount, is(messages.size()));
+        } finally {
+            log.info("Disconnecting");
+            if ( client != null ) {
+                client.disconnect();
+            }
+        }
+
+    }
+
+    protected void customizeClient(Builder mqttClientBuilder) {
+        //optional to implement
+    }
+
+    protected String topicPlan() {
+        return getDefaultPlan(AddressType.TOPIC);
+    }
+
+}

--- a/systemtests/src/test/java/io/enmasse/systemtest/brokered/mqtt/PublishTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/brokered/mqtt/PublishTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.systemtest.brokered.mqtt;
+
+import org.junit.jupiter.api.Test;
+
+import io.enmasse.systemtest.Endpoint;
+import io.enmasse.systemtest.Kubernetes;
+import io.enmasse.systemtest.ability.ITestBaseBrokered;
+import io.enmasse.systemtest.bases.mqtt.MqttPublishTestBase;
+import io.enmasse.systemtest.mqtt.MqttClientFactory.Builder;
+import io.enmasse.systemtest.utils.AddressSpaceUtils;
+
+public class PublishTest extends MqttPublishTestBase implements ITestBaseBrokered{
+
+    @Test
+    @Override
+    public void testPublishQoS0() throws Exception {
+        super.testPublishQoS0();
+    }
+
+    @Test
+    @Override
+    public void testPublishQoS1() throws Exception {
+        super.testPublishQoS1();
+    }
+
+    @Test
+    @Override
+    public void testPublishQoS2() throws Exception {
+        super.testPublishQoS2();
+    }
+
+    @Test
+    @Override
+    public void testRetainedMessages() throws Exception {
+        super.testRetainedMessages();
+    }
+
+    @Override
+    protected void customizeClient(Builder mqttClientBuilder) {
+        Endpoint messagingEndpoint = AddressSpaceUtils.getEndpointByServiceName(sharedAddressSpace, "messaging");
+        if (messagingEndpoint == null) {
+            String externalEndpointName = AddressSpaceUtils.getExternalEndpointName(sharedAddressSpace, "messaging");
+            messagingEndpoint = Kubernetes.getInstance().getExternalEndpoint(externalEndpointName + "-" + AddressSpaceUtils.getAddressSpaceInfraUuid(sharedAddressSpace));
+        }
+        mqttClientBuilder.endpoint(messagingEndpoint);
+    }
+
+
+
+}

--- a/systemtests/src/test/java/io/enmasse/systemtest/standard/mqtt/PublishTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/standard/mqtt/PublishTest.java
@@ -18,110 +18,44 @@ import io.enmasse.systemtest.DestinationPlan;
 import io.enmasse.systemtest.UserCredentials;
 import io.enmasse.systemtest.ability.ITestBaseWithMqtt;
 import io.enmasse.systemtest.amqp.AmqpClient;
-import io.enmasse.systemtest.bases.TestBaseWithShared;
+import io.enmasse.systemtest.bases.mqtt.MqttPublishTestBase;
 import io.enmasse.systemtest.mqtt.MqttClientFactory;
-import io.enmasse.systemtest.mqtt.MqttUtils;
 import io.enmasse.systemtest.standard.AnycastTest;
 import io.enmasse.systemtest.utils.AddressSpaceUtils;
 import io.enmasse.systemtest.utils.AddressUtils;
 import org.eclipse.paho.client.mqttv3.IMqttClient;
-import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
-import org.eclipse.paho.client.mqttv3.MqttMessage;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests related to publish messages via MQTT
  */
-public class PublishTest extends TestBaseWithShared implements ITestBaseWithMqtt {
-    private static final String MYTOPIC = "mytopic";
-    private static final Logger log = CustomLogger.getLogger();
+public class PublishTest extends MqttPublishTestBase implements ITestBaseWithMqtt {
 
     @Test
-    void testPublishQoS0() throws Exception {
-        List<MqttMessage> messages = Stream.generate(MqttMessage::new).limit(3).collect(Collectors.toList());
-        messages.forEach(m -> {
-            m.setPayload(UUID.randomUUID().toString().getBytes(StandardCharsets.UTF_8));
-            m.setQos(0);
-        });
-
-        this.publish(messages, 0);
+    @Override
+    public void testPublishQoS0() throws Exception {
+        super.testPublishQoS0();
     }
 
     @Test
-    void testPublishQoS1() throws Exception {
-        List<MqttMessage> messages = Stream.generate(MqttMessage::new).limit(3).collect(Collectors.toList());
-        messages.forEach(m -> {
-            m.setPayload(UUID.randomUUID().toString().getBytes(StandardCharsets.UTF_8));
-            m.setQos(1);
-        });
-
-        this.publish(messages, 1);
+    @Override
+    public void testPublishQoS1() throws Exception {
+        super.testPublishQoS1();
     }
 
+    @Override
     @Test
     @Disabled
-    void testPublishQoS2() throws Exception {
-
-        List<MqttMessage> messages = Stream.generate(MqttMessage::new).limit(3).collect(Collectors.toList());
-        messages.forEach(m -> {
-            m.setPayload(UUID.randomUUID().toString().getBytes(StandardCharsets.UTF_8));
-            m.setQos(2);
-        });
-
-        this.publish(messages, 2);
+    public void testPublishQoS2() throws Exception {
+        super.testPublishQoS2();
     }
 
+    @Override
     @Test
     @Disabled("related issue: #1529")
-    void testRetainedMessages() throws Exception {
-        Address topic = new AddressBuilder()
-                .withNewMetadata()
-                .withNamespace(sharedAddressSpace.getMetadata().getNamespace())
-                .withName(AddressUtils.generateAddressMetadataName(sharedAddressSpace, "test-topic1"))
-                .endMetadata()
-                .withNewSpec()
-                .withType("topic")
-                .withAddress("test-topic1")
-                .withPlan(DestinationPlan.STANDARD_LARGE_TOPIC)
-                .endSpec()
-                .build();
-        setAddresses(topic);
-
-        MqttMessage retainedMessage = new MqttMessage();
-        retainedMessage.setQos(1);
-        retainedMessage.setPayload("retained-message".getBytes(StandardCharsets.UTF_8));
-        retainedMessage.setId(1);
-        retainedMessage.setRetained(true);
-
-        //send retained message to the topic
-        IMqttClient publisher = mqttClientFactory.create();
-        publisher.connect();
-        publisher.publish(topic.getSpec().getAddress(), retainedMessage);
-        publisher.disconnect();
-
-        //each client which will subscribe to the topic should receive retained message!
-        IMqttClient subscriber = mqttClientFactory.create();
-        subscriber.connect();
-        CompletableFuture<MqttMessage> messageFuture = new CompletableFuture<>();
-        subscriber.subscribe(topic.getSpec().getAddress(), (topic1, message) -> messageFuture.complete(message));
-        MqttMessage receivedMessage = messageFuture.get(1, TimeUnit.MINUTES);
-        assertTrue(receivedMessage.isRetained(), "Retained message expected");
-
-        subscriber.disconnect();
+    public void testRetainedMessages() throws Exception {
+        super.testRetainedMessages();
     }
 
     @Test
@@ -213,46 +147,11 @@ public class PublishTest extends TestBaseWithShared implements ITestBaseWithMqtt
         }
     }
 
-    private void publish(List<MqttMessage> messages, int subscriberQos) throws Exception {
-
-        Address dest = new AddressBuilder()
-                .withNewMetadata()
-                .withNamespace(sharedAddressSpace.getMetadata().getNamespace())
-                .withName(AddressUtils.generateAddressMetadataName(sharedAddressSpace, MYTOPIC))
-                .endMetadata()
-                .withNewSpec()
-                .withType("topic")
-                .withAddress(MYTOPIC)
-                .withPlan(DestinationPlan.STANDARD_LARGE_TOPIC)
-                .endSpec()
-                .build();
-        setAddresses(dest);
-
-        MqttConnectOptions options = new MqttConnectOptions();
-        options.setConnectionTimeout(options.getConnectionTimeout() * 2);
-        options.setAutomaticReconnect(true);
-        IMqttClient client = mqttClientFactory.build().mqttConnectionOptions(options).create();
-        try {
-            log.info("Connecting");
-            client.connect();
-
-
-            List<CompletableFuture<MqttMessage>> receiveFutures = MqttUtils.subscribeAndReceiveMessages(client, dest.getSpec().getAddress(), messages.size(), subscriberQos);
-            List<CompletableFuture<Void>> publishFutures = MqttUtils.publish(client, dest.getSpec().getAddress(), messages);
-
-            int publishCount = MqttUtils.awaitAndReturnCode(publishFutures, 1, TimeUnit.MINUTES);
-            assertThat("Incorrect count of messages published",
-                    publishCount, is(messages.size()));
-
-            int receivedCount = MqttUtils.awaitAndReturnCode(receiveFutures, 1, TimeUnit.MINUTES);
-            assertThat("Incorrect count of messages received",
-                    receivedCount, is(messages.size()));
-        } finally {
-            log.info("Disconnecting");
-            if (client != null) {
-                client.disconnect();
-            }
-        }
-
+    @Override
+    protected String topicPlan() {
+        return DestinationPlan.STANDARD_LARGE_TOPIC;
     }
+
+
+
 }


### PR DESCRIPTION
Adds a PublishTest class for the tests of brokered address space and shares the logic with the already existent for the standard address space