### PR TITLE
suite improvements and fixes

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/web/GlobalConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/web/GlobalConsoleTest.java
@@ -22,7 +22,6 @@ import io.enmasse.systemtest.selenium.page.GlobalConsolePage;
 import io.enmasse.systemtest.utils.AddressSpaceUtils;
 import io.enmasse.systemtest.utils.AuthServiceUtils;
 import io.enmasse.systemtest.utils.TestUtils;
-import org.junit.jupiter.api.AfterEach;
 import org.slf4j.Logger;
 
 import java.util.Optional;
@@ -162,7 +161,7 @@ public abstract class GlobalConsoleTest extends TestBase {
                 .endAuthenticationService()
                 .endSpec()
                 .build();
-
+        addToAddressSpacess(addressSpace);
         globalConsolePage = new GlobalConsolePage(selenium, TestUtils.getGlobalConsoleRoute(), clusterUser);
         globalConsolePage.openGlobalConsolePage();
         globalConsolePage.createAddressSpace(addressSpace);

--- a/systemtests/src/test/java/io/enmasse/systemtest/common/plans/PlansTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/common/plans/PlansTest.java
@@ -748,14 +748,14 @@ class PlansTest extends TestBase {
             log.info("Address {} => {}", q.getMetadata().getName(), a.getStatus().getBrokerStatuses());
         });
 
-        //send 1000 messages to each queue
+        //send 500 messages to each queue
         UserCredentials user = new UserCredentials("test-scale-user-name", "test_scale_user_pswd");
         createOrUpdateUser(messagePersistAddressSpace, user);
 
         AmqpClient queueClient = amqpClientFactory.createQueueClient(messagePersistAddressSpace);
         queueClient.getConnectOptions().setCredentials(user);
 
-        List<String> msgs = TestUtils.generateMessages(1000);
+        List<String> msgs = TestUtils.generateMessages(500);
         Future<Integer> sendResult1 = queueClient.sendMessages(queue1.getSpec().getAddress(), msgs);
         Future<Integer> sendResult2 = queueClient.sendMessages(queue2.getSpec().getAddress(), msgs);
         Future<Integer> sendResult3 = queueClient.sendMessages(queue3.getSpec().getAddress(), msgs);


### PR DESCRIPTION
Decreases the messages sent in `PlansTest#testMessagePersistenceAfterAutoScale` because of problems with timeouts in openshift 4 tests.
Fixes a bug in `GlobalConsoleTest#doTestSwitchAddressSpacePlan` that made `GlobalConsoleTest#doTestConnectToAddressSpaceConsole` fail 