### PR TITLE
Ensure bundle upgrade test uses persistent-claim

### DIFF
--- a/api-model/src/main/java/io/enmasse/admin/model/v1/AuthenticationServiceSpecStandard.java
+++ b/api-model/src/main/java/io/enmasse/admin/model/v1/AuthenticationServiceSpecStandard.java
@@ -23,11 +23,12 @@ import java.util.Objects;
         },
         inline = @Inline(type = Doneable.class, prefix = "Doneable", value = "done")
 )
-@JsonPropertyOrder({"credentialsSecret", "certificateSecret"})
+@JsonPropertyOrder({"credentialsSecret", "certificateSecret", "storage"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class AuthenticationServiceSpecStandard extends AbstractWithAdditionalProperties {
     private SecretReference credentialsSecret;
     private SecretReference certificateSecret;
+    private AuthenticationServiceSpecStandardStorage storage;
 
     public SecretReference getCredentialsSecret() {
         return credentialsSecret;
@@ -43,12 +44,13 @@ public class AuthenticationServiceSpecStandard extends AbstractWithAdditionalPro
         if (o == null || getClass() != o.getClass()) return false;
         AuthenticationServiceSpecStandard that = (AuthenticationServiceSpecStandard) o;
         return Objects.equals(credentialsSecret, that.credentialsSecret) &&
-                Objects.equals(certificateSecret, that.certificateSecret);
+                Objects.equals(certificateSecret, that.certificateSecret) &&
+                Objects.equals(storage, that.storage);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(credentialsSecret, certificateSecret);
+        return Objects.hash(credentialsSecret, certificateSecret, storage);
     }
 
     @Override
@@ -56,6 +58,7 @@ public class AuthenticationServiceSpecStandard extends AbstractWithAdditionalPro
         return "AuthenticationServiceSpecStandard{" +
                 "credentialsSecret=" + credentialsSecret +
                 ", certificateSecret=" + certificateSecret +
+                ", storage=" + storage +
                 '}';
     }
 
@@ -65,5 +68,13 @@ public class AuthenticationServiceSpecStandard extends AbstractWithAdditionalPro
 
     public void setCertificateSecret(SecretReference certificateSecret) {
         this.certificateSecret = certificateSecret;
+    }
+
+    public AuthenticationServiceSpecStandardStorage getStorage() {
+        return storage;
+    }
+
+    public void setStorage(AuthenticationServiceSpecStandardStorage storage) {
+        this.storage = storage;
     }
 }

--- a/api-model/src/main/java/io/enmasse/admin/model/v1/AuthenticationServiceSpecStandardStorage.java
+++ b/api-model/src/main/java/io/enmasse/admin/model/v1/AuthenticationServiceSpecStandardStorage.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.admin.model.v1;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.fabric8.kubernetes.api.model.Doneable;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.SecretReference;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import io.sundr.builder.annotations.Inline;
+
+import java.util.Objects;
+
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = "io.fabric8.kubernetes.api.builder",
+        refs= {
+                @BuildableReference(AbstractWithAdditionalProperties.class)
+        },
+        inline = @Inline(type = Doneable.class, prefix = "Doneable", value = "done")
+)
+@JsonPropertyOrder({"type", "size"})
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AuthenticationServiceSpecStandardStorage extends AbstractWithAdditionalProperties {
+    private AuthenticationServiceSpecStandardType type;
+    private Quantity size;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AuthenticationServiceSpecStandardStorage that = (AuthenticationServiceSpecStandardStorage) o;
+        return type == that.type && Objects.equals(size, that.size);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, size);
+    }
+
+    @Override
+    public String toString() {
+        return "AuthenticationServiceSpecStandardStorage{" +
+                "type=" + type +
+                ", size=" + size +
+                '}';
+    }
+
+    public AuthenticationServiceSpecStandardType getType() {
+        return type;
+    }
+
+    public void setType(AuthenticationServiceSpecStandardType type) {
+        this.type = type;
+    }
+
+    public Quantity getSize() {
+        return size;
+    }
+
+    public void setSize(Quantity size) {
+        this.size = size;
+    }
+}

--- a/api-model/src/main/java/io/enmasse/admin/model/v1/AuthenticationServiceSpecStandardType.java
+++ b/api-model/src/main/java/io/enmasse/admin/model/v1/AuthenticationServiceSpecStandardType.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2019, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.admin.model.v1;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum AuthenticationServiceSpecStandardType {
+    @JsonProperty("ephemeral")
+    ephemeral,
+    @JsonProperty("persistent-claim")
+    persistent_claim;
+}

--- a/systemtests/src/test/java/io/enmasse/systemtest/common/upgrade/UpgradeTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/common/upgrade/UpgradeTest.java
@@ -331,7 +331,7 @@ class UpgradeTest extends TestBase {
                 log.info("Replacement auth service : {}", replacement);
 
                 Thread.sleep(30_000);
-                waitUntilDeployed(kubernetes.getInfraNamespace());
+                TestUtils.waitUntilDeployed(kubernetes.getInfraNamespace());
             }
         }
     }


### PR DESCRIPTION
The bundle upgrade test was failing when upgrading from 0.28.  This was because the bundle doesn't define a persistent standard authentication service, so the users were lost.   The test is changed to replace the standard authentication service if it is not persistent.