### PR TITLE
Handle 409 - object is being deleted: authenticationservices already exists.

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/common/upgrade/UpgradeTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/common/upgrade/UpgradeTest.java
@@ -323,8 +323,8 @@ class UpgradeTest extends TestBase {
             AuthenticationServiceSpecStandardStorage storage = authService.getSpec().getStandard().getStorage();
             if (storage == null || !AuthenticationServiceSpecStandardType.persistent_claim.equals(storage.getType())) {
                 log.info("Installed auth service {} does not use persistent claim, recreating it ", authServiceName);
-                Boolean delete = kubernetes.getAuthenticationServiceClient().withName(authServiceName).delete();
-                log.info("Deleted {}", delete);
+                AdminResourcesManager.getInstance().removeAuthService(authService);
+
                 AuthenticationService replacement = AuthServiceUtils.createStandardAuthServiceObject(authServiceName, true);
                 kubernetes.getAuthenticationServiceClient().create(replacement);
 


### PR DESCRIPTION
Test failed on CI with:

`Failure executing: POST at: https://10.0.132.97:8443/apis/admin.enmasse.io/v1beta1/namespaces/enmasse-infra/authenticationservices. Message: object is being deleted: authenticationservices.admin.enmasse.io "standard-authservice" already exists. Received status: Status(apiVersion=v1, code=409, details=StatusDetails(causes=[], group=admin.enmasse.io, kind=authenticationservices, name=standard-authservice, retryAfterSeconds=null, uid=null, additionalProperties={}), kind=Status, message=object is being deleted: authenticationservices.admin.enmasse.io "standard-authservice" already exists, metadata=ListMeta(_continue=null, resourceVersion=null, selfLink=null, additionalProperties={}), reason=AlreadyExists, status=Failure, additionalProperties={})`