### PR TITLE
Allow ${VERSION} substitution in OLM metadata

### DIFF
--- a/templates/Makefile
+++ b/templates/Makefile
@@ -58,7 +58,7 @@ replace_images: prepare
 		cat $$i | sed -e 's,\$${ADDRESS_SPACE_CONTROLLER_IMAGE},$(ADDRESS_SPACE_CONTROLLER_IMAGE),g' \
 					  -e 's,\$${MAVEN_VERSION},$(MAVEN_VERSION),g' \
 					  -e 's,\$${NAMESPACE},$(DEFAULT_PROJECT),g' \
-					  -e 's,\$${ENMASSE_VERSION},$(VERSION),g' \
+					  -e 's,\$${VERSION},$(VERSION),g' \
 					  -e 's,\$${IMAGE_PULL_POLICY},$(IMAGE_PULL_POLICY),g' \
 					  -e 's,\$${STANDARD_CONTROLLER_IMAGE},$(STANDARD_CONTROLLER_IMAGE),g' \
 					  -e 's,\$${ROUTER_IMAGE},$(ROUTER_IMAGE),g' \


### PR DESCRIPTION
Allow the use of `${VERSION}` as a replacement in OLM metadata.  It will carry the two part release number from `pom.properties`.