### PR TITLE
Increase timeout on receive MsgPatternsInternalTest

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/AbstractClient.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/AbstractClient.java
@@ -180,13 +180,14 @@ public abstract class AbstractClient {
             executor = new Executor(logPath);
             int ret = executor.execute(prepareCommand(), timeout);
             synchronized (lock) {
-                log.info("Return code - " + ret);
+                log.info("{} {} Return code - {}", this.getClass().getName(), clientType,  ret);
                 if (logToOutput) {
+                    log.info("{} {} stdout : {}", this.getClass().getName(), clientType, executor.getStdOut());
+                    if (!executor.getStdErr().isEmpty()) {
+                        log.error("{} {} stderr : {}", this.getClass().getName(), clientType, executor.getStdErr());
+                    }
                     if (ret == 0) {
-                        log.info(executor.getStdOut());
                         parseToJson(executor.getStdOut());
-                    } else {
-                        log.error(executor.getStdErr());
                     }
                 }
             }
@@ -299,6 +300,7 @@ public abstract class AbstractClient {
                     try {
                         messages.add(new JsonObject(line));
                     } catch (Exception ignored) {
+                        log.warn("{} - Failed to parse client output '{}' as JSON", clientType, line);
                     }
                 }
             }

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/clients/ClusterClientTestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/clients/ClusterClientTestBase.java
@@ -75,6 +75,7 @@ public abstract class ClusterClientTestBase extends TestBaseWithShared {
         }
 
         sender.setArguments(arguments);
+        arguments.put(ClientArgument.TIMEOUT, "10");  // In seconds, maximum time the consumer waits for a single message
         arguments.remove(ClientArgument.MSG_CONTENT);
         receiver.setArguments(arguments);
 


### PR DESCRIPTION
Previously the consumer was using a timeout of 200ms, which I think is too low in a stressed environment.  Also improved the logging for diagnostic purposes (Test change only).