### PR TITLE
Upgrade org.codehaus.mojo:license-maven-plugin version to 2.0.0

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -5,7 +5,7 @@
 To build EnMasse, you need
 
    * [JDK](http://openjdk.java.net/) >= 11
-   * [Apache Maven](https://maven.apache.org/) >= 3.3.1
+   * [Apache Maven](https://maven.apache.org/) >= 3.5.4
    * [Docker](https://www.docker.com/)
    * [GNU Make](https://www.gnu.org/software/make/)
    * [Asciidoctor](https://asciidoctor.org/) >= 1.5.7

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <asciidoctor-maven-plugin.version>1.5.6</asciidoctor-maven-plugin.version>
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
         <mycila-license-maven-plugin.version>2.11</mycila-license-maven-plugin.version>
-        <codehaus-license-maven-plugin.version>1.17</codehaus-license-maven-plugin.version>
+        <codehaus-license-maven-plugin.version>2.0.0</codehaus-license-maven-plugin.version>
         <frontend-maven-plugin.version>1.6</frontend-maven-plugin.version>
         <jmx_prometheus_javaagent.version>0.3.1</jmx_prometheus_javaagent.version>
         <properties-maven-plugin.version>1.0.0</properties-maven-plugin.version>


### PR DESCRIPTION
Requires maven version 3.5.4

Signed-off-by: Vanessa <vbusch@redhat.com>