### PR TITLE
reduces the messages sent in some tests and fix a possible NPE

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/clients/ClientTestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/clients/ClientTestBase.java
@@ -55,8 +55,10 @@ public abstract class  ClientTestBase extends TestBaseWithShared {
     @AfterEach
     public void teardownClient() {
         arguments.clear();
-        clients.forEach(AbstractClient::stop);
-        clients.clear();
+        if (clients != null) {
+            clients.forEach(AbstractClient::stop);
+            clients.clear();
+        }
     }
 
     private Endpoint getMessagingRoute(AddressSpace addressSpace, boolean websocket) throws Exception {

--- a/systemtests/src/test/java/io/enmasse/systemtest/common/plans/PlansTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/common/plans/PlansTest.java
@@ -755,7 +755,7 @@ class PlansTest extends TestBase {
         AmqpClient queueClient = amqpClientFactory.createQueueClient(messagePersistAddressSpace);
         queueClient.getConnectOptions().setCredentials(user);
 
-        List<String> msgs = TestUtils.generateMessages(500);
+        List<String> msgs = TestUtils.generateMessages(350);
         Future<Integer> sendResult1 = queueClient.sendMessages(queue1.getSpec().getAddress(), msgs);
         Future<Integer> sendResult2 = queueClient.sendMessages(queue2.getSpec().getAddress(), msgs);
         Future<Integer> sendResult3 = queueClient.sendMessages(queue3.getSpec().getAddress(), msgs);

--- a/systemtests/src/test/java/io/enmasse/systemtest/standard/QueueTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/standard/QueueTest.java
@@ -326,7 +326,7 @@ public class QueueTest extends TestBaseWithShared implements ITestBaseStandard {
 
         AmqpClient client = amqpClientFactory.createQueueClient();
         final List<String> prefixes = Arrays.asList("foo", "bar", "baz", "quux");
-        final int numMessages = 1000;
+        final int numMessages = 500;
         final int totalNumMessages = numMessages * prefixes.size();
         final int numReceiveBeforeDraining = numMessages / 2;
         final int numReceivedAfterScaled = totalNumMessages - numReceiveBeforeDraining;


### PR DESCRIPTION
Reduces the amount of messages sent in some tests to deal with the slowness in ocp4 testing and fixes an sporadic NPE that happened in recent test runs.