### PR TITLE
Re-deploy auth service in case the permissions change

### DIFF
--- a/pkg/controller/iotconfig/iotconfig_controller.go
+++ b/pkg/controller/iotconfig/iotconfig_controller.go
@@ -180,7 +180,7 @@ func (r *ReconcileIoTConfig) Reconcile(request reconcile.Request) (reconcile.Res
 		case DeviceRegistryFileBased:
 			return r.processFileDeviceRegistry(ctx, config)
 		default:
-			return reconcile.Result{}, fmt.Errorf("illegal device registry configuration.")
+			return reconcile.Result{}, fmt.Errorf("illegal device registry configuration")
 		}
 	})
 	rc.Process(func() (reconcile.Result, error) {

--- a/pkg/util/cchange/change.go
+++ b/pkg/util/cchange/change.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package cchange
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"hash"
+	"sort"
+)
+
+type ConfigChangeRecorder struct {
+	hasher hash.Hash
+}
+
+func NewRecorder() *ConfigChangeRecorder {
+	return &ConfigChangeRecorder{
+		hasher: sha256.New(),
+	}
+}
+
+func (c *ConfigChangeRecorder) AddStringsFromMap(data map[string]string, onlyKeys ...string) {
+
+	if onlyKeys != nil {
+		sort.Strings(onlyKeys)
+	}
+
+	for k, v := range data {
+		if onlyKeys != nil {
+			if sort.SearchStrings(onlyKeys, k) >= len(onlyKeys) {
+				continue
+			}
+		}
+		c.hasher.Write([]byte(v))
+	}
+
+}
+
+func (c *ConfigChangeRecorder) AddString(data string) {
+	c.hasher.Write([]byte(data))
+}
+
+func (c ConfigChangeRecorder) Hash() []byte {
+	return c.hasher.Sum(nil)
+}
+
+func (c ConfigChangeRecorder) HashString() string {
+	return hex.EncodeToString(c.Hash())
+}

--- a/pkg/util/cchange/change_test.go
+++ b/pkg/util/cchange/change_test.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package cchange
+
+import (
+	"testing"
+)
+
+func TestStringEqual(t *testing.T) {
+	change1 := NewRecorder()
+	change2 := NewRecorder()
+
+	change1.AddString("foo")
+	change2.AddString("foo")
+
+	if change1.HashString() != change2.HashString() {
+		t.Errorf("Should be equal - 1: %s, 2: %s", change1.HashString(), change2.HashString())
+	}
+}
+
+func TestMap1(t *testing.T) {
+	change1 := NewRecorder()
+	change2 := NewRecorder()
+
+	change1.AddStringsFromMap(map[string]string{
+		"baz": "123",
+	})
+	change2.AddStringsFromMap(map[string]string{
+		"baz": "123",
+	})
+
+	if change1.HashString() != change2.HashString() {
+		t.Error("Should be equal")
+	}
+}
+
+func TestMap2(t *testing.T) {
+	change1 := NewRecorder()
+	change2 := NewRecorder()
+
+	change1.AddStringsFromMap(map[string]string{
+		"baz": "123",
+		"foo": "456",
+	}, "baz")
+	change2.AddStringsFromMap(map[string]string{
+		"baz": "123",
+	})
+
+	if change1.HashString() != change2.HashString() {
+		t.Error("Should be equal")
+	}
+}

--- a/pkg/util/install/utils.go
+++ b/pkg/util/install/utils.go
@@ -6,10 +6,11 @@
 package install
 
 import (
+	"strconv"
+
 	"github.com/enmasseproject/enmasse/pkg/apis/enmasse/v1beta1"
 	"github.com/enmasseproject/enmasse/pkg/util"
 	"github.com/enmasseproject/enmasse/pkg/util/images"
-	"strconv"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -45,6 +46,18 @@ func ApplyServiceDefaults(service *corev1.Service, component string, name string
 
 }
 
+func CreateDefaultAnnotations(annotations map[string]string) map[string]string {
+
+	// currently we only ensure the annotations map is not null
+
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	return annotations
+
+}
+
 // Apply some default deployment values
 func ApplyDeploymentDefaults(deployment *appsv1.Deployment, component string, name string) {
 
@@ -56,9 +69,15 @@ func ApplyDeploymentDefaults(deployment *appsv1.Deployment, component string, na
 		}
 	}
 
+	if deployment.Annotations == nil {
+		deployment.Annotations = map[string]string{}
+	}
+
 	replicas := int32(1)
 	deployment.Spec.Replicas = &replicas
-	deployment.Spec.Template.ObjectMeta.Labels = CreateDefaultLabels(deployment.Spec.Template.ObjectMeta.Labels, component, name)
+
+	deployment.Spec.Template.Annotations = CreateDefaultAnnotations(deployment.Spec.Template.Annotations)
+	deployment.Spec.Template.Labels = CreateDefaultLabels(deployment.Spec.Template.Labels, component, name)
 
 }
 


### PR DESCRIPTION
When reconciling fails, it may be that the "config map", holding the inter-service credentials gets updated, without any updates to the authentication service. In this case the authentication service will not pick up the changes, as Hono services do require a restart by design to pick up changes.

This change calculates a hash from the relevant parts of the configuration and sets this hash to an annotation on the pod spec template. So if the config changes, the hash changes and so does the annotation. A changed annotation on the pod spec template will cause a new deployment and thus a pod re-start.