### PR TITLE
Increase the timeout to 10sec. from the default 200ms

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/clients/ClientTestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/clients/ClientTestBase.java
@@ -293,6 +293,7 @@ public abstract class  ClientTestBase extends TestBaseWithShared {
         arguments.put(ClientArgument.ADDRESS, dest.getSpec().getAddress());
         arguments.put(ClientArgument.COUNT, Integer.toString(expectedMsgCount));
         arguments.put(ClientArgument.MSG_CONTENT, "msg no. %d");
+        arguments.put(ClientArgument.TIMEOUT, "10");  // In seconds, maximum time the consumer waits for a single message
 
         sender.setArguments(arguments);
         arguments.remove(ClientArgument.MSG_CONTENT);

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/clients/ClientTestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/clients/ClientTestBase.java
@@ -293,12 +293,12 @@ public abstract class  ClientTestBase extends TestBaseWithShared {
         arguments.put(ClientArgument.ADDRESS, dest.getSpec().getAddress());
         arguments.put(ClientArgument.COUNT, Integer.toString(expectedMsgCount));
         arguments.put(ClientArgument.MSG_CONTENT, "msg no. %d");
-        arguments.put(ClientArgument.TIMEOUT, "10");  // In seconds, maximum time the consumer waits for a single message
 
         sender.setArguments(arguments);
         arguments.remove(ClientArgument.MSG_CONTENT);
 
         arguments.put(ClientArgument.COUNT, "0");
+        arguments.put(ClientArgument.TIMEOUT, "10");  // In seconds, maximum time the consumer waits for a single message
         receiver.setArguments(arguments);
 
         assertTrue(sender.run(), "Sender failed, expected return code 0");


### PR DESCRIPTION
Increase the timeout to 10sec. from the default 200ms.  

To solve: org.opentest4j.AssertionFailedError: Expected 50 received messages ==> expected: <50> but was: <10> 

Signed-off-by: Vanessa <vbusch@redhat.com>

