### PR TITLE
Increase timeouts to solve MQTT PublishTest sporadic failure.

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/mqtt/MqttUtils.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/mqtt/MqttUtils.java
@@ -8,6 +8,9 @@ import org.eclipse.paho.client.mqttv3.IMqttClient;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
 
+import org.slf4j.Logger;
+import io.enmasse.systemtest.CustomLogger;
+
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -21,6 +24,8 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class MqttUtils {
+
+    private static Logger log = CustomLogger.getLogger();
     public static <T> int awaitAndReturnCode(List<CompletableFuture<T>> futures, int timeout, TimeUnit timeUnit) throws InterruptedException, ExecutionException {
         CompletableFuture<Void> future = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
         try {
@@ -53,6 +58,7 @@ public class MqttUtils {
         Iterator<CompletableFuture<MqttMessage>> resultItr = receiveFutures.iterator();
         client.subscribe(address, qos, (t, m) -> {
             assertThat("Unexpected message", resultItr.hasNext(), is(true));
+            log.debug("Received expected message: {}, Topic: {}", m, t);
             resultItr.next().complete(m);
         });
         return receiveFutures;

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/mqtt/MqttPublishTestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/mqtt/MqttPublishTestBase.java
@@ -122,7 +122,8 @@ public abstract class MqttPublishTestBase extends TestBaseWithShared {
         setAddresses(dest);
 
         MqttConnectOptions options = new MqttConnectOptions();
-        options.setConnectionTimeout(options.getConnectionTimeout() * 2);
+        options.setConnectionTimeout(options.getConnectionTimeout() * 2);  //Default is 30 seconds, increase it to 1 min.
+        options.setKeepAliveInterval(options.getKeepAliveInterval() * 2);  //Default is 60 seconds, increase it to 2 min.
         options.setAutomaticReconnect(true);
         Builder clientBuilder = mqttClientFactory.build().mqttConnectionOptions(options);
         customizeClient(clientBuilder);
@@ -140,7 +141,7 @@ public abstract class MqttPublishTestBase extends TestBaseWithShared {
             assertThat("Incorrect count of messages published",
                     publishCount, is(messages.size()));
 
-            int receivedCount = MqttUtils.awaitAndReturnCode(receiveFutures, 1, TimeUnit.MINUTES);
+            int receivedCount = MqttUtils.awaitAndReturnCode(receiveFutures, 2, TimeUnit.MINUTES);
             assertThat("Incorrect count of messages received",
                     receivedCount, is(messages.size()));
         } finally {

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/mqtt/MqttPublishTestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/mqtt/MqttPublishTestBase.java
@@ -123,7 +123,6 @@ public abstract class MqttPublishTestBase extends TestBaseWithShared {
 
         MqttConnectOptions options = new MqttConnectOptions();
         options.setConnectionTimeout(options.getConnectionTimeout() * 2);  //Default is 30 seconds, increase it to 1 min.
-        options.setKeepAliveInterval(options.getKeepAliveInterval() * 2);  //Default is 60 seconds, increase it to 2 min.
         options.setAutomaticReconnect(true);
         Builder clientBuilder = mqttClientFactory.build().mqttConnectionOptions(options);
         customizeClient(clientBuilder);


### PR DESCRIPTION
Increase timeouts to solve:
java.lang.AssertionError: Incorrect count of messages received
Expected: is <3> but: was <2>

Signed-off-by: Vanessa <vbusch@redhat.com>