### PR TITLE
Unconditionally set AMQ_RESET_CONFIG unless overridden by ENMASSE scoped variable

### DIFF
--- a/broker-plugin/plugin/src/main/sh/launch-broker.sh
+++ b/broker-plugin/plugin/src/main/sh/launch-broker.sh
@@ -2,7 +2,7 @@
 
 # Turn on AMQ_RESET_CONFIG so that Artemis config/scripts get unconditionally rewritten on startup.  Required to handle
 # all Artemis upgrade cases properly (see http://activemq.apache.org/components/artemis/documentation/latest/versions.html)
-AMQ_RESET_CONFIG="${AMQ_RESET_CONFIG:-true}"
+AMQ_RESET_CONFIG="${ENMASSE_AMQ_RESET_CONFIG:-true}"
 BROKER_DIR=${ARTEMIS_HOME}
 BROKER_CUSTOM_DIR=${BROKER_DIR}/custom
 sed -i '$ d' ${BROKER_DIR}/bin/launch.sh


### PR DESCRIPTION
The downstream broker image (unlike the upstream one), defines AMQ_RESET_CONFIG=false at the Docker level.  Unconditionally apply true unless an ENMASSE specific variable is set overriding it.