### PR TITLE
increase timeouts in smoke tests

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/brokered/SmokeTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/brokered/SmokeTest.java
@@ -98,15 +98,15 @@ class SmokeTest extends TestBase implements ITestBaseBrokered {
 
         assertAll("All senders should send all messages",
                 () -> assertThat("Wrong count of messages sent: batch1",
-                        amqpTopicCli.sendMessages(topicB.getSpec().getAddress(), msgsBatch).get(1, TimeUnit.MINUTES), is(msgsBatch.size())),
+                        amqpTopicCli.sendMessages(topicB.getSpec().getAddress(), msgsBatch).get(3, TimeUnit.MINUTES), is(msgsBatch.size())),
                 () -> assertThat("Wrong count of messages sent: batch2",
-                        amqpTopicCli.sendMessages(topicB.getSpec().getAddress(), msgsBatch2).get(1, TimeUnit.MINUTES), is(msgsBatch2.size())));
+                        amqpTopicCli.sendMessages(topicB.getSpec().getAddress(), msgsBatch2).get(3, TimeUnit.MINUTES), is(msgsBatch2.size())));
 
         assertAll("All receivers should receive all messages",
                 () -> assertThat("Wrong count of messages received",
-                        recvResults.get(0).get(1, TimeUnit.MINUTES).size(), is(msgsBatch.size() + msgsBatch2.size())),
+                        recvResults.get(0).get(3, TimeUnit.MINUTES).size(), is(msgsBatch.size() + msgsBatch2.size())),
                 () -> assertThat("Wrong count of messages received",
-                        recvResults.get(1).get(1, TimeUnit.MINUTES).size(), is(msgsBatch.size() + msgsBatch2.size())));
+                        recvResults.get(1).get(3, TimeUnit.MINUTES).size(), is(msgsBatch.size() + msgsBatch2.size())));
     }
 
     @Test

--- a/systemtests/src/test/java/io/enmasse/systemtest/standard/QueueTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/standard/QueueTest.java
@@ -55,7 +55,7 @@ public class QueueTest extends TestBaseWithShared implements ITestBaseStandard {
     public static void runQueueTest(AmqpClient client, Address dest, int countMessages) throws InterruptedException, TimeoutException, ExecutionException, IOException {
         List<String> msgs = TestUtils.generateMessages(countMessages);
         Count<Message> predicate = new Count<>(msgs.size());
-        long timeoutMs = countMessages * 150; //estimate in worst case it takes at most 150ms to send one message
+        long timeoutMs = countMessages * 200; //estimate in worst case it takes at most 200ms to send one message
         log.info("Start sending with "+timeoutMs+" ms timeout");
         Future<Integer> numSent = client.sendMessages(dest.getSpec().getAddress(), msgs, predicate);
 

--- a/systemtests/src/test/java/io/enmasse/systemtest/standard/SmokeTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/standard/SmokeTest.java
@@ -153,7 +153,7 @@ class SmokeTest extends TestBase implements ITestBaseStandard {
     private void testTopic() throws Exception {
         AmqpClient client = amqpClientFactory.createTopicClient(addressSpace);
         client.getConnectOptions().setCredentials(cred);
-        List<String> msgs = TestUtils.generateMessages(1000);
+        List<String> msgs = TestUtils.generateMessages(500);
 
         List<Future<List<Message>>> recvResults = Arrays.asList(
                 client.recvMessages(topic.getSpec().getAddress(), msgs.size()),
@@ -165,21 +165,21 @@ class SmokeTest extends TestBase implements ITestBaseStandard {
 
         Thread.sleep(10_000);
         assertThat("Wrong count of messages sent",
-                client.sendMessages(topic.getSpec().getAddress(), msgs).get(1, TimeUnit.MINUTES), is(msgs.size()));
+                client.sendMessages(topic.getSpec().getAddress(), msgs).get(3, TimeUnit.MINUTES), is(msgs.size()));
 
         assertAll("Every subscriber should receive all messages",
                 () -> assertThat("Wrong count of messages received: receiver0",
-                        recvResults.get(0).get(1, TimeUnit.MINUTES).size(), is(msgs.size())),
+                        recvResults.get(0).get(3, TimeUnit.MINUTES).size(), is(msgs.size())),
                 () -> assertThat("Wrong count of messages received: receiver1",
-                        recvResults.get(1).get(1, TimeUnit.MINUTES).size(), is(msgs.size())),
+                        recvResults.get(1).get(3, TimeUnit.MINUTES).size(), is(msgs.size())),
                 () -> assertThat("Wrong count of messages received: receiver2",
-                        recvResults.get(2).get(1, TimeUnit.MINUTES).size(), is(msgs.size())),
+                        recvResults.get(2).get(3, TimeUnit.MINUTES).size(), is(msgs.size())),
                 () -> assertThat("Wrong count of messages received: receiver3",
-                        recvResults.get(3).get(1, TimeUnit.MINUTES).size(), is(msgs.size())),
+                        recvResults.get(3).get(3, TimeUnit.MINUTES).size(), is(msgs.size())),
                 () -> assertThat("Wrong count of messages received: receiver4",
-                        recvResults.get(4).get(1, TimeUnit.MINUTES).size(), is(msgs.size())),
+                        recvResults.get(4).get(3, TimeUnit.MINUTES).size(), is(msgs.size())),
                 () -> assertThat("Wrong count of messages received: receiver5",
-                        recvResults.get(5).get(1, TimeUnit.MINUTES).size(), is(msgs.size()))
+                        recvResults.get(5).get(3, TimeUnit.MINUTES).size(), is(msgs.size()))
         );
     }
 


### PR DESCRIPTION
Increases some timeouts for the smoke tests because in openshift 4 test runs are slower 