### PR TITLE
collect logs in monitoring namespace in case MonitoringTest fails

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/GlobalLogCollector.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/GlobalLogCollector.java
@@ -106,6 +106,22 @@ public class GlobalLogCollector {
         });
     }
 
+    public void collectLogsOfPodsInNamespace(String namespace) {
+        log.info("Store logs from all pods in namespace '{}'", namespace);
+        kubernetes.getLogsOfAllPods(namespace).forEach((podName, podLogs) -> {
+            try {
+                String filename = String.format("%s.%s.log", namespace, podName);
+                Path podLog = resolveLogFile(filename);
+                log.info("log of '{}' pod will be archived with path: '{}'", podName, podLog);
+                try (BufferedWriter bf = Files.newBufferedWriter(podLog)) {
+                    bf.write(podLogs);
+                }
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        });
+    }
+
     public void collectEvents() throws IOException {
         long timestamp = System.currentTimeMillis();
         log.info("Collecting events in {}", namespace);

--- a/systemtests/src/test/java/io/enmasse/systemtest/common/monitoring/MonitoringTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/common/monitoring/MonitoringTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.slf4j.Logger;
 
 import com.google.common.collect.Ordering;
@@ -118,7 +119,10 @@ public class MonitoringTest extends TestBase{
     }
 
     @AfterEach
-    void uninstallMonitoring() {
+    void uninstallMonitoring(ExtensionContext context) {
+        if (context.getExecutionException().isPresent()) { //test failed
+            logCollector.collectLogsOfPodsInNamespace(environment.getMonitoringNamespace());
+        }
         KubeCMDClient.switchProject(kubernetes.getInfraNamespace());
         KubeCMDClient.deleteFromFile(kubernetes.getInfraNamespace(), Paths.get(templatesDir.toString(), "install", "bundles", "monitoring"));
         KubeCMDClient.switchProject(environment.getMonitoringNamespace());


### PR DESCRIPTION
collects the logs of all pods in `enmasse-monitoring` namespace in case MonitoringTest fails 