### PR TITLE
Fix unreliable WebConsoleTest tests

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/SystemtestsKubernetesApps.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/SystemtestsKubernetesApps.java
@@ -10,15 +10,19 @@ import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.api.model.extensions.*;
+import org.slf4j.Logger;
 
 import java.io.File;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Base64;
 import java.util.concurrent.TimeUnit;
 
 public class SystemtestsKubernetesApps {
+    private static Logger log = CustomLogger.getLogger();
+
     public static final String MESSAGING_CLIENTS = "systemtests-clients";
     public static final String SELENIUM_FIREFOX = "selenium-firefox";
     public static final String SELENIUM_CHROME = "selenium-chrome";
@@ -44,6 +48,18 @@ public class SystemtestsKubernetesApps {
         TestUtils.waitForExpectedReadyPods(Kubernetes.getInstance(), MESSAGING_PROJECT, 1, new TimeoutBudget(1, TimeUnit.MINUTES));
         return getMessagingAppPodName();
     }
+
+
+    public static void collectMessagingClientAppLogs(Path path) {
+        try {
+            Files.createDirectories(path);
+            GlobalLogCollector collector = new GlobalLogCollector(Kubernetes.getInstance(), path.toFile(), SystemtestsKubernetesApps.MESSAGING_PROJECT);
+            collector.collectLogsOfPodsInNamespace(SystemtestsKubernetesApps.MESSAGING_PROJECT);
+        } catch (Exception e) {
+            log.error("Failed to collect pod logs from namespace : {}", SystemtestsKubernetesApps.MESSAGING_PROJECT);
+        }
+    }
+
 
     public static void deleteMessagingClientApp() {
         if (Kubernetes.getInstance().deploymentExists(MESSAGING_PROJECT, MESSAGING_CLIENTS)) {

--- a/systemtests/src/main/java/io/enmasse/systemtest/ability/TestWatcher.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/ability/TestWatcher.java
@@ -108,7 +108,7 @@ public class TestWatcher implements TestExecutionExceptionHandler, LifecycleMeth
         throw throwable;
     }
 
-    private static Path getPath(Method testMethod, Class<?> testClass) {
+    public static Path getPath(Method testMethod, Class<?> testClass) {
         Path path = Paths.get(
                 Environment.getInstance().testLogDir(),
                 "failed_test_logs",

--- a/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/ExternalClientsExtension.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/ExternalClientsExtension.java
@@ -4,8 +4,17 @@
  */
 package io.enmasse.systemtest.messagingclients;
 
+import io.enmasse.systemtest.Environment;
+import io.enmasse.systemtest.GlobalLogCollector;
+import io.enmasse.systemtest.Kubernetes;
 import io.enmasse.systemtest.SystemtestsKubernetesApps;
+import io.enmasse.systemtest.ability.TestWatcher;
+import io.enmasse.systemtest.selenium.SeleniumProvider;
 import org.junit.jupiter.api.extension.*;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 public class ExternalClientsExtension implements BeforeTestExecutionCallback, AfterTestExecutionCallback, BeforeAllCallback, AfterAllCallback {
     private boolean isFullClass = false;
@@ -24,6 +33,12 @@ public class ExternalClientsExtension implements BeforeTestExecutionCallback, Af
 
     @Override
     public void afterTestExecution(ExtensionContext extensionContext) throws Exception {
+        if (extensionContext.getExecutionException().isPresent()) {
+            Path path = TestWatcher.getPath(extensionContext.getTestMethod().get(), extensionContext.getTestClass().get());
+            SystemtestsKubernetesApps.collectMessagingClientAppLogs(path);
+        }
+
+
         if (!isFullClass) {
             SystemtestsKubernetesApps.deleteMessagingClientApp();
         }

--- a/systemtests/src/main/java/io/enmasse/systemtest/selenium/SeleniumProvider.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/selenium/SeleniumProvider.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SeleniumProvider {
 
@@ -327,13 +328,16 @@ public class SeleniumProvider {
             Exception {
         log.info("Waiting until data will be present");
         int attempts = 0;
+        Integer actual = null;
         while (attempts < timeoutInSeconds) {
-            if (expectedValue == item.get())
+            actual = item.get();
+            if (expectedValue == actual)
                 break;
             Thread.sleep(1000);
             attempts++;
         }
         log.info("End of waiting");
+        assertEquals(expectedValue, actual, String.format("Property does not have expected value %d after timeout %ds.", expectedValue, timeoutInSeconds));
     }
 
     //================================================================================================

--- a/systemtests/src/main/java/io/enmasse/systemtest/selenium/page/ConsoleWebPage.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/selenium/page/ConsoleWebPage.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -329,7 +330,8 @@ public class ConsoleWebPage implements IWebPage {
      */
     public List<ConnectionWebItem> getConnectionItems(int expectedCount) {
         List<ConnectionWebItem> connectionItems = new ArrayList<>();
-        long endTime = System.currentTimeMillis() + 30000;
+        int timeout = 30000;
+        long endTime = System.currentTimeMillis() + timeout;
         while (connectionItems.size() != expectedCount && endTime > System.currentTimeMillis()) {
             log.info("First iteration waiting for {} connections items", expectedCount);
             WebElement content = getContentContainer();
@@ -342,7 +344,14 @@ public class ConsoleWebPage implements IWebPage {
                     connectionItems.add(item);
                 }
             }
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
         }
+        assertEquals(expectedCount, connectionItems.size(), String.format("Unexpected number of connections after timeout %d", timeout));
         return connectionItems;
     }
 

--- a/systemtests/src/main/java/io/enmasse/systemtest/selenium/page/ConsoleWebPage.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/selenium/page/ConsoleWebPage.java
@@ -330,7 +330,7 @@ public class ConsoleWebPage implements IWebPage {
      */
     public List<ConnectionWebItem> getConnectionItems(int expectedCount) {
         List<ConnectionWebItem> connectionItems = new ArrayList<>();
-        int timeout = 30000;
+        int timeout = 60000;
         long endTime = System.currentTimeMillis() + timeout;
         while (connectionItems.size() != expectedCount && endTime > System.currentTimeMillis()) {
             log.info("First iteration waiting for {} connections items", expectedCount);

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/TestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/TestBase.java
@@ -763,21 +763,15 @@ public abstract class TestBase implements ITestBase, ITestSeparator {
     }
 
     /**
-     * attach N receivers into one address with default username/password
-     */
-    protected List<AbstractClient> attachReceivers(AddressSpace addressSpace, Address destination,
-                                                   int receiverCount) throws Exception {
-        return attachReceivers(addressSpace, destination, receiverCount, defaultCredentials);
-    }
-
-    /**
      * attach N receivers into one address with own username/password
      */
-    List<AbstractClient> attachReceivers(AddressSpace addressSpace, Address destination,
-                                         int receiverCount, UserCredentials credentials) throws Exception {
+    public List<AbstractClient> attachReceivers(AddressSpace addressSpace, Address destination,
+                                                int receiverCount, int timeout, UserCredentials credentials) throws Exception {
         ClientArgumentMap arguments = new ClientArgumentMap();
         arguments.put(ClientArgument.BROKER, getMessagingRoute(addressSpace).toString());
-        arguments.put(ClientArgument.TIMEOUT, "120");
+        if (timeout > 0) {
+            arguments.put(ClientArgument.TIMEOUT, Integer.toString(timeout));
+        }
         arguments.put(ClientArgument.CONN_SSL, "true");
         arguments.put(ClientArgument.USERNAME, credentials.getUsername());
         arguments.put(ClientArgument.PASSWORD, credentials.getPassword());
@@ -801,12 +795,14 @@ public abstract class TestBase implements ITestBase, ITestSeparator {
     /**
      * attach senders to destinations (for N-th destination is attached N+1 senders)
      */
-    List<AbstractClient> attachSenders(AddressSpace addressSpace, List<Address> destinations) throws Exception {
+    public List<AbstractClient> attachSenders(AddressSpace addressSpace, List<Address> destinations, int timeout, UserCredentials defaultCredentials) throws Exception {
         List<AbstractClient> senders = new ArrayList<>();
 
         ClientArgumentMap arguments = new ClientArgumentMap();
         arguments.put(ClientArgument.BROKER, getMessagingRoute(addressSpace).toString());
-        arguments.put(ClientArgument.TIMEOUT, "60");
+        if (timeout > 0) {
+            arguments.put(ClientArgument.TIMEOUT, Integer.toString(timeout));
+        }
         arguments.put(ClientArgument.CONN_SSL, "true");
         arguments.put(ClientArgument.USERNAME, defaultCredentials.getUsername());
         arguments.put(ClientArgument.PASSWORD, defaultCredentials.getPassword());
@@ -833,15 +829,17 @@ public abstract class TestBase implements ITestBase, ITestSeparator {
     /**
      * attach receivers to destinations (for N-th destination is attached N+1 senders)
      */
-    List<AbstractClient> attachReceivers(AddressSpace addressSpace, List<Address> destinations) throws Exception {
+    public List<AbstractClient> attachReceivers(AddressSpace addressSpace, List<Address> destinations, int timeout, UserCredentials userCredentials) throws Exception {
         List<AbstractClient> receivers = new ArrayList<>();
 
         ClientArgumentMap arguments = new ClientArgumentMap();
         arguments.put(ClientArgument.BROKER, getMessagingRoute(addressSpace).toString());
-        arguments.put(ClientArgument.TIMEOUT, "60");
+        if (timeout > 0) {
+            arguments.put(ClientArgument.TIMEOUT, Integer.toString(timeout));
+        }
         arguments.put(ClientArgument.CONN_SSL, "true");
-        arguments.put(ClientArgument.USERNAME, defaultCredentials.getUsername());
-        arguments.put(ClientArgument.PASSWORD, defaultCredentials.getPassword());
+        arguments.put(ClientArgument.USERNAME, userCredentials.getUsername());
+        arguments.put(ClientArgument.PASSWORD, userCredentials.getPassword());
         arguments.put(ClientArgument.LOG_MESSAGES, "json");
         arguments.put(ClientArgument.CONN_PROPERTY, "connection_property1~50");
         arguments.put(ClientArgument.CONN_PROPERTY, "connection_property2~testValue");
@@ -864,10 +862,12 @@ public abstract class TestBase implements ITestBase, ITestSeparator {
      */
     protected AbstractClient attachConnector(AddressSpace addressSpace, Address destination,
                                              int connectionCount,
-                                             int senderCount, int receiverCount, UserCredentials credentials) throws Exception {
+                                             int senderCount, int receiverCount, UserCredentials credentials, int timeout) throws Exception {
         ClientArgumentMap arguments = new ClientArgumentMap();
         arguments.put(ClientArgument.BROKER, getMessagingRoute(addressSpace).toString());
-        arguments.put(ClientArgument.TIMEOUT, "120");
+        if (timeout > 0) {
+            arguments.put(ClientArgument.TIMEOUT, Integer.toString(timeout));
+        }
         arguments.put(ClientArgument.CONN_SSL, "true");
         arguments.put(ClientArgument.USERNAME, credentials.getUsername());
         arguments.put(ClientArgument.PASSWORD, credentials.getPassword());

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/TestBaseWithShared.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/TestBaseWithShared.java
@@ -12,7 +12,6 @@ import io.enmasse.systemtest.UserCredentials;
 import io.enmasse.systemtest.ability.SharedAddressSpaceManager;
 import io.enmasse.systemtest.amqp.AmqpClient;
 import io.enmasse.systemtest.amqp.AmqpClientFactory;
-import io.enmasse.systemtest.messagingclients.AbstractClient;
 import io.enmasse.systemtest.mqtt.MqttClientFactory;
 import io.enmasse.systemtest.utils.TestUtils;
 import io.enmasse.systemtest.utils.UserUtils;
@@ -119,42 +118,6 @@ public abstract class TestBaseWithShared extends TestBase {
     //====================================== Test help methods =======================================
     //================================================================================================
 
-
-    /**
-     * attach N receivers into one address with default username/password
-     */
-    protected List<AbstractClient> attachReceivers(Address destination, int receiverCount) throws Exception {
-        return attachReceivers(sharedAddressSpace, destination, receiverCount, defaultCredentials);
-    }
-
-    /**
-     * attach N receivers into one address with own username/password
-     */
-    protected List<AbstractClient> attachReceivers(Address destination, int receiverCount, UserCredentials credentials) throws Exception {
-        return attachReceivers(sharedAddressSpace, destination, receiverCount, credentials);
-    }
-
-    /**
-     * attach senders to destinations
-     */
-    protected List<AbstractClient> attachSenders(List<Address> destinations) throws Exception {
-        return attachSenders(sharedAddressSpace, destinations);
-    }
-
-    /**
-     * attach receivers to destinations
-     */
-    protected List<AbstractClient> attachReceivers(List<Address> destinations) throws Exception {
-        return attachReceivers(sharedAddressSpace, destinations);
-    }
-
-    /**
-     * create M connections with N receivers and K senders
-     */
-    protected AbstractClient attachConnector(Address destination, int connectionCount,
-                                             int senderCount, int receiverCount) throws Exception {
-        return attachConnector(sharedAddressSpace, destination, connectionCount, senderCount, receiverCount, defaultCredentials);
-    }
 
     /**
      * Create users within groups (according to destNamePrefix and customerIndex), wait until destinations are ready to use

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/web/WebConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/web/WebConsoleTest.java
@@ -412,15 +412,32 @@ public abstract class WebConsoleTest extends TestBaseWithShared {
         consoleWebPage.createAddressesWebConsole(addresses.toArray(new Address[0]));
         consoleWebPage.openConnectionsPageWebConsole();
 
+        assertEquals(0, consoleWebPage.getConnectionItems().size(), "Unexpected number of connections present before attaching clients");
+
         clientsList = attachClients(addresses);
 
-        consoleWebPage.sortItems(SortType.SENDERS, true);
-        assertSorted("Console failed, items are not sorted by count of senders asc",
-                consoleWebPage.getConnectionItems(6), Comparator.comparingInt(ConnectionWebItem::getSendersCount));
+        boolean pass=false;
+        try {
+            consoleWebPage.sortItems(SortType.SENDERS, true);
+            assertSorted("Console failed, items are not sorted by count of senders asc",
+                    consoleWebPage.getConnectionItems(6), Comparator.comparingInt(ConnectionWebItem::getSendersCount));
 
-        consoleWebPage.sortItems(SortType.SENDERS, false);
-        assertSorted("Console failed, items are not sorted by count of senders desc",
-                consoleWebPage.getConnectionItems(6), true, Comparator.comparingInt(ConnectionWebItem::getSendersCount));
+            consoleWebPage.sortItems(SortType.SENDERS, false);
+            assertSorted("Console failed, items are not sorted by count of senders desc",
+                    consoleWebPage.getConnectionItems(6), true, Comparator.comparingInt(ConnectionWebItem::getSendersCount));
+            pass = true;
+        } finally {
+            if (!pass) {
+                clientsList.forEach(c -> {
+                    c.stop();
+                    log.info("=======================================");
+                    log.info("stderr {}", c.getStdErr());
+                    log.info("stdout {}", c.getStdOut());
+                });
+                clientsList.clear();
+            }
+
+        }
     }
 
     protected void doTestSortConnectionsByReceivers() throws Exception {


### PR DESCRIPTION
In some test environments, the sender/receivers/connectors terminate whilst the test was still making observations about the state of the UI.  I've changed the timeouts of sender/receivers/connectors to avoid the problem and used try/finally in a couple of places to be assured on clean-up.