### PR TITLE
FirefoxWebConsoleTest#testCannotOpenConsolePage fails sporadically

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/selenium/page/ConsoleWebPage.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/selenium/page/ConsoleWebPage.java
@@ -14,6 +14,7 @@ import io.enmasse.systemtest.selenium.resources.*;
 import io.enmasse.systemtest.utils.AddressUtils;
 import io.enmasse.systemtest.utils.TestUtils;
 import org.openqa.selenium.By;
+import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.Select;
@@ -27,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 @SuppressWarnings("unused")
 public class ConsoleWebPage implements IWebPage {
@@ -94,6 +96,17 @@ public class ConsoleWebPage implements IWebPage {
 
     public WebElement getRemoveButton() throws Exception {
         return selenium.getWebElement(() -> selenium.getDriver().findElement(ByAngular.buttonText("Delete")));
+    }
+
+    public void assertDialogPresent(String id) {
+        int timeout = 30;
+        try {
+            WebElement dialog = selenium.getDriverWait().withTimeout(Duration.ofSeconds(timeout)).until(ExpectedConditions.visibilityOfElementLocated(By.id(id)));
+            assertNotNull(dialog);
+        } catch (TimeoutException e) {
+            selenium.takeScreenShot();
+            fail(String.format("Expected dialog with id %s did not appear within timeout %d s", id, timeout));
+        }
     }
 
     /**

--- a/systemtests/src/test/java/io/enmasse/systemtest/brokered/web/ChromeWebConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/brokered/web/ChromeWebConsoleTest.java
@@ -160,13 +160,13 @@ class ChromeWebConsoleTest extends WebConsoleTest implements ITestBaseBrokered {
     @Test()
     void testCannotOpenConsolePage() {
         assertThrows(IllegalAccessException.class,
-                () -> doTestCanOpenConsolePage(new UserCredentials("nonexistsUser", "pepaPa555")));
+                () -> doTestCanOpenConsolePage(new UserCredentials("nonexistsUser", "pepaPa555"), false));
     }
 
     @Test
     @Disabled("Only few chrome tests are enabled, rest functionality is covered by firefox")
     void testCanOpenConsolePage() throws Exception {
-        doTestCanOpenConsolePage(clusterUser);
+        doTestCanOpenConsolePage(clusterUser, true);
     }
 
     @Test

--- a/systemtests/src/test/java/io/enmasse/systemtest/brokered/web/FirefoxWebConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/brokered/web/FirefoxWebConsoleTest.java
@@ -152,12 +152,12 @@ class FirefoxWebConsoleTest extends WebConsoleTest implements ITestBaseBrokered 
     @Test()
     void testCannotOpenConsolePage() {
         assertThrows(IllegalAccessException.class,
-                () -> doTestCanOpenConsolePage(new UserCredentials("noexistuser", "pepaPa555")));
+                () -> doTestCanOpenConsolePage(new UserCredentials("noexistuser", "pepaPa555"), false));
     }
 
     @Test
     void testCanOpenConsolePage() throws Exception {
-        doTestCanOpenConsolePage(clusterUser);
+        doTestCanOpenConsolePage(clusterUser, true);
     }
 
     @Test

--- a/systemtests/src/test/java/io/enmasse/systemtest/standard/web/ChromeWebConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/standard/web/ChromeWebConsoleTest.java
@@ -243,13 +243,13 @@ public class ChromeWebConsoleTest extends WebConsoleTest implements ITestBaseSta
 
     @Test()
     void testCannotOpenConsolePage() {
-        assertThrows(IllegalAccessException.class, () -> doTestCanOpenConsolePage(new UserCredentials("noexistuser", "pepaPa555")));
+        assertThrows(IllegalAccessException.class, () -> doTestCanOpenConsolePage(new UserCredentials("noexistuser", "pepaPa555"), false));
     }
 
     @Test
     @Disabled("Only few chrome tests are enabled, rest functionality is covered by firefox")
     void testCanOpenConsolePage() throws Exception {
-        doTestCanOpenConsolePage(clusterUser);
+        doTestCanOpenConsolePage(clusterUser, true);
     }
 
     @Test

--- a/systemtests/src/test/java/io/enmasse/systemtest/standard/web/FirefoxWebConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/standard/web/FirefoxWebConsoleTest.java
@@ -231,12 +231,12 @@ public class FirefoxWebConsoleTest extends WebConsoleTest implements ITestBaseSt
     @Test()
     void testCannotOpenConsolePage() {
         assertThrows(IllegalAccessException.class,
-                () -> doTestCanOpenConsolePage(new UserCredentials("noexistuser", "pepaPa555")));
+                () -> doTestCanOpenConsolePage(new UserCredentials("noexistuser", "pepaPa555"), false));
     }
 
     @Test
     void testCanOpenConsolePage() throws Exception {
-        doTestCanOpenConsolePage(clusterUser);
+        doTestCanOpenConsolePage(clusterUser, true);
     }
 
     @Test


### PR DESCRIPTION
The issue was a race condition within the test itself.  The test  is changed to explicitly await the no rbac dialogue box.
