### PR TITLE
Persistent message test: Wait for all pods to be running (or terminated), before starting

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/common/PersistentMessagesTestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/common/PersistentMessagesTestBase.java
@@ -37,6 +37,9 @@ public class PersistentMessagesTestBase extends TestBaseWithShared {
     protected void doTestQueuePersistentMessages(Address address, int messagesBatch) throws Exception {
         setAddresses(address);
 
+        // Wait for the first console pod to be terminated
+        TestUtils.waitUntilDeployed(kubernetes.getInfraNamespace());
+
         int podCount = kubernetes.listPods().size();
 
         sendDurableMessages(getSharedAddressSpace(), address, defaultCredentials, messagesBatch);


### PR DESCRIPTION
Attempt to fix timing issue where not all pods are started in ocp4

Signed-off-by: Vanessa <vbusch@redhat.com>