### PR TITLE
Bounce the monitoring pods rather than fully deleting/recreating the whole namespace.

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
@@ -224,7 +224,9 @@ public class TestUtils {
             log.info("Got {} pods, expected: {}", pods.size(), numExpected);
         }
         if (pods.size() != numExpected) {
-            throw new IllegalStateException("Unable to find " + numExpected + " pods. Found : " + printPods(pods));
+            Set<Pod> ready = new HashSet<>(pods);
+            Set<Pod> unready = client.listPods(namespace).stream().filter(pod -> !ready.contains(pod)).collect(Collectors.toSet());
+            throw new IllegalStateException(String.format("Unable to find %d ready pods. Ready : %s, Unready : %s", numExpected, printPods(ready), printPods(unready)));
         }
         for (Pod pod : pods) {
             client.waitUntilPodIsReady(pod);
@@ -237,7 +239,7 @@ public class TestUtils {
      * @param pods list of pods that should be printed
      * @return
      */
-    public static String printPods(List<Pod> pods) {
+    public static String printPods(Collection<Pod> pods) {
         return pods.stream()
                 .map(pod -> "{" + pod.getMetadata().getName() + ", " + pod.getStatus().getPhase() + "}")
                 .collect(Collectors.joining(","));

--- a/systemtests/src/test/java/io/enmasse/systemtest/common/monitoring/MonitoringTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/common/monitoring/MonitoringTest.java
@@ -69,7 +69,7 @@ public class MonitoringTest extends TestBase{
         } catch (IllegalStateException e) {
             log.info("Trying to workaround https://github.com/EnMasseProject/enmasse/issues/2918");
             //workaround for https://github.com/EnMasseProject/enmasse/issues/2918
-            Set<Pod> readyPods = new HashSet<>(TestUtils.listReadyPods(kubernetes));
+            Set<Pod> readyPods = new HashSet<>(TestUtils.listReadyPods(kubernetes, environment.getMonitoringNamespace()));
             kubernetes.listPods(environment.getMonitoringNamespace()).stream().filter(p -> !readyPods.contains(p)).forEach(
                     p -> {
 


### PR DESCRIPTION
(I still see errors in an OCP4 environment with original test workaround.  Testing this an alternative approach #2918.)