### PR TITLE
Capture the logs from the Firefox console during Selenium tests

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/GlobalLogCollector.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/GlobalLogCollector.java
@@ -31,9 +31,13 @@ public class GlobalLogCollector {
     private final String namespace;
 
     public GlobalLogCollector(Kubernetes kubernetes, File logDir) {
+        this(kubernetes, logDir, kubernetes.getInfraNamespace());
+    }
+
+    public GlobalLogCollector(Kubernetes kubernetes, File logDir, String namespace) {
         this.kubernetes = kubernetes;
         this.logDir = logDir;
-        this.namespace = kubernetes.getInfraNamespace();
+        this.namespace = namespace;
     }
 
 

--- a/systemtests/src/main/java/io/enmasse/systemtest/selenium/SeleniumManagement.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/selenium/SeleniumManagement.java
@@ -5,15 +5,14 @@
 package io.enmasse.systemtest.selenium;
 
 
-import io.enmasse.systemtest.CustomLogger;
-import io.enmasse.systemtest.Kubernetes;
-import io.enmasse.systemtest.SystemtestsKubernetesApps;
-import io.enmasse.systemtest.TimeoutBudget;
+import io.enmasse.systemtest.*;
 import io.enmasse.systemtest.timemeasuring.SystemtestsOperation;
 import io.enmasse.systemtest.timemeasuring.TimeMeasuringSystem;
 import io.enmasse.systemtest.utils.TestUtils;
 import org.slf4j.Logger;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -51,6 +50,16 @@ public class SeleniumManagement {
         String operationID = TimeMeasuringSystem.startOperation(SystemtestsOperation.DELETE_SELENIUM_CONTAINER);
         SystemtestsKubernetesApps.deleteFirefoxSeleniumApp(SystemtestsKubernetesApps.SELENIUM_PROJECT, Kubernetes.getInstance());
         TimeMeasuringSystem.stopOperation(operationID);
+    }
+
+    public static void collectAppLogs(Path path) {
+        try {
+            Files.createDirectories(path);
+            GlobalLogCollector collector = new GlobalLogCollector(Kubernetes.getInstance(), path.toFile(), SystemtestsKubernetesApps.SELENIUM_PROJECT);
+            collector.collectLogsOfPodsInNamespace(SystemtestsKubernetesApps.SELENIUM_PROJECT);
+        } catch (Exception e) {
+            log.error("Failed to collect pod logs from namespace : {}", SystemtestsKubernetesApps.SELENIUM_PROJECT);
+        }
     }
 
     public static void removeChromeApp() throws Exception {

--- a/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
@@ -22,7 +22,9 @@ import io.vertx.core.json.JsonObject;
 import org.junit.jupiter.api.function.ThrowingSupplier;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.firefox.FirefoxDriverLogLevel;
 import org.openqa.selenium.firefox.FirefoxOptions;
+import org.openqa.selenium.firefox.FirefoxProfile;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.slf4j.Logger;
 
@@ -492,7 +494,14 @@ public class TestUtils {
 
     public static RemoteWebDriver getFirefoxDriver() throws Exception {
         Endpoint endpoint = SystemtestsKubernetesApps.getFirefoxSeleniumAppEndpoint(Kubernetes.getInstance());
-        return getRemoteDriver(endpoint.getHost(), endpoint.getPort(), new FirefoxOptions());
+        FirefoxOptions options = new FirefoxOptions();
+        FirefoxProfile myProfile = new FirefoxProfile();
+        // https://github.com/mozilla/geckodriver/issues/330 enable the emission of console.info(), warn() etc
+        // to stdout of the browser process.  Works around the fact that Firefox logs do are not available through
+        // WebDriver.manage().logs()
+        myProfile.setPreference("devtools.console.stdout.content", true);
+        options.setProfile(myProfile);
+        return getRemoteDriver(endpoint.getHost(), endpoint.getPort(), options);
     }
 
     public static RemoteWebDriver getChromeDriver() throws Exception {


### PR DESCRIPTION
Currently for the Firefox tests, the console logs aren't collected owing to [this issue in the driver](https://github.com/mozilla/geckodriver/issues/284).  This change utilises a [Firefox specific workaround](https://github.com/mozilla/geckodriver/issues/284#issuecomment-458305621) that directs console.log() etc. to the process's stdout. We then collect it from the pod's logs.
