### PR TITLE
Added wait for console rolling update to complete

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
@@ -639,6 +639,14 @@ public class TestUtils {
         }, new TimeoutBudget(10, TimeUnit.MINUTES));
     }
 
+    public static void waitForConsoleRollingUpdate(String namespace) throws Exception {
+        TestUtils.waitUntilCondition("Wait for console rolling update to complete", waitPhase -> {
+            List<Pod> pods = Kubernetes.getInstance().listPods(namespace);
+            pods.removeIf(pod -> !pod.getSpec().getContainers().get(0).getName().equals("console-proxy"));
+            return pods.size() == 1;
+        }, new TimeoutBudget(10, TimeUnit.MINUTES));
+    }
+
     public static void cleanAllEnmasseResourcesFromNamespace(String namespace) {
         Kubernetes kube = Kubernetes.getInstance();
         var brInfraConfigClient = kube.getBrokeredInfraConfigClient(namespace);

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/common/PersistentMessagesTestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/common/PersistentMessagesTestBase.java
@@ -38,6 +38,7 @@ public class PersistentMessagesTestBase extends TestBaseWithShared {
         setAddresses(address);
 
         // Wait for the first console pod to be terminated
+        TestUtils.waitForConsoleRollingUpdate(kubernetes.getInfraNamespace());
         TestUtils.waitUntilDeployed(kubernetes.getInfraNamespace());
 
         int podCount = kubernetes.listPods().size();


### PR DESCRIPTION
The initial pod count in the test is increased by 1, due to having 2 consoles.
Added a wait until there is only 1 console pod, before getting intial pod count.

Signed-off-by: Vanessa <vbusch@redhat.com>