### PR TITLE
Correct address allocation equality.

### DIFF
--- a/agent/bin/agent.js
+++ b/agent/bin/agent.js
@@ -15,6 +15,7 @@
  */
 'use strict';
 
+var v8 = require('v8');
 var log = require("../lib/log.js").logger();
 var AddressSource = require('../lib/internal_address_source.js');
 var BrokerAddressSettings = require('../lib/broker_address_settings.js');
@@ -82,6 +83,10 @@ function start(env) {
                         exitHandler();
                     });
                 });
+
+                setInterval(() => {
+                    log.info("Heap statistics : %j", v8.getHeapStatistics());
+                }, 60000);
             }).catch((e) => {log.error("Failed to listen ", e)})
 
         });

--- a/agent/lib/internal_address_source.js
+++ b/agent/lib/internal_address_source.js
@@ -68,7 +68,7 @@ function same_allocation(a, b) {
         var equal = false;
         for (var j in b) {
             if (a[i].containerId === b[j].containerId && a[i].clusterId === b[j].clusterId && a[i].state === b[j].state) {
-                equal = false;
+                equal = true;
                 break;
             }
         }
@@ -80,10 +80,10 @@ function same_allocation(a, b) {
 }
 
 function same_address_definition(a, b) {
-    if (a.address === b.address && a.type === b.type && same_allocation(a.allocated_to, b.allocated_to)) {
+    if (a.address === b.address && a.type === b.type && !same_allocation(a.allocated_to, b.allocated_to)) {
         log.info('allocation changed for %s %s: %s <-> %s', a.type, a.address, JSON.stringify(a.allocated_to), JSON.stringify(b.allocated_to));
     }
-    return a.address === b.address && a.type === b.type && a.allocated_to === b.allocated_to;
+    return a.address === b.address && a.type === b.type && same_allocation(a.allocated_to, b.allocated_to);
 }
 
 function same_address_status(a, b) {


### PR DESCRIPTION
This defect meant that all existing addresses were considered modified even if they weren't.
This lead to unnecessary reconcilations against all routers and brokers. 