### PR TITLE
Fix for randomly failing test: io.enmasse.systemtest.common.BrokeredPersistentMessagesTest#testBrokeredQueue

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/Kubernetes.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/Kubernetes.java
@@ -331,6 +331,10 @@ public abstract class Kubernetes {
         return client.pods().withLabels(labelSelector).list().getItems();
     }
 
+    public List<Pod> listPods(String namespace, Map<String, String> labelSelector) {
+       return client.pods().inNamespace(namespace).withLabels(labelSelector).list().getItems();
+    }
+
     public List<Pod> listPods(Map<String, String> labelSelector, Map<String, String> annotationSelector) {
         return client.pods().withLabels(labelSelector).list().getItems().stream().filter(pod -> {
             for (Map.Entry<String, String> entry : annotationSelector.entrySet()) {

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/TestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/TestBase.java
@@ -684,6 +684,13 @@ public abstract class TestBase implements ITestBase, ITestSeparator {
         TestUtils.waitForNReplicas(expectedReplicas, labels, budget);
     }
 
+    protected void waitForPodsToTerminate(List<String> uids) throws Exception {
+        log.info("Waiting for following pods to be deleted {}", uids);
+        assertWaitForValue(true, () -> (kubernetes.listPods(kubernetes.getInfraNamespace()).stream()
+                .filter(pod -> uids.contains(pod.getMetadata().getUid()))
+                .collect(Collectors.toList()).size() > 0), new TimeoutBudget(2, TimeUnit.MINUTES));
+    }
+
     /**
      * Wait for destinations are in isReady=true state within default timeout (10 MINUTE)
      */


### PR DESCRIPTION
- Wait for the broker pods to begin to restart, before checking if they are up.

Signed-off-by: Vanessa <vbusch@redhat.com>