### PR TITLE
Turn off EventEmitter#maxListeners check for router management connections

### DIFF
--- a/agent/lib/qdr.js
+++ b/agent/lib/qdr.js
@@ -54,6 +54,8 @@ var Router = function (connection, router, agent) {
             self.health_check();
         }, interval);
     }
+
+    this.connection.setMaxListeners(0);
     this.connection.on('receiver_open', this.ready.bind(this));
     this.connection.on('disconnected', this.disconnected.bind(this));
     this.connection.on('sender_error', this.on_sender_error.bind(this));


### PR DESCRIPTION
This issue occurs if you increase the number of routers beyond 10.  I don't think this is a likely production configuration, but it should not fail as it does right now.