### PR TITLE
Restrict the number of active promises when creating/deleting entities on the routers

### DIFF
--- a/agent/lib/router_config.js
+++ b/agent/lib/router_config.js
@@ -272,7 +272,6 @@ function ensure_elements(entity, desired, router, collected) {
                 var limit = plimit(250);
                 let delete_fn = limit.bind(null, delete_config_element.bind(null, router, entity));
                 let create_fn = limit.bind(null, create_config_element.bind(null, router, entity));
-                log.info("KWDEBUG using batches");
                 return Promise.all(stale.map(delete_fn)).then(
                     function (deletions) {
                         report(entity, stale, deletions, actual, 'deleted');

--- a/agent/lib/router_config.js
+++ b/agent/lib/router_config.js
@@ -19,6 +19,7 @@ var util = require('util');
 var qdr = require('./qdr.js');
 var myutils = require('./utils.js');
 var log = require('./log.js').logger();
+var plimit = require('p-limit');
 
 const ID_QUALIFIER = 'ragent-';
 const MAX_RETRIES = 3;
@@ -268,14 +269,16 @@ function ensure_elements(entity, desired, router, collected) {
             let missing = delta.added.concat(delta.modified);
 
             if (stale.length || missing.length) {
-                let delete_fn = delete_config_element.bind(null, router, entity);
-                let create_fn = create_config_element.bind(null, router, entity);
+                var limit = plimit(250);
+                let delete_fn = limit.bind(null, delete_config_element.bind(null, router, entity));
+                let create_fn = limit.bind(null, create_config_element.bind(null, router, entity));
+                log.info("KWDEBUG using batches");
                 return Promise.all(stale.map(delete_fn)).then(
                     function (deletions) {
-                        report(entity, stale, deletions, actual, 'deleted')
+                        report(entity, stale, deletions, actual, 'deleted');
                         return Promise.all(missing.map(create_fn)).then(
                             function (creations) {
-                                report(entity, missing, creations, actual, 'created')
+                                report(entity, missing, creations, actual, 'created');
                                 return false;//recheck when changed
                             }
                         ).catch(function (error) {

--- a/agent/npm-shrinkwrap.json
+++ b/agent/npm-shrinkwrap.json
@@ -1474,7 +1474,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
             "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
-            "dev": true,
             "requires": {
                 "p-try": "^2.0.0"
             }
@@ -1507,8 +1506,7 @@
         "p-try": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-            "dev": true
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
         },
         "parent-module": {
             "version": "1.0.1",

--- a/agent/package.json
+++ b/agent/package.json
@@ -11,6 +11,7 @@
     "dependencies": {
         "debug": "^3.1.*",
         "openid-client": "^2.4.5",
+        "p-limit": "^2.2.0",
         "rhea": ">=0.2.11",
         "simple-oauth2": "^2.2.1",
         "ws": "*"


### PR DESCRIPTION
This change limits the number of promises that can be created when create/delete entities on the router.  Previous n promises would be created at once, where n was the number of address defined in the standard address space.