### PR TITLE
Improve api server address create performance

### DIFF
--- a/api-server/src/test/java/io/enmasse/api/server/HTTPServerTest.java
+++ b/api-server/src/test/java/io/enmasse/api/server/HTTPServerTest.java
@@ -398,7 +398,7 @@ public class HTTPServerTest {
                 JsonObject data = buffer.toJsonObject();
                 System.out.println(data.toString());
                 assertTrue(data.containsKey("items"));
-                assertEquals(1, data.getJsonArray("items").size());
+                assertEquals(2, data.getJsonArray("items").size());
             });
         });
 

--- a/k8s-api-testutil/src/main/java/io/enmasse/k8s/api/TestSchemaApi.java
+++ b/k8s-api-testutil/src/main/java/io/enmasse/k8s/api/TestSchemaApi.java
@@ -26,7 +26,28 @@ import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 public class TestSchemaApi implements SchemaApi {
     public Schema getSchema() {
         return new SchemaBuilder()
-                .withAddressSpaceTypes(Collections.singletonList(
+                .withAddressSpaceTypes(Arrays.asList(
+                        new AddressSpaceTypeBuilder()
+                                .withName("brokered")
+                                .withDescription("Test Type")
+                                .withAddressTypes(Collections.singletonList(
+                                        new AddressTypeBuilder()
+                                                .withName("queue")
+                                                .withPlans(Arrays.asList(
+                                                        new AddressPlanBuilder()
+                                                                .withMetadata(new ObjectMetaBuilder()
+                                                                        .withName("plan1")
+                                                                        .build())
+                                                                .withAddressType("queue")
+                                                                .withRequiredResources(Arrays.asList(
+                                                                        new ResourceRequestBuilder()
+                                                                                .withName("broker")
+                                                                                .withCredit(0.1)
+                                                                                .build()))
+                                                                .build()
+                                                ))
+                                                .build()))
+                            .build(),
                         new AddressSpaceTypeBuilder()
                                 .withName("type1")
                                 .withDescription("Test Type")
@@ -88,7 +109,19 @@ public class TestSchemaApi implements SchemaApi {
                                                 .withVersion("1.0")
                                                 .build())
                                         .build()))
-                                .withPlans(Collections.singletonList(
+                                .withPlans(Arrays.asList(
+                                        new AddressSpacePlanBuilder()
+                                                .withMetadata(new ObjectMetaBuilder()
+                                                        .addToAnnotations(AnnotationKeys.DEFINED_BY, "infra")
+                                                        .withName("myplan")
+                                                        .build())
+                                                .withAddressSpaceType("brokered")
+                                                .withResources(Arrays.asList(new ResourceAllowanceBuilder()
+                                                        .withName("broker")
+                                                        .withMax(1.0)
+                                                        .build()))
+                                                .withAddressPlans(Arrays.asList("plan1"))
+                                                .build(),
                                         new AddressSpacePlanBuilder()
                                                 .withMetadata(new ObjectMetaBuilder()
                                                         .addToAnnotations(AnnotationKeys.DEFINED_BY, "infra")

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/AddressController.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/AddressController.java
@@ -99,10 +99,9 @@ public class AddressController implements Watcher<Address> {
         }
 
         AddressSpaceResolver addressSpaceResolver = new AddressSpaceResolver(schema);
-        Set<Address> addressSet = new LinkedHashSet<>(addressList);
 
-        final Map<String, ProvisionState> previousStatus = addressSet.stream()
-                .collect(Collectors.toMap(a -> a.getSpec().getAddress(),
+        final Map<String, ProvisionState> previousStatus = addressList.stream()
+                .collect(Collectors.toMap(a -> a.getMetadata().getName(),
                                           a -> new ProvisionState(a.getStatus(), a.getAnnotation(AnnotationKeys.APPLIED_PLAN))));
 
         AddressSpacePlan addressSpacePlan = addressSpaceType.findAddressSpacePlan(options.getAddressSpacePlanName()).orElseThrow(() -> new RuntimeException("Unable to handle updates: address space plan " + options.getAddressSpacePlanName() + " not found!"));
@@ -113,13 +112,34 @@ public class AddressController implements Watcher<Address> {
 
         AddressProvisioner provisioner = new AddressProvisioner(addressSpaceResolver, addressResolver, addressSpacePlan, clusterGenerator, kubernetes, eventLogger, options.getInfraUuid(), brokerIdGenerator);
 
+        Map<String, Address> validAddresses = new HashMap<>();
         List<Phase> readyPhases = Arrays.asList(Configuring, Active);
         for (Address address : addressList) {
             address.getStatus().clearMessages();
             if (readyPhases.contains(address.getStatus().getPhase())) {
                 address.getStatus().setReady(true);
             }
+
+            Address existing = validAddresses.get(address.getSpec().getAddress());
+            if (existing != null) {
+                if (!address.getStatus().getPhase().equals(Pending) && existing.getStatus().getPhase().equals(Pending)) {
+                    // If existing address is pending, and we are not pending, we take priority
+                    String errorMessage = String.format("Address '%s' already exists with resource name '%s'", address.getSpec().getAddress(), address.getMetadata().getName());
+                    existing.getStatus().setPhase(Pending);
+                    existing.getStatus().appendMessage(errorMessage);
+                    validAddresses.put(address.getSpec().getAddress(), address);
+                } else {
+                    // Existing address has already been accepted, or we are both pending, existing takes priority.
+                    String errorMessage = String.format("Address '%s' already exists with resource name '%s'", address.getSpec().getAddress(), existing.getMetadata().getName());
+                    address.getStatus().setPhase(Pending);
+                    address.getStatus().appendMessage(errorMessage);
+                }
+            } else {
+                validAddresses.put(address.getSpec().getAddress(), address);
+            }
         }
+
+        Set<Address> addressSet = new LinkedHashSet<>(validAddresses.values());
 
         Map<Phase, Long> countByPhase = countPhases(addressSet);
         log.info("Total: {}, Active: {}, Configuring: {}, Pending: {}, Terminating: {}, Failed: {}", addressSet.size(), countByPhase.get(Active), countByPhase.get(Configuring), countByPhase.get(Pending), countByPhase.get(Terminating), countByPhase.get(Failed));
@@ -176,8 +196,8 @@ public class AddressController implements Watcher<Address> {
         long upgradeClusters = System.nanoTime();
 
         int staleCount = 0;
-        for (Address address : addressSet) {
-            ProvisionState previous = previousStatus.get(address.getSpec().getAddress());
+        for (Address address : addressList) {
+            ProvisionState previous = previousStatus.get(address.getMetadata().getName());
             ProvisionState current = new ProvisionState(address.getStatus(), address.getAnnotation(AnnotationKeys.APPLIED_PLAN));
             if (!current.equals(previous)) {
                 try {

--- a/standard-controller/src/test/java/io/enmasse/controller/standard/AddressControllerTest.java
+++ b/standard-controller/src/test/java/io/enmasse/controller/standard/AddressControllerTest.java
@@ -121,6 +121,150 @@ public class AddressControllerTest {
     }
 
     @Test
+    public void testDuplicatePendingPendingAddresses() throws Exception {
+
+        Address a1 = new AddressBuilder()
+                .withNewMetadata()
+                .withName("myspace.a1")
+                .endMetadata()
+                .withNewSpec()
+                .withAddress("a")
+                .withType("anycast")
+                .withPlan("small-anycast")
+                .endSpec()
+                .build();
+
+        Address a2 = new AddressBuilder()
+                .withNewMetadata()
+                .withName("myspace.a2")
+                .endMetadata()
+                .withNewSpec()
+                .withAddress("a")
+                .withType("anycast")
+                .withPlan("small-anycast")
+                .endSpec()
+                .build();
+
+        controller.onUpdate(Arrays.asList(a1, a2));
+
+        assertEquals(Phase.Configuring, a1.getStatus().getPhase());
+
+        assertEquals(Phase.Pending, a2.getStatus().getPhase());
+        assertEquals("Address 'a' already exists with resource name 'myspace.a1'", a2.getStatus().getMessages().get(0));
+    }
+
+    @Test
+    public void testDuplicatePendingActiveAddresses() throws Exception {
+
+        Address a1 = new AddressBuilder()
+                .withNewMetadata()
+                .withName("myspace.a1")
+                .endMetadata()
+                .withNewSpec()
+                .withAddress("a")
+                .withType("anycast")
+                .withPlan("small-anycast")
+                .endSpec()
+                .build();
+
+        Address a2 = new AddressBuilder()
+                .withNewMetadata()
+                .withName("myspace.a2")
+                .endMetadata()
+                .withNewSpec()
+                .withAddress("a")
+                .withType("anycast")
+                .withPlan("small-anycast")
+                .endSpec()
+                .editOrNewStatus()
+                .withPhase(Phase.Active)
+                .endStatus()
+                .build();
+
+        controller.onUpdate(Arrays.asList(a1, a2));
+
+        assertEquals(Phase.Pending, a1.getStatus().getPhase());
+        assertEquals("Address 'a' already exists with resource name 'myspace.a2'", a1.getStatus().getMessages().get(0));
+
+        assertEquals(Phase.Active, a2.getStatus().getPhase());
+    }
+
+    @Test
+    public void testDuplicateActivePendingAddresses() throws Exception {
+
+        Address a1 = new AddressBuilder()
+                .withNewMetadata()
+                .withName("myspace.a1")
+                .endMetadata()
+                .withNewSpec()
+                .withAddress("a")
+                .withType("anycast")
+                .withPlan("small-anycast")
+                .endSpec()
+                .editOrNewStatus()
+                .withPhase(Phase.Active)
+                .endStatus()
+                .build();
+
+        Address a2 = new AddressBuilder()
+                .withNewMetadata()
+                .withName("myspace.a2")
+                .endMetadata()
+                .withNewSpec()
+                .withAddress("a")
+                .withType("anycast")
+                .withPlan("small-anycast")
+                .endSpec()
+                .build();
+
+        controller.onUpdate(Arrays.asList(a1, a2));
+
+        assertEquals(Phase.Active, a1.getStatus().getPhase());
+
+        assertEquals(Phase.Pending, a2.getStatus().getPhase());
+        assertEquals("Address 'a' already exists with resource name 'myspace.a1'", a2.getStatus().getMessages().get(0));
+    }
+
+    @Test
+    public void testDuplicateActiveActiveAddresses() throws Exception {
+
+        Address a1 = new AddressBuilder()
+                .withNewMetadata()
+                .withName("myspace.a1")
+                .endMetadata()
+                .withNewSpec()
+                .withAddress("a")
+                .withType("anycast")
+                .withPlan("small-anycast")
+                .endSpec()
+                .editOrNewStatus()
+                .withPhase(Phase.Active)
+                .endStatus()
+                .build();
+
+        Address a2 = new AddressBuilder()
+                .withNewMetadata()
+                .withName("myspace.a2")
+                .endMetadata()
+                .withNewSpec()
+                .withAddress("a")
+                .withType("anycast")
+                .withPlan("small-anycast")
+                .endSpec()
+                .editOrNewStatus()
+                .withPhase(Phase.Active)
+                .endStatus()
+                .build();
+
+        controller.onUpdate(Arrays.asList(a1, a2));
+
+        assertEquals(Phase.Active, a1.getStatus().getPhase());
+
+        assertEquals(Phase.Pending, a2.getStatus().getPhase());
+        assertEquals("Address 'a' already exists with resource name 'myspace.a1'", a2.getStatus().getMessages().get(0));
+    }
+
+    @Test
     public void testDeleteUnusedClusters() throws Exception {
         Address alive = new AddressBuilder()
                 .withNewMetadata()


### PR DESCRIPTION
This change improves api server address create performance by almost an order of magnitude when 1000 addresses are defined.
The changes moves the validation of spec.address to standard-controller for the standard address space. For the brokered address space, the validation remains in the api-server, as it would require adding write-back capability to the agent. Future refactoring/consolidation of agent/standard-controller should incorporate this validation.

Fixes #3111