### PR TITLE
Backport 0.26: Improve api server address create performance

### DIFF
--- a/api-server/src/test/java/io/enmasse/api/v1/AddressApiHelperTest.java
+++ b/api-server/src/test/java/io/enmasse/api/v1/AddressApiHelperTest.java
@@ -47,15 +47,6 @@ public class AddressApiHelperTest {
     }
 
     @Test
-    public void testCreateAddressResourceNameAlreadyExists() throws Exception {
-        when(addressApi.listAddresses(any())).thenReturn(Collections.singleton(createAddress("q1", "q1")));
-        Address invalidAddress = createAddress("someOtherName", "q1");
-        Throwable exception = assertThrows(BadRequestException.class, () -> helper.createAddress("test", invalidAddress));
-        assertEquals("Address 'q1' already exists with resource name 'q1'", exception.getMessage());
-        verify(addressApi, never()).createAddress(any(Address.class));
-    }
-
-    @Test
     public void testCreateAddress() throws Exception {
         when(addressApi.listAddresses(any())).thenReturn(Collections.emptySet());
 
@@ -123,19 +114,6 @@ public class AddressApiHelperTest {
     }
 
     @Test
-    public void testReplaceAddressWithInvalidAddress() throws Exception {
-        Set<Address> addresses = new HashSet<>();
-        addresses.add(createAddress("q1", "q1"));
-        addresses.add(createAddress("q2", "q2"));
-        when(addressApi.listAddresses(any())).thenReturn(addresses);
-        when(addressApi.replaceAddress(any())).thenReturn(true);
-        Address invalidAddress = createAddress("q1", "q2");
-        Throwable exception = assertThrows(BadRequestException.class, () -> helper.replaceAddress("test", invalidAddress));
-        assertEquals("Address 'q2' already exists with resource name 'q2'", exception.getMessage());
-        verify(addressApi, never()).replaceAddress(any(Address.class));
-    }
-
-    @Test
     public void testDeleteAddress() throws Exception {
         Address address = createAddress("testAddress");
         when(addressApi.getAddressWithName(same("ns"), same(address.getAddress()))).thenReturn(Optional.of(address));
@@ -156,18 +134,6 @@ public class AddressApiHelperTest {
         when(addressApi.getAddressWithName(same("ns"), same(address.getAddress()))).thenReturn(Optional.of(address));
         when(addressApi.deleteAddress(same(address))).thenReturn(false);
         assertNull(helper.deleteAddress("ns", "test", address.getName()));
-    }
-
-    @Test
-    public void testDuplicateAddresses() throws Exception {
-        when(addressApi.listAddresses(any())).thenReturn(Sets.newSet(createAddress("q1"), createAddress("q2")));
-
-        try {
-            helper.createAddress("test", createAddress("q3", "q1"));
-            fail("Expected exception for duplicate address");
-        } catch (BadRequestException e) {
-            assertThat(e.getMessage(), is("Address 'q1' already exists with resource name 'q1'"));
-        }
     }
 
     @Test

--- a/standard-controller/src/test/java/io/enmasse/controller/standard/AddressControllerTest.java
+++ b/standard-controller/src/test/java/io/enmasse/controller/standard/AddressControllerTest.java
@@ -92,6 +92,110 @@ public class AddressControllerTest {
     }
 
     @Test
+    public void testDuplicatePendingPendingAddresses() throws Exception {
+
+        Address a1 = new Address.Builder()
+                .setName("myspace.a1")
+                .setAddress("a")
+                .setType("anycast")
+                .setPlan("small-anycast")
+                .build();
+
+        Address a2 = new Address.Builder()
+                .setName("myspace.a2")
+                .setAddress("a")
+                .setType("anycast")
+                .setPlan("small-anycast")
+                .build();
+
+        controller.onUpdate(Arrays.asList(a1, a2));
+
+        assertEquals(Status.Phase.Configuring, a1.getStatus().getPhase());
+
+        assertEquals(Status.Phase.Pending, a2.getStatus().getPhase());
+        assertEquals("Address 'a' already exists with resource name 'myspace.a1'", a2.getStatus().getMessages().iterator().next());
+    }
+
+    @Test
+    public void testDuplicatePendingActiveAddresses() throws Exception {
+
+        Address a1 = new Address.Builder()
+                .setName("myspace.a1")
+                .setAddress("a")
+                .setType("anycast")
+                .setPlan("small-anycast")
+                .build();
+
+        Address a2 = new Address.Builder()
+                .setName("myspace.a2")
+                .setAddress("a")
+                .setType("anycast")
+                .setPlan("small-anycast")
+                .setStatus(new Status(true).setPhase(Status.Phase.Active))
+                .build();
+
+        controller.onUpdate(Arrays.asList(a1, a2));
+
+        assertEquals(Status.Phase.Pending, a1.getStatus().getPhase());
+        assertEquals("Address 'a' already exists with resource name 'myspace.a2'", a1.getStatus().getMessages().iterator().next());
+
+        assertEquals(Status.Phase.Active, a2.getStatus().getPhase());
+    }
+
+    @Test
+    public void testDuplicateActivePendingAddresses() throws Exception {
+
+        Address a1 = new Address.Builder()
+                .setName("myspace.a1")
+                .setAddress("a")
+                .setType("anycast")
+                .setPlan("small-anycast")
+                .setStatus(new Status(true).setPhase(Status.Phase.Active))
+                .build();
+
+        Address a2 = new Address.Builder()
+                .setName("myspace.a2")
+                .setAddress("a")
+                .setType("anycast")
+                .setPlan("small-anycast")
+                .build();
+
+        controller.onUpdate(Arrays.asList(a1, a2));
+
+        assertEquals(Status.Phase.Active, a1.getStatus().getPhase());
+
+        assertEquals(Status.Phase.Pending, a2.getStatus().getPhase());
+        assertEquals("Address 'a' already exists with resource name 'myspace.a1'", a2.getStatus().getMessages().iterator().next());
+    }
+
+    @Test
+    public void testDuplicateActiveActiveAddresses() throws Exception {
+
+        Address a1 = new Address.Builder()
+                .setName("myspace.a1")
+                .setAddress("a")
+                .setType("anycast")
+                .setPlan("small-anycast")
+                .setStatus(new Status(true).setPhase(Status.Phase.Active))
+                .build();
+
+        Address a2 = new Address.Builder()
+                .setName("myspace.a2")
+                .setAddress("a")
+                .setType("anycast")
+                .setPlan("small-anycast")
+                .setStatus(new Status(true).setPhase(Status.Phase.Active))
+                .build();
+
+        controller.onUpdate(Arrays.asList(a1, a2));
+
+        assertEquals(Status.Phase.Active, a1.getStatus().getPhase());
+
+        assertEquals(Status.Phase.Pending, a2.getStatus().getPhase());
+        assertEquals("Address 'a' already exists with resource name 'myspace.a1'", a2.getStatus().getMessages().iterator().next());
+    }
+
+    @Test
     public void testDeleteUnusedClusters() throws Exception {
         Address alive = new Address.Builder()
                 .setName("q1")


### PR DESCRIPTION
This change improves api server address create performance by almost an order of magnitude when 1000 addresses are defined.
The changes moves the validation of spec.address to standard-controller for the standard address space. For the brokered address space, the validation remains in the api-server, as it would require adding write-back capability to the agent. Future refactoring/consolidation of agent/standard-controller should incorporate this validation.

Fixes #3111