### PR TITLE
Ensure that images render correctly in doc

### DIFF
--- a/documentation/common/attributes.adoc
+++ b/documentation/common/attributes.adoc
@@ -12,6 +12,7 @@
 :toc: left
 :linkattrs:
 :toclevels: 3
+:Asciidoctor:
 
 // Product attributes
 

--- a/documentation/common/attributes.adoc
+++ b/documentation/common/attributes.adoc
@@ -12,7 +12,6 @@
 :toc: left
 :linkattrs:
 :toclevels: 3
-:Asciidoctor:
 
 // Product attributes
 
@@ -77,3 +76,4 @@
 :Downloading:
 :Minishift:
 :Prereqs:
+:Asciidoctor:

--- a/documentation/master-kubernetes.adoc
+++ b/documentation/master-kubernetes.adoc
@@ -5,7 +5,7 @@ include::common/attributes.adoc[]
 
 :parent-context: messaging
 :context: messaging
-:imagesdir: ../openshift/images
+:imagesdir: ../kubernetes/images
 :cmdcli: kubectl
 :KubePlatform: Kubernetes
 :OperatorNamespace: operators

--- a/documentation/modules/con-configuring.adoc
+++ b/documentation/modules/con-configuring.adoc
@@ -17,5 +17,10 @@ When created, these resources define the configuration that is available to the 
 
 The following diagram illustrates the relationship between the different service configuration resources (green) and how they are referenced by the messaging tenant resources (blue).
 
-image::{imagesdir}/enmasse-entities.svg[{ProductName} entities]
+ifdef::Asciidoctor[]
+image::enmasse-entities.svg[{ProductName} entities]
+endif::Asciidoctor[]
 
+ifndef::Asciidoctor[]
+image::{imagesdir}/enmasse-entities.svg[{ProductName} entities]
+endif::Asciidoctor[]

--- a/documentation/modules/proc-logging-in-console.adoc
+++ b/documentation/modules/proc-logging-in-console.adoc
@@ -13,5 +13,10 @@
 
 . Log in with your OpenShift user credentials. The {ConsoleName} opens.
 
-image::{imagesdir}/console-screenshot.png[{ConsoleName}]
+ifdef::Asciidoctor[]
+image::console-screenshot.png[{ConsoleName}]
+endif::Asciidoctor[]
 
+ifndef::Asciidoctor[]
+image::{imagesdir}/console-screenshot.png[{ConsoleName}]
+endif::Asciidoctor[]


### PR DESCRIPTION
The {imagesdir} attribute is added automatically when using the image reference. The current docs are not showing any images referenced this way.