### PR TITLE
Clean up a few odd things in the IoTConfig controller

### DIFF
--- a/api-model/src/main/java/io/enmasse/iot/model/v1/AdapterStatus.java
+++ b/api-model/src/main/java/io/enmasse/iot/model/v1/AdapterStatus.java
@@ -25,12 +25,22 @@ public class AdapterStatus {
 
     private String interServicePassword;
 
+    private boolean enabled;
+
     public String getInterServicePassword() {
         return interServicePassword;
     }
 
     public void setInterServicePassword(String interServicePassword) {
         this.interServicePassword = interServicePassword;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
     }
 
 }

--- a/pkg/apis/iot/v1alpha1/types.go
+++ b/pkg/apis/iot/v1alpha1/types.go
@@ -287,7 +287,8 @@ type IoTConfigStatus struct {
 }
 
 type AdapterStatus struct {
-	InterServicePassword string `json:"interServicePassword"`
+	InterServicePassword string `json:"interServicePassword,omitempty"`
+	Enabled              bool   `json:"enabled"`
 }
 
 const (

--- a/pkg/controller/iotconfig/auth_test.go
+++ b/pkg/controller/iotconfig/auth_test.go
@@ -13,34 +13,41 @@ import (
 
 func TestAdapterStatus(t *testing.T) {
 
-	as := make(map[string]iotv1alpha1.AdapterStatus)
+	config := &iotv1alpha1.IoTConfig{
+		Status: iotv1alpha1.IoTConfigStatus{
+			Adapters: map[string]iotv1alpha1.AdapterStatus{},
+		},
+	}
 
-	as["foo"] = iotv1alpha1.AdapterStatus{}
-	as["bar"] = iotv1alpha1.AdapterStatus{}
-	as["boo"] = iotv1alpha1.AdapterStatus{
+	as := config.Status.Adapters
+
+	as["mqtt"] = iotv1alpha1.AdapterStatus{}
+	as["lorawan"] = iotv1alpha1.AdapterStatus{}
+	as["http"] = iotv1alpha1.AdapterStatus{
 		InterServicePassword: "foobar",
 	}
 
-	as = ensureAdapterStatus(as, "foo", "baz", "boo")
+	config.Status.Adapters = ensureAdapterStatus(as)
+	as = config.Status.Adapters
 
-	err := ensureAdapterAuthCredentials(as)
+	err := initConfigStatus(config)
 	if err != nil {
-		t.Fatal("ensureAdapterAuthCredentials failed: ", err)
+		t.Fatal("initConfigStatus failed: ", err)
 		return
 	}
 
-	if len(as) != 3 {
-		t.Fatalf("Length must be 3, but was %d", len(as))
+	if len(as) != 4 {
+		t.Fatalf("Length must be 4, but was %d", len(as))
 		return
 	}
 
-	if as["foo"].InterServicePassword == "" {
-		t.Error("InterServicePassword for 'foo' is not set")
+	if as["mqtt"].InterServicePassword == "" {
+		t.Error("InterServicePassword for 'mqtt' is not set")
 	}
-	if as["baz"].InterServicePassword == "" {
-		t.Error("InterServicePassword for 'baz' is not set")
+	if as["lorawan"].InterServicePassword == "" {
+		t.Error("InterServicePassword for 'lorawan' is not set")
 	}
-	if as["boo"].InterServicePassword != "foobar" {
-		t.Error("InterServicePassword for 'boo' has changed")
+	if as["http"].InterServicePassword != "foobar" {
+		t.Error("InterServicePassword for 'http' has changed")
 	}
 }

--- a/pkg/controller/iotconfig/collector.go
+++ b/pkg/controller/iotconfig/collector.go
@@ -23,9 +23,6 @@ func (r *ReconcileIoTConfig) reconcileCollectorDeployment(config *iotv1alpha1.Io
 
 	install.ApplyDeploymentDefaults(deployment, "iot", deployment.Name)
 
-	var ONE int32 = 1
-	deployment.Spec.Replicas = &ONE
-
 	err := install.ApplyContainerWithError(deployment, "collector", func(container *corev1.Container) error {
 		if err := install.SetContainerImage(container, "iot-gc", config); err != nil {
 			return err

--- a/pkg/controller/iotconfig/data.go
+++ b/pkg/controller/iotconfig/data.go
@@ -16,11 +16,6 @@ const DefaultLogbackConfig = `<?xml version="1.0" encoding="UTF-8"?>
 	<root level="INFO">
 		<appender-ref ref="STDOUT" />
 	</root>
-	<springProfile name="dev">
-		<logger name="org.eclipse.hono" level="DEBUG"/>
-	</springProfile>
-	<springProfile name="prod">
-		<logger name="org.eclipse.hono" level="INFO"/>
-	</springProfile>
+	<logger name="org.eclipse.hono" level="INFO"/>
 </configuration>
 `

--- a/pkg/controller/iotconfig/file_device_registry.go
+++ b/pkg/controller/iotconfig/file_device_registry.go
@@ -65,6 +65,7 @@ func (r *ReconcileIoTConfig) processFileDeviceRegistry(ctx context.Context, conf
 func (r *ReconcileIoTConfig) reconcileFileDeviceRegistryDeployment(config *iotv1alpha1.IoTConfig, deployment *appsv1.Deployment) error {
 
 	install.ApplyDeploymentDefaults(deployment, "iot", deployment.Name)
+	deployment.Annotations[RegistryTypeAnnotation] = "file"
 
 	applyDefaultDeploymentConfig(deployment, config.Spec.ServicesConfig.DeviceRegistry.ServiceConfig)
 

--- a/pkg/controller/iotconfig/infinispan_device_registry.go
+++ b/pkg/controller/iotconfig/infinispan_device_registry.go
@@ -57,6 +57,7 @@ func (r *ReconcileIoTConfig) processInfinispanDeviceRegistry(ctx context.Context
 func (r *ReconcileIoTConfig) reconcileInfinispanDeviceRegistryDeployment(config *iotv1alpha1.IoTConfig, deployment *appsv1.Deployment) error {
 
 	install.ApplyDeploymentDefaults(deployment, "iot", deployment.Name)
+	deployment.Annotations[RegistryTypeAnnotation] = "infinispan"
 
 	applyDefaultDeploymentConfig(deployment, config.Spec.ServicesConfig.DeviceRegistry.ServiceConfig)
 

--- a/pkg/controller/iotconfig/iotconfig_controller.go
+++ b/pkg/controller/iotconfig/iotconfig_controller.go
@@ -35,6 +35,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
+const RegistryTypeAnnotation = "iot.enmasse.io/registry.type"
+
 var log = logf.Log.WithName("controller_iotconfig")
 
 type DeviceRegistryImplementation int
@@ -417,11 +419,11 @@ func (r *ReconcileIoTConfig) processGeneratedCredentials(ctx context.Context, co
 
 	// ensure we have all adapter status entries we want
 
-	config.Status.Adapters = ensureAdapterStatus(config.Status.Adapters, "mqtt", "http", "lorawan", "sigfox")
+	config.Status.Adapters = ensureAdapterStatus(config.Status.Adapters)
 
 	// generate adapter users
 
-	if err := ensureAdapterAuthCredentials(config.Status.Adapters); err != nil {
+	if err := initConfigStatus(config); err != nil {
 		return err
 	}
 

--- a/pkg/util/install/utils.go
+++ b/pkg/util/install/utils.go
@@ -89,6 +89,24 @@ func ApplyContainer(deployment *appsv1.Deployment, name string, mutator func(*co
 	})
 }
 
+func DropContainer(deployment *appsv1.Deployment, name string) {
+	if deployment.Spec.Template.Spec.Containers == nil {
+		return
+	}
+
+	// removing an entry from an array in go is tricky ...
+
+	for i := len(deployment.Spec.Template.Spec.Containers) - 1; i >= 0; i-- {
+		c := deployment.Spec.Template.Spec.Containers[i]
+		if c.Name == name {
+			deployment.Spec.Template.Spec.Containers = append(
+				deployment.Spec.Template.Spec.Containers[:i],
+				deployment.Spec.Template.Spec.Containers[i+1:]...,
+			)
+		}
+	}
+}
+
 func ApplyContainerWithError(deployment *appsv1.Deployment, name string, mutator func(*corev1.Container) error) error {
 
 	if deployment.Spec.Template.Spec.Containers == nil {


### PR DESCRIPTION
* All adapter containers are now called "adapter".
* All code required to be executed per-adapter is now controlled by
  an array of adapters.
* A label was added to the device registry, indicating which type it
  actually is.
* A duplicate replica assignment was dropped.
* The default logback configuration no longer uses profiles which we
  didn't use in the first place.
* Pass enabled status to status section