### PR TITLE
Bump default limits of operator

### DIFF
--- a/templates/csv/enmasse.clusterserviceversion.yaml
+++ b/templates/csv/enmasse.clusterserviceversion.yaml
@@ -515,9 +515,6 @@ spec:
                   value: "${CONSOLE_PROXY_KUBERNETES_IMAGE}"
                 - name: CONSOLE_HTTPD_IMAGE
                   value: "${CONSOLE_HTTPD_IMAGE}"
-                resources:
-                  limits:
-                    memory: 128Mi
       - name: user-api-server
         spec:
           replicas: 1

--- a/templates/enmasse-operator/050-Deployment-enmasse-operator.yaml
+++ b/templates/enmasse-operator/050-Deployment-enmasse-operator.yaml
@@ -89,6 +89,3 @@ spec:
           value: "${CONSOLE_PROXY_KUBERNETES_IMAGE}"
         - name: CONSOLE_HTTPD_IMAGE
           value: "${CONSOLE_HTTPD_IMAGE}"
-        resources:
-          limits:
-            memory: 128Mi


### PR DESCRIPTION
As a temporary "fix" for #3133, use default memory settings to increase
unlikelyness that the issue will be seen.