### PR TITLE
Issue 3150 connector support

### DIFF
--- a/address-space-controller/src/main/java/io/enmasse/controller/RouterConfigController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/RouterConfigController.java
@@ -564,10 +564,12 @@ public class RouterConfigController implements Controller {
 
             remoteConnector.setSaslMechanisms(String.join(" ", saslMechanisms));
 
+            String prefix = String.format("%s/", connector.getName());
             for (AddressSpaceSpecConnectorAddressRule rule : connector.getAddresses()) {
                 LinkRoute linkRouteIn = new LinkRoute();
                 linkRouteIn.setName("override.connector." + connector.getName() + "." + rule.getName() + ".in");
-                linkRouteIn.setPattern(connector.getName() + "/" + rule.getPattern());
+                linkRouteIn.setPattern(prefix + rule.getPattern());
+                linkRouteIn.setDelExternalPrefix(prefix);
                 linkRouteIn.setDirection(LinkRoute.Direction.in);
                 linkRouteIn.setConnection(connector.getName());
                 linkRoutes.add(linkRouteIn);
@@ -575,6 +577,7 @@ public class RouterConfigController implements Controller {
                 LinkRoute linkRouteOut = new LinkRoute();
                 linkRouteOut.setName("override.connector." + connector.getName() + "." + rule.getName() + ".out");
                 linkRouteOut.setPattern(connector.getName() + "/" + rule.getPattern());
+                linkRouteOut.setDelExternalPrefix(prefix);
                 linkRouteOut.setDirection(LinkRoute.Direction.out);
                 linkRouteOut.setConnection(connector.getName());
                 linkRoutes.add(linkRouteOut);

--- a/address-space-controller/src/main/java/io/enmasse/controller/router/config/Address.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/router/config/Address.java
@@ -12,6 +12,8 @@ import java.util.Objects;
 public class Address {
     private String name;
     private String prefix;
+    private String pattern;
+    private Boolean waypoint;
     private Distribution distribution;
 
     public String getName() {
@@ -38,11 +40,29 @@ public class Address {
         this.distribution = distribution;
     }
 
+    public String getPattern() {
+        return pattern;
+    }
+
+    public void setPattern(String pattern) {
+        this.pattern = pattern;
+    }
+
+    public Boolean getWaypoint() {
+        return waypoint;
+    }
+
+    public void setWaypoint(Boolean waypoint) {
+        this.waypoint = waypoint;
+    }
+
     @Override
     public String toString() {
         return "Address{" +
                 "name='" + name + '\'' +
                 ", prefix='" + prefix + '\'' +
+                ", pattern='" + pattern + '\'' +
+                ", waypoint=" + waypoint +
                 ", distribution=" + distribution +
                 '}';
     }
@@ -54,11 +74,13 @@ public class Address {
         Address address = (Address) o;
         return Objects.equals(name, address.name) &&
                 Objects.equals(prefix, address.prefix) &&
+                Objects.equals(pattern, address.pattern) &&
+                Objects.equals(waypoint, address.waypoint) &&
                 distribution == address.distribution;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, prefix, distribution);
+        return Objects.hash(name, prefix, pattern, waypoint, distribution);
     }
 }

--- a/address-space-controller/src/main/java/io/enmasse/controller/router/config/Connector.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/router/config/Connector.java
@@ -6,14 +6,21 @@ package io.enmasse.controller.router.config;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import java.util.List;
 import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Connector {
+    private String name;
     private String host;
     private int port;
     private String sslProfile;
     private Boolean verifyHostname;
+    private String saslUsername;
+    private String saslPassword;
+    private String saslMechanisms;
+    private String failoverUrls;
+    private Role role;
 
     public String getHost() {
         return host;
@@ -47,13 +54,65 @@ public class Connector {
         this.verifyHostname = verifyHostname;
     }
 
+    public String getSaslUsername() {
+        return saslUsername;
+    }
+
+    public void setSaslUsername(String saslUsername) {
+        this.saslUsername = saslUsername;
+    }
+
+    public String getSaslPassword() {
+        return saslPassword;
+    }
+
+    public void setSaslPassword(String saslPassword) {
+        this.saslPassword = saslPassword;
+    }
+
+    public String getSaslMechanisms() {
+        return saslMechanisms;
+    }
+
+    public void setSaslMechanisms(String saslMechanisms) {
+        this.saslMechanisms = saslMechanisms;
+    }
+
+    public String getFailoverUrls() {
+        return failoverUrls;
+    }
+
+    public void setFailoverUrls(String failoverUrls) {
+        this.failoverUrls = failoverUrls;
+    }
+
+    public Role getRole() {
+        return role;
+    }
+
+    public void setRole(Role role) {
+        this.role = role;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
     @Override
     public String toString() {
         return "Connector{" +
-                "host='" + host + '\'' +
+                "name='" + name + '\'' +
+                ", host='" + host + '\'' +
                 ", port=" + port +
                 ", sslProfile='" + sslProfile + '\'' +
                 ", verifyHostname=" + verifyHostname +
+                ", saslMechanisms='" + saslMechanisms + '\'' +
+                ", failoverUrls='" + failoverUrls + '\'' +
+                ", role=" + role +
                 '}';
     }
 
@@ -63,13 +122,19 @@ public class Connector {
         if (o == null || getClass() != o.getClass()) return false;
         Connector connector = (Connector) o;
         return port == connector.port &&
+                Objects.equals(name, connector.name) &&
                 Objects.equals(host, connector.host) &&
                 Objects.equals(sslProfile, connector.sslProfile) &&
-                Objects.equals(verifyHostname, connector.verifyHostname);
+                Objects.equals(verifyHostname, connector.verifyHostname) &&
+                Objects.equals(saslUsername, connector.saslUsername) &&
+                Objects.equals(saslPassword, connector.saslPassword) &&
+                Objects.equals(saslMechanisms, connector.saslMechanisms) &&
+                Objects.equals(failoverUrls, connector.failoverUrls) &&
+                role == connector.role;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(host, port, sslProfile, verifyHostname);
+        return Objects.hash(name, host, port, sslProfile, verifyHostname, saslUsername, saslPassword, saslMechanisms, failoverUrls, role);
     }
 }

--- a/address-space-controller/src/main/java/io/enmasse/controller/router/config/LinkRoute.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/router/config/LinkRoute.java
@@ -13,6 +13,7 @@ public class LinkRoute {
     private String name;
     private String prefix;
     private String pattern;
+    private String delExternalPrefix;
     private Direction direction;
     private String containerId;
     private String connection;
@@ -65,12 +66,21 @@ public class LinkRoute {
         this.pattern = pattern;
     }
 
+    public String getDelExternalPrefix() {
+        return delExternalPrefix;
+    }
+
+    public void setDelExternalPrefix(String delExternalPrefix) {
+        this.delExternalPrefix = delExternalPrefix;
+    }
+
     @Override
     public String toString() {
         return "LinkRoute{" +
                 "name='" + name + '\'' +
                 ", prefix='" + prefix + '\'' +
                 ", pattern='" + pattern + '\'' +
+                ", delExternalPrefix='" + delExternalPrefix + '\'' +
                 ", direction=" + direction +
                 ", containerId='" + containerId + '\'' +
                 ", connection='" + connection + '\'' +
@@ -85,6 +95,7 @@ public class LinkRoute {
         return Objects.equals(name, linkRoute.name) &&
                 Objects.equals(prefix, linkRoute.prefix) &&
                 Objects.equals(pattern, linkRoute.pattern) &&
+                Objects.equals(delExternalPrefix, linkRoute.delExternalPrefix) &&
                 direction == linkRoute.direction &&
                 Objects.equals(containerId, linkRoute.containerId) &&
                 Objects.equals(connection, linkRoute.connection);
@@ -92,7 +103,7 @@ public class LinkRoute {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, prefix, pattern, direction, containerId, connection);
+        return Objects.hash(name, prefix, pattern, delExternalPrefix, direction, containerId, connection);
     }
 
     public enum Direction {

--- a/address-space-controller/src/main/java/io/enmasse/controller/router/config/LinkRoute.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/router/config/LinkRoute.java
@@ -12,8 +12,10 @@ import java.util.Objects;
 public class LinkRoute {
     private String name;
     private String prefix;
+    private String pattern;
     private Direction direction;
     private String containerId;
+    private String connection;
 
     public String getName() {
         return name;
@@ -47,13 +49,31 @@ public class LinkRoute {
         this.containerId = containerId;
     }
 
+    public String getConnection() {
+        return connection;
+    }
+
+    public void setConnection(String connection) {
+        this.connection = connection;
+    }
+
+    public String getPattern() {
+        return pattern;
+    }
+
+    public void setPattern(String pattern) {
+        this.pattern = pattern;
+    }
+
     @Override
     public String toString() {
         return "LinkRoute{" +
                 "name='" + name + '\'' +
                 ", prefix='" + prefix + '\'' +
+                ", pattern='" + pattern + '\'' +
                 ", direction=" + direction +
                 ", containerId='" + containerId + '\'' +
+                ", connection='" + connection + '\'' +
                 '}';
     }
 
@@ -64,13 +84,15 @@ public class LinkRoute {
         LinkRoute linkRoute = (LinkRoute) o;
         return Objects.equals(name, linkRoute.name) &&
                 Objects.equals(prefix, linkRoute.prefix) &&
+                Objects.equals(pattern, linkRoute.pattern) &&
                 direction == linkRoute.direction &&
-                Objects.equals(containerId, linkRoute.containerId);
+                Objects.equals(containerId, linkRoute.containerId) &&
+                Objects.equals(connection, linkRoute.connection);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, prefix, direction, containerId);
+        return Objects.hash(name, prefix, pattern, direction, containerId, connection);
     }
 
     public enum Direction {

--- a/api-model/src/main/java/io/enmasse/address/model/AddressSpaceSpec.java
+++ b/api-model/src/main/java/io/enmasse/address/model/AddressSpaceSpec.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
+import javax.validation.valueextraction.ExtractedValue;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSetter;
@@ -45,6 +46,8 @@ public class AddressSpaceSpec extends AbstractWithAdditionalProperties {
     private String plan;
     @Valid
     private AuthenticationService authenticationService;
+
+    private List<@Valid AddressSpaceSpecConnector> connectors;
 
     public AddressSpaceSpec() {
     }
@@ -89,6 +92,14 @@ public class AddressSpaceSpec extends AbstractWithAdditionalProperties {
         return authenticationService;
     }
 
+    public List<AddressSpaceSpecConnector> getConnectors() {
+        return connectors;
+    }
+
+    public void setConnectors(List<AddressSpaceSpecConnector> connectors) {
+        this.connectors = connectors;
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("{");
@@ -97,9 +108,9 @@ public class AddressSpaceSpec extends AbstractWithAdditionalProperties {
                 .append("type=").append(type).append(",")
                 .append("plan=").append(plan).append(",")
                 .append("endpoints=").append(endpoints).append(",")
-                .append("networkPolicy=").append(networkPolicy);
+                .append("networkPolicy=").append(networkPolicy).append(",")
+                .append("connectors=").append(connectors);
 
         return sb.toString();
     }
-
 }

--- a/api-model/src/main/java/io/enmasse/address/model/AddressSpaceSpecConnector.java
+++ b/api-model/src/main/java/io/enmasse/address/model/AddressSpaceSpecConnector.java
@@ -4,6 +4,7 @@
  */
 package io.enmasse.address.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
@@ -18,7 +19,6 @@ import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 @Buildable(
         editableEnabled = false,
@@ -37,14 +37,10 @@ public class AddressSpaceSpecConnector extends AbstractWithAdditionalProperties 
     private String name;
 
     @NotEmpty
-    @JsonSetter(nulls = Nulls.AS_EMPTY)
     private List<@Valid  AddressSpaceSpecConnectorEndpoint> endpointHosts = Collections.emptyList();
 
     private AddressSpaceSpecConnectorCredentials credentials;
-
     private AddressSpaceSpecConnectorTls tls;
-
-    @JsonSetter(nulls = Nulls.AS_EMPTY)
     private List<AddressSpaceSpecConnectorAddressRule> addresses = Collections.emptyList();
 
     public String getName() {
@@ -85,6 +81,17 @@ public class AddressSpaceSpecConnector extends AbstractWithAdditionalProperties 
 
     public void setAddresses(List<AddressSpaceSpecConnectorAddressRule> addresses) {
         this.addresses = addresses;
+    }
+
+    @JsonIgnore
+    public int getPort(Integer port) {
+        if (port != null) {
+            return port;
+        } else if (tls != null) {
+            return 5671; // IANA AMQPS
+        } else {
+            return 5672; // IANA AMQP
+        }
     }
 
     @Override

--- a/api-model/src/main/java/io/enmasse/address/model/AddressSpaceSpecConnector.java
+++ b/api-model/src/main/java/io/enmasse/address/model/AddressSpaceSpecConnector.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2019, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.address.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import io.enmasse.admin.model.v1.AbstractWithAdditionalProperties;
+import io.fabric8.kubernetes.api.model.Doneable;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import io.sundr.builder.annotations.Inline;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = "io.fabric8.kubernetes.api.builder",
+        refs= {@BuildableReference(AbstractWithAdditionalProperties.class)},
+        inline = @Inline(
+                type = Doneable.class,
+                prefix = "Doneable",
+                value = "done"
+        )
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AddressSpaceSpecConnector extends AbstractWithAdditionalProperties {
+    @NotNull
+    private String name;
+
+    @NotEmpty
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
+    private List<@Valid  AddressSpaceSpecConnectorEndpoint> endpointHosts = Collections.emptyList();
+
+    private AddressSpaceSpecConnectorCredentials credentials;
+
+    private AddressSpaceSpecConnectorTls tls;
+
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
+    private List<AddressSpaceSpecConnectorAddressRule> addresses = Collections.emptyList();
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<AddressSpaceSpecConnectorEndpoint> getEndpointHosts() {
+        return endpointHosts;
+    }
+
+    public void setEndpointHosts(List<AddressSpaceSpecConnectorEndpoint> endpointHosts) {
+        this.endpointHosts = endpointHosts;
+    }
+
+    public AddressSpaceSpecConnectorCredentials getCredentials() {
+        return credentials;
+    }
+
+    public void setCredentials(AddressSpaceSpecConnectorCredentials credentials) {
+        this.credentials = credentials;
+    }
+
+    public AddressSpaceSpecConnectorTls getTls() {
+        return tls;
+    }
+
+    public void setTls(AddressSpaceSpecConnectorTls tls) {
+        this.tls = tls;
+    }
+
+    public List<AddressSpaceSpecConnectorAddressRule> getAddresses() {
+        return addresses;
+    }
+
+    public void setAddresses(List<AddressSpaceSpecConnectorAddressRule> addresses) {
+        this.addresses = addresses;
+    }
+
+    @Override
+    public String toString() {
+        return "AddressSpaceSpecConnector{" +
+                "name='" + name + '\'' +
+                ", endpointHosts=" + endpointHosts +
+                ", credentials=" + credentials +
+                ", tls=" + tls +
+                ", addresses=" + addresses +
+                '}';
+    }
+}

--- a/api-model/src/main/java/io/enmasse/address/model/AddressSpaceSpecConnectorAddressRule.java
+++ b/api-model/src/main/java/io/enmasse/address/model/AddressSpaceSpecConnectorAddressRule.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.address.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.enmasse.admin.model.v1.AbstractWithAdditionalProperties;
+import io.fabric8.kubernetes.api.model.Doneable;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import io.sundr.builder.annotations.Inline;
+
+import javax.validation.constraints.NotNull;
+
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = "io.fabric8.kubernetes.api.builder",
+        refs= {@BuildableReference(AbstractWithAdditionalProperties.class)},
+        inline = @Inline(
+                type = Doneable.class,
+                prefix = "Doneable",
+                value = "done"
+        )
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AddressSpaceSpecConnectorAddressRule {
+    @NotNull
+    private String name;
+    @NotNull
+    private String pattern;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getPattern() {
+        return pattern;
+    }
+
+    public void setPattern(String pattern) {
+        this.pattern = pattern;
+    }
+}

--- a/api-model/src/main/java/io/enmasse/address/model/AddressSpaceSpecConnectorCredentials.java
+++ b/api-model/src/main/java/io/enmasse/address/model/AddressSpaceSpecConnectorCredentials.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.address.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.enmasse.admin.model.v1.AbstractWithAdditionalProperties;
+import io.fabric8.kubernetes.api.model.Doneable;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import io.sundr.builder.annotations.Inline;
+
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = "io.fabric8.kubernetes.api.builder",
+        refs= {@BuildableReference(AbstractWithAdditionalProperties.class)},
+        inline = @Inline(
+                type = Doneable.class,
+                prefix = "Doneable",
+                value = "done"
+        )
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AddressSpaceSpecConnectorCredentials extends AbstractWithAdditionalProperties {
+    private StringOrSecretSelector username;
+    private StringOrSecretSelector password;
+
+    public StringOrSecretSelector getUsername() {
+        return username;
+    }
+
+    public void setUsername(StringOrSecretSelector username) {
+        this.username = username;
+    }
+
+    public StringOrSecretSelector getPassword() {
+        return password;
+    }
+
+    public void setPassword(StringOrSecretSelector password) {
+        this.password = password;
+    }
+
+    @Override
+    public String toString() {
+        return "AddressSpaceSpecConnectorCredentials{" +
+                "username=" + username +
+                ", password=" + password +
+                '}';
+    }
+}

--- a/api-model/src/main/java/io/enmasse/address/model/AddressSpaceSpecConnectorEndpoint.java
+++ b/api-model/src/main/java/io/enmasse/address/model/AddressSpaceSpecConnectorEndpoint.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.address.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.enmasse.admin.model.v1.AbstractWithAdditionalProperties;
+import io.fabric8.kubernetes.api.model.Doneable;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import io.sundr.builder.annotations.Inline;
+
+import javax.validation.constraints.NotNull;
+
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = "io.fabric8.kubernetes.api.builder",
+        refs= {@BuildableReference(AbstractWithAdditionalProperties.class)},
+        inline = @Inline(
+                type = Doneable.class,
+                prefix = "Doneable",
+                value = "done"
+        )
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AddressSpaceSpecConnectorEndpoint extends AbstractWithAdditionalProperties {
+    @NotNull
+    private String host;
+    private int port;
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    @Override
+    public String toString() {
+        return "AddressSpaceSpecConnectorEndpoint{" +
+                "host='" + host + '\'' +
+                ", port=" + port +
+                '}';
+    }
+}

--- a/api-model/src/main/java/io/enmasse/address/model/AddressSpaceSpecConnectorEndpoint.java
+++ b/api-model/src/main/java/io/enmasse/address/model/AddressSpaceSpecConnectorEndpoint.java
@@ -28,7 +28,8 @@ import javax.validation.constraints.NotNull;
 public class AddressSpaceSpecConnectorEndpoint extends AbstractWithAdditionalProperties {
     @NotNull
     private String host;
-    private int port;
+
+    private Integer port;
 
     public String getHost() {
         return host;
@@ -38,11 +39,11 @@ public class AddressSpaceSpecConnectorEndpoint extends AbstractWithAdditionalPro
         this.host = host;
     }
 
-    public int getPort() {
+    public Integer getPort() {
         return port;
     }
 
-    public void setPort(int port) {
+    public void setPort(Integer port) {
         this.port = port;
     }
 

--- a/api-model/src/main/java/io/enmasse/address/model/AddressSpaceSpecConnectorTls.java
+++ b/api-model/src/main/java/io/enmasse/address/model/AddressSpaceSpecConnectorTls.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.address.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.enmasse.admin.model.v1.AbstractWithAdditionalProperties;
+import io.fabric8.kubernetes.api.model.Doneable;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import io.sundr.builder.annotations.Inline;
+
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = "io.fabric8.kubernetes.api.builder",
+        refs= {@BuildableReference(AbstractWithAdditionalProperties.class)},
+        inline = @Inline(
+                type = Doneable.class,
+                prefix = "Doneable",
+                value = "done"
+        )
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AddressSpaceSpecConnectorTls extends AbstractWithAdditionalProperties {
+    private StringOrSecretSelector caCert;
+    private StringOrSecretSelector clientCert;
+    private StringOrSecretSelector clientKey;
+
+    public StringOrSecretSelector getCaCert() {
+        return caCert;
+    }
+
+    public void setCaCert(StringOrSecretSelector caCert) {
+        this.caCert = caCert;
+    }
+
+    public StringOrSecretSelector getClientCert() {
+        return clientCert;
+    }
+
+    public void setClientCert(StringOrSecretSelector clientCert) {
+        this.clientCert = clientCert;
+    }
+
+    public StringOrSecretSelector getClientKey() {
+        return clientKey;
+    }
+
+    public void setClientKey(StringOrSecretSelector clientKey) {
+        this.clientKey = clientKey;
+    }
+
+    @Override
+    public String toString() {
+        return "AddressSpaceSpecConnectorTls{" +
+                "caCert=" + caCert +
+                ", clientCert=" + clientCert +
+                ", clientKey=" + clientKey +
+                '}';
+    }
+}

--- a/api-model/src/main/java/io/enmasse/address/model/AddressSpaceStatus.java
+++ b/api-model/src/main/java/io/enmasse/address/model/AddressSpaceStatus.java
@@ -53,6 +53,9 @@ public class AddressSpaceStatus extends AbstractWithAdditionalProperties {
     @ValidBase64
     private String caCert;
 
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
+    private List<AddressSpaceStatusConnector> connectorStatuses = new ArrayList<>();
+
     public AddressSpaceStatus() {
     }
 
@@ -63,6 +66,7 @@ public class AddressSpaceStatus extends AbstractWithAdditionalProperties {
     public AddressSpaceStatus(AddressSpaceStatus other) {
         this.ready = other.isReady();
         this.endpointStatuses = new ArrayList<>(other.getEndpointStatuses());
+        this.connectorStatuses = new ArrayList<>(other.getConnectorStatuses());
         this.messages.addAll(other.getMessages());
         this.phase = other.getPhase();
     }
@@ -123,12 +127,13 @@ public class AddressSpaceStatus extends AbstractWithAdditionalProperties {
         return ready == status.ready &&
                 phase == status.phase &&
                 Objects.equals(endpointStatuses, status.endpointStatuses) &&
-                Objects.equals(messages, status.messages);
+                Objects.equals(messages, status.messages) &&
+                Objects.equals(connectorStatuses, status.connectorStatuses);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(ready, phase, endpointStatuses, messages);
+        return Objects.hash(ready, phase, endpointStatuses, messages, connectorStatuses);
     }
 
     @Override
@@ -138,6 +143,7 @@ public class AddressSpaceStatus extends AbstractWithAdditionalProperties {
                 .append(",").append("phase=").append(phase)
                 .append(",").append("endpointStatuses=").append(endpointStatuses)
                 .append(",").append("messages=").append(messages)
+                .append(",").append("connectorStatuses=").append(connectorStatuses)
                 .append("}")
                 .toString();
     }
@@ -151,4 +157,18 @@ public class AddressSpaceStatus extends AbstractWithAdditionalProperties {
         endpointStatuses.add(endpointStatus);
         return this;
     }
+
+    public AddressSpaceStatus appendConnectorStatus(AddressSpaceStatusConnector connectorStatus) {
+        connectorStatuses.add(connectorStatus);
+        return this;
+    }
+
+    public List<AddressSpaceStatusConnector> getConnectorStatuses() {
+        return connectorStatuses;
+    }
+
+    public void setConnectorStatuses(List<AddressSpaceStatusConnector> connectorStatuses) {
+        this.connectorStatuses = connectorStatuses;
+    }
+
 }

--- a/api-model/src/main/java/io/enmasse/address/model/AddressSpaceStatusConnector.java
+++ b/api-model/src/main/java/io/enmasse/address/model/AddressSpaceStatusConnector.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.address.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import io.enmasse.admin.model.v1.AbstractWithAdditionalProperties;
+import io.fabric8.kubernetes.api.model.Doneable;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import io.sundr.builder.annotations.Inline;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Buildable(
+    editableEnabled = false,
+    generateBuilderPackage = false,
+    builderPackage = "io.fabric8.kubernetes.api.builder",
+    refs= {@BuildableReference(AbstractWithAdditionalProperties.class)},
+    inline = @Inline(
+        type = Doneable.class,
+        prefix = "Doneable",
+        value = "done"
+    )
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AddressSpaceStatusConnector extends AbstractWithAdditionalProperties {
+    private String name;
+
+    @JsonProperty("isReady")
+    private boolean ready = false;
+
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
+    private List<String> messages = new ArrayList<>();
+
+    public boolean isReady() {
+        return ready;
+    }
+
+    public void setReady(boolean ready) {
+        this.ready = ready;
+    }
+
+    public List<String> getMessages() {
+        return messages;
+    }
+
+
+    public void appendMessage(String message) {
+        this.messages.add(message);
+    }
+
+    public void clearMessages() {
+        this.messages.clear();
+    }
+
+    public void setMessages(List<String> messages) {
+        this.messages = messages;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "AddressSpaceStatusConnector{" +
+                "name='" + name + '\'' +
+                ", ready=" + ready +
+                ", messages=" + messages +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AddressSpaceStatusConnector that = (AddressSpaceStatusConnector) o;
+        return ready == that.ready &&
+                Objects.equals(name, that.name) &&
+                Objects.equals(messages, that.messages);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, ready, messages);
+    }
+}

--- a/api-model/src/main/java/io/enmasse/address/model/StringOrSecretSelector.java
+++ b/api-model/src/main/java/io/enmasse/address/model/StringOrSecretSelector.java
@@ -47,7 +47,6 @@ public class StringOrSecretSelector extends AbstractWithAdditionalProperties {
     @Override
     public String toString() {
         return "StringOrSecretSelector{" +
-                "value='" + value + '\'' +
                 ", valueFromSecret=" + valueFromSecret +
                 '}';
     }

--- a/api-model/src/main/java/io/enmasse/address/model/StringOrSecretSelector.java
+++ b/api-model/src/main/java/io/enmasse/address/model/StringOrSecretSelector.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.address.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.enmasse.admin.model.v1.AbstractWithAdditionalProperties;
+import io.fabric8.kubernetes.api.model.Doneable;
+import io.fabric8.kubernetes.api.model.SecretKeySelector;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import io.sundr.builder.annotations.Inline;
+
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = "io.fabric8.kubernetes.api.builder",
+        refs= {@BuildableReference(AbstractWithAdditionalProperties.class)},
+        inline = @Inline(
+                type = Doneable.class,
+                prefix = "Doneable",
+                value = "done"
+        )
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class StringOrSecretSelector extends AbstractWithAdditionalProperties {
+    private String value;
+    private SecretKeySelector valueFromSecret;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public SecretKeySelector getValueFromSecret() {
+        return valueFromSecret;
+    }
+
+    public void setValueFromSecret(SecretKeySelector valueFromSecret) {
+        this.valueFromSecret = valueFromSecret;
+    }
+
+    @Override
+    public String toString() {
+        return "StringOrSecretSelector{" +
+                "value='" + value + '\'' +
+                ", valueFromSecret=" + valueFromSecret +
+                '}';
+    }
+}

--- a/api-model/src/main/java/io/enmasse/config/AnnotationKeys.java
+++ b/api-model/src/main/java/io/enmasse/config/AnnotationKeys.java
@@ -30,4 +30,5 @@ public interface AnnotationKeys {
     String APPLIED_INFRA_CONFIG = "enmasse.io/applied-infra-config";
     String OPENSHIFT_SERVING_CERT_SECRET_NAME = "service.alpha.openshift.io/serving-cert-secret-name";
     String APPLIED_PLAN = "enmasse.io/applied-plan";
+    String GENERATION = "enmasse.io/generation";
 }

--- a/api-server/src/main/java/io/enmasse/api/v1/http/HttpAddressSpaceService.java
+++ b/api-server/src/main/java/io/enmasse/api/v1/http/HttpAddressSpaceService.java
@@ -235,6 +235,7 @@ public class HttpAddressSpaceService {
                     .withEndpoints(addressSpace.getSpec().getEndpoints())
                     .withNetworkPolicy(addressSpace.getSpec().getNetworkPolicy())
                     .withPlan(addressSpace.getSpec().getPlan())
+                    .withConnectors(addressSpace.getSpec().getConnectors())
                     .endSpec()
 
                     .build();

--- a/api-server/src/main/resources/swagger.json
+++ b/api-server/src/main/resources/swagger.json
@@ -1625,9 +1625,23 @@
 		},
 		"addresses": {
 		    "type": "array",
-		    "description": "List of addresses to make be accessible via this address space. The addresses will be prefixed by the connector name and a forward slash ('myconnector/') and may be expressed as a pattern. A pattern consists of one or more tokens separated by a forward slash /. A token can be one of the following: a * character, a # character, or a sequence of characters that do not include /, *, or #. The * token matches any single token. The # token matches zero or more tokens. * has higher precedence than #, and exact match has the highest precedence.",
+		    "description": "Addresses to make be accessible via this address space.",
 		    "items": {
-			"type": "string"
+			"type": "object",
+			"required": [
+			    "name",
+			    "pattern"
+			],
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": "Identifier of address pattern. Used to uniquely identify a pattern"
+                            },
+                            "pattern": {
+                                "type": "string",
+                                "description": "Pattern used to match addresses. The pattern will be prefixed by the connector name and a forward slash ('myconnector/'). A pattern consists of one or more tokens separated by a forward slash /. A token can be one of the following: a * character, a # character, or a sequence of characters that do not include /, *, or #. The * token matches any single token. The # token matches zero or more tokens. * has higher precedence than #, and exact match has the highest precedence."
+                            }
+			}
 		    }
 		}
 	    }

--- a/documentation/common/restapi-reference.adoc
+++ b/documentation/common/restapi-reference.adoc
@@ -2112,7 +2112,7 @@ __optional__|< <<_io_k8s_api_networking_v1_networkpolicyingressrule,io.k8s.api.n
 |===
 |Name|Description|Schema
 |**addresses** +
-__optional__|List of addresses to make be accessible via this address space. The addresses will be prefixed by the connector name and a forward slash ('myconnector/') and may be expressed as a pattern. A pattern consists of one or more tokens separated by a forward slash /. A token can be one of the following: a * character, a # character, or a sequence of characters that do not include /, *, or #. The * token matches any single token. The # token matches zero or more tokens. * has higher precedence than #, and exact match has the highest precedence.|< string > array
+__optional__|Addresses to make be accessible via this address space.|< <<_io_enmasse_v1beta1_addressspacespecconnector_addresses,addresses>> > array
 |**credentials** +
 __optional__|Credentials used when connecting to endpoints. Either 'username' and 'password', or 'secret' must be defined.|<<_io_enmasse_v1beta1_addressspacespecconnector_credentials,credentials>>
 |**endpointHosts** +
@@ -2121,6 +2121,18 @@ __required__|List of hosts that should be connected to. Must contain at least 1 
 __required__|Name of the connector.|string
 |**tls** +
 __optional__|TLS settings for the connectors. If not specified, TLS will not be used.|<<_io_enmasse_v1beta1_addressspacespecconnector_tls,tls>>
+|===
+
+[[_io_enmasse_v1beta1_addressspacespecconnector_addresses]]
+**addresses**
+
+[options="header", cols=".^3a,.^11a,.^4a"]
+|===
+|Name|Description|Schema
+|**name** +
+__required__|Identifier of address pattern. Used to uniquely identify a pattern|string
+|**pattern** +
+__required__|Pattern used to match addresses. The pattern will be prefixed by the connector name and a forward slash ('myconnector/'). A pattern consists of one or more tokens separated by a forward slash /. A token can be one of the following: a * character, a # character, or a sequence of characters that do not include /, *, or #. The * token matches any single token. The # token matches zero or more tokens. * has higher precedence than #, and exact match has the highest precedence.|string
 |===
 
 [[_io_enmasse_v1beta1_addressspacespecconnector_credentials]]

--- a/documentation/design/proposals/bridging_external.adoc
+++ b/documentation/design/proposals/bridging_external.adoc
@@ -55,11 +55,12 @@ spec:
           key: password # Optional, default is `password`
       password: bar
     addresses: # A list of remote addresses accessible via this address space. The addresses will be prefixed with the connector name (remote1/foo*). Addresses follows the pattern format as described in https://qpid.apache.org/releases/qpid-dispatch-master/man/qdrouterd.conf.html#_address
-    - name: foo*
+    - name: foo
+      pattern: foo*
 status:
   connectors:
   - name: remote1
-    ready: true
+    isReady: true
     messages: [] # Error messages if not ready
 ```
 
@@ -88,7 +89,7 @@ spec:
 status:
   forwarders:
   - name: fwd1
-    ready: true
+    isReady: true
     messages: [] # Error messages
 ```
 

--- a/templates/address-space-controller/020-Role-address-space-controller.yaml
+++ b/templates/address-space-controller/020-Role-address-space-controller.yaml
@@ -10,7 +10,7 @@ rules:
     verbs: [ "get", "list", "watch" ]
   - apiGroups: [ "" ]
     resources: [ "pods" ]
-    verbs: [ "get", "list" ]
+    verbs: [ "get", "list", "patch", "update" ]
   - apiGroups: [ "" ]
     resources: [ "configmaps" ]
     verbs: [ "create", "update", "patch", "get", "list", "watch", "delete" ]


### PR DESCRIPTION
Create router connectors and addresses based on address space connector specification.

* Reconcile secrets storing the connector certs
* Update router config based on connectors
* Add generation annotation to statefulset pod template to allow triggering a rolling update when the router config changes.
* Unit test for reconciling secrets and router config

@famartinrh With this PR, it should be possible to write tests to connect to remote brokers and send/receive messages via address space to them. Forwarding will come in another PR.