### PR TITLE
Issue 3150 connector metrics

### DIFF
--- a/address-space-controller/src/main/java/io/enmasse/controller/AddressSpaceController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/AddressSpaceController.java
@@ -23,7 +23,6 @@ import io.enmasse.user.keycloak.KubeKeycloakFactory;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
-import io.vertx.core.Vertx;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -87,7 +86,7 @@ public class AddressSpaceController {
                 AuthenticationServiceType.standard, keycloakUserApi));
 
         Metrics metrics = new Metrics();
-        controllerChain = new ControllerChain(kubernetes, addressSpaceApi, schemaProvider, eventLogger, metrics, options.getVersion(), options.getRecheckInterval(), options.getResyncInterval());
+        controllerChain = new ControllerChain(addressSpaceApi, schemaProvider, eventLogger, options.getRecheckInterval(), options.getResyncInterval());
         controllerChain.addController(new CreateController(kubernetes, schemaProvider, infraResourceFactory, eventLogger, authController.getDefaultCertProvider(), options.getVersion(), addressSpaceApi));
         controllerChain.addController(new RouterConfigController(controllerClient, controllerClient.getNamespace(), authenticationServiceResolver));
         controllerChain.addController(new RealmController(keycloakUserApi, authenticationServiceRegistry));
@@ -98,6 +97,7 @@ public class AddressSpaceController {
         controllerChain.addController(new ExportsController(controllerClient));
         controllerChain.addController(authController);
         controllerChain.addController(new DeleteController(kubernetes));
+        controllerChain.addController(new MetricsReporterController(metrics, options.getVersion()));
         controllerChain.start();
 
         metricsServer = new HTTPServer(8080, metrics);

--- a/address-space-controller/src/main/java/io/enmasse/controller/MetricsReporterController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/MetricsReporterController.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.controller;
+
+import io.enmasse.address.model.AddressSpace;
+import io.enmasse.address.model.AddressSpaceStatusConnector;
+import io.enmasse.metrics.api.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MetricsReporterController implements Controller {
+    private final Metrics metrics;
+    private final String version;
+
+    public MetricsReporterController(Metrics metrics, String version) {
+        this.metrics = metrics;
+        this.version = version;
+    }
+
+    public void reconcileAll(List<AddressSpace> addressSpaces) throws Exception {
+        long now = System.currentTimeMillis();
+        metrics.reportMetric(new Metric(
+            "version",
+            "The version of the address-space-controller",
+            MetricType.gauge,
+            new MetricValue(0, now, new MetricLabel("name", "address-space-controller"), new MetricLabel("version", version))));
+
+        List<MetricValue> readyValues = new ArrayList<>();
+        List<MetricValue> notReadyValues = new ArrayList<>();
+        List<MetricValue> readyConnectorValues = new ArrayList<>();
+        List<MetricValue> notReadyConnectorValues = new ArrayList<>();
+        List<MetricValue> numConnectors = new ArrayList<>();
+        for (AddressSpace addressSpace : addressSpaces) {
+            MetricLabel[] labels = new MetricLabel[]{new MetricLabel("name", addressSpace.getMetadata().getName()), new MetricLabel("namespace", addressSpace.getMetadata().getNamespace())};
+            readyValues.add(new MetricValue(addressSpace.getStatus().isReady() ? 1 : 0, now, labels));
+            notReadyValues.add(new MetricValue(addressSpace.getStatus().isReady() ? 0 : 1, now, labels));
+            numConnectors.add(new MetricValue(addressSpace.getStatus().getConnectorStatuses().size(), now, labels));
+
+            for (AddressSpaceStatusConnector connectorStatus : addressSpace.getStatus().getConnectorStatuses()) {
+
+                MetricLabel[] connectorLabels = new MetricLabel[]{new MetricLabel("name", addressSpace.getMetadata().getName()), new MetricLabel("namespace", addressSpace.getMetadata().getNamespace())};
+                readyConnectorValues.add(new MetricValue(connectorStatus.isReady() ? 1 : 0, now, connectorLabels));
+                notReadyConnectorValues.add(new MetricValue(connectorStatus.isReady() ? 0 : 1, now, connectorLabels));
+            }
+        }
+
+        metrics.reportMetric(new Metric(
+                "address_space_status_ready",
+                "Describes whether the address space is in a ready state",
+                MetricType.gauge,
+                readyValues));
+        metrics.reportMetric(new Metric(
+                "address_space_status_not_ready",
+                "Describes whether the address space is in a not_ready state",
+                MetricType.gauge,
+                notReadyValues));
+        metrics.reportMetric(new Metric(
+                "address_spaces_total",
+                "Total number of address spaces",
+                MetricType.gauge,
+                new MetricValue(addressSpaces.size(), now)));
+        metrics.reportMetric(new Metric(
+                "address_space_connector_status_ready",
+                "Describes whether the connector in an address space is in a ready state",
+                MetricType.gauge,
+                readyConnectorValues));
+        metrics.reportMetric(new Metric(
+                "address_space_connector_status_not_ready",
+                "Describes whether the connector in an address space is in a not_ready state",
+                MetricType.gauge,
+                notReadyConnectorValues));
+        metrics.reportMetric(new Metric(
+                "address_space_connectors_total",
+                "Total number of connectors of address spaces",
+                MetricType.gauge,
+                numConnectors));
+    }
+}

--- a/address-space-controller/src/main/java/io/enmasse/controller/RouterStatusController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/RouterStatusController.java
@@ -193,7 +193,6 @@ public class RouterStatusController implements Controller {
         return filtered;
     }
 
-
     @Override
     public String toString() {
         return "RouterStatusController";

--- a/address-space-controller/src/test/java/io/enmasse/controller/ControllerChainTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/ControllerChainTest.java
@@ -4,30 +4,20 @@
  */
 package io.enmasse.controller;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.time.Duration;
-import java.util.Arrays;
-import java.util.List;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import io.enmasse.address.model.AddressSpace;
 import io.enmasse.address.model.AddressSpaceBuilder;
 import io.enmasse.controller.common.Kubernetes;
 import io.enmasse.k8s.api.EventLogger;
 import io.enmasse.k8s.api.TestAddressSpaceApi;
-import io.enmasse.metrics.api.Metric;
-import io.enmasse.metrics.api.Metrics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Arrays;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 public class ControllerChainTest {
     private TestAddressSpaceApi testApi;
@@ -44,8 +34,7 @@ public class ControllerChainTest {
     @Test
     public void testController() throws Exception {
         EventLogger testLogger = mock(EventLogger.class);
-        Metrics metrics = new Metrics();
-        ControllerChain controllerChain = new ControllerChain(kubernetes, testApi, new TestSchemaProvider(), testLogger, metrics, "1.0", Duration.ofSeconds(5), Duration.ofSeconds(5));
+        ControllerChain controllerChain = new ControllerChain(testApi, new TestSchemaProvider(), testLogger, Duration.ofSeconds(5), Duration.ofSeconds(5));
         Controller mockController = mock(Controller.class);
         controllerChain.addController(mockController);
 
@@ -84,10 +73,7 @@ public class ControllerChainTest {
         verify(mockController).reconcile(eq(a1));
         verify(mockController).reconcile(eq(a2));
 
-        List<Metric> metricList = metrics.snapshot();
-        assertThat(metricList.size(), is(4));
-        assertTrue(a1.getStatus().isReady());
-        assertTrue(a2.getStatus().isReady());
+
     }
 }
 

--- a/address-space-controller/src/test/java/io/enmasse/controller/MetricsReporterTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/MetricsReporterTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.controller;
+
+import io.enmasse.address.model.AddressSpace;
+import io.enmasse.address.model.AddressSpaceBuilder;
+import io.enmasse.metrics.api.Metric;
+import io.enmasse.metrics.api.Metrics;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class MetricsReporterTest {
+    @Test
+    public void testController() throws Exception {
+        Metrics metrics = new Metrics();
+
+        MetricsReporterController controller = new MetricsReporterController(metrics, "1.0");
+
+        controller.reconcileAll(Arrays.asList(
+                createAddressSpace("s1", true),
+                createAddressSpace("s2", true),
+                createAddressSpace("s3", false)));
+
+        List<Metric> metricList = metrics.snapshot();
+        assertEquals(7, metricList.size());
+        Metric numReady = findMetric("address_space_status_ready", metricList);
+        assertNotNull(numReady);
+        assertEquals(3, numReady.getValues().size());
+
+        Metric numNotReady = findMetric("address_space_status_not_ready", metricList);
+        assertNotNull(numNotReady);
+        assertEquals(3, numNotReady.getValues().size());
+
+        Metric total = findMetric("address_spaces_total", metricList);
+        assertNotNull(total);
+        assertEquals(3, total.getValues().iterator().next().getValue());
+
+    }
+
+    private Metric findMetric(String name, List<Metric> metricList) {
+        for (Metric metric : metricList) {
+            if (name.equals(metric.getName())) {
+                return metric;
+            }
+        }
+        return null;
+    }
+
+    private AddressSpace createAddressSpace(String name, boolean isReady) {
+        return new AddressSpaceBuilder()
+                .editOrNewMetadata()
+                .withName(name)
+                .endMetadata()
+                .editOrNewSpec()
+                .withType("standard")
+                .withPlan("plan1")
+                .endSpec()
+                .editOrNewStatus()
+                .withReady(isReady)
+                .endStatus()
+                .build();
+
+    }
+}


### PR DESCRIPTION
This PR (based #3172) adds support for exposing connector metrics to the address space controller prometheus endpoint.

* Track number of connectors ready, notready and total
* Refactor metrics reporting into its own controller