### PR TITLE
Add support for address forwarding to standard address space

### DIFF
--- a/agent/lib/artemis.js
+++ b/agent/lib/artemis.js
@@ -560,16 +560,29 @@ Artemis.prototype.findDivert = function (name) {
     );
 };
 
-Artemis.prototype.createConnectorService = function (name, source, target) {
+Artemis.prototype.createConnectorService = function (connector) {
     var parameters = {
         "host": process.env.MESSAGING_SERVICE_HOST,
         "port": process.env.MESSAGING_SERVICE_PORT_AMQPS_BROKER,
-        "containerId": name,
-        "clusterId": name,
-        "clientAddress": target,
-        "sourceAddress": source
+        "clusterId": connector.clusterId
     };
-    return this._request('broker', 'createConnectorService', [name, "org.apache.activemq.artemis.integration.amqp.AMQPConnectorServiceFactory", parameters]);
+
+    if (connector.containerId !== undefined) {
+	parameters.containerId = connector.containerId;
+    }
+    if (connector.linkName !== undefined) {
+	parameters.linkName = connector.linkName;
+    }
+    if (connector.targetAddress !== undefined) {
+	parameters.targetAddress = connector.targetAddress;
+    }
+    if (connector.sourceAddress !== undefined) {
+	parameters.sourceAddress = connector.sourceAddress;
+    }
+    if (connector.direction !== undefined) {
+	parameters.direction = connector.direction;
+    }
+    return this._request('broker', 'createConnectorService', [connector.name, "org.apache.activemq.artemis.integration.amqp.AMQPConnectorServiceFactory", parameters]);
 }
 
 
@@ -625,12 +638,12 @@ Artemis.prototype.getGlobalMaxSize = function ()
 /**
  * Create connector service if one does not already exist.
  */
-Artemis.prototype.ensureConnectorService = function (name, source, target) {
+Artemis.prototype.ensureConnectorService = function (connector) {
     var broker = this;
-    return broker.findConnectorService(name).then(
+    return broker.findConnectorService(connector.name).then(
         function (found) {
             if (!found) {
-                return broker.createConnectorService(name, source, target);
+                return broker.createConnectorService(connector);
             }
         }
     );

--- a/agent/lib/broker_controller.js
+++ b/agent/lib/broker_controller.js
@@ -556,7 +556,7 @@ function connectors_of_interest(name) {
 	name !== 'address-connector-in' &&
 	name !== 'address-connector-out' &&
 	name !== 'ragent-connector' &&
-	!name.startsWith("$override";
+	!name.startsWith("$override");
 }
 
 function connector_compare(a, b) {

--- a/agent/lib/broker_controller.js
+++ b/agent/lib/broker_controller.js
@@ -548,7 +548,15 @@ BrokerController.prototype.create_connectors = function (connectors) {
 };
 
 function connectors_of_interest(name) {
-    return name !== 'amqp-connector' && name !== 'router-connector-in' && name !== 'router-connector-out' && name !== 'amqp-connector-in' && name !== 'amqp-connector-out' && !name.startsWith("$override");
+    return name !== 'amqp-connector' &&
+	name !== 'router-connector-in' &&
+	name !== 'router-connector-out' &&
+	name !== 'amqp-connector-in' &&
+	name !== 'amqp-connector-out' &&
+	name !== 'address-connector-in' &&
+	name !== 'address-connector-out' &&
+	name !== 'ragent-connector' &&
+	!name.startsWith("$override";
 }
 
 function connector_compare(a, b) {

--- a/agent/lib/broker_controller.js
+++ b/agent/lib/broker_controller.js
@@ -578,13 +578,15 @@ BrokerController.prototype._sync_broker_forwarders = function () {
 		    var forwarder_name = address_name + "." + forwarder.name + "." + forwarder.direction;
 		    // Only create forwarder for subscriptions if the direction is outward
 		    if (address_type === "queue" || (address_type === "subscription" && forwarder.direction === "out")) {
+			var sourceAddress = forwarder.direction === "out" ? address : forwarder.remoteAddress;
+			var targetAddress = forwarder.direction === "out" ? forwarder.remoteAddress : address;
 			var forwarder_entry = {
 			    name: forwarder_name,
 			    clusterId: address_name,
 			    containerId: address_name,
 			    linkName: forwarder_name,
-			    targetAddress: forwarder.remoteAddress,
-			    sourceAddress: address,
+			    targetAddress: targetAddress,
+			    sourceAddress: sourceAddress,
 			    direction: forwarder.direction
 			};
 			desired.push(forwarder_entry);

--- a/agent/lib/broker_controller.js
+++ b/agent/lib/broker_controller.js
@@ -548,7 +548,7 @@ BrokerController.prototype.create_connectors = function (connectors) {
 };
 
 function connectors_of_interest(name) {
-    return name !== 'amqp-connector' && name !== 'router-connector-in' && name !== 'router-connector-out' && name !== 'amqp-connector-in' && name !== 'amqp-connector-out';
+    return name !== 'amqp-connector' && name !== 'router-connector-in' && name !== 'router-connector-out' && name !== 'amqp-connector-in' && name !== 'amqp-connector-out' && !name.startsWith("$override");
 }
 
 function connector_compare(a, b) {

--- a/agent/lib/subctrl.js
+++ b/agent/lib/subctrl.js
@@ -118,7 +118,7 @@ SubscriptionControl.prototype.subscribe = function (subscription_id, topics) {
         function (pod) {
             log.info('after ensure looking at pod ' + JSON.stringify(pod.name) + " with broker undefined " + (pod.broker === undefined));
 	    var connector = {
-		name: subscription_id,
+		name: "$override." + subscription_id,
 		clusterId: subscription_id,
 		linkName: subscription_id,
 		sourceAddress: subscription_id,

--- a/agent/lib/subctrl.js
+++ b/agent/lib/subctrl.js
@@ -117,7 +117,16 @@ SubscriptionControl.prototype.subscribe = function (subscription_id, topics) {
     return ensure_queue(subscription_id, pods).then(
         function (pod) {
             log.info('after ensure looking at pod ' + JSON.stringify(pod.name) + " with broker undefined " + (pod.broker === undefined));
-            return pod.broker.ensureConnectorService(subscription_id, subscription_id, subscription_id).then(
+	    var connector = {
+		name: subscription_id,
+		clusterId: subscription_id,
+		linkName: subscription_id,
+		sourceAddress: subscription_id,
+		targetAddress: subscription_id,
+		containerId: subscription_id,
+		direction: 'out'
+	    };
+            return pod.broker.ensureConnectorService(connector).then(
                 function () {
                     return Promise.all(Object.keys(topics).map(
                         function (topic) {

--- a/agent/testlib/mock_broker.js
+++ b/agent/testlib/mock_broker.js
@@ -193,7 +193,7 @@ function MockBroker (name) {
             if (self.objects.some(function (o) { return o.type === 'connector' && o.name === name; })) {
                 throw new Error('connector for ' + name + ' already exists!');
             } else {
-                self.add_connector(name, {name: name, source: params.sourceAddress, target: params.clientAddress});
+                self.add_connector(name, {name: name, source: params.sourceAddress, target: params.targetAddress});
             }
         },
         destroyConnectorService : function (name) {

--- a/api-model/src/main/java/io/enmasse/address/model/Address.java
+++ b/api-model/src/main/java/io/enmasse/address/model/Address.java
@@ -10,6 +10,7 @@ import java.util.*;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.enmasse.common.model.AbstractHasMetadata;
 import io.enmasse.common.model.DefaultCustomResource;
 import io.enmasse.model.validation.AddressName;
@@ -43,7 +44,7 @@ public class Address extends AbstractHasMetadata<Address> implements AddressOrAd
     @NotNull @Valid
     private AddressSpec spec = new AddressSpec();
     @NotNull @Valid
-    private Status status = new Status();
+    private AddressStatus status = new AddressStatus();
 
     public Address() {
         super(KIND, CoreCrd.API_VERSION);
@@ -59,11 +60,11 @@ public class Address extends AbstractHasMetadata<Address> implements AddressOrAd
         return spec;
     }
 
-    public void setStatus(Status status) {
+    public void setStatus(AddressStatus status) {
         this.status = status;
     }
 
-    public Status getStatus() {
+    public AddressStatus getStatus() {
         return status;
     }
 
@@ -130,5 +131,10 @@ public class Address extends AbstractHasMetadata<Address> implements AddressOrAd
             return addressValue;
         }
         return extractAddressFromName(address);
+    }
+
+    @JsonIgnore
+    public String getForwarderLinkName(AddressSpecForwarder forwarder) {
+        return String.format("%s.%s.%s", getMetadata().getName(), forwarder.getName(), forwarder.getDirection().name());
     }
 }

--- a/api-model/src/main/java/io/enmasse/address/model/AddressSpec.java
+++ b/api-model/src/main/java/io/enmasse/address/model/AddressSpec.java
@@ -4,8 +4,10 @@
  */
 package io.enmasse.address.model;
 
+import java.util.List;
 import java.util.Objects;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -38,6 +40,8 @@ public class AddressSpec extends AbstractWithAdditionalProperties {
     @NotNull
     private String plan;
     private String topic;
+
+    private List<@Valid AddressSpecForwarder> forwarders;
 
     public void setAddress(String address) {
         this.address = address;
@@ -83,16 +87,27 @@ public class AddressSpec extends AbstractWithAdditionalProperties {
         return this.topic;
     }
 
+    public List<AddressSpecForwarder> getForwarders() {
+        return forwarders;
+    }
+
+    public void setForwarders(List<AddressSpecForwarder> forwarders) {
+        this.forwarders = forwarders;
+    }
+
     @Override
     public String toString() {
 
          final StringBuilder sb = new StringBuilder("{");
 
-         sb.append("address=").append(address).append(",");
-         sb.append("type=").append(type).append(",");
-         sb.append("plan=").append(plan).append(",");
+         sb.append("address=").append(address);
+         sb.append(",type=").append(type);
+         sb.append(",plan=").append(plan);
          if (topic != null) {
-             sb.append("topic=").append(topic);
+             sb.append(",topic=").append(topic);
+         }
+         if (forwarders != null) {
+             sb.append(",forwarders=").append(forwarders);
          }
          sb.append("}");
 
@@ -116,5 +131,4 @@ public class AddressSpec extends AbstractWithAdditionalProperties {
     public int hashCode() {
         return Objects.hash(address, addressSpace);
     }
-
 }

--- a/api-model/src/main/java/io/enmasse/address/model/AddressSpecForwarder.java
+++ b/api-model/src/main/java/io/enmasse/address/model/AddressSpecForwarder.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.address.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.enmasse.admin.model.v1.AbstractWithAdditionalProperties;
+import io.fabric8.kubernetes.api.model.Doneable;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import io.sundr.builder.annotations.Inline;
+
+import javax.validation.constraints.NotNull;
+
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = "io.fabric8.kubernetes.api.builder",
+        refs= {@BuildableReference(AbstractWithAdditionalProperties.class)},
+        inline = @Inline(
+                type = Doneable.class,
+                prefix = "Doneable",
+                value = "done"
+        )
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AddressSpecForwarder extends AbstractWithAdditionalProperties {
+    @NotNull
+    private String name;
+    @NotNull
+    private String remoteAddress;
+    @NotNull
+    private AddressSpecForwarderDirection direction;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getRemoteAddress() {
+        return remoteAddress;
+    }
+
+    public void setRemoteAddress(String remoteAddress) {
+        this.remoteAddress = remoteAddress;
+    }
+
+    public AddressSpecForwarderDirection getDirection() {
+        return direction;
+    }
+
+    public void setDirection(AddressSpecForwarderDirection direction) {
+        this.direction = direction;
+    }
+
+    @Override
+    public String toString() {
+        return "AddressSpecForwarder{" +
+                "name='" + name + '\'' +
+                ", remoteAddress='" + remoteAddress + '\'' +
+                ", direction=" + direction +
+                '}';
+    }
+}

--- a/api-model/src/main/java/io/enmasse/address/model/AddressSpecForwarderDirection.java
+++ b/api-model/src/main/java/io/enmasse/address/model/AddressSpecForwarderDirection.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2019, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.address.model;
+
+public enum AddressSpecForwarderDirection {
+    in,
+    out
+}

--- a/api-model/src/main/java/io/enmasse/address/model/AddressStatus.java
+++ b/api-model/src/main/java/io/enmasse/address/model/AddressStatus.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Objects;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -35,7 +36,7 @@ import io.sundr.builder.annotations.Inline;
                 )
         )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class Status extends AbstractWithAdditionalProperties {
+public class AddressStatus extends AbstractWithAdditionalProperties {
 
     @JsonProperty("isReady")
     private boolean ready = false;
@@ -44,14 +45,16 @@ public class Status extends AbstractWithAdditionalProperties {
     private List<@Valid BrokerStatus> brokerStatuses = new ArrayList<>();
     private AddressPlanStatus planStatus;
 
-    public Status() {
+    private List<@Valid AddressStatusForwarder> forwarderStatuses;
+
+    public AddressStatus() {
     }
 
-    public Status(boolean ready) {
+    public AddressStatus(boolean ready) {
         this.ready = ready;
     }
 
-    public Status(io.enmasse.address.model.Status other) {
+    public AddressStatus(AddressStatus other) {
         this.ready = other.isReady();
         this.phase = other.getPhase();
         this.messages = new ArrayList<>(other.getMessages());
@@ -59,6 +62,15 @@ public class Status extends AbstractWithAdditionalProperties {
         for (BrokerStatus brokerStatus : other.getBrokerStatuses()) {
             brokerStatuses.add(new BrokerStatus(brokerStatus.getClusterId(), brokerStatus.getContainerId(), brokerStatus.getState()));
         }
+        this.forwarderStatuses = new ArrayList<>();
+        for (AddressStatusForwarder forwarderStatus : other.getForwarderStatuses()) {
+            forwarderStatuses.add(new AddressStatusForwarderBuilder()
+                    .withName(forwarderStatus.getName())
+                    .withReady(forwarderStatus.isReady())
+                    .withMessages(forwarderStatus.getMessages())
+                    .build());
+        }
+
     }
 
     public boolean isReady() {
@@ -73,12 +85,12 @@ public class Status extends AbstractWithAdditionalProperties {
         return Collections.unmodifiableList(brokerStatuses);
     }
 
-    public Status setReady(boolean ready) {
+    public AddressStatus setReady(boolean ready) {
         this.ready = ready;
         return this;
     }
 
-    public Status setPhase(Phase phase) {
+    public AddressStatus setPhase(Phase phase) {
         this.phase = phase;
         return this;
     }
@@ -87,27 +99,27 @@ public class Status extends AbstractWithAdditionalProperties {
         return messages;
     }
 
-    public Status appendMessage(String message) {
+    public AddressStatus appendMessage(String message) {
         this.messages.add(message);
         return this;
     }
 
-    public Status clearMessages() {
+    public AddressStatus clearMessages() {
         this.messages.clear();
         return this;
     }
 
-    public Status setMessages(List<String> messages) {
+    public AddressStatus setMessages(List<String> messages) {
         this.messages = new ArrayList<>(messages);
         return this;
     }
 
-    public Status appendBrokerStatus(BrokerStatus brokerStatus) {
+    public AddressStatus appendBrokerStatus(BrokerStatus brokerStatus) {
         this.brokerStatuses.add(brokerStatus);
         return this;
     }
 
-    public Status setBrokerStatuses(List<BrokerStatus> brokerStatuses) {
+    public AddressStatus setBrokerStatuses(List<BrokerStatus> brokerStatuses) {
         this.brokerStatuses = new ArrayList<>(brokerStatuses);
         return this;
     }
@@ -117,17 +129,18 @@ public class Status extends AbstractWithAdditionalProperties {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        Status status = (Status) o;
+        AddressStatus status = (AddressStatus) o;
         return ready == status.ready &&
                 phase == status.phase &&
                 Objects.equals(messages, status.messages) &&
                 Objects.equals(brokerStatuses, status.brokerStatuses) &&
-                Objects.equals(planStatus, status.planStatus);
+                Objects.equals(planStatus, status.planStatus) &&
+                Objects.equals(forwarderStatuses, status.forwarderStatuses);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(ready, phase, messages, brokerStatuses, planStatus);
+        return Objects.hash(ready, phase, messages, brokerStatuses, planStatus, forwarderStatuses);
     }
 
 
@@ -139,6 +152,7 @@ public class Status extends AbstractWithAdditionalProperties {
                 .append(",").append("messages=").append(messages)
                 .append(",").append("brokerStatuses=").append(brokerStatuses)
                 .append(",").append("planStatus=").append(planStatus)
+                .append(",").append("forwarderStatuses=").append(forwarderStatuses)
                 .append("}")
                 .toString();
     }
@@ -153,5 +167,13 @@ public class Status extends AbstractWithAdditionalProperties {
 
     public void setPlanStatus(AddressPlanStatus planStatus) {
         this.planStatus = planStatus;
+    }
+
+    public List<AddressStatusForwarder> getForwarderStatuses() {
+        return forwarderStatuses;
+    }
+
+    public void setForwarderStatuses(List<AddressStatusForwarder> forwarderStatuses) {
+        this.forwarderStatuses = forwarderStatuses;
     }
 }

--- a/api-model/src/main/java/io/enmasse/address/model/AddressStatus.java
+++ b/api-model/src/main/java/io/enmasse/address/model/AddressStatus.java
@@ -62,13 +62,15 @@ public class AddressStatus extends AbstractWithAdditionalProperties {
         for (BrokerStatus brokerStatus : other.getBrokerStatuses()) {
             brokerStatuses.add(new BrokerStatus(brokerStatus.getClusterId(), brokerStatus.getContainerId(), brokerStatus.getState()));
         }
-        this.forwarderStatuses = new ArrayList<>();
-        for (AddressStatusForwarder forwarderStatus : other.getForwarderStatuses()) {
-            forwarderStatuses.add(new AddressStatusForwarderBuilder()
-                    .withName(forwarderStatus.getName())
-                    .withReady(forwarderStatus.isReady())
-                    .withMessages(forwarderStatus.getMessages())
-                    .build());
+        if (other.getForwarderStatuses() != null) {
+            this.forwarderStatuses = new ArrayList<>();
+            for (AddressStatusForwarder forwarderStatus : other.getForwarderStatuses()) {
+                forwarderStatuses.add(new AddressStatusForwarderBuilder()
+                        .withName(forwarderStatus.getName())
+                        .withReady(forwarderStatus.isReady())
+                        .withMessages(new ArrayList<>(forwarderStatus.getMessages()))
+                        .build());
+            }
         }
 
     }
@@ -174,6 +176,6 @@ public class AddressStatus extends AbstractWithAdditionalProperties {
     }
 
     public void setForwarderStatuses(List<AddressStatusForwarder> forwarderStatuses) {
-        this.forwarderStatuses = forwarderStatuses;
+        this.forwarderStatuses = new ArrayList<>(forwarderStatuses);
     }
 }

--- a/api-model/src/main/java/io/enmasse/address/model/AddressStatusForwarder.java
+++ b/api-model/src/main/java/io/enmasse/address/model/AddressStatusForwarder.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2019, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.address.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.enmasse.admin.model.v1.AbstractWithAdditionalProperties;
+import io.fabric8.kubernetes.api.model.Doneable;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import io.sundr.builder.annotations.Inline;
+
+import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = "io.fabric8.kubernetes.api.builder",
+        refs= {@BuildableReference(AbstractWithAdditionalProperties.class)},
+        inline = @Inline(
+                type = Doneable.class,
+                prefix = "Doneable",
+                value = "done"
+        )
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AddressStatusForwarder extends AbstractWithAdditionalProperties {
+
+    @NotNull
+    private String name;
+
+    @JsonProperty("isReady")
+    private boolean ready = false;
+
+    private List<String> messages = new ArrayList<>();
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<String> getMessages() {
+        return messages;
+    }
+
+    public void setMessages(List<String> messages) {
+        this.messages = messages;
+    }
+
+    @Override
+    public String toString() {
+        return "AddressStatusForwarder{" +
+                "name='" + name + '\'' +
+                ", ready=" + ready +
+                ", messages=" + messages +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AddressStatusForwarder that = (AddressStatusForwarder) o;
+        return ready == that.ready &&
+                Objects.equals(name, that.name) &&
+                Objects.equals(messages, that.messages);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, ready, messages);
+    }
+
+    public boolean isReady() {
+        return ready;
+    }
+
+    public void setReady(boolean ready) {
+        this.ready = ready;
+    }
+
+    public void appendMessage(String message) {
+        this.messages.add(message);
+    }
+}

--- a/api-model/src/main/java/io/enmasse/address/model/AddressStatusForwarder.java
+++ b/api-model/src/main/java/io/enmasse/address/model/AddressStatusForwarder.java
@@ -52,7 +52,7 @@ public class AddressStatusForwarder extends AbstractWithAdditionalProperties {
     }
 
     public void setMessages(List<String> messages) {
-        this.messages = messages;
+        this.messages = new ArrayList<>(messages);
     }
 
     @Override

--- a/api-model/src/test/java/io/enmasse/address/model/v1/address/AddressTest.java
+++ b/api-model/src/test/java/io/enmasse/address/model/v1/address/AddressTest.java
@@ -8,7 +8,7 @@ import io.enmasse.address.model.Address;
 import io.enmasse.address.model.AddressBuilder;
 import io.enmasse.address.model.AddressList;
 import io.enmasse.address.model.Phase;
-import io.enmasse.address.model.Status;
+import io.enmasse.address.model.AddressStatus;
 import org.junit.jupiter.api.Test;
 
 import static io.enmasse.address.model.validation.ValidationMatchers.isValid;
@@ -116,7 +116,7 @@ public class AddressTest {
                 .withAddressSpace("myspace")
                 .endSpec()
 
-                .withStatus(new Status(true).setPhase(Phase.Active).appendMessage("foo"))
+                .withStatus(new AddressStatus(true).setPhase(Phase.Active).appendMessage("foo"))
                 .build();
 
         Address b = new AddressBuilder(a).build();
@@ -144,7 +144,7 @@ public class AddressTest {
                 .withType("t1")
                 .endSpec()
 
-                .withStatus(new Status(true).setPhase(Phase.Active).appendMessage("foo"))
+                .withStatus(new AddressStatus(true).setPhase(Phase.Active).appendMessage("foo"))
                 .build();
 
         Address b = new AddressBuilder(a).build();

--- a/broker-plugin/amqp-connector/src/main/java/org/apache/activemq/artemis/integration/amqp/AMQPConnectorService.java
+++ b/broker-plugin/amqp-connector/src/main/java/org/apache/activemq/artemis/integration/amqp/AMQPConnectorService.java
@@ -59,7 +59,7 @@ public class AMQPConnectorService implements ConnectorService, BaseConnectionLif
    private volatile boolean started = false;
    private final Map<String, Object> connectorConfig;
 
-   public AMQPConnectorService(String connectorName, Map<String, Object> connectorConfig, String containerId, String groupId, Optional<SubscriberInfo> subscriberInfo, ActiveMQServer server, ScheduledExecutorService scheduledExecutorService, ExecutorService nettyThreadPool, int idleTimeout) {
+   public AMQPConnectorService(String connectorName, Map<String, Object> connectorConfig, String containerId, String groupId, Optional<LinkInfo> linkInfo, ActiveMQServer server, ScheduledExecutorService scheduledExecutorService, ExecutorService nettyThreadPool, int idleTimeout) {
       this.name = connectorName;
       this.connectorConfig = connectorConfig;
       this.server = server;
@@ -96,7 +96,7 @@ public class AMQPConnectorService implements ConnectorService, BaseConnectionLif
       } else  {
          ActiveMQAMQPLogger.LOGGER.infov("Disabling SSL for AMQP Connector {0}", name);
       }
-      this.lifecycleHandler = new ProtonClientConnectionManager(factory, subscriberInfo.map(LinkInitiator::new), saslClientFactory);
+      this.lifecycleHandler = new ProtonClientConnectionManager(factory, linkInfo.map(LinkInitiator::new), saslClientFactory);
    }
 
    @Override

--- a/broker-plugin/amqp-connector/src/main/java/org/apache/activemq/artemis/integration/amqp/Direction.java
+++ b/broker-plugin/amqp-connector/src/main/java/org/apache/activemq/artemis/integration/amqp/Direction.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2019, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package org.apache.activemq.artemis.integration.amqp;
+
+public enum Direction {
+    in,
+    out
+}

--- a/broker-plugin/amqp-connector/src/main/java/org/apache/activemq/artemis/integration/amqp/LinkInfo.java
+++ b/broker-plugin/amqp-connector/src/main/java/org/apache/activemq/artemis/integration/amqp/LinkInfo.java
@@ -20,26 +20,42 @@
  */
 package org.apache.activemq.artemis.integration.amqp;
 
-public class SubscriberInfo {
-   private final String clientId;
+public class LinkInfo {
+   private final String linkName;
    private final String sourceAddress;
-   private final String clientAddress;
+   private final String targetAddress;
+   private final Direction direction;
 
-   public SubscriberInfo(String clientId, String sourceAddress, String clientAddress) {
-      this.clientId = clientId;
+   public LinkInfo(String linkName, String sourceAddress, String targetAddress, Direction direction) {
+      this.linkName = linkName;
       this.sourceAddress = sourceAddress;
-      this.clientAddress = clientAddress;
+      this.targetAddress = targetAddress;
+      this.direction = direction;
    }
 
-   public String getClientAddress() {
-      return clientAddress;
+   public String getTargetAddress() {
+      return targetAddress;
    }
 
-   public String getClientId() {
-      return clientId;
+   public String getLinkName() {
+      return linkName;
    }
 
    public String getSourceAddress() {
       return sourceAddress;
+   }
+
+   public Direction getDirection() {
+      return direction;
+   }
+
+   @Override
+   public String toString() {
+      return "LinkInfo{" +
+              "linkName='" + linkName + '\'' +
+              ", sourceAddress='" + sourceAddress + '\'' +
+              ", targetAddress='" + targetAddress + '\'' +
+              ", direction=" + direction +
+              '}';
    }
 }

--- a/broker-plugin/amqp-connector/src/main/java/org/apache/activemq/artemis/integration/amqp/LinkInitiator.java
+++ b/broker-plugin/amqp-connector/src/main/java/org/apache/activemq/artemis/integration/amqp/LinkInitiator.java
@@ -137,17 +137,18 @@ public class LinkInitiator implements EventHandler {
 
    @Override
    public void onRemoteOpen(Link link) throws Exception {
-
+      ActiveMQAMQPLogger.LOGGER.infov("{0} onRemoteOpen", link.getName());
    }
 
    @Override
    public void onLocalClose(Link link) throws Exception {
-
+      ActiveMQAMQPLogger.LOGGER.infov("{0} onLocalClose", link.getName());
    }
 
    @Override
    public void onRemoteClose(Link link) throws Exception {
-
+      ActiveMQAMQPLogger.LOGGER.infov("Link {0} closed. Closing connection", link.getName());
+      link.getSession().getConnection().close();
    }
 
    @Override
@@ -162,12 +163,13 @@ public class LinkInitiator implements EventHandler {
 
    @Override
    public void onRemoteDetach(Link link) throws Exception {
-
+      ActiveMQAMQPLogger.LOGGER.infov("Link {0} detached. Closing connection", link.getName());
+      link.getSession().getConnection().close();
    }
 
    @Override
    public void onLocalDetach(Link link) throws Exception {
-
+      ActiveMQAMQPLogger.LOGGER.infov("{0} onLocalDetach", link.getName());
    }
 
    @Override
@@ -177,6 +179,9 @@ public class LinkInitiator implements EventHandler {
 
    @Override
    public boolean flowControl(ReadyListener readyListener) {
+      if (this.linkInfo.getDirection().equals(Direction.in)) {
+         readyListener.readyForWriting();
+      }
       return true;
    }
 

--- a/broker-plugin/amqp-connector/src/main/java/org/apache/activemq/artemis/integration/amqp/LinkInitiator.java
+++ b/broker-plugin/amqp-connector/src/main/java/org/apache/activemq/artemis/integration/amqp/LinkInitiator.java
@@ -10,7 +10,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,24 +24,20 @@ import io.netty.buffer.ByteBuf;
 import org.apache.activemq.artemis.protocol.amqp.proton.handler.EventHandler;
 import org.apache.activemq.artemis.protocol.amqp.proton.handler.ProtonHandler;
 import org.apache.activemq.artemis.spi.core.remoting.ReadyListener;
+import org.apache.qpid.proton.amqp.messaging.Received;
 import org.apache.qpid.proton.amqp.messaging.Source;
 import org.apache.qpid.proton.amqp.messaging.Target;
 import org.apache.qpid.proton.amqp.messaging.TerminusDurability;
-import org.apache.qpid.proton.engine.Connection;
-import org.apache.qpid.proton.engine.Delivery;
-import org.apache.qpid.proton.engine.Link;
-import org.apache.qpid.proton.engine.Sender;
-import org.apache.qpid.proton.engine.Session;
-import org.apache.qpid.proton.engine.Transport;
+import org.apache.qpid.proton.engine.*;
 
 /**
  * Event handler for establishing outgoing links
  */
 public class LinkInitiator implements EventHandler {
-   private final SubscriberInfo subscriberInfo;
+   private final LinkInfo linkInfo;
 
-   public LinkInitiator(SubscriberInfo subscriberInfo) {
-      this.subscriberInfo = subscriberInfo;
+   public LinkInitiator(LinkInfo linkInfo) {
+      this.linkInfo = linkInfo;
    }
 
    @Override
@@ -51,12 +47,12 @@ public class LinkInitiator implements EventHandler {
 
    @Override
    public void onSaslRemoteMechanismChosen(ProtonHandler handler, String mech) {
-      
+
    }
 
    @Override
    public void onAuthFailed(final ProtonHandler protonHandler, final Connection connection) {
-      
+
    }
 
    @Override
@@ -111,7 +107,7 @@ public class LinkInitiator implements EventHandler {
 
    @Override
    public void onRemoteOpen(Session session) throws Exception {
-      createSender(session);
+      createLink(session);
    }
 
    @Override
@@ -181,7 +177,7 @@ public class LinkInitiator implements EventHandler {
 
    @Override
    public boolean flowControl(ReadyListener readyListener) {
-       return true;
+      return true;
    }
 
    @Override
@@ -194,14 +190,48 @@ public class LinkInitiator implements EventHandler {
 
    }
 
-   private void createSender(org.apache.qpid.proton.engine.Session session) throws Exception {
-      Sender sender = session.sender(subscriberInfo.getClientId());
+   private void createLink(org.apache.qpid.proton.engine.Session session) throws Exception {
+      switch (linkInfo.getDirection()) {
+         case out:
+            createSender(session);
+            break;
+         case in:
+            createReceiver(session);
+            break;
+      }
+   }
+
+   private void createReceiver(Session session) {
+      Receiver receiver;
+      if (linkInfo.getLinkName() != null) {
+         receiver = session.receiver(linkInfo.getLinkName());
+      } else {
+         receiver = session.receiver(linkInfo.getSourceAddress());
+      }
       Target target = new Target();
-      target.setAddress(subscriberInfo.getClientAddress());
+      target.setAddress(linkInfo.getTargetAddress());
+      receiver.setTarget(target);
+
+      Source source = new Source();
+      source.setAddress(linkInfo.getSourceAddress());
+      source.setDurable(TerminusDurability.UNSETTLED_STATE);
+      receiver.setSource(source);
+      receiver.open();
+   }
+
+   private void createSender(Session session) {
+      Sender sender;
+      if (linkInfo.getLinkName() != null) {
+         sender = session.sender(linkInfo.getLinkName());
+      } else {
+         sender = session.sender(linkInfo.getTargetAddress());
+      }
+      Target target = new Target();
+      target.setAddress(linkInfo.getTargetAddress());
       sender.setTarget(target);
 
       Source source = new Source();
-      source.setAddress(subscriberInfo.getClientAddress());
+      source.setAddress(linkInfo.getSourceAddress());
       source.setDurable(TerminusDurability.UNSETTLED_STATE);
       sender.setSource(source);
 

--- a/documentation/design/proposals/bridging_external.adoc
+++ b/documentation/design/proposals/bridging_external.adoc
@@ -123,7 +123,7 @@ The standard controller will collect statistics about forwarders and attach to a
 
 ==== Agent
 
-For each forwarder on an address, the agent will create an autoLink pointing to a connector matching the address pattern.
+For each forwarder on an address, the agent will create a connector from the broker to the remote address. 
 
 == Testing
 

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/AddressProvisioner.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/AddressProvisioner.java
@@ -143,7 +143,7 @@ public class AddressProvisioner {
             Map<String, Map<String, UsageInfo>> newUsageMap, Map<String, Double> limits) {
         for (Address address : pending) {
             if (!Phase.Configuring.equals(address.getStatus().getPhase())) {
-                Status previousStatus = new Status(address.getStatus());
+                AddressStatus previousStatus = new AddressStatus(address.getStatus());
 
                 Map<String, Map<String, UsageInfo>> neededMap = checkQuotaForAddress(limits, newUsageMap, address, all);
                 if (neededMap != null) {
@@ -254,7 +254,7 @@ public class AddressProvisioner {
 
     private Map<String, Map<String, UsageInfo>> checkQuotaForAddress(Map<String, Double> limits, Map<String, Map<String, UsageInfo>> usage, Address address, Set<Address> addressSet) {
         AddressPlan desiredPlan = addressResolver.getDesiredPlan(address);
-        AddressPlanStatus appliedPlan = Optional.ofNullable(address.getStatus()).map(Status::getPlanStatus).orElse(null);
+        AddressPlanStatus appliedPlan = Optional.ofNullable(address.getStatus()).map(AddressStatus::getPlanStatus).orElse(null);
 
         Map<String, Map<String, UsageInfo>> needed = copyUsageMap(usage);
 

--- a/standard-controller/src/test/java/io/enmasse/controller/standard/AddressProvisionerTest.java
+++ b/standard-controller/src/test/java/io/enmasse/controller/standard/AddressProvisionerTest.java
@@ -35,22 +35,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import io.enmasse.address.model.*;
 import io.enmasse.admin.model.v1.StandardInfraConfig;
 import io.enmasse.admin.model.v1.StandardInfraConfigSpec;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.internal.util.collections.Sets;
 
-import io.enmasse.address.model.Address;
-import io.enmasse.address.model.AddressBuilder;
-import io.enmasse.address.model.AddressPlanStatus;
-import io.enmasse.address.model.AddressResolver;
-import io.enmasse.address.model.AddressSpaceResolver;
-import io.enmasse.address.model.BrokerState;
-import io.enmasse.address.model.BrokerStatus;
-import io.enmasse.address.model.BrokerStatusBuilder;
-import io.enmasse.address.model.Phase;
-import io.enmasse.address.model.StatusBuilder;
 import io.enmasse.admin.model.v1.ResourceAllowance;
 import io.enmasse.config.AnnotationKeys;
 import io.enmasse.k8s.api.EventLogger;
@@ -133,7 +124,7 @@ public class AddressProvisionerTest {
                 .withType("queue")
                 .endSpec()
 
-                .withStatus(new StatusBuilder()
+                .withStatus(new AddressStatusBuilder()
                         .withReady(true)
                         .addToBrokerStatuses(new BrokerStatus("broker-0", "broker-0-0").setState(BrokerState.Active))
                         .build())


### PR DESCRIPTION
* Doc: Update design doc
* Model: Add classes for forwarder spec and status
* Broker AMQP Connector: Add support for creating links in both directions
* Agent: Add support for creating broker -> router connectors + links based on forwarder definitions
* Standard Controller: Collect forwarder status from routers and report metrics on the number of forwarders in ready vs not ready state.
* Other: Rename Status to AddressStatus

Issue #3150

@famartinrh With this it should be possible to test forwarding of queues and subscriptions as well