### PR TITLE
Allow setting the netty-tcnative classifier as a build property

### DIFF
--- a/iot/pom.xml
+++ b/iot/pom.xml
@@ -20,7 +20,9 @@
     <logback.version>1.2.3</logback.version>
     <spring.boot.version>2.1.5.RELEASE</spring.boot.version>
     <micrometer.version>1.1.4</micrometer.version>
+
     <netty-tcnative.version>2.0.25.Final</netty-tcnative.version>
+    <netty-tcnative.classifier>linux-x86_64-fedora</netty-tcnative.classifier>
   </properties>
 
   <modules>
@@ -90,7 +92,7 @@
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative</artifactId>
         <version>${netty-tcnative.version}</version>
-        <classifier>linux-x86_64-fedora</classifier>
+        <classifier>${netty-tcnative.classifier}</classifier>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
This change allows to set the classifier for netty-tcnative using a build property. So that we can, later on, replace it.