### PR TITLE
Remove infraType label to prevent accidental delete

### DIFF
--- a/address-space-controller/src/main/java/io/enmasse/controller/AddressSpaceController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/AddressSpaceController.java
@@ -65,7 +65,7 @@ public class AddressSpaceController {
         schemaApi.watchSchema(schemaProvider, options.getResyncInterval());
         Kubernetes kubernetes = new KubernetesHelper(controllerClient.getNamespace(), controllerClient, options.getTemplateDir(), isOpenShift);
 
-        AddressSpaceApi addressSpaceApi = new ConfigMapAddressSpaceApi(controllerClient);
+        AddressSpaceApi addressSpaceApi = new ConfigMapAddressSpaceApi(controllerClient, options.getVersion());
         EventLogger eventLogger = options.isEnableEventLogger() ? new KubeEventLogger(controllerClient, controllerClient.getNamespace(), Clock.systemUTC(), "address-space-controller")
                 : new LogEventLogger();
 

--- a/agent/lib/internal_address_source.js
+++ b/agent/lib/internal_address_source.js
@@ -229,6 +229,7 @@ AddressSource.prototype.update_status = function (record, ready) {
         }
         var updateOwnerRef = false;
         if (configmap.metadata.ownerReferences === undefined && self.ownerReference !== undefined) {
+            def.metadata.annotations = myutils.merge(def.metadata.annotations, {"enmasse.io/version": self.config.VERSION});
             configmap.metadata.ownerReferences = [self.ownerReference];
             updateOwnerRef = true;
         }

--- a/agent/lib/internal_address_source.js
+++ b/agent/lib/internal_address_source.js
@@ -146,9 +146,9 @@ function AddressSource(config) {
     events.EventEmitter.call(this);
 }
 
-AddressSource.prototype.start = function(ownerreference) {
+AddressSource.prototype.start = function(ownerReference) {
     var options = myutils.merge({selector: this.selector}, this.config);
-    this.ownerreference = ownerreference;
+    this.ownerReference = ownerReference;
     this.watcher = kubernetes.watch('configmaps', options);
     this.watcher.on('updated', this.updated.bind(this));
     this.readiness = {};
@@ -227,10 +227,12 @@ AddressSource.prototype.update_status = function (record, ready) {
         if (def.status === undefined) {
             def.status = {};
         }
-        if (configmap.metadata.ownerReferences === undefined && self.ownerreferences !== undefined) {
-            configmap.metadata.ownerReferences = [self.ownerreference];
+        var updateOwnerRef = false;
+        if (configmap.metadata.ownerReferences === undefined && self.ownerReference !== undefined) {
+            configmap.metadata.ownerReferences = [self.ownerReference];
+            updateOwnerRef = true;
         }
-        if (def.status.isReady !== ready) {
+        if (def.status.isReady !== ready || updateOwnerRef) {
             def.status.isReady = ready;
             def.status.phase = ready ? 'Active' : 'Pending';
             configmap.data['config.json'] = JSON.stringify(def);

--- a/api-model/src/main/java/io/enmasse/config/AnnotationKeys.java
+++ b/api-model/src/main/java/io/enmasse/config/AnnotationKeys.java
@@ -31,4 +31,5 @@ public interface AnnotationKeys {
     String OPENSHIFT_SERVING_CERT_SECRET_NAME = "service.alpha.openshift.io/serving-cert-secret-name";
     String APPLIED_PLAN = "enmasse.io/applied-plan";
     String GENERATION = "enmasse.io/generation";
+    String VERSION = "enmasse.io/version";
 }

--- a/api-server/src/main/java/io/enmasse/api/server/ApiServer.java
+++ b/api-server/src/main/java/io/enmasse/api/server/ApiServer.java
@@ -65,7 +65,7 @@ public class ApiServer extends AbstractVerticle {
         CachingSchemaProvider schemaProvider = new CachingSchemaProvider();
         schemaApi.watchSchema(schemaProvider, options.getResyncInterval());
 
-        AddressSpaceApi addressSpaceApi = new ConfigMapAddressSpaceApi(client);
+        AddressSpaceApi addressSpaceApi = new ConfigMapAddressSpaceApi(client, options.getVersion());
 
         AuthApi authApi = new KubeAuthApi(client, client.getConfiguration().getOauthToken());
 

--- a/k8s-api/src/main/java/io/enmasse/k8s/api/ConfigMapAddressApi.java
+++ b/k8s-api/src/main/java/io/enmasse/k8s/api/ConfigMapAddressApi.java
@@ -54,11 +54,13 @@ public class ConfigMapAddressApi implements AddressApi, ListerWatcher<ConfigMap,
     private final WorkQueue<ConfigMap> cache = new EventCache<>(new HasMetadataFieldExtractor<>());
     private ObjectMapper mapper = new ObjectMapper();
     private final OwnerReference ownerReference;
+    private final String version;
 
-    public ConfigMapAddressApi(NamespacedKubernetesClient client, String infraUuid, OwnerReference ownerReference) {
+    public ConfigMapAddressApi(NamespacedKubernetesClient client, String infraUuid, OwnerReference ownerReference, String version) {
         this.client = client;
         this.infraUuid = infraUuid;
         this.ownerReference = ownerReference;
+        this.version = version;
     }
 
     @Override
@@ -193,6 +195,10 @@ public class ConfigMapAddressApi implements AddressApi, ListerWatcher<ConfigMap,
             builder.editMetadata()
                 .addToOwnerReferences(ownerReference)
                 .endMetadata();
+        }
+
+        if (version != null) {
+            address.putAnnotation(AnnotationKeys.VERSION, version);
         }
 
         if (address.getMetadata().getResourceVersion() != null) {

--- a/k8s-api/src/main/java/io/enmasse/k8s/api/ConfigMapAddressSpaceApi.java
+++ b/k8s-api/src/main/java/io/enmasse/k8s/api/ConfigMapAddressSpaceApi.java
@@ -48,9 +48,11 @@ public class ConfigMapAddressSpaceApi implements AddressSpaceApi, ListerWatcher<
     protected final Logger log = LoggerFactory.getLogger(getClass().getName());
     private final NamespacedKubernetesClient client;
     private final ObjectMapper mapper = new ObjectMapper();
+    private final String version;
 
-    public ConfigMapAddressSpaceApi(NamespacedKubernetesClient client) {
+    public ConfigMapAddressSpaceApi(NamespacedKubernetesClient client, String version) {
         this.client = client;
+        this.version = version;
     }
 
     public static String getConfigMapName(String namespace, String name) {
@@ -251,7 +253,7 @@ public class ConfigMapAddressSpaceApi implements AddressSpaceApi, ListerWatcher<
                 .withName(getConfigMapName(addressSpace.getMetadata().getNamespace(), addressSpace.getMetadata().getName()))
                 .withUid(addressSpace.getMetadata().getUid())
                 .build();
-        return new ConfigMapAddressApi(client, addressSpace.getAnnotation(AnnotationKeys.INFRA_UUID), ownerReference);
+        return new ConfigMapAddressApi(client, addressSpace.getAnnotation(AnnotationKeys.INFRA_UUID), ownerReference, version);
     }
 
     @SuppressWarnings("unused")

--- a/k8s-api/src/main/java/io/enmasse/k8s/api/ConfigMapAddressSpaceApi.java
+++ b/k8s-api/src/main/java/io/enmasse/k8s/api/ConfigMapAddressSpaceApi.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import io.fabric8.kubernetes.api.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,9 +36,6 @@ import io.enmasse.k8s.api.cache.ListOptions;
 import io.enmasse.k8s.api.cache.ListerWatcher;
 import io.enmasse.k8s.api.cache.Reflector;
 import io.enmasse.k8s.api.cache.WorkQueue;
-import io.fabric8.kubernetes.api.model.ConfigMap;
-import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
-import io.fabric8.kubernetes.api.model.ConfigMapList;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.RequestConfig;
@@ -55,7 +53,7 @@ public class ConfigMapAddressSpaceApi implements AddressSpaceApi, ListerWatcher<
         this.client = client;
     }
 
-    private static String getConfigMapName(String namespace, String name) {
+    public static String getConfigMapName(String namespace, String name) {
         return namespace + "." + name;
     }
 
@@ -245,7 +243,15 @@ public class ConfigMapAddressSpaceApi implements AddressSpaceApi, ListerWatcher<
 
     @Override
     public AddressApi withAddressSpace(AddressSpace addressSpace) {
-        return new ConfigMapAddressApi(client, addressSpace.getAnnotation(AnnotationKeys.INFRA_UUID));
+        OwnerReference ownerReference = new OwnerReferenceBuilder()
+                .withApiVersion("v1")
+                .withKind("ConfigMap")
+                .withBlockOwnerDeletion(true)
+                .withController(true)
+                .withName(getConfigMapName(addressSpace.getMetadata().getNamespace(), addressSpace.getMetadata().getName()))
+                .withUid(addressSpace.getMetadata().getUid())
+                .build();
+        return new ConfigMapAddressApi(client, addressSpace.getAnnotation(AnnotationKeys.INFRA_UUID), ownerReference);
     }
 
     @SuppressWarnings("unused")

--- a/k8s-api/src/test/java/io/enmasse/k8s/api/ConfigMapAddressApiTest.java
+++ b/k8s-api/src/test/java/io/enmasse/k8s/api/ConfigMapAddressApiTest.java
@@ -34,7 +34,7 @@ class ConfigMapAddressApiTest extends JULInitializingTest {
     void setUp() {
         kubeServer.before();
         NamespacedKubernetesClient client = kubeServer.getClient();
-        api = new ConfigMapAddressApi(client, UUID.randomUUID().toString());
+        api = new ConfigMapAddressApi(client, UUID.randomUUID().toString(), null);
     }
 
     @AfterEach

--- a/k8s-api/src/test/java/io/enmasse/k8s/api/ConfigMapAddressApiTest.java
+++ b/k8s-api/src/test/java/io/enmasse/k8s/api/ConfigMapAddressApiTest.java
@@ -34,7 +34,7 @@ class ConfigMapAddressApiTest extends JULInitializingTest {
     void setUp() {
         kubeServer.before();
         NamespacedKubernetesClient client = kubeServer.getClient();
-        api = new ConfigMapAddressApi(client, UUID.randomUUID().toString(), null);
+        api = new ConfigMapAddressApi(client, UUID.randomUUID().toString(), null, null);
     }
 
     @AfterEach

--- a/k8s-api/src/test/java/io/enmasse/k8s/api/ConfigMapAddressSpaceApiTest.java
+++ b/k8s-api/src/test/java/io/enmasse/k8s/api/ConfigMapAddressSpaceApiTest.java
@@ -38,7 +38,7 @@ class ConfigMapAddressSpaceApiTest extends JULInitializingTest {
     @BeforeEach
     void setUp() {
         kubeServer.before();
-        api = new ConfigMapAddressSpaceApi(kubeServer.getClient());
+        api = new ConfigMapAddressSpaceApi(kubeServer.getClient(), null);
     }
 
     @AfterEach

--- a/service-broker/src/main/java/io/enmasse/osb/ServiceBroker.java
+++ b/service-broker/src/main/java/io/enmasse/osb/ServiceBroker.java
@@ -69,7 +69,7 @@ public class ServiceBroker extends AbstractVerticle {
         ensureRouteExists(client.adapt(OpenShiftClient.class), options);
         ensureCredentialsExist(client, options);
 
-        AddressSpaceApi addressSpaceApi = new ConfigMapAddressSpaceApi(client);
+        AddressSpaceApi addressSpaceApi = new ConfigMapAddressSpaceApi(client, options.getVersion());
         AuthApi authApi = new KubeAuthApi(client, client.getConfiguration().getOauthToken());
 
         UserApi userApi = createUserApi(options, schemaProvider);

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/StandardController.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/StandardController.java
@@ -7,16 +7,13 @@ package io.enmasse.controller.standard;
 import java.time.Clock;
 import java.util.Map;
 
+import io.enmasse.address.model.AddressSpace;
+import io.enmasse.k8s.api.*;
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.enmasse.k8s.api.CachingSchemaProvider;
-import io.enmasse.k8s.api.ConfigMapAddressApi;
-import io.enmasse.k8s.api.EventLogger;
-import io.enmasse.k8s.api.KubeEventLogger;
-import io.enmasse.k8s.api.KubeSchemaApi;
-import io.enmasse.k8s.api.LogEventLogger;
-import io.enmasse.k8s.api.SchemaApi;
 import io.enmasse.metrics.api.Metrics;
 import io.enmasse.model.CustomResourceDefinitions;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
@@ -90,9 +87,22 @@ public class StandardController {
 
         BrokerClientFactory brokerClientFactory = new MutualTlsBrokerClientFactory(vertx, options);
 
+        AddressSpaceApi addressSpaceApi = new ConfigMapAddressSpaceApi(kubeClient);
+        AddressSpace addressSpace = addressSpaceApi.getAddressSpaceWithName(options.getAddressSpaceNamespace(), options.getAddressSpace()).orElseThrow(() ->
+                new IllegalStateException("Unable to lookup address space " + options.getAddressSpace()));
+
+        OwnerReference ownerReference = new OwnerReferenceBuilder()
+                .withApiVersion("v1")
+                .withKind("ConfigMap")
+                .withBlockOwnerDeletion(true)
+                .withController(true)
+                .withName(ConfigMapAddressSpaceApi.getConfigMapName(addressSpace.getMetadata().getNamespace(), addressSpace.getMetadata().getName()))
+                .withUid(addressSpace.getMetadata().getUid())
+                .build();
+
         addressController = new AddressController(
                 options,
-                new ConfigMapAddressApi(kubeClient, options.getInfraUuid()),
+                new ConfigMapAddressApi(kubeClient, options.getInfraUuid(), ownerReference),
                 kubernetes,
                 clusterGenerator,
                 eventLogger,

--- a/templates/address-space-controller/020-Role-address-space-admin.yaml
+++ b/templates/address-space-controller/020-Role-address-space-admin.yaml
@@ -12,7 +12,7 @@ rules:
     resources: [ "pods", "secrets" ]
     verbs: [ "get", "list", "watch" ]
   - apiGroups: [ "" ]
-    resources: [ "configmaps" ]
+    resources: [ "configmaps", "configmaps/finalizers" ]
     verbs: [ "create", "update", "patch", "get", "list", "watch", "delete" ]
   - apiGroups: [ "" ]
     resources: [ "events" ]

--- a/templates/address-space-controller/020-Role-address-space-controller.yaml
+++ b/templates/address-space-controller/020-Role-address-space-controller.yaml
@@ -12,7 +12,7 @@ rules:
     resources: [ "pods" ]
     verbs: [ "get", "list", "patch", "update" ]
   - apiGroups: [ "" ]
-    resources: [ "configmaps" ]
+    resources: [ "configmaps", "configmaps/finalizers" ]
     verbs: [ "create", "update", "patch", "get", "list", "watch", "delete" ]
   - apiGroups: [ "" ]
     resources: [ "events" ]

--- a/templates/api-server/020-Role-api-server.yaml
+++ b/templates/api-server/020-Role-api-server.yaml
@@ -9,7 +9,7 @@ rules:
     resources: [ "services", "secrets" ]
     verbs: [ "get", "list", "watch" ]
   - apiGroups: [ "" ]
-    resources: [ "configmaps" ]
+    resources: [ "configmaps", "configmaps/finalizers" ]
     verbs: [ "create", "update", "patch", "get", "list", "watch", "delete" ]
   - apiGroups: [ "admin.enmasse.io" ]
     resources: [ "addressspaceplans", "addressplans", "standardinfraconfigs", "brokeredinfraconfigs", "authenticationservices", "consoleservices"]


### PR DESCRIPTION
Use ownerreferences instead to make sure address configmaps are deleted
when an address space configmap is deleted.