### PR TITLE
More bridging tests

### DIFF
--- a/api-model/src/main/java/io/enmasse/model/validation/AddressSpaceConnectorAddressRulePatternValidator.java
+++ b/api-model/src/main/java/io/enmasse/model/validation/AddressSpaceConnectorAddressRulePatternValidator.java
@@ -13,7 +13,7 @@ import java.util.regex.Pattern;
 
 public class AddressSpaceConnectorAddressRulePatternValidator implements ConstraintValidator<AddressSpaceConnectorAddressRulePattern, AddressSpaceSpecConnectorAddressRule> {
 
-    private static final Pattern PATTERN = Pattern.compile("([^/]+(/?[^/]+)*)*");
+    private static final Pattern PATTERN = Pattern.compile("([^/#*]+|\\*|#)(/([^/#*]+|\\*|#))*");
 
     @Override
     public boolean isValid(AddressSpaceSpecConnectorAddressRule rule, ConstraintValidatorContext context) {

--- a/api-model/src/test/java/io/enmasse/address/model/AddressSpaceSpecConnectorAddressRuleTest.java
+++ b/api-model/src/test/java/io/enmasse/address/model/AddressSpaceSpecConnectorAddressRuleTest.java
@@ -6,11 +6,7 @@ package io.enmasse.address.model;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-
-import static io.enmasse.address.model.validation.ValidationMatchers.isNotValid;
 import static io.enmasse.address.model.validation.ValidationMatchers.isValid;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -40,6 +36,7 @@ public class AddressSpaceSpecConnectorAddressRuleTest {
         assertFalse(validRule("a", "*/"));
         assertFalse(validRule("a", "*//"));
         assertFalse(validRule("a", "//"));
+        assertFalse(validRule("a", "a*"));
     }
 
     private boolean validRule(String name, String pattern) {

--- a/documentation/design/proposals/bridging_external.adoc
+++ b/documentation/design/proposals/bridging_external.adoc
@@ -130,20 +130,20 @@ For each forwarder on an address, the agent will create a connector from the bro
 * Set up an AMQP broker (i.e. Artemis) on a remote host
 * Configure an address space with connectors and create addresses with forwarders for the 4 different use cases listed initially
 
-List of functionalities/behaviours to test:
-  - [tested] Sending messages to a remote AMQP endpoint via a local address space - by creating a connector and using prefixing
-  - [tested] Receiving messages from a remote AMQP endpoint via a local address space - by creating a connector and using prefixing
-  - [tested] config a connector to refer to a host that does not exist. addressspace should report ready true and the connector's status should report the failure.
-  - invalid connector names (ie: using / in connector name)
-  - invalid patterns in address rule in connector (ie: queue*)
-  - Restart broker to ensure router reattached to broker and you can send/recv messages
-  - use TLS
-  - Using mutual TLS (SASL EXTERNAL) instead of credentials
-  - [tested] Forwarding messages from a local queue in a local address space to a destination on a remote AMQP endpoint
-  - [tested] Forwarding messages to a local queue in a local address space from a destination on a remote AMQP endpoint
-  - forward to FULL remote queue
-  - forward to FULL local queue
-  - try to forward messages when the remote broker is unavailable , and check how the messages are automatically forwarded when the remote broker comes back up
+=== List of functionalities/behaviours to test:
+* [tested] Sending messages to a remote AMQP endpoint via a local address space - by creating a connector and using prefixing
+* [tested] Receiving messages from a remote AMQP endpoint via a local address space - by creating a connector and using prefixing
+* [tested] config a connector to refer to a host that does not exist. addressspace should report ready true and the connector's status should report the failure.
+* [tested] invalid connector names (ie: using / in connector name)
+* [tested] invalid patterns in address rule in connector (ie: queue*)
+* [tested] Restart broker to ensure router reattached to broker and you can send/recv messages
+* use TLS
+* Using mutual TLS (SASL EXTERNAL) instead of credentials
+* [tested] Forwarding messages from a local queue in a local address space to a destination on a remote AMQP endpoint
+* [tested] Forwarding messages to a local queue in a local address space from a destination on a remote AMQP endpoint
+* forward to FULL remote queue
+* forward to FULL local queue
+* [tested] try to forward messages when the remote broker is unavailable , and check how the messages are automatically forwarded when the remote broker comes back up
 
 == Documentation
 

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/Kubernetes.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/Kubernetes.java
@@ -366,8 +366,8 @@ public abstract class Kubernetes {
         return logs;
     }
 
-    public void setDeploymentReplicas(String name, int numReplicas) {
-        client.apps().deployments().inNamespace(infraNamespace).withName(name).scale(numReplicas, true);
+    public void setDeploymentReplicas(String namespace, String name, int numReplicas) {
+        client.apps().deployments().inNamespace(namespace).withName(name).scale(numReplicas, true);
     }
 
     public void setStatefulSetReplicas(String name, int numReplicas) {

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/apps/SystemtestsKubernetesApps.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/apps/SystemtestsKubernetesApps.java
@@ -268,6 +268,18 @@ public class SystemtestsKubernetesApps {
         Thread.sleep(5000);
     }
 
+    public static void scaleDownAMQBroker(String namespace) throws Exception {
+        Kubernetes kubeCli = Kubernetes.getInstance();
+        kubeCli.setDeploymentReplicas(namespace, AMQ_BROKER, 0);
+        TestUtils.waitForExpectedReadyPods(kubeCli, namespace, 0, new TimeoutBudget(30, TimeUnit.SECONDS));
+    }
+
+    public static void scaleUpAMQBroker(String namespace) throws Exception {
+        Kubernetes kubeCli = Kubernetes.getInstance();
+        kubeCli.setDeploymentReplicas(namespace, AMQ_BROKER, 1);
+        TestUtils.waitForExpectedReadyPods(kubeCli, namespace, 1, new TimeoutBudget(30, TimeUnit.SECONDS));
+    }
+
     public static void applyDirectories(final Function<InputStream, InputStream> streamManipulator, final Path... paths) throws Exception {
         loadDirectories(streamManipulator, Applicable::createOrReplace, paths);
     }

--- a/systemtests/src/main/java/io/enmasse/systemtest/utils/AddressSpaceUtils.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/utils/AddressSpaceUtils.java
@@ -230,6 +230,17 @@ public class AddressSpaceUtils {
         return addressSpace.getSpec().getType().equals(AddressSpaceType.BROKERED.toString());
     }
 
+    public static void waitForAddressSpaceConnectorsNotReady(AddressSpace addressSpace) throws Exception {
+        TestUtils.waitUntilCondition("Connectors report not ready", phase -> {
+            try {
+                AddressSpaceUtils.waitForAddressSpaceConnectorsReady(addressSpace, new TimeoutBudget(20, TimeUnit.SECONDS));
+                return false;
+            } catch (Exception ex) {
+                return ex instanceof IllegalStateException;
+            }
+        }, new TimeoutBudget(5, TimeUnit.MINUTES));
+    }
+
     public static AddressSpace waitForAddressSpaceConnectorsReady(AddressSpace addressSpace) throws Exception {
         return waitForAddressSpaceConnectorsReady(addressSpace, new TimeoutBudget(5, TimeUnit.MINUTES));
     }

--- a/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
@@ -63,7 +63,7 @@ public class TestUtils {
      * scale up/down specific pod (type: Deployment) in address space
      */
     public static void setReplicas(Kubernetes kubernetes, String infraUuid, String deployment, int numReplicas, TimeoutBudget budget) throws InterruptedException {
-        kubernetes.setDeploymentReplicas(deployment, numReplicas);
+        kubernetes.setDeploymentReplicas(kubernetes.getInfraNamespace(), deployment, numReplicas);
         Map<String, String> labels = new HashMap<>();
         labels.put("name", deployment);
         if (infraUuid != null) {

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/bridging/BridgingBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/bridging/BridgingBase.java
@@ -58,6 +58,14 @@ public abstract class BridgingBase extends TestBase implements ITestIsolatedStan
         SystemtestsKubernetesApps.deleteAMQBroker(remoteBrokerNamespace);
     }
 
+    protected void scaleDownBroker() throws Exception {
+        SystemtestsKubernetesApps.scaleDownAMQBroker(remoteBrokerNamespace);
+    }
+
+    protected void scaleUpBroker() throws Exception {
+        SystemtestsKubernetesApps.scaleUpAMQBroker(remoteBrokerNamespace);
+    }
+
     protected AddressSpace createAddressSpace(String name, String addressRule) throws Exception {
         AddressSpace space = new AddressSpaceBuilder()
                 .withNewMetadata()

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/bridging/BridgingBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/bridging/BridgingBase.java
@@ -35,10 +35,10 @@ public abstract class BridgingBase extends TestBase implements ITestIsolatedStan
 
     protected static final String REMOTE_NAME = "remote1";
 
-    private final String remoteBrokerNamespace = "systemtests-external-broker";
-    private final String remoteBrokerUsername = "test-user";
-    private final String remoteBrokerPassword = "test-password";
-    private Endpoint remoteBrokerEndpoint;
+    protected final String remoteBrokerNamespace = "systemtests-external-broker";
+    protected final String remoteBrokerUsername = "test-user";
+    protected final String remoteBrokerPassword = "test-password";
+    protected Endpoint remoteBrokerEndpoint;
 
     protected abstract String[] remoteBrokerQueues();
 
@@ -59,10 +59,12 @@ public abstract class BridgingBase extends TestBase implements ITestIsolatedStan
     }
 
     protected void scaleDownBroker() throws Exception {
+        log.info("Scaling down broker");
         SystemtestsKubernetesApps.scaleDownAMQBroker(remoteBrokerNamespace);
     }
 
     protected void scaleUpBroker() throws Exception {
+        log.info("Scaling up broker");
         SystemtestsKubernetesApps.scaleUpAMQBroker(remoteBrokerNamespace);
     }
 

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/bridging/ForwardersTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/bridging/ForwardersTest.java
@@ -68,20 +68,7 @@ public class ForwardersTest extends BridgingBase {
 
         int messagesBatch = 50;
 
-        //send to address with forwarder
-
-        AmqpClient localClient = getAmqpClientFactory().createQueueClient(space);
-        localClient.getConnectOptions().setCredentials(localUser);
-
-        localClient.sendMessages(forwarder.getSpec().getAddress(), TestUtils.generateMessages(messagesBatch));
-
-        //receive in remote broker
-
-        AmqpClient clientToRemote = createClientToRemoteBroker();
-
-        var receivedInRemote = clientToRemote.recvMessages(REMOTE_QUEUE1, messagesBatch);
-
-        assertThat("Wrong count of messages received from remote queue: "+REMOTE_QUEUE1, receivedInRemote.get(1, TimeUnit.MINUTES).size(), is(messagesBatch));
+        doTestSendToForwarder(space, forwarder, localUser, REMOTE_QUEUE1, messagesBatch);
 
     }
 
@@ -127,6 +114,85 @@ public class ForwardersTest extends BridgingBase {
 
         assertThat("Wrong count of messages received in local address: "+forwarder.getSpec().getAddress(), receivedInRemote.get(1, TimeUnit.MINUTES).size(), is(messagesBatch));
 
+    }
+
+    @Test
+    public void testForwardToUnavailableBroker() throws Exception {
+
+        AddressSpace space = createAddressSpace("forward-to-remote", "*");
+        Address forwarder = new AddressBuilder()
+                .withNewMetadata()
+                .withName(AddressUtils.generateAddressMetadataName(space, "forwarder-queue1"))
+                .withNamespace(kubernetes.getInfraNamespace())
+                .endMetadata()
+                .withNewSpec()
+                .withAddress("forwarder-queue1")
+                .withType(AddressType.QUEUE.toString())
+                .withPlan(DestinationPlan.STANDARD_SMALL_QUEUE)
+                .addToForwarders(new AddressSpecForwarderBuilder()
+                        .withName("forwarder1")
+                        .withRemoteAddress(REMOTE_NAME + "/" + REMOTE_QUEUE1)
+                        .withDirection(AddressSpecForwarderDirection.out)
+                        .build())
+                .endSpec()
+                .build();
+        resourcesManager.setAddresses(forwarder);
+        AddressUtils.waitForForwardersReady(new TimeoutBudget(1, TimeUnit.MINUTES), forwarder);
+
+        UserCredentials localUser = new UserCredentials("test", "test");
+        resourcesManager.createOrUpdateUser(space, localUser);
+
+        doTestSendToForwarder(space, forwarder, localUser, REMOTE_QUEUE1, 5);
+
+        //make broker unavailable
+        scaleDownBroker();
+
+        //check address forwarder is not ready
+//        Assertions.assertThrows(IllegalStateException.class, () -> {
+//            AddressUtils.waitForForwardersReady(new TimeoutBudget(30, TimeUnit.SECONDS), forwarder);
+//        });
+        AddressUtils.waitForDestinationsReady(new TimeoutBudget(30, TimeUnit.SECONDS), forwarder);
+
+        //send to forwarder
+        int messagesBatch = 50;
+        AmqpClient localClient = getAmqpClientFactory().createQueueClient(space);
+        localClient.getConnectOptions().setCredentials(localUser);
+
+        localClient.sendMessages(forwarder.getSpec().getAddress(), TestUtils.generateMessages(messagesBatch));
+
+        //wake up the broker
+        scaleUpBroker();
+
+        //wait until forwarder is ready again
+        AddressUtils.waitForDestinationsReady(new TimeoutBudget(30, TimeUnit.SECONDS), forwarder);
+        AddressUtils.waitForForwardersReady(new TimeoutBudget(1, TimeUnit.MINUTES), forwarder);
+
+        //wait a bit for the forwarding to happen
+        Thread.sleep(10000);
+
+        //check messages where automatically forwarded once broker is back up again
+        AmqpClient clientToRemote = createClientToRemoteBroker();
+
+        var receivedInRemote = clientToRemote.recvMessages(REMOTE_QUEUE1, messagesBatch);
+
+        assertThat("Wrong count of messages received from remote queue: "+REMOTE_QUEUE1, receivedInRemote.get(1, TimeUnit.MINUTES).size(), is(messagesBatch));
+    }
+
+    private void doTestSendToForwarder(AddressSpace space, Address forwarder, UserCredentials localUser, String rometeAddress, int messagesBatch) throws Exception {
+        //send to address with forwarder
+
+        AmqpClient localClient = getAmqpClientFactory().createQueueClient(space);
+        localClient.getConnectOptions().setCredentials(localUser);
+
+        localClient.sendMessages(forwarder.getSpec().getAddress(), TestUtils.generateMessages(messagesBatch));
+
+        //receive in remote broker
+
+        AmqpClient clientToRemote = createClientToRemoteBroker();
+
+        var receivedInRemote = clientToRemote.recvMessages(rometeAddress, messagesBatch);
+
+        assertThat("Wrong count of messages received from remote queue: "+rometeAddress, receivedInRemote.get(1, TimeUnit.MINUTES).size(), is(messagesBatch));
     }
 
 }


### PR DESCRIPTION
#### This PR includes tests for:
* invalid connector names (ie: using / in connector name) - it works 
* invalid patterns in address rule in connector (ie: queue*) - it's failing added a unit test too, maybe the pattern needs to be modified ( could you check that @lulf )
* Restart broker to ensure router reattached to broker and you can send/recv messages - it works
* try to forward messages when the remote broker is unavailable , and check how the messages are automatically forwarded when the remote broker comes back up - it works