### PR TITLE
increase timeout of iot deployment in tests

### DIFF
--- a/api-model/src/main/java/io/enmasse/iot/model/v1/AdapterConfig.java
+++ b/api-model/src/main/java/io/enmasse/iot/model/v1/AdapterConfig.java
@@ -24,10 +24,17 @@ import io.sundr.builder.annotations.Inline;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class AdapterConfig extends ServiceConfig {
 
+    private Boolean enabled;
     private EndpointConfig endpoint;
     private CommonAdapterContainers containers;
     private JavaContainerOptions java;
 
+    public Boolean getEnabled() {
+        return enabled;
+    }
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
     public EndpointConfig getEndpoint() {
         return endpoint;
     }

--- a/systemtests/src/test/java/io/enmasse/systemtest/iot/registry/DeviceRegistryTestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/iot/registry/DeviceRegistryTestBase.java
@@ -5,6 +5,7 @@
 package io.enmasse.systemtest.iot.registry;
 
 import io.enmasse.iot.model.v1.IoTConfig;
+import io.enmasse.iot.model.v1.IoTConfigBuilder;
 import io.enmasse.iot.model.v1.IoTProject;
 import io.enmasse.systemtest.Endpoint;
 import io.enmasse.systemtest.platform.Kubernetes;
@@ -32,7 +33,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.slf4j.Logger;
 
-import java.net.HttpURLConnection;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.UUID;
@@ -82,7 +82,7 @@ public abstract class DeviceRegistryTestBase extends IoTTestBase {
         }
     }
 
-    protected abstract IoTConfig provideIoTConfig() throws Exception;
+    protected abstract IoTConfigBuilder provideIoTConfig() throws Exception;
 
     protected void removeIoTConfig() throws Exception {
         log.info("Shared IoTConfig will be removed");
@@ -109,7 +109,21 @@ public abstract class DeviceRegistryTestBase extends IoTTestBase {
     @BeforeEach
     void init() throws Exception {
         if (iotConfig == null) {
-            iotConfig = provideIoTConfig();
+            var iotConfigBuilder = provideIoTConfig();
+            iotConfig = iotConfigBuilder.editSpec()
+                    .withNewAdapters()
+                    .withNewMqtt()
+                    .withEnabled(false)
+                    .endMqtt()
+                    .withNewLoraWan()
+                    .withEnabled(false)
+                    .endLoraWan()
+                    .withNewSigfox()
+                    .withEnabled(false)
+                    .endSigfox()
+                    .endAdapters()
+                    .endSpec()
+                    .build();
             createIoTConfig(iotConfig);
         }
         if (iotProject == null) {

--- a/systemtests/src/test/java/io/enmasse/systemtest/iot/registry/FileDeviceRegistryTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/iot/registry/FileDeviceRegistryTest.java
@@ -4,22 +4,16 @@
  */
 package io.enmasse.systemtest.iot.registry;
 
-import io.enmasse.iot.model.v1.IoTConfig;
 import io.enmasse.iot.model.v1.IoTConfigBuilder;
-import io.enmasse.systemtest.certs.CertBundle;
-import io.enmasse.systemtest.utils.CertificateUtils;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-
-import java.nio.ByteBuffer;
 
 import static io.enmasse.systemtest.bases.DefaultDeviceRegistry.newFileBased;
 
 public class FileDeviceRegistryTest extends DeviceRegistryTestBase {
 
     @Override
-    protected IoTConfig provideIoTConfig() throws Exception {
-        CertBundle certBundle = CertificateUtils.createCertBundle();
+    protected IoTConfigBuilder provideIoTConfig() throws Exception {
         return new IoTConfigBuilder()
                 .withNewMetadata()
                 .withName("default")
@@ -28,18 +22,7 @@ public class FileDeviceRegistryTest extends DeviceRegistryTestBase {
                 .withNewServices()
                 .withDeviceRegistry(newFileBased())
                 .endServices()
-                .withNewAdapters()
-                .withNewMqtt()
-                .withNewEndpoint()
-                .withNewKeyCertificateStrategy()
-                .withCertificate(ByteBuffer.wrap(certBundle.getCert().getBytes()))
-                .withKey(ByteBuffer.wrap(certBundle.getKey().getBytes()))
-                .endKeyCertificateStrategy()
-                .endEndpoint()
-                .endMqtt()
-                .endAdapters()
-                .endSpec()
-                .build();
+                .endSpec();
     }
 
     @Test

--- a/systemtests/src/test/java/io/enmasse/systemtest/iot/registry/InfinispanDeviceRegistryTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/iot/registry/InfinispanDeviceRegistryTest.java
@@ -6,21 +6,15 @@ package io.enmasse.systemtest.iot.registry;
 
 import static io.enmasse.systemtest.bases.DefaultDeviceRegistry.newInfinispanBased;
 
-import java.nio.ByteBuffer;
-
 import org.junit.jupiter.api.Test;
 
-import io.enmasse.iot.model.v1.IoTConfig;
 import io.enmasse.iot.model.v1.IoTConfigBuilder;
-import io.enmasse.systemtest.certs.CertBundle;
 import io.enmasse.systemtest.platform.apps.SystemtestsKubernetesApps;
-import io.enmasse.systemtest.utils.CertificateUtils;
 
 public class InfinispanDeviceRegistryTest extends DeviceRegistryTestBase {
 
     @Override
-    protected IoTConfig provideIoTConfig() throws Exception {
-        CertBundle certBundle = CertificateUtils.createCertBundle();
+    protected IoTConfigBuilder provideIoTConfig() throws Exception {
         return new IoTConfigBuilder()
                 .withNewMetadata()
                 .withName("default")
@@ -29,18 +23,7 @@ public class InfinispanDeviceRegistryTest extends DeviceRegistryTestBase {
                 .withNewServices()
                 .withDeviceRegistry(newInfinispanBased())
                 .endServices()
-                .withNewAdapters()
-                .withNewMqtt()
-                .withNewEndpoint()
-                .withNewKeyCertificateStrategy()
-                .withCertificate(ByteBuffer.wrap(certBundle.getCert().getBytes()))
-                .withKey(ByteBuffer.wrap(certBundle.getKey().getBytes()))
-                .endKeyCertificateStrategy()
-                .endEndpoint()
-                .endMqtt()
-                .endAdapters()
-                .endSpec()
-                .build();
+                .endSpec();
     }
 
     @Override


### PR DESCRIPTION
this PR also adds the capability of enable/disable adapters in systemtests, which will help decreasing the deployment time