### PR TITLE
Fix cert bundle certificate provider test

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/utils/AddressSpaceUtils.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/utils/AddressSpaceUtils.java
@@ -197,7 +197,7 @@ public class AddressSpaceUtils {
                 EndpointStatus status = getEndpointByServiceName(addrSpaceEndpoint.getService(), addressSpace.getStatus().getEndpointStatuses());
                 log.info("Got endpoint: name: {}, service-name: {}, host: {}, port: {}",
                         addrSpaceEndpoint.getName(), addrSpaceEndpoint.getService(), status.getExternalHost(),
-                        status.getExternalPorts().values().stream().findAny().get());
+                        status.getExternalPorts().values().stream().findAny());
                 if (status.getExternalHost() == null) {
                     return null;
                 } else {

--- a/systemtests/src/main/java/io/enmasse/systemtest/utils/CertificateUtils.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/utils/CertificateUtils.java
@@ -41,14 +41,14 @@ public class CertificateUtils {
         return crtFile;
     }
 
-    public static CertBundle createCertBundle() throws Exception {
+    public static CertBundle createCertBundle(String cn) throws Exception {
         File caCert = File.createTempFile("certAuthority", "crt");
         File caKey = File.createTempFile("certAuthority", "key");
         createSelfSignedCert(caCert, caKey);
         String randomName = UUID.randomUUID().toString();
         File keyFile = File.createTempFile(randomName, "key");
         File csrFile = File.createTempFile(randomName, "csr");
-        createCsr(keyFile, csrFile, null);
+        createCsr(keyFile, csrFile, cn);
         File crtFile = signCsr(caKey, caCert, keyFile, csrFile);
         try {
             return new CertBundle(FileUtils.readFileToString(caCert, StandardCharsets.UTF_8),
@@ -57,6 +57,10 @@ public class CertificateUtils {
         } finally {
             deleteFiles(caCert, caKey, keyFile, csrFile, crtFile);
         }
+    }
+
+    public static CertBundle createCertBundle() throws Exception {
+        return createCertBundle(null);
     }
 
     public static BrokerCertBundle createBrokerCertBundle(String cn) throws Exception {


### PR DESCRIPTION
* Configure route hosts as well as certificate CN
* Refactor tests to set endpoints and explicitly specify expose
* Limit tests to OpenShift environment as Minikube does not have the capability to do SNI based routing out of the box.
* Reenable tests failing due to http client redirect being followed (#2427)

Fixes #2427