### PR TITLE
Update examples to use service account group rather than a specific service account

### DIFF
--- a/documentation/design/proposals/bridging_external.adoc
+++ b/documentation/design/proposals/bridging_external.adoc
@@ -36,12 +36,12 @@ spec:
       caCert:
 	value: "" # PEM encoded value or
 	valueFromSecret: # Certificate stored in secret
-          name: remote1-secret # Secret containing CA to be trusted for this connector. NB! Secret must be readable by the system:serviceaccount:enmasse-infra:address-space-controller service account.
+          name: remote1-secret # Secret containing CA to be trusted for this connector. NB! Secret must be readable by the system:serviceaccounts:enmasse-infra group.
 	   key:  ca.crt # If using something different than default
       clientCert:
 	value: "" # PEM encoded value or
 	valueFromSecret: # Certificate stored in secret
-	   name: client-remot1-secret # Secret containing client cert to be used for this connector. NB! Secret must be readable by the system:serviceaccount:enmasse-infra:address-space-controller service account.
+	   name: client-remot1-secret # Secret containing client cert to be used for this connector. NB!  Secret must be readable by the system:serviceaccounts:enmasse-infra group.
     credentials:
       username:
         value: foo # Allow specifying credentials in plain text or

--- a/documentation/modules/ref-address-space-example-connectors.adoc
+++ b/documentation/modules/ref-address-space-example-connectors.adoc
@@ -45,7 +45,7 @@ spec:
 <1> (Required) Specifies the name of the connector. All remote addresses are prefixed with the connector name and a forward slash, `/`.
 <2> (Required) Specifies a list of endpoints for this connector. This list must contain at least one entry, and any additional entries are used for failover. If not otherwise specified, the `port` field value is set to the registered IANA port for AMQP (or AMQPS if TLS is enabled).
 <3> (Optional) Enable TLS. The connector trusts global root CAs by default. To use a custom CA, specify a value for the `caCert` field.
-<4> (Optional) Specifies the username and password credentials to use for this connector. The values can be specified inline or by referencing a secret along with an optional key specifying the location within the secret. The secret must be readable by the {ProductName} `address-space-controller` service account.
+<4> (Optional) Specifies the username and password credentials to use for this connector. The values can be specified inline or by referencing a secret along with an optional key specifying the location within the secret. The secret must be readable by the `system:serviceaccounts:_{ProductNamespace}_` group.
 <5> (Required) Specifies a list of patterns matching addresses to be exposed on the remote endpoint. The pattern consists of one or more tokens separated by a forward slash, `/`. A token can be one of the following: a * character, a # character, or a sequence of characters that do not include /, *, or #. The * token matches any single token. The # token matches zero or more tokens. * has higher precedence than #, and exact match has the highest precedence.
 
 == Connector using mutual TLS
@@ -85,6 +85,6 @@ spec:
 ----
 <1> (Required) Specifies the name of the connector. All remote addresses are prefixed with the connector name and a forward slash, `/`.
 <2> (Required) Specifies a list of endpoints for this connector. This list must contain at least one entry, and any additional entries are used for failover. If not otherwise specified, the `port` field value is set to the registered IANA port for AMQP (or AMQPS if TLS is enabled).
-<3> (Optional) Specifies the CA certificate to trust for the remote connection. The referenced secret must be readable by the {ProductName} `address-space-controller` service account.
-<4> (Optional) Specifies the client certificate to use for mutual TLS authentication. The referenced secret must be readable by the {ProductName} `address-space-controller` service account.
-<5> (Optional) Specifies the client private key to use for mutual TLS authentication. The referenced secret must be readable by the {ProductName} `address-space-controller` service account.
+<3> (Optional) Specifies the CA certificate to trust for the remote connection. The referenced secret must be readable by the `system:serviceaccounts:_{ProductNamespace}_` group.
+<4> (Optional) Specifies the client certificate to use for mutual TLS authentication. The referenced secret must be readable by the `system:serviceaccounts:_{ProductNamespace}_` group.
+<5> (Optional) Specifies the client private key to use for mutual TLS authentication. The referenced secret must be readable by the `system:serviceaccounts:_{ProductNamespace}_` group.

--- a/documentation/modules/ref-address-space-example-exporting-endpoints.adoc
+++ b/documentation/modules/ref-address-space-example-exporting-endpoints.adoc
@@ -33,10 +33,8 @@ shown in link:{BookUrlBase}{BaseProductVersion}{BookNameUrl}#ref-address-space-e
 inject endpoint information or provide a proxy service in the same namespace as the application. For more information see link:{BookUrlBase}{BaseProductVersion}{BookNameUrl}#ref-address-space-example-exports-messaging[example exports format].
 <2> (Required) The name of the resource to create and update.
 
-When exporting endpoint information, the {ProductName} `address-space-controller` service account
-running in the {ProductName} namespace must be granted privileges to create, update, and delete the
-configmap specified in the exports list. You can do this by creating an RBAC role and role-binding
-such as this one:
+When exporting endpoint information, the `system:serviceaccounts:_{ProductNamespace}_` group must be granted privileges to create, update, and delete the
+configmap specified in the exports list. You can do this by creating an RBAC role and role-binding such as this one:
 
 [source,yaml,options="nowrap",subs="+quotes,attributes"]
 ----
@@ -62,8 +60,7 @@ roleRef:
   kind: Role
   name: rbac
 subjects:
-- kind: ServiceAccount
-  name: address-space-controller
-  namespace: _{ProductNamespace}_
+- kind: Group
+  name: system:serviceaccounts:_{ProductNamespace}_
 ----
 


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Documentation

### Description

Simplify the description on how to provide access to secrets and configmaps for EnMasse infrastructure. By not mentioning the specific service account, we will be free to change the service account without breaking any API.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Update/write design documentation in `./documentation/design`
- [x] Update documentation
