### PR TITLE
Add global DLQ stats to console page

### DIFF
--- a/agent/lib/broker_stats.js
+++ b/agent/lib/broker_stats.js
@@ -33,7 +33,7 @@ function list_addresses(broker) {
 function get_stats_for_address(stats, address) {
     var s = stats[address];
     if (s === undefined) {
-        s = {depth:0, shards:[]};
+        s = {depth:0, dlq_depth: 0, shards:[]};
         stats[address] = s;
     }
     return s;
@@ -75,7 +75,9 @@ BrokerStats.prototype._retrieve = function() {
         for (var i = 0; i < results.length; i++) {
             for (var name in results[i]) {
                 var s = get_stats_for_address(stats, name);
+                var dlq = results[i]["!!GLOBAL_DLQ"];
                 var shard = merge(results[i][name], {name:brokers[i].connection.container_id});
+                if (dlq !== undefined && dlq.messages) s.dlq_depth += dlq.messages;
                 if (shard.messages) s.depth += shard.messages;
                 s.shards.push(shard);
             }

--- a/agent/www/components/addresses/addresses.html
+++ b/agent/www/components/addresses/addresses.html
@@ -71,6 +71,9 @@
         <div class="list-view-pf-additional-info-item"  ng-if="item.type === 'queue' || item.type === 'topic' || item.type === 'subscription'">
           <span class="fa fa-envelope-o"></span><strong>{{item.depth}}</strong> Stored
         </div>
+        <div class="list-view-pf-additional-info-item"  ng-if="item.type === 'queue'">
+          <span class="fa fa-envelope-o"></span><strong>{{item.dlq_depth}}</strong> Global DLQ
+        </div>
         <div class="list-view-pf-additional-info-item"  ng-if="item.type === 'queue' || item.type === 'topic'">
           <span class="fa fa-database"></span><strong>{{item.shards.length}}</strong> Shards
         </div>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

This change adds another field 'Global DLQ' to addresses of type queue in the console, showing the depth of the '!!GLOBAL_DLQ' address.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
