### PR TITLE
systemtests bridging to full queue

### DIFF
--- a/documentation/design/proposals/bridging_external.adoc
+++ b/documentation/design/proposals/bridging_external.adoc
@@ -137,13 +137,14 @@ For each forwarder on an address, the agent will create a connector from the bro
 * [tested] invalid connector names (ie: using / in connector name)
 * [tested] invalid patterns in address rule in connector (ie: queue*)
 * [tested] Restart broker to ensure router reattached to broker and you can send/recv messages
-* use TLS
-* Using mutual TLS (SASL EXTERNAL) instead of credentials
+* [tested] use TLS
+* [tested] Using mutual TLS (SASL EXTERNAL) instead of credentials
 * [tested] Forwarding messages from a local queue in a local address space to a destination on a remote AMQP endpoint
 * [tested] Forwarding messages to a local queue in a local address space from a destination on a remote AMQP endpoint
-* forward to FULL remote queue
+* [tested] forward to FULL remote queue
 * forward to FULL local queue
 * [tested] try to forward messages when the remote broker is unavailable , and check how the messages are automatically forwarded when the remote broker comes back up
+* [tested] use secrets in connector configuration
 
 == Documentation
 

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/apps/SystemtestsKubernetesApps.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/apps/SystemtestsKubernetesApps.java
@@ -21,6 +21,10 @@ import io.fabric8.kubernetes.api.model.extensions.Ingress;
 import io.fabric8.kubernetes.api.model.extensions.IngressBackend;
 import io.fabric8.kubernetes.api.model.extensions.IngressBuilder;
 import io.fabric8.kubernetes.api.model.extensions.IngressRuleBuilder;
+import io.fabric8.kubernetes.api.model.rbac.PolicyRuleBuilder;
+import io.fabric8.kubernetes.api.model.rbac.RoleBindingBuilder;
+import io.fabric8.kubernetes.api.model.rbac.RoleBuilder;
+import io.fabric8.kubernetes.api.model.rbac.SubjectBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.Applicable;
 import io.fabric8.kubernetes.client.dsl.Deletable;
@@ -232,7 +236,32 @@ public class SystemtestsKubernetesApps {
             kubeCli.createNamespace(namespace);
         }
 
-        kubeCli.createSecret(namespace, getBrokerSecret(name, certBundle));
+        kubeCli.getClient().rbac().roles().inNamespace(namespace).create(new RoleBuilder()
+                .withNewMetadata()
+                .withName(name)
+                .withNamespace(namespace)
+                .endMetadata()
+                .withRules(new PolicyRuleBuilder()
+                        .addToApiGroups("")
+                        .addToResources("secrets")
+                        .addToResourceNames(name)
+                        .addToVerbs("get")
+                        .build())
+                .build());
+        kubeCli.getClient().rbac().roleBindings().inNamespace(namespace).create(new RoleBindingBuilder()
+                .withNewMetadata()
+                .withName(name)
+                .withNamespace(namespace)
+                .endMetadata()
+                .withNewRoleRef("rbac.authorization.k8s.io", "Role", name)
+                .withSubjects(new SubjectBuilder()
+                        .withKind("ServiceAccount")
+                        .withName("address-space-controller")
+                        .withNamespace("enmasse-infra")
+                        .build())
+                .build());
+
+        kubeCli.createSecret(namespace, getBrokerSecret(name, certBundle, user, password));
 
         kubeCli.createDeploymentFromResource(namespace, getBrokerDeployment(name, user, password));
 
@@ -271,6 +300,8 @@ public class SystemtestsKubernetesApps {
 
     public static void deleteAMQBroker(String namespace, String name) throws Exception {
         Kubernetes kubeCli = Kubernetes.getInstance();
+        kubeCli.getClient().rbac().roles().inNamespace(namespace).withName(name).delete();
+        kubeCli.getClient().rbac().roleBindings().inNamespace(namespace).withName(name).delete();
         kubeCli.deleteSecret(namespace, name);
         kubeCli.deleteService(namespace, name);
         kubeCli.deleteDeployment(namespace, name);
@@ -612,7 +643,7 @@ public class SystemtestsKubernetesApps {
                 .build();
     }
 
-    private static Secret getBrokerSecret(String name, BrokerCertBundle certBundle) throws Exception {
+    private static Secret getBrokerSecret(String name, BrokerCertBundle certBundle, String user, String password) throws Exception {
         Map<String, String> data = new HashMap<>();
 
         byte[] content = Files.readAllBytes(new File("src/main/resources/broker/broker.xml").toPath());
@@ -627,6 +658,8 @@ public class SystemtestsKubernetesApps {
                 .withName(name)
                 .endMetadata()
                 .addToData(data)
+                .addToStringData("user", user)
+                .addToStringData("password", password)
                 .build();
     }
 
@@ -699,10 +732,6 @@ public class SystemtestsKubernetesApps {
                             new VolumeMountBuilder()
                             .withName(name)
                             .withMountPath("/etc/amq-secret-volume")
-                            .build())
-                    .addToEnv(new EnvVarBuilder()
-                            .withName("_JAVA_OPTIONS")
-                            .withValue("-Djavax.net.debug=all")
                             .build())
                     .endContainer()
                 .addToVolumes(new VolumeBuilder()

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/apps/SystemtestsKubernetesApps.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/apps/SystemtestsKubernetesApps.java
@@ -257,7 +257,7 @@ public class SystemtestsKubernetesApps {
                 .withSubjects(new SubjectBuilder()
                         .withKind("ServiceAccount")
                         .withName("address-space-controller")
-                        .withNamespace("enmasse-infra")
+                        .withNamespace(kubeCli.getInfraNamespace())
                         .build())
                 .build());
 

--- a/systemtests/src/main/resources/broker/broker.xml
+++ b/systemtests/src/main/resources/broker/broker.xml
@@ -109,6 +109,7 @@ under the License.
             <global-max-size>100Mb</global-max-size>
 
       -->
+      <global-max-size>10Mb</global-max-size>
 
       <acceptors>
 
@@ -163,13 +164,11 @@ under the License.
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
-            <dead-letter-address>DLQ</dead-letter-address>
-            <expiry-address>ExpiryQueue</expiry-address>
             <redelivery-delay>0</redelivery-delay>
             <!-- with -1 only the global-max-size is in use for limiting -->
-            <max-size-bytes>-1</max-size-bytes>
+            <max-size-bytes>15240</max-size-bytes>
             <message-counter-history-day-limit>10</message-counter-history-day-limit>
-            <address-full-policy>PAGE</address-full-policy>
+            <address-full-policy>FAIL</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
             <auto-create-jms-queues>true</auto-create-jms-queues>

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/bridging/ConnectorsTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/bridging/ConnectorsTest.java
@@ -16,8 +16,6 @@ import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import io.enmasse.address.model.Address;
-import io.enmasse.address.model.AddressBuilder;
 import io.enmasse.address.model.AddressSpace;
 import io.enmasse.address.model.AddressSpaceBuilder;
 import io.enmasse.address.model.AddressSpaceSpecConnectorAddressRuleBuilder;
@@ -29,7 +27,6 @@ import io.enmasse.systemtest.amqp.AmqpClient;
 import io.enmasse.systemtest.bases.bridging.BridgingBase;
 import io.enmasse.systemtest.model.addressspace.AddressSpacePlans;
 import io.enmasse.systemtest.model.addressspace.AddressSpaceType;
-import io.enmasse.systemtest.shared.standard.QueueTest;
 import io.enmasse.systemtest.time.TimeoutBudget;
 import io.enmasse.systemtest.utils.AddressSpaceUtils;
 import io.enmasse.systemtest.utils.TestUtils;
@@ -43,22 +40,6 @@ class ConnectorsTest extends BridgingBase {
     private static final String SLASHED_QUEUE2 = "dummy/baz";
     private static final String BASIC_QUEUES_PATTERN = "*";
     private static final String SLASHED_QUEUES_PATTERN = "dummy/*";
-
-    @Test
-    void testBrokerDeployment() throws Exception {
-        AmqpClient client = createClientToRemoteBroker();
-
-        Address testQueue = new AddressBuilder()
-                .withNewMetadata()
-                .withName("testtt")
-                .endMetadata()
-                .withNewSpec()
-                .withAddress(SLASHED_QUEUE1)
-                .endSpec()
-                .build();
-        QueueTest.runQueueTest(client, testQueue);
-        client.close();
-    }
 
     @Test
     void testSendThroughConnector1() throws Exception {
@@ -200,12 +181,12 @@ class ConnectorsTest extends BridgingBase {
 
     @Test
     void testRestartBroker() throws Exception {
-        AddressSpace space = createAddressSpace("restart-broker", BASIC_QUEUES_PATTERN);
+        AddressSpace space = createAddressSpace("restart-broker", BASIC_QUEUES_PATTERN, null, defaultCredentials());
 
         UserCredentials localUser = new UserCredentials("test", "test");
         resourcesManager.createOrUpdateUser(space, localUser);
 
-        int messagesBatch = 50;
+        int messagesBatch = 20;
         String[] remoteQueues = new String [] {BASIC_QUEUE1};
         sendToConnectorReceiveInBroker(space, localUser, remoteQueues, messagesBatch);
 
@@ -222,12 +203,12 @@ class ConnectorsTest extends BridgingBase {
     @Test
     @Tag(ACCEPTANCE)
     public void testConnectorTLS() throws Exception {
-        AddressSpace space = createAddressSpace("tls-test", BASIC_QUEUES_PATTERN, true, false);
+        AddressSpace space = createAddressSpace("tls-test", BASIC_QUEUES_PATTERN, defaultTls(), defaultCredentials());
 
         UserCredentials localUser = new UserCredentials("test", "test");
         resourcesManager.createOrUpdateUser(space, localUser);
 
-        int messagesBatch = 50;
+        int messagesBatch = 20;
         String[] remoteQueues = new String [] {BASIC_QUEUE1};
 
         sendToConnectorReceiveInBroker(space, localUser, remoteQueues, messagesBatch);
@@ -236,12 +217,12 @@ class ConnectorsTest extends BridgingBase {
 
     @Test
     public void testConnectorMutualTLS() throws Exception {
-        AddressSpace space = createAddressSpace("tls-test", BASIC_QUEUES_PATTERN, true, true);
+        AddressSpace space = createAddressSpace("tls-test", BASIC_QUEUES_PATTERN, defaultMutualTls(), null);
 
         UserCredentials localUser = new UserCredentials("test", "test");
         resourcesManager.createOrUpdateUser(space, localUser);
 
-        int messagesBatch = 50;
+        int messagesBatch = 20;
         String[] remoteQueues = new String [] {BASIC_QUEUE1};
 
         sendToConnectorReceiveInBroker(space, localUser, remoteQueues, messagesBatch);
@@ -249,23 +230,23 @@ class ConnectorsTest extends BridgingBase {
     }
 
     private void doTestSendThroughConnector(String addressRule, String[] remoteQueues) throws Exception, InterruptedException, ExecutionException, TimeoutException {
-        AddressSpace space = createAddressSpace("send-to-connector", addressRule);
+        AddressSpace space = createAddressSpace("send-to-connector", addressRule, null, defaultCredentials());
 
         UserCredentials localUser = new UserCredentials("test", "test");
         resourcesManager.createOrUpdateUser(space, localUser);
 
-        int messagesBatch = 50;
+        int messagesBatch = 20;
 
         sendToConnectorReceiveInBroker(space, localUser, remoteQueues, messagesBatch);
     }
 
     private void doTestReceiveThroughConnector(String addressRule, String[] remoteQueues) throws Exception {
-        AddressSpace space = createAddressSpace("receive-from-connector", addressRule);
+        AddressSpace space = createAddressSpace("receive-from-connector", addressRule, null, defaultCredentials());
 
         UserCredentials localUser = new UserCredentials("test", "test");
         resourcesManager.createOrUpdateUser(space, localUser);
 
-        int messagesBatch = 50;
+        int messagesBatch = 20;
 
         sendToBrokerReceiveInConnector(space, localUser, remoteQueues, messagesBatch);
     }

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/bridging/ForwardersTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/bridging/ForwardersTest.java
@@ -4,52 +4,65 @@
  */
 package io.enmasse.systemtest.isolated.bridging;
 
+import static io.enmasse.systemtest.TestTag.ACCEPTANCE;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.qpid.proton.amqp.Binary;
+import org.apache.qpid.proton.amqp.messaging.AmqpValue;
+import org.apache.qpid.proton.amqp.messaging.Data;
+import org.apache.qpid.proton.message.Message;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+
 import io.enmasse.address.model.Address;
 import io.enmasse.address.model.AddressBuilder;
 import io.enmasse.address.model.AddressSpace;
+import io.enmasse.address.model.AddressSpaceSpecConnectorCredentials;
+import io.enmasse.address.model.AddressSpaceSpecConnectorTls;
 import io.enmasse.address.model.AddressSpecForwarderBuilder;
 import io.enmasse.address.model.AddressSpecForwarderDirection;
 import io.enmasse.systemtest.UserCredentials;
 import io.enmasse.systemtest.amqp.AmqpClient;
 import io.enmasse.systemtest.bases.bridging.BridgingBase;
+import io.enmasse.systemtest.logs.CustomLogger;
 import io.enmasse.systemtest.model.address.AddressType;
 import io.enmasse.systemtest.model.addressplan.DestinationPlan;
 import io.enmasse.systemtest.time.TimeoutBudget;
 import io.enmasse.systemtest.utils.AddressSpaceUtils;
 import io.enmasse.systemtest.utils.AddressUtils;
 import io.enmasse.systemtest.utils.TestUtils;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-
-import java.util.concurrent.TimeUnit;
-import static io.enmasse.systemtest.TestTag.ACCEPTANCE;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 class ForwardersTest extends BridgingBase {
 
+    private static Logger log = CustomLogger.getLogger();
     private static final String REMOTE_QUEUE1 = "queue1";
 
     @Test
     @Tag(ACCEPTANCE)
     void testForwardToRemoteQueue() throws Exception {
-        doTestForwarderOut(false, false);
+        doTestForwarderOut(null, defaultCredentials());
     }
 
     @Test
     void testForwardFromRemoteQueue() throws Exception {
-        doTestForwarderIn(false, false);
+        doTestForwarderIn(null, defaultCredentials());
 
     }
 
     @Test
     void testForwardToUnavailableBroker() throws Exception {
 
-        AddressSpace space = createAddressSpace("forward-to-remote", "*");
+        AddressSpace space = createAddressSpace("forward-to-remote", "*", null, defaultCredentials());
         Address forwarder = new AddressBuilder()
                 .withNewMetadata()
                 .withName(AddressUtils.generateAddressMetadataName(space, "forwarder-queue1"))
-                .withNamespace(kubernetes.getInfraNamespace())
+                .withNamespace(remoteBrokerNamespace)
                 .endMetadata()
                 .withNewSpec()
                 .withAddress("forwarder-queue1")
@@ -87,7 +100,7 @@ class ForwardersTest extends BridgingBase {
         AddressUtils.waitForDestinationsReady(new TimeoutBudget(30, TimeUnit.SECONDS), forwarder);
 
         //send to forwarder
-        int messagesBatch = 50;
+        int messagesBatch = 20;
         AmqpClient localClient = getAmqpClientFactory().createQueueClient(space);
         localClient.getConnectOptions().setCredentials(localUser);
 
@@ -111,30 +124,36 @@ class ForwardersTest extends BridgingBase {
 
     @Test
     public void testForwarderTLSOut() throws Exception {
-        doTestForwarderOut(true, false);
+        doTestForwarderOut(defaultTls(), defaultCredentials());
     }
 
     @Test
     public void testForwarderMutualTLSOut() throws Exception {
-        doTestForwarderOut(true, true);
+        doTestForwarderOut(defaultMutualTls(), null);
     }
 
     @Test
     public void testForwarderTLSIn() throws Exception {
-        doTestForwarderIn(true, false);
+        doTestForwarderIn(defaultTls(), defaultCredentials());
     }
 
     @Test
     public void testForwarderMutualTLSIn() throws Exception {
-        doTestForwarderIn(true, true);
+        doTestForwarderIn(defaultMutualTls(), null);
     }
 
-    private void doTestForwarderOut(boolean tls, boolean mutualTls) throws Exception {
-        AddressSpace space = createAddressSpace("forward-to-remote", "*", tls, mutualTls);
+    @Test
+    void testForwardSecretSettings() throws Exception {
+        doTestForwarderOut(tlsInSecret(), credentialsInSecret());
+    }
+
+    @Test
+    void testForwardToFullQueue() throws Exception {
+        AddressSpace space = createAddressSpace("forward-to-full", "*", null, defaultCredentials());
         Address forwarder = new AddressBuilder()
                 .withNewMetadata()
                 .withName(AddressUtils.generateAddressMetadataName(space, "forwarder-queue1"))
-                .withNamespace(kubernetes.getInfraNamespace())
+                .withNamespace(remoteBrokerNamespace)
                 .endMetadata()
                 .withNewSpec()
                 .withAddress("forwarder-queue1")
@@ -153,17 +172,76 @@ class ForwardersTest extends BridgingBase {
         UserCredentials localUser = new UserCredentials("test", "test");
         resourcesManager.createOrUpdateUser(space, localUser);
 
-        int messagesBatch = 50;
+        //send until remote broker is full
+        AmqpClient clientToRemote = createClientToRemoteBroker();
+        boolean full = false;
+        byte[] bytes = new byte[1024];
+        Random random = new Random();
+        TimeoutBudget timeout = new TimeoutBudget(30, TimeUnit.SECONDS);
+        do {
+            Message message = Message.Factory.create();
+            random.nextBytes(bytes);
+            message.setBody(new AmqpValue(new Data(new Binary(bytes))));
+            message.setAddress(REMOTE_QUEUE1);
+            try {
+                clientToRemote.sendMessage(REMOTE_QUEUE1, message).get(5, TimeUnit.SECONDS);
+                if (timeout.timeoutExpired()) {
+                   Assertions.fail("Timeout waiting for remote broker to become full, probably error in test env configuration");
+                }
+            } catch (Exception e) {
+                full = true;
+                log.info("broker is full");
+            }
+        } while(!full);
+
+        int messagesBatch = 20;
+
+        AmqpClient localClient = getAmqpClientFactory().createQueueClient(space);
+        localClient.getConnectOptions().setCredentials(localUser);
+        //send to address with forwarder wich will forward to special local global_dlq address because of full remote broker
+        localClient.sendMessages(forwarder.getSpec().getAddress(), TestUtils.generateMessages(messagesBatch));
+
+        //receive in special global_dlq address in local broker
+        var receivedInDLQ = localClient.recvMessages("!!GLOBAL_DLQ", messagesBatch);
+        assertThat("Wrong count of messages received !!GLOBAL_DLQ address after address is full in remote broker", receivedInDLQ.get(1, TimeUnit.MINUTES).size(), is(messagesBatch));
+
+    }
+
+    private void doTestForwarderOut(AddressSpaceSpecConnectorTls tlsSettings, AddressSpaceSpecConnectorCredentials credentials) throws Exception {
+        AddressSpace space = createAddressSpace("forward-to-remote", "*", tlsSettings, credentials);
+        Address forwarder = new AddressBuilder()
+                .withNewMetadata()
+                .withName(AddressUtils.generateAddressMetadataName(space, "forwarder-queue1"))
+                .withNamespace(remoteBrokerNamespace)
+                .endMetadata()
+                .withNewSpec()
+                .withAddress("forwarder-queue1")
+                .withType(AddressType.QUEUE.toString())
+                .withPlan(DestinationPlan.STANDARD_SMALL_QUEUE)
+                .addToForwarders(new AddressSpecForwarderBuilder()
+                        .withName("forwarder1")
+                        .withRemoteAddress(REMOTE_NAME + "/" + REMOTE_QUEUE1)
+                        .withDirection(AddressSpecForwarderDirection.out)
+                        .build())
+                .endSpec()
+                .build();
+        resourcesManager.setAddresses(forwarder);
+        AddressUtils.waitForForwardersReady(new TimeoutBudget(1, TimeUnit.MINUTES), forwarder);
+
+        UserCredentials localUser = new UserCredentials("test", "test");
+        resourcesManager.createOrUpdateUser(space, localUser);
+
+        int messagesBatch = 20;
 
         doTestSendToForwarder(space, forwarder, localUser, REMOTE_QUEUE1, messagesBatch);
     }
 
-    private void doTestForwarderIn(boolean tls, boolean mutualTls) throws Exception {
-        AddressSpace space = createAddressSpace("forward-from-remote", "*", tls, mutualTls);
+    private void doTestForwarderIn(AddressSpaceSpecConnectorTls tlsSettings, AddressSpaceSpecConnectorCredentials credentials) throws Exception {
+        AddressSpace space = createAddressSpace("forward-from-remote", "*", tlsSettings, credentials);
         Address forwarder = new AddressBuilder()
                 .withNewMetadata()
                 .withName(AddressUtils.generateAddressMetadataName(space, "forwarder-queue1"))
-                .withNamespace(kubernetes.getInfraNamespace())
+                .withNamespace(remoteBrokerNamespace)
                 .endMetadata()
                 .withNewSpec()
                 .withAddress("forwarder-queue1")
@@ -182,7 +260,7 @@ class ForwardersTest extends BridgingBase {
         UserCredentials localUser = new UserCredentials("test", "test");
         resourcesManager.createOrUpdateUser(space, localUser);
 
-        int messagesBatch = 50;
+        int messagesBatch = 20;
 
         doTestReceiveInForwarder(space, forwarder, localUser, REMOTE_QUEUE1, messagesBatch);
     }


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

new systemtests

### Description

This PR includes 2 new tests for the bridging features:
- forwarding to a full queue and consuming the exceeded messages in '!!GLOBAL_DLQ' 
- configure a connector using secrets

In order to write those tests some minor refactor has been needed in the exsisting bridging classes

