### PR TITLE
Go types - ConnectorAddressRule should be an array type

### DIFF
--- a/pkg/apis/enmasse/v1beta1/types.go
+++ b/pkg/apis/enmasse/v1beta1/types.go
@@ -77,7 +77,7 @@ type ConnectorSpec struct {
 	EndpointHosts []ConnectorEndpointHost  `json:"endpointHosts"`
 	Tls           ConnectorTlsSpec         `json:"tls,omitempty"`
 	Credentials   ConnectorCredentialsSpec `json:"credentials,omitempty"`
-	Addresses     ConnectorAddressRule     `json:"addresses"`
+	Addresses     []ConnectorAddressRule   `json:"addresses"`
 }
 
 type ConnectorEndpointHost struct {

--- a/pkg/apis/enmasse/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/enmasse/v1beta1/zz_generated.deepcopy.go
@@ -428,7 +428,11 @@ func (in *ConnectorSpec) DeepCopyInto(out *ConnectorSpec) {
 	}
 	out.Tls = in.Tls
 	out.Credentials = in.Credentials
-	out.Addresses = in.Addresses
+	if in.Addresses != nil {
+		in, out := &in.Addresses, &out.Addresses
+		*out = make([]ConnectorAddressRule, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 


### PR DESCRIPTION
Unmarshalling an addressspace instance in Go with fowarding defined fails with an exception like this:

`panic: v1beta1.AddressSpaceList.Items: []v1beta1.AddressSpace: v1beta1.AddressSpace.Spec: v1beta1.AddressSpaceSpec.Connectors: []v1beta1.ConnectorSpec: v1beta1.ConnectorSpec.Addresses: readObjectStart: expect { or n, but found [, error found in #10 byte of ...|dresses":[{"name":"m|..., bigger context ...|uest"},"password":{"value":"guest"}},"addresses":[{"name":"myqueueKW","pattern":"*"},{"name":"X","pa|...
`