### PR TITLE
Fix upgrade test

### DIFF
--- a/agent/lib/router_config.js
+++ b/agent/lib/router_config.js
@@ -86,7 +86,22 @@ function listener_compare(a, b) {
 }
 
 function same_listener_definition(a, b) {
-    return a.host === b.host && a.port === b.port && a.authenticatePeer === b.authenticatePeer && a.metrics === b.metrics && a.healthz === b.healthz && a.http === b.http && a.websockets === b.websockets && a.httpRootDir === b.httpRootDir;
+    // NOTE: Special comparsion needed for legacy probe as schema for listener changed between
+    // router versions
+    if (a.port === '56711' && b.port === '56711') {
+        return a.host === b.host &&
+            a.port === b.port &&
+            a.authenticatePeer === b.authenticatePeer;
+    } else {
+        return a.host === b.host &&
+            a.port === b.port &&
+            a.authenticatePeer === b.authenticatePeer && 
+            a.metrics === b.metrics &&
+            a.healthz === b.healthz &&
+            a.http === b.http &&
+            a.websockets === b.websockets &&
+            a.httpRootDir === b.httpRootDir;
+    }
 }
 
 function listener_describe (a) {
@@ -390,6 +405,9 @@ function desired_address_config(high_level_address_definitions) {
         }
     }
     config.add_listener({host:'0.0.0.0', port: '8080', authenticatePeer: false, metrics: true, healthz: true, http: true, websockets: false, httpRootDir: 'invalid'})
+    // NOTE: The following listener exists in order to be able to proceed with upgrade from 0.26.x
+    // to master as the statefulset controller will not start rollout if probe is failing
+    config.add_listener({host:'0.0.0.0', port: '56711', authenticatePeer: true});
     sort_config(config);
     log.debug('mapped %j => %j', high_level_address_definitions, config);
     return config;

--- a/broker-plugin/plugin/src/main/resources/standard/sharded-queue/README.md
+++ b/broker-plugin/plugin/src/main/resources/standard/sharded-queue/README.md
@@ -1,0 +1,3 @@
+*NOTE*: The `broker.xml` file in this folder is needed to support upgrading
+from 0.26.X where sharded queues were deployed using this broker.xml rather 
+than as a colocated broker which is the case after 0.26.x.

--- a/broker-plugin/plugin/src/main/resources/standard/sharded-queue/broker.xml
+++ b/broker-plugin/plugin/src/main/resources/standard/sharded-queue/broker.xml
@@ -1,0 +1,144 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration xmlns="urn:activemq"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+
+   <core xmlns="urn:activemq:core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="urn:activemq:core ">
+
+      <name>$CONTAINER_ID</name>
+
+      <persistence-enabled>true</persistence-enabled>
+
+      <!-- this could be ASYNCIO or NIO
+       -->
+      <journal-type>ASYNCIO</journal-type>
+
+      <paging-directory>./data/paging</paging-directory>
+
+      <bindings-directory>./data/bindings</bindings-directory>
+
+      <journal-directory>./data/journal</journal-directory>
+
+      <large-messages-directory>./data/large-messages</large-messages-directory>
+
+      <journal-datasync>true</journal-datasync>
+
+      <journal-min-files>2</journal-min-files>
+
+      <journal-pool-files>-1</journal-pool-files>
+
+      <journal-file-size>10M</journal-file-size>
+
+      <journal-buffer-timeout>2212000</journal-buffer-timeout>
+
+
+      <!-- how often we are looking for how many bytes are being used on the disk in ms -->
+      <disk-scan-period>5000</disk-scan-period>
+
+      <!-- once the disk hits this limit the system will block, or close the connection in certain protocols
+           that won't support flow control. -->
+      <max-disk-usage>90</max-disk-usage>
+
+      <!-- should the broker detect dead locks and other issues -->
+      <critical-analyzer>true</critical-analyzer>
+
+      <critical-analyzer-timeout>120000</critical-analyzer-timeout>
+
+      <critical-analyzer-check-period>60000</critical-analyzer-check-period>
+
+      <critical-analyzer-policy>HALT</critical-analyzer-policy>
+
+      <global-max-size>${GLOBAL_MAX_SIZE}</global-max-size>
+
+      <acceptors>
+         <acceptor name="artemis">tcp://0.0.0.0:61616?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=CORE</acceptor>
+         <acceptor name="amqp">tcp://0.0.0.0:5673?protocols=AMQP;sslEnabled=true;keyStorePath=${KEYSTORE_PATH};keyStorePassword=enmasse;trustStorePath=${TRUSTSTORE_PATH};trustStorePassword=enmasse;verifyHost=false;needClientAuth=true</acceptor>
+      </acceptors>
+
+
+      <security-settings>
+         <security-setting-plugin class-name="io.enmasse.artemis.sasl_delegation.SaslGroupBasedSecuritySettingsPlugin">
+            <setting name="name" value="enmasse"/>
+            <setting name="useGroupsFromSaslDelegation" value="$KEYCLOAK_GROUP_PERMISSIONS"/>
+         </security-setting-plugin>
+      </security-settings>
+
+      <address-settings>
+         <!--default for catch all-->
+         <address-setting match="#">
+            <max-delivery-attempts>-1</max-delivery-attempts>
+            <redelivery-delay>1</redelivery-delay>
+            <redelivery-delay-multiplier>1.5</redelivery-delay-multiplier>
+            <max-redelivery-delay>10000</max-redelivery-delay>
+            <dead-letter-address>!!GLOBAL_DLQ</dead-letter-address>
+            <!-- with -1 only the global-max-size is in use for limiting -->
+            <max-size-bytes>-1</max-size-bytes>
+            <message-counter-history-day-limit>10</message-counter-history-day-limit>
+            <address-full-policy>${ADDRESS_FULL_POLICY}</address-full-policy>
+         </address-setting>
+      </address-settings>
+      <addresses>
+         <address name="!!GLOBAL_DLQ">
+           <anycast>
+             <queue name="!!GLOBAL_DLQ" />
+           </anycast>
+         </address>
+      </addresses>
+      <wildcard-addresses>
+        <enabled>true</enabled>
+        <delimiter>/</delimiter>
+        <any-words>#</any-words>
+        <single-word>+</single-word>
+      </wildcard-addresses>
+      <connector-services>
+        <connector-service name="$${dummy}override-amqp-connector-in">
+          <factory-class>org.apache.activemq.artemis.integration.amqp.AMQPConnectorServiceFactory</factory-class>
+          <param key="host" value="$MESSAGING_SERVICE_HOST" />
+          <param key="port" value="$MESSAGING_SERVICE_PORT_AMQPS_BROKER" />
+          <param key="containerId" value="$QUEUE_NAME-in" />
+          <param key="clusterId" value="$QUEUE_NAME" />
+          <param key="idleTimeoutMs" value="$CONNECTOR_IN_IDLE_TIMEOUT_MS" />
+          <param key="nettyThreads" value="$CONNECTOR_IN_NETTY_THREADS" />
+        </connector-service>
+        <connector-service name="$${dummy}override-amqp-connector-out">
+          <factory-class>org.apache.activemq.artemis.integration.amqp.AMQPConnectorServiceFactory</factory-class>
+          <param key="host" value="$MESSAGING_SERVICE_HOST" />
+          <param key="port" value="$MESSAGING_SERVICE_PORT_AMQPS_BROKER" />
+          <param key="containerId" value="$QUEUE_NAME-out" />
+          <param key="clusterId" value="$QUEUE_NAME" />
+          <param key="idleTimeoutMs" value="$CONNECTOR_OUT_IDLE_TIMEOUT_MS" />
+          <param key="nettyThreads" value="$CONNECTOR_OUT_NETTY_THREADS" />
+        </connector-service>
+        <connector-service name="$${dummy}override-dlq-out">
+          <factory-class>org.apache.activemq.artemis.integration.amqp.AMQPConnectorServiceFactory</factory-class>
+          <param key="host" value="$MESSAGING_SERVICE_HOST" />
+          <param key="port" value="$MESSAGING_SERVICE_PORT_AMQPS_BROKER" />
+          <param key="containerId" value="broker-global-dlq-out" />
+          <param key="clusterId" value="$QUEUE_NAME" />
+          <param key="idleTimeoutMs" value="$CONNECTOR_OUT_IDLE_TIMEOUT_MS" />
+          <param key="nettyThreads" value="$CONNECTOR_OUT_NETTY_THREADS" />
+        </connector-service>
+      </connector-services>
+   </core>
+</configuration>
+

--- a/broker-plugin/plugin/src/main/resources/standard/sharded-queue/broker.xml
+++ b/broker-plugin/plugin/src/main/resources/standard/sharded-queue/broker.xml
@@ -18,6 +18,12 @@ specific language governing permissions and limitations
 under the License.
 -->
 
+<!--
+NOTE: This file is needed to support upgrading from 0.26.X where sharded 
+queues were deployed using this broker.xml rather than as a colocated 
+broker which is the case after 0.26.x.
+-->
+
 <configuration xmlns="urn:activemq"
                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

This fixes an issue when upgrading where the router statefulset is not
completely rolled out after the upgrade. Once upgraded, the new agent
image will delete the old probe listener on the old router, causing the
readiness probe to fail. While the readiness probe is failing, the
rollout fails to proceed.

This fix re-adds the old probe which have to be kept around until
upgrading from 0.26.x is no longer supported.

Another upgrade issue fixed in this PR is that a missing sharded-queue/broker.xml causes sharded queues to not be reachable, as the draining broker is missing its broker.xml to be able to connect to the router.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
