### PR TITLE
Remove the need to parameterize TEMPLATE_DIR and RESOURCES_DIR during build

### DIFF
--- a/address-space-controller/Dockerfile
+++ b/address-space-controller/Dockerfile
@@ -11,4 +11,4 @@ ADD target/address-space-controller-${MAVEN_VERSION}-dist.tar.gz /
 
 ENV LOG_LEVEL info
 
-CMD ["/opt/run-java/launch_java.sh", "/address-space-controller.jar"]
+CMD ["/opt/run-java/launch_java.sh", "/opt/address-space-controller.jar"]

--- a/address-space-controller/src/assembly/unix-dist.xml
+++ b/address-space-controller/src/assembly/unix-dist.xml
@@ -28,7 +28,7 @@
     <fileSets>
         <fileSet>
           <directory>${project.basedir}/target/classes</directory>
-          <outputDirectory>/</outputDirectory>
+          <outputDirectory>/opt</outputDirectory>
           <includes>
             <include>brokeredinfraconfigs/*</include>
             <include>standardinfraconfigs/*</include>
@@ -42,9 +42,9 @@
     <files>
         <file>
           <source>${project.basedir}/target/address-space-controller-${project.version}.jar</source>
-          <outputDirectory>/</outputDirectory>
+          <outputDirectory>/opt</outputDirectory>
           <destName>address-space-controller.jar</destName>
-           <fileMode>0644</fileMode>
+          <fileMode>0644</fileMode>
         </file>
     </files>
 </assembly>

--- a/address-space-controller/src/main/resources/templates/standard-space-infra.yaml
+++ b/address-space-controller/src/main/resources/templates/standard-space-infra.yaml
@@ -237,7 +237,7 @@ objects:
           - name: CERT_DIR
             value: /etc/enmasse-certs
           - name: TEMPLATE_DIR
-            value: /templates
+            value: /opt/templates
           - name: STANDARD_INFRA_CONFIG_NAME
             value: ${STANDARD_INFRA_CONFIG_NAME}
           - name: ADDRESS_SPACE

--- a/standard-controller/Dockerfile
+++ b/standard-controller/Dockerfile
@@ -7,4 +7,4 @@ ENV VERSION=${version} COMMIT=${commit} MAVEN_VERSION=${maven_version}
 
 ADD target/standard-controller-${MAVEN_VERSION}-dist.tar.gz /
 
-CMD ["/opt/run-java/launch_java.sh", "/standard-controller.jar"]
+CMD ["/opt/run-java/launch_java.sh", "/opt/standard-controller.jar"]

--- a/standard-controller/src/assembly/unix-dist.xml
+++ b/standard-controller/src/assembly/unix-dist.xml
@@ -28,7 +28,7 @@
     <fileSets>
         <fileSet>
           <directory>${project.basedir}/target/classes</directory>
-          <outputDirectory>/</outputDirectory>
+          <outputDirectory>/opt</outputDirectory>
           <includes>
             <include>templates/*</include>
           </includes>
@@ -37,7 +37,7 @@
     <files>
         <file>
           <source>${project.basedir}/target/standard-controller-${project.version}.jar</source>
-          <outputDirectory>/</outputDirectory>
+          <outputDirectory>/opt</outputDirectory>
           <destName>standard-controller.jar</destName>
            <fileMode>0644</fileMode>
         </file>

--- a/templates/Makefile
+++ b/templates/Makefile
@@ -14,8 +14,6 @@ INSTALLNAME=enmasse-$(TAG)
 INSTALLDIR=$(BUILDDIR)/$(INSTALLNAME)
 PACKAGE_INSTALL_DIR=$(INSTALLDIR)/install
 HASHMARK = $(shell echo "\#")
-TEMPLATE_DIR=/templates
-RESOURCES_DIR=/
 
 IOT_MODULES=\
 	iot/api \
@@ -111,8 +109,6 @@ replace_images: prepare
 					  -e 's,\$${REPOSITORY},$(REPOSITORY),g' \
 					  -e 's,\$${SHORT_PRODUCT_NAME},$(SHORT_PRODUCT_NAME),g' \
 					  -e 's,\$${VERSIONED_NAME},$(VERSIONED_NAME),g' \
-					  -e 's,\$${TEMPLATE_DIR},$(TEMPLATE_DIR),g' \
-					  -e 's,\$${RESOURCES_DIR},$(RESOURCES_DIR),g' \
 					  -e 's,\$${CONSOLE_HTTPD_IMAGE},$(CONSOLE_HTTPD_IMAGE),g' \
 					> $$i.tmp; \
 		mv $$i.tmp $$i; \

--- a/templates/address-space-controller/050-Deployment-address-space-controller.yaml
+++ b/templates/address-space-controller/050-Deployment-address-space-controller.yaml
@@ -48,9 +48,9 @@ spec:
               name: address-space-controller-config
               optional: true
         - name: TEMPLATE_DIR
-          value: /templates
+          value: /opt/templates
         - name: RESOURCES_DIR
-          value: /
+          value: /opt
         - name: STANDARD_AUTHSERVICE_CONFIG_NAME
           value: keycloak-config
         - name: STANDARD_AUTHSERVICE_CREDENTIALS_SECRET_NAME

--- a/templates/csv/enmasse.clusterserviceversion.yaml
+++ b/templates/csv/enmasse.clusterserviceversion.yaml
@@ -790,9 +790,9 @@ spec:
                       name: address-space-controller-config
                       optional: true
                 - name: TEMPLATE_DIR
-                  value: ${TEMPLATE_DIR}
+                  value: /opt/templates
                 - name: RESOURCES_DIR
-                  value: ${RESOURCES_DIR}
+                  value: /opt
                 - name: STANDARD_AUTHSERVICE_CONFIG_NAME
                   value: keycloak-config
                 - name: STANDARD_AUTHSERVICE_CREDENTIALS_SECRET_NAME


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

This simplifies build process as there is no need to care about these variables.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
