### PR TITLE
Fix #3247: Fix path to probe endpoint used when running on Kubernetes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.30.0
 * Fix go tool vet on newer versions of go
+* #3247: Fix path to probe endpoint used when running on Kubernetes
 
 
 ## 0.29.0

--- a/pkg/controller/consoleservice/consoleservice_controller.go
+++ b/pkg/controller/consoleservice/consoleservice_controller.go
@@ -620,7 +620,7 @@ func applyDeployment(consoleservice *v1beta1.ConsoleService, deployment *appsv1.
 				return err
 			}
 			container.Args = []string{"-config=/apps/cfg/oauth-proxy-openshift.cfg"}
-			applyOauthProxyContainer(container, consoleservice)
+			applyOauthProxyContainer(container, consoleservice, "/oauth/healthz")
 
 			return nil
 		}); err != nil {
@@ -669,7 +669,7 @@ func applyDeployment(consoleservice *v1beta1.ConsoleService, deployment *appsv1.
 
 			container.Args = []string{"-config=/apps/cfg/oauth-proxy-kubernetes.cfg"}
 
-			applyOauthProxyContainer(container, consoleservice)
+			applyOauthProxyContainer(container, consoleservice, "/ping")
 
 			if consoleservice.Spec.Scope != nil {
 				install.ApplyEnv(container, "SSL_CERT_DIR", func(envvar *corev1.EnvVar) {
@@ -686,7 +686,7 @@ func applyDeployment(consoleservice *v1beta1.ConsoleService, deployment *appsv1.
 	return nil
 }
 
-func applyOauthProxyContainer(container *corev1.Container, consoleservice *v1beta1.ConsoleService) {
+func applyOauthProxyContainer(container *corev1.Container, consoleservice *v1beta1.ConsoleService, path string) {
 	install.ApplyVolumeMountSimple(container, "apps", "/apps", false)
 	install.ApplyVolumeMountSimple(container, "console-tls", "/etc/tls/private", true)
 	if consoleservice.Spec.OauthClientSecret != nil {
@@ -703,7 +703,7 @@ func applyOauthProxyContainer(container *corev1.Container, consoleservice *v1bet
 		Handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
 				Port:   intstr.FromString("https"),
-				Path:   "/oauth/healthz",
+				Path:   path,
 				Scheme: "HTTPS",
 			},
 		},
@@ -713,7 +713,7 @@ func applyOauthProxyContainer(container *corev1.Container, consoleservice *v1bet
 		Handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
 				Port:   intstr.FromString("https"),
-				Path:   "/oauth/healthz",
+				Path:   path,
 				Scheme: "HTTPS",
 			},
 		},


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Defect fix. Fix path to probe endpoint used when running on Kubernetes.  Caused crash looping pod owing to failing health probe.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md