### PR TITLE
Fix #2919: Document configuring OIDC for EnMasse Console on Kubernetes

### DIFF
--- a/documentation/assemblies/assembly-configuring.adoc
+++ b/documentation/assemblies/assembly-configuring.adoc
@@ -25,3 +25,10 @@ include::../assemblies/assembly-auth-services.adoc[leveloffset=+1]
 
 include::../modules/ref-example-roles.adoc[leveloffset=+1]
 
+ifeval::["{cmdcli}" == "kubectl"]
+include::../modules/proc-configure-openid-connect-for-kubernetes.adoc[leveloffset=+1]
+endif::[]
+
+
+
+

--- a/documentation/assemblies/assembly-using-console.adoc
+++ b/documentation/assemblies/assembly-using-console.adoc
@@ -7,6 +7,11 @@
 [id='assembly-using-console-{context}']
 = Using the {ConsoleName}
 
+ifeval::["{cmdcli}" == "kubectl"]
+.Prerequisites
+* You must have configured Kubernetes and the {Product Name} Console to use OpenID Connect. For more information see link:{BookUrlBase}{BaseProductVersion}{BookNameUrl}#config-openid-connect-for-kubernetes[Configuring the EnMasse Console to use OpenID Connect].
+endif::[]
+
 You can use the {ConsoleName} to perform tasks such as link:{BookUrlBase}{BaseProductVersion}{BookNameUrl}#proc-create-address-space-console-messaging[creating] and link:{BookUrlBase}{BaseProductVersion}{BookNameUrl}#proc-delete-address-space-console-messaging[deleting an address space], link:{BookUrlBase}{BaseProductVersion}{BookNameUrl}#create-address-console-messaging[creating an address], and link:{BookUrlBase}{BaseProductVersion}{BookNameUrl}#ref-view-message-connection-stats-table-messaging[viewing message and connection statistics].
 
 include::../modules/con-console.adoc[leveloffset=+1]

--- a/documentation/modules/proc-configure-openid-connect-for-kubernetes.adoc
+++ b/documentation/modules/proc-configure-openid-connect-for-kubernetes.adoc
@@ -14,7 +14,7 @@ as an Authentication Strategy.  Then you must create a `consoleservice` resource
 Before you begin you need to know the following details from your OpenID Connect provider:
 
 - OIDC Discovery URL
-- OIDC scopes
+** OIDC scopes
 - client id
 - client secret
 

--- a/documentation/modules/proc-configure-openid-connect-for-kubernetes.adoc
+++ b/documentation/modules/proc-configure-openid-connect-for-kubernetes.adoc
@@ -9,25 +9,22 @@ To use the {ProductName} Console on Kubernetes, you must configure Kubernetes to
 https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens[OpenID Connect (OIDC)]
 as an Authentication Strategy.  Then you must create a `consoleservice` resource refering to your OIDC Provider.
 
+
 .Prerequestises
-
-Before you begin you need to know the following details from your OpenID Connect provider:
-
-- OIDC Discovery URL
+* Before you begin you need to know the following details from your OpenID Connect provider:
+** OIDC Discovery URL
 ** OIDC scopes
 ** client ID
 ** client secret
++
+NOTE: If using a public OIDC provider (such as Google, Azure, GitHub, etc) the
+https://pusher.github.io/oauth2_proxy/auth-configuration[OAuthProxy configuration guide] offers specific guidance.
 
 * The Kubernetes api-server must be configured to use the
 https://kubernetes.io/docs/reference/access-authn-authz/authentication/#configuring-the-api-server[OpenID Connect plugin].
 +
 If you are using minikube, see  https://minikube.sigs.k8s.io/docs/tutorials/openid_connect_auth/[these instructions].
 will guide you.
-
-The correct setting for OIDC scopes varies depending on the OIDC provider.  Refer to your OIDC Provider's instructions.
-If using a public provider (such as Google, Azure, GitHub, etc) the
-https://pusher.github.io/oauth2_proxy/auth-configuration[OAuthProxy configuration guide] offers specific
-guidance for these providers.
 
 .Procedure
 

--- a/documentation/modules/proc-configure-openid-connect-for-kubernetes.adoc
+++ b/documentation/modules/proc-configure-openid-connect-for-kubernetes.adoc
@@ -18,7 +18,7 @@ Before you begin you need to know the following details from your OpenID Connect
 ** client ID
 ** client secret
 
-The Kubernetes api-server must be configured to use the
+* The Kubernetes api-server must be configured to use the
 https://kubernetes.io/docs/reference/access-authn-authz/authentication/#configuring-the-api-server[OpenID Connect plugin].
 +
 If you are using minikube, see  https://minikube.sigs.k8s.io/docs/tutorials/openid_connect_auth/[these instructions].

--- a/documentation/modules/proc-configure-openid-connect-for-kubernetes.adoc
+++ b/documentation/modules/proc-configure-openid-connect-for-kubernetes.adoc
@@ -5,7 +5,7 @@
 [id='config-openid-connect-for-kubernetes']
 = Configuring {ProductName} Console to use OpenID Connect
 
-In order to use the EnMasse Console on Kubernetes, you must configure Kubernetes to use
+To use the {ProductName} Console on Kubernetes, you must configure Kubernetes to use
 https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens[OpenID Connect (OIDC)]
 as an Authentication Strategy.  Then you must create a `consoleservice` resource refering to your OIDC Provider.
 

--- a/documentation/modules/proc-configure-openid-connect-for-kubernetes.adoc
+++ b/documentation/modules/proc-configure-openid-connect-for-kubernetes.adoc
@@ -15,7 +15,7 @@ Before you begin you need to know the following details from your OpenID Connect
 
 - OIDC Discovery URL
 ** OIDC scopes
-- client id
+** client ID
 - client secret
 
 The Kubernetes api-server must be configured to use the

--- a/documentation/modules/proc-configure-openid-connect-for-kubernetes.adoc
+++ b/documentation/modules/proc-configure-openid-connect-for-kubernetes.adoc
@@ -14,8 +14,8 @@ as an Authentication Strategy.  Then you must create a `consoleservice` resource
 * Before you begin you need to know the following details from your OpenID Connect provider:
 ** OIDC Discovery URL
 ** OIDC scopes
-** client ID
-** client secret
+** Client ID
+** Client secret
 +
 NOTE: If using a public OIDC provider (such as Google, Azure, GitHub, etc) the
 https://pusher.github.io/oauth2_proxy/auth-configuration[OAuthProxy configuration guide] offers specific guidance.

--- a/documentation/modules/proc-configure-openid-connect-for-kubernetes.adoc
+++ b/documentation/modules/proc-configure-openid-connect-for-kubernetes.adoc
@@ -16,7 +16,7 @@ Before you begin you need to know the following details from your OpenID Connect
 - OIDC Discovery URL
 ** OIDC scopes
 ** client ID
-- client secret
+** client secret
 
 The Kubernetes api-server must be configured to use the
 https://kubernetes.io/docs/reference/access-authn-authz/authentication/#configuring-the-api-server[OpenID Connect plugin].

--- a/documentation/modules/proc-configure-openid-connect-for-kubernetes.adoc
+++ b/documentation/modules/proc-configure-openid-connect-for-kubernetes.adoc
@@ -1,0 +1,66 @@
+// Module included in the following assemblies:
+//
+// assembly-configuring.adoc
+
+[id='config-openid-connect-for-kubernetes']
+= Configuring EnMasse Console to use OpenID Connect
+
+In order to use the EnMasse Console on Kubernetes, you must configure Kubernetes to use
+https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens[OpenID Connect (OIDC)]
+as an Authentication Strategy.  Then you must create a `consoleservice` resource refering to your OIDC Provider.
+
+.Prerequestises
+
+Before you begin you need to know the following details from your OpenID Connect provider:
+
+- OIDC Discovery URL
+- OIDC scopes
+- client id
+- client secret
+
+The Kubernetes api-server must be configured to use the
+https://kubernetes.io/docs/reference/access-authn-authz/authentication/#configuring-the-api-server[OpenID Connect plugin].
+If you are using minikube https://minikube.sigs.k8s.io/docs/tutorials/openid_connect_auth/[these instructions]
+will guide you.
+
+The correct setting for OIDC scopes varies depending on the OIDC provider.  Refer to your OIDC Provider's instructions.
+If using a public provider (such as Google, Azure, GitHub, etc) the
+https://pusher.github.io/oauth2_proxy/auth-configuration[OAuthProxy configuration guide] offers specific
+guidance for these providers.
+
+.Procedure
+
+. Select the namespace where {ProductName} is installed:
++
+[subs="+quotes,attributes",options="nowrap"]
+----
+{cmdcli} config set-context $(kubectl config current-context) --namespace=_{ProductNamespace}_
+----
+
+. Create a secret definition with the client-id/client-secret pair of your OIDC provider:
++
+[options="nowrap",subs="attributes"]
+----
+{cmdcli} create secret generic my-google-oidc-secret --from-literal=client-id=myclientid --from-literal=client-secret=mysecret
+----
+
+. Create a console services definition:
++
+[options="nowrap",subs="+quotes,attributes"]
+----
+cat <<EOF | {cmdcli} apply -f -
+apiVersion: admin.enmasse.io/v1beta1
+kind: ConsoleService
+metadata:
+    name: console
+spec:
+    discoveryMetadataURL: https://accounts.google.com/.well-known/openid-configuration
+    oauthClientSecret:
+        name: my-google-oidc-secret
+    scope: openid email
+EOF
+----
++
+NOTE: Replace the discovery URL and scopes with the appropriate values from your OIDC provider.  Ensure that
+oauthClientSecret references the secret created in the previous step.
+

--- a/documentation/modules/proc-configure-openid-connect-for-kubernetes.adoc
+++ b/documentation/modules/proc-configure-openid-connect-for-kubernetes.adoc
@@ -3,7 +3,7 @@
 // assembly-configuring.adoc
 
 [id='config-openid-connect-for-kubernetes']
-= Configuring EnMasse Console to use OpenID Connect
+= Configuring {ProductName} Console to use OpenID Connect
 
 In order to use the EnMasse Console on Kubernetes, you must configure Kubernetes to use
 https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens[OpenID Connect (OIDC)]

--- a/documentation/modules/proc-configure-openid-connect-for-kubernetes.adoc
+++ b/documentation/modules/proc-configure-openid-connect-for-kubernetes.adoc
@@ -20,7 +20,8 @@ Before you begin you need to know the following details from your OpenID Connect
 
 The Kubernetes api-server must be configured to use the
 https://kubernetes.io/docs/reference/access-authn-authz/authentication/#configuring-the-api-server[OpenID Connect plugin].
-If you are using minikube https://minikube.sigs.k8s.io/docs/tutorials/openid_connect_auth/[these instructions]
++
+If you are using minikube, see  https://minikube.sigs.k8s.io/docs/tutorials/openid_connect_auth/[these instructions].
 will guide you.
 
 The correct setting for OIDC scopes varies depending on the OIDC provider.  Refer to your OIDC Provider's instructions.


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Documentation

### Description

Contribute docs around configuring OIDC on Kubernetes to enable use of the EnMasse Console.  Does not apply to OpenShift.
 
### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md