### PR TITLE
Remove now redundant workaround restart of the router pods following upgrade

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/upgrade/UpgradeTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/upgrade/UpgradeTest.java
@@ -252,9 +252,6 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
         String images = Files.readString(imageEnvDir);
         log.info("Expected images: {}", images);
 
-        kubernetes.listPods().stream().filter(pod -> pod.getMetadata().getName().matches("^qdrouterd-.*-0"))
-                .forEach(pod -> kubernetes.deletePod(kubernetes.getInfraNamespace(), pod.getMetadata().getName()));
-
         TestUtils.waitUntilCondition("Images are updated", (phase) -> {
             AtomicBoolean ready = new AtomicBoolean(true);
             log.info("=======================================================");


### PR DESCRIPTION
Removes test workaround - relates to #3256
