### PR TITLE
improve testMessagingDuringRestartComponents

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/CommonTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/CommonTest.java
@@ -414,16 +414,21 @@ class CommonTest extends TestBase implements ITestBaseIsolated {
             for (Address addr : brokeredAddresses) {
                 log.info("Starting messaging in address {} and address space {}", addr.getSpec().getAddress(), brokered.getMetadata().getName());
                 for (Label label : labels) {
+                    getClientUtils().assertCanConnect(brokered, user, brokeredAddresses, resourcesManager);
                     doMessagingDuringRestart(label, runningPodsBefore, user, brokered, addr);
+                    getClientUtils().assertCanConnect(brokered, user, brokeredAddresses, resourcesManager);
                 }
             }
 
             for (Address addr : standardAddresses) {
                 log.info("Starting messaging in address {} and address space {}", addr.getSpec().getAddress(), standard.getMetadata().getName());
                 for (Label label : labels) {
+                    getClientUtils().assertCanConnect(standard, user, standardAddresses, resourcesManager);
                     doMessagingDuringRestart(label, runningPodsBefore, user, standard, addr);
+                    getClientUtils().assertCanConnect(standard, user, standardAddresses, resourcesManager);
                 }
             }
+
         } finally {
             // Ensure that EnMasse's API services are finished re-registering (after api-server restart) before ending
             // the test otherwise test clean-up will fail.


### PR DESCRIPTION
### Description

this PR reimplements the test CommonTest#testMessagingDuringRestartComponents in order to consume less resources because we have seen cases in which this test fails because of the recursion used

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
