### PR TITLE
Allow specifying the max number of router replicas

### DIFF
--- a/api-model/src/main/java/io/enmasse/admin/model/v1/StandardInfraConfigSpecRouter.java
+++ b/api-model/src/main/java/io/enmasse/admin/model/v1/StandardInfraConfigSpecRouter.java
@@ -27,6 +27,7 @@ import io.sundr.builder.annotations.Inline;
 public class StandardInfraConfigSpecRouter extends AbstractWithAdditionalProperties {
     private StandardInfraConfigSpecRouterResources resources;
     private Integer minReplicas;
+    private Integer maxReplicas;
     private Integer linkCapacity;
     private Integer handshakeTimeout;
     private Integer idleTimeout;
@@ -98,6 +99,14 @@ public class StandardInfraConfigSpecRouter extends AbstractWithAdditionalPropert
         this.policy = policy;
     }
 
+    public Integer getMaxReplicas() {
+        return maxReplicas;
+    }
+
+    public void setMaxReplicas(Integer maxReplicas) {
+        this.maxReplicas = maxReplicas;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -105,6 +114,7 @@ public class StandardInfraConfigSpecRouter extends AbstractWithAdditionalPropert
         StandardInfraConfigSpecRouter that = (StandardInfraConfigSpecRouter) o;
         return Objects.equals(resources, that.resources) &&
                 Objects.equals(minReplicas, that.minReplicas) &&
+                Objects.equals(maxReplicas, that.maxReplicas) &&
                 Objects.equals(handshakeTimeout, that.handshakeTimeout) &&
                 Objects.equals(idleTimeout, that.idleTimeout) &&
                 Objects.equals(linkCapacity, that.linkCapacity) &&
@@ -115,7 +125,7 @@ public class StandardInfraConfigSpecRouter extends AbstractWithAdditionalPropert
 
     @Override
     public int hashCode() {
-        return Objects.hash(resources, linkCapacity, minReplicas, handshakeTimeout, idleTimeout, workerThreads, policy, podTemplate);
+        return Objects.hash(resources, linkCapacity, minReplicas, maxReplicas, handshakeTimeout, idleTimeout, workerThreads, policy, podTemplate);
     }
 
     @Override
@@ -123,6 +133,7 @@ public class StandardInfraConfigSpecRouter extends AbstractWithAdditionalPropert
         return "StandardInfraConfigSpecRouter{" +
                 "resources=" + resources +
                 ", minReplicas=" + minReplicas +
+                ", maxReplicas=" + maxReplicas +
                 ", linkCapacity=" + linkCapacity +
                 ", handshakeTimeout=" + handshakeTimeout +
                 ", idleTimeout=" + idleTimeout +
@@ -131,4 +142,5 @@ public class StandardInfraConfigSpecRouter extends AbstractWithAdditionalPropert
                 ", podTemplate=" + podTemplate +
                 '}';
     }
+
 }

--- a/api-server/src/main/resources/swagger.json
+++ b/api-server/src/main/resources/swagger.json
@@ -482,6 +482,9 @@
                 "minReplicas": {
                     "type": "integer"
                 },
+                "maxReplicas": {
+                    "type": "integer"
+                },
                 "podTemplate": {
                     "$ref": "#/definitions/io.enmasse.admin.v1beta1.InfraConfigPodSpec"
                 },

--- a/documentation/common/restapi-reference.adoc
+++ b/documentation/common/restapi-reference.adoc
@@ -1640,6 +1640,8 @@ __optional__|integer
 __optional__|integer
 |**linkCapacity** +
 __optional__|integer
+|**maxReplicas** +
+__optional__|integer
 |**minReplicas** +
 __optional__|integer
 |**podTemplate** +

--- a/documentation/modules/ref-standard-infra-config-fields.adoc
+++ b/documentation/modules/ref-standard-infra-config-fields.adoc
@@ -43,6 +43,7 @@ This table shows the fields available for the standard infrastructure configurat
 |`router.linkCapacity` |Specifies the default number of credits issued on AMQP links for the router.
 |`router.handshakeTimeout` |Specifies the amount of time in seconds to wait for the secure handshake to be initiated.
 |`router.minReplicas` |Specifies the minimum number of router Pods to run; a minimum of two are required for high availability (HA) configuration.
+|`router.maxReplicas` |Specifies the maximum number of router Pods to run.
 |`router.podTemplate.metadata.labels` |Specifies the labels added to the router Pod.
 |`router.podTemplate.spec.affinity` |Specifies the affinity settings for the router Pod so you can specify where on particular nodes a pod runs, or if it cannot run together with other instances.
 |`router.podTemplate.spec.priorityClassName` |Specifies the priority class to use for the router Pod so you can prioritize router pods over other pods in the {KubePlatform} cluster.

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/AddressProvisioner.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/AddressProvisioner.java
@@ -448,7 +448,11 @@ public class AddressProvisioner {
                         .flatMap(infraConfig -> Optional.ofNullable(router.getInfraConfig().getSpec().getRouter()))
                         .flatMap(routerSpec -> Optional.ofNullable(routerSpec.getMinReplicas()))
                         .orElse(1);
-                router.setNewReplicas(Math.max(totalNeeded, infraConfigMin));
+                int infraConfigMax = Optional.ofNullable(router.getInfraConfig())
+                        .flatMap(infraConfig -> Optional.ofNullable(router.getInfraConfig().getSpec().getRouter()))
+                        .flatMap(routerSpec -> Optional.ofNullable(routerSpec.getMaxReplicas()))
+                        .orElse(Integer.MAX_VALUE);
+                router.setNewReplicas(Math.min(Math.max(totalNeeded, infraConfigMin), infraConfigMax));
             } else if ("broker".equals(resourceName)) {
                 // Provision pooled broker
                 int needPooled = sumNeededMatching(entry.getValue(), pooledPattern);

--- a/systemtests/src/main/java/io/enmasse/systemtest/utils/PlanUtils.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/utils/PlanUtils.java
@@ -66,9 +66,10 @@ public class PlanUtils {
     // Resources standard
     //////////////////////////////////////////////////////////////////////////////
 
-    public static StandardInfraConfigSpecRouter createStandardRouterResourceObject(String memory, int linkCapacity, int minReplicas) {
+    public static StandardInfraConfigSpecRouter createStandardRouterResourceObject(String memory, int linkCapacity, int minReplicas, int maxReplicas) {
         return new StandardInfraConfigSpecRouterBuilder()
                 .withMinReplicas(minReplicas)
+                .withMaxReplicas(maxReplicas)
                 .withLinkCapacity(linkCapacity)
                 .withNewPolicy()
                 .withMaxConnections(1000)

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/infra/standard/InfraTestStandard.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/infra/standard/InfraTestStandard.java
@@ -170,7 +170,7 @@ class InfraTestStandard extends InfraTestBase implements ITestIsolatedStandard {
                         .withStorage(brokerStorage)
                         .endResources()
                         .build())
-                .withRouter(PlanUtils.createStandardRouterResourceObject(routerMemory, 200, routerReplicas))
+                .withRouter(PlanUtils.createStandardRouterResourceObject(routerMemory, 200, routerReplicas, 6))
                 .withAdmin(new StandardInfraConfigSpecAdminBuilder()
                         .withNewResources()
                         .withMemory(adminMemory)
@@ -230,7 +230,7 @@ class InfraTestStandard extends InfraTestBase implements ITestIsolatedStandard {
                         .withStorage("1Gi")
                         .endResources()
                         .build())
-                .withRouter(PlanUtils.createStandardRouterResourceObject("256Mi", 200, 2))
+                .withRouter(PlanUtils.createStandardRouterResourceObject("256Mi", 200, 2, 6))
                 .withAdmin(new StandardInfraConfigSpecAdminBuilder()
                         .withNewResources()
                         .withMemory("512Mi")
@@ -260,6 +260,7 @@ class InfraTestStandard extends InfraTestBase implements ITestIsolatedStandard {
         assertEquals(expectedRouter.getResources().getMemory(), actualRouter.getResources().getMemory());
         assertEquals(expectedRouter.getLinkCapacity(), actualRouter.getLinkCapacity());
         assertEquals(expectedRouter.getMinReplicas(), actualRouter.getMinReplicas());
+        assertEquals(expectedRouter.getMaxReplicas(), actualRouter.getMaxReplicas());
         assertEquals(expectedRouter.getPolicy(), actualRouter.getPolicy());
     }
 

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/plans/standard/PlansTestStandard.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/plans/standard/PlansTestStandard.java
@@ -80,7 +80,7 @@ class PlansTestStandard extends TestBase implements ITestIsolatedStandard {
                         .withStorage("2Gi")
                         .endResources()
                         .build())
-                .withRouter(PlanUtils.createStandardRouterResourceObject("1Gi", 300, 1))
+                .withRouter(PlanUtils.createStandardRouterResourceObject("1Gi", 300, 1, 6))
                 .withAdmin(new StandardInfraConfigSpecAdminBuilder()
                         .withNewResources()
                         .withMemory("1Gi")

--- a/templates/crds/010-standardinfraconfigs.crd.yaml
+++ b/templates/crds/010-standardinfraconfigs.crd.yaml
@@ -142,6 +142,8 @@ spec:
                       type: string
                 minReplicas:
                   type: integer
+                maxReplicas:
+                  type: integer
                 linkCapacity:
                   type: integer
                 idleTimeout:


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

If this is set, the max number of routers in the address space plan will
be overridden by this value.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./documentation/design`
- [x] Write tests and make sure they pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
