### PR TITLE
Fix return code when device was already registered

### DIFF
--- a/iot/iot-device-registry-infinispan/src/main/java/io/enmasse/iot/registry/infinispan/device/impl/DeviceManagementServiceImpl.java
+++ b/iot/iot-device-registry-infinispan/src/main/java/io/enmasse/iot/registry/infinispan/device/impl/DeviceManagementServiceImpl.java
@@ -22,6 +22,7 @@ import org.eclipse.hono.service.management.Id;
 import org.eclipse.hono.service.management.OperationResult;
 import org.eclipse.hono.service.management.Result;
 import org.eclipse.hono.service.management.device.Device;
+import org.infinispan.client.hotrod.Flag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -54,6 +55,7 @@ public class DeviceManagementServiceImpl extends AbstractDeviceManagementService
         value.setRegistrationInformation(Json.encode(device));
 
         return this.managementCache
+                .withFlags(Flag.FORCE_RETURN_VALUE)
                 .putIfAbsentAsync(key, value)
                 .thenApply(result -> {
                     if (result == null) {

--- a/systemtests/src/test/java/io/enmasse/systemtest/iot/isolated/registry/DeviceRegistryTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/iot/isolated/registry/DeviceRegistryTest.java
@@ -19,11 +19,14 @@ import io.enmasse.systemtest.utils.IoTUtils;
 import org.eclipse.hono.service.management.device.Device;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
+
 import java.time.Duration;
 import java.time.Instant;
 import java.util.UUID;
 
 import static io.enmasse.systemtest.TestTag.SMOKE;
+import static java.net.HttpURLConnection.HTTP_CONFLICT;
+import static java.net.HttpURLConnection.HTTP_CREATED;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -37,11 +40,11 @@ abstract class DeviceRegistryTest extends TestBase implements ITestIoTIsolated {
 
 
     private String randomDeviceId;
-    private IoTConfig iotConfig = null;
-    private IoTProject iotProject = null;
-    private Endpoint deviceRegistryEndpoint = null;
-    private Endpoint httpAdapterEndpoint = null;
-    private DeviceRegistryClient client = null;
+    private IoTConfig iotConfig;
+    private IoTProject iotProject;
+    private Endpoint deviceRegistryEndpoint;
+    private Endpoint httpAdapterEndpoint;
+    private DeviceRegistryClient client;
 
     private UserCredentials credentials;
 
@@ -217,5 +220,19 @@ abstract class DeviceRegistryTest extends TestBase implements ITestIoTIsolated {
         assertEquals(HTTP_NOT_FOUND, response.statusCode());
     }
 
+    protected void doCreateDuplicateDeviceFails() throws Exception {
+        var tenantId = isolatedIoTManager.getTenantId();
+        var deviceId = UUID.randomUUID().toString();
+
+        // create device
+
+        var response = client.registerDeviceWithResponse(tenantId, deviceId);
+        assertEquals(HTTP_CREATED, response.statusCode());
+
+        // create device a second time
+
+        var response2 = client.registerDeviceWithResponse(tenantId, deviceId);
+        assertEquals(HTTP_CONFLICT, response2.statusCode());
+    }
 
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/iot/isolated/registry/FileDeviceRegistryTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/iot/isolated/registry/FileDeviceRegistryTest.java
@@ -5,11 +5,9 @@
 package io.enmasse.systemtest.iot.isolated.registry;
 
 import io.enmasse.iot.model.v1.IoTConfigBuilder;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static io.enmasse.systemtest.iot.DefaultDeviceRegistry.newFileBased;
-import static io.enmasse.systemtest.iot.DefaultDeviceRegistry.newInfinispanBased;
 import static io.enmasse.systemtest.utils.IoTUtils.assertCorrectRegistryType;
 
 class FileDeviceRegistryTest extends DeviceRegistryTest {
@@ -49,19 +47,8 @@ class FileDeviceRegistryTest extends DeviceRegistryTest {
     }
 
     @Test
-    @Disabled("Caches expire a bit unpredictably")
-    void testCacheExpiryForCredentials() throws Exception {
-        super.doTestCacheExpiryForCredentials();
-    }
-
-    @Test
     void testSetExpiryForCredentials() throws Exception {
         super.doTestSetExpiryForCredentials();
     }
 
-    @Test
-    @Disabled
-    void testCreateForNonExistingTenantFails() throws Exception {
-        super.doTestCreateForNonExistingTenantFails();
-    }
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/iot/isolated/registry/InfinispanDeviceRegistryTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/iot/isolated/registry/InfinispanDeviceRegistryTest.java
@@ -62,4 +62,9 @@ class InfinispanDeviceRegistryTest extends DeviceRegistryTest {
     void testCreateForNonExistingTenantFails() throws Exception {
         super.doTestCreateForNonExistingTenantFails();
     }
+
+    @Test
+    void testCreateDuplicateDeviceFails() throws Exception {
+        super.doCreateDuplicateDeviceFails();
+    }
 }


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

When a device gets created with the same id a second time, the request has to fail, but that didn't happen. The device was not created, and still "success" was returned.

This PR fixes this issue, and also adds a system test.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./documentation/design`
- [X] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [X] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
