### PR TITLE
Run router status collection in a separate thread

### DIFF
--- a/k8s-api/src/main/java/io/enmasse/k8s/api/ResourceChecker.java
+++ b/k8s-api/src/main/java/io/enmasse/k8s/api/ResourceChecker.java
@@ -29,6 +29,8 @@ public class ResourceChecker<T> implements CacheWatcher<T>, Runnable {
     public void start() {
         running = true;
         thread = new Thread(this);
+        thread.setName("resource-checker");
+        thread.setDaemon(true);
         thread.start();
 
     }

--- a/k8s-api/src/main/java/io/enmasse/k8s/api/cache/EventCache.java
+++ b/k8s-api/src/main/java/io/enmasse/k8s/api/cache/EventCache.java
@@ -78,7 +78,7 @@ public class EventCache<T> implements WorkQueue<T> {
             }
         }
         String key = firstEvent.obj != null ? fieldExtractor.getKey(firstEvent.obj) : null;
-        log.info("Processing event {} with key {}", firstEvent.eventType, key);
+        log.debug("Processing event {} with key {}", firstEvent.eventType, key);
         processor.process(firstEvent.obj);
     }
 

--- a/k8s-api/src/main/java/io/enmasse/k8s/api/cache/Reflector.java
+++ b/k8s-api/src/main/java/io/enmasse/k8s/api/cache/Reflector.java
@@ -54,7 +54,7 @@ public class Reflector<T extends HasMetadata, LT extends KubernetesResourceList<
                 nextResync = Instant.now(clock).plus(resyncInterval);
             }
             long sleepTime = Math.max(1, nextResync.toEpochMilli() - now.toEpochMilli());
-            log.info("Waiting on event queue for {} ms unless notified", sleepTime);
+            log.debug("Waiting on event queue for {} ms unless notified", sleepTime);
             queue.pop(processor, sleepTime, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/RouterStatusCache.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/RouterStatusCache.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2019, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.controller.standard;
+
+import io.enmasse.amqp.RouterManagement;
+import io.enmasse.k8s.api.EventLogger;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.internal.readiness.Readiness;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import static io.enmasse.controller.standard.ControllerKind.AddressSpace;
+import static io.enmasse.controller.standard.ControllerReason.RouterCheckFailed;
+import static io.enmasse.k8s.api.EventLogger.Type.Warning;
+
+public class RouterStatusCache implements Runnable {
+    private static final Logger log = LoggerFactory.getLogger(RouterStatusCache.class);
+    private final RouterManagement routerManagement;
+    private final Kubernetes kubernetes;
+    private final EventLogger eventLogger;
+    private final String addressSpace;
+
+    private volatile boolean running = false;
+    private Thread thread;
+    private final Duration checkInterval;
+    private final Object monitor = new Object();
+    private boolean needCheck = false;
+
+    private AtomicInteger routerCheckFailures = new AtomicInteger(0);
+    private volatile boolean checkRouterLinks = false;
+    private volatile List<RouterStatus> latestResult = Collections.emptyList();
+
+    RouterStatusCache(RouterManagement routerManagement, Kubernetes kubernetes, EventLogger eventLogger, String addressSpace, Duration checkInterval) {
+        this.routerManagement = routerManagement;
+        this.kubernetes = kubernetes;
+        this.eventLogger = eventLogger;
+        this.addressSpace = addressSpace;
+        this.checkInterval = checkInterval;
+    }
+
+    List<RouterStatus> getLatestResults() {
+        return latestResult;
+    }
+
+    void checkRouterStatus() {
+        RouterStatusCollector routerStatusCollector = new RouterStatusCollector(routerManagement, checkRouterLinks);
+        List<RouterStatus> routerStatusList = new ArrayList<>();
+        List<Pod> routers = kubernetes.listRouters().stream()
+                .filter(Readiness::isPodReady)
+                .collect(Collectors.toList());
+
+        log.info("Collecting status from {} routers", routers.size());
+        for (Pod router : routers) {
+            try {
+                RouterStatus routerStatus = routerStatusCollector.collect(router);
+                if (routerStatus != null) {
+                    routerStatusList.add(routerStatus);
+                }
+            } catch (Exception e) {
+                log.info("Error requesting router status from {}. Ignoring", router.getMetadata().getName(), e);
+                eventLogger.log(RouterCheckFailed, e.getMessage(), Warning, AddressSpace, addressSpace);
+                routerCheckFailures.incrementAndGet();
+            }
+        }
+        this.latestResult = routerStatusList;
+    }
+
+    public void setCheckRouterLinks(boolean checkRouterLinks) {
+        this.checkRouterLinks = checkRouterLinks;
+    }
+
+
+    public int getRouterCheckFailures() {
+        return routerCheckFailures.get();
+    }
+
+    public void start() {
+        running = true;
+        thread = new Thread(this);
+        thread.start();
+    }
+
+    public void stop() {
+        try {
+            running = false;
+            thread.interrupt();
+            thread.join();
+        } catch (InterruptedException ignored) {
+            log.warn("Interrupted while stopping", ignored);
+        }
+    }
+
+    @Override
+    public void run() {
+        while (running) {
+            try {
+                checkRouterStatus();
+                synchronized (monitor) {
+                    if (!needCheck) {
+                        monitor.wait(checkInterval.toMillis());
+                    }
+                    needCheck = false;
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (Exception e) {
+                log.warn("Exception in collector task", e);
+            }
+        }
+    }
+
+    public void wakeup() {
+        synchronized (monitor) {
+            needCheck = true;
+            monitor.notifyAll();
+        }
+    }
+}

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/RouterStatusCache.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/RouterStatusCache.java
@@ -87,6 +87,8 @@ public class RouterStatusCache implements Runnable {
     public void start() {
         running = true;
         thread = new Thread(this);
+        thread.setName("router-status-collector");
+        thread.setDaemon(true);
         thread.start();
     }
 

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/RouterStatusCollector.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/RouterStatusCollector.java
@@ -57,7 +57,7 @@ class RouterStatusCollector {
 
     private RouterStatus doCollectStatus(Pod router, int port) throws Exception {
         String host = router.getStatus().getPodIP();
-        log.debug("Checking router status of router : {}", router.getMetadata().getName());
+        log.debug("Collecting router status of router : {}", router.getMetadata().getName());
 
         Map<RouterEntity, List<List>> results;
         if (checkRouterLinks) {

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/StandardControllerOptions.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/StandardControllerOptions.java
@@ -18,6 +18,7 @@ public class StandardControllerOptions {
     private String infraUuid;
     private Duration resyncInterval;
     private Duration recheckInterval;
+    private Duration statusCheckInterval;
     private String version;
     private boolean enableEventLogger;
     private String authenticationServiceHost;
@@ -162,6 +163,10 @@ public class StandardControllerOptions {
                 .map(i -> Duration.ofSeconds(Long.parseLong(i)))
                 .orElse(Duration.ofSeconds(30)));
 
+        options.setStatusCheckInterval(getEnv(env, "STATUS_CHECK_INTERVAL")
+                .map(i -> Duration.ofSeconds(Long.parseLong(i)))
+                .orElse(Duration.ofSeconds(30)));
+
         options.setVersion(getEnvOrThrow(env, "VERSION"));
         options.setEnableEventLogger(getEnv(env, "ENABLE_EVENT_LOGGER").map(Boolean::parseBoolean).orElse(false));
 
@@ -241,5 +246,13 @@ public class StandardControllerOptions {
 
     public void setManagementConnectTimeout(Duration managementConnectTimeout) {
         this.managementConnectTimeout = managementConnectTimeout;
+    }
+
+    public Duration getStatusCheckInterval() {
+        return statusCheckInterval;
+    }
+
+    public void setStatusCheckInterval(Duration statusCheckInterval) {
+        this.statusCheckInterval = statusCheckInterval;
     }
 }


### PR DESCRIPTION


### Type of change

_Select the type of your PR_

- Bugfix

### Description

This change spins of router status collection into a separate thread. This prevents the status collection to block the reconciliation loop and should speed up the time between address creation and addresses being ready.

Fixes #3299

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
