### PR TITLE
Fix #3309: Filter router entity earlier to avoid router recon errors

### DIFF
--- a/agent/lib/router_config.js
+++ b/agent/lib/router_config.js
@@ -115,7 +115,8 @@ const entities = [
         equality:same_address_definition,
         describe:address_describe,
         type:'org.apache.qpid.dispatch.router.config.address',
-        singular:'address'
+        singular:'address',
+        filter: matches_qualifier
     },
     {
         name:'autolinks',
@@ -123,7 +124,8 @@ const entities = [
         equality:same_autolink_definition,
         describe:autolink_describe,
         type:'org.apache.qpid.dispatch.router.config.autoLink',
-        singular:'autolink'
+        singular:'autolink',
+        filter: matches_qualifier
     },
     {
         name:'linkroutes',
@@ -131,7 +133,8 @@ const entities = [
         equality:same_linkroute_definition,
         describe:linkroute_describe,
         type:'org.apache.qpid.dispatch.router.config.linkRoute',
-        singular:'linkroute'
+        singular:'linkroute',
+        filter: matches_qualifier
     },
     {
         name:'listeners',
@@ -139,7 +142,8 @@ const entities = [
         equality:same_listener_definition,
         describe:listener_describe,
         type:'org.apache.qpid.dispatch.listener',
-        singular:'listener'
+        singular:'listener',
+        filter: matches_qualifier
     }
 ];
 
@@ -231,6 +235,9 @@ function retrieve_elements(entity, router) {
     return router.query(entity.type).then(function (results) {
         if (Array.isArray(results)) {
             log.debug('retrieved %s from %s', entity.name, router_id);
+            if (entity.filter) {
+                results = results.filter(r => entity.filter(r));
+            }
             results.sort(entity.comparator);
             return results;
         } else {
@@ -280,7 +287,7 @@ function ensure_elements(entity, desired, router, collected) {
         var delta = myutils.changes(actual, desired, entity.comparator, entity.equality);
         if (delta) {
             log.debug('on %s, have %j, want %j => %s', router_id, actual, desired, delta.description);
-            let stale = delta.removed.filter(matches_qualifier).concat(delta.modified);
+            let stale = delta.removed.concat(delta.modified);
             let missing = delta.added.concat(delta.modified);
 
             if (stale.length || missing.length) {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Filter internally defined router entities earlier to avoid spurious reconciliation errors.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
