### PR TITLE
Hash plain text passwords in device registry

### DIFF
--- a/iot/iot-device-registry-infinispan/src/main/java/io/enmasse/iot/registry/infinispan/config/DeviceServiceConfiguration.java
+++ b/iot/iot-device-registry-infinispan/src/main/java/io/enmasse/iot/registry/infinispan/config/DeviceServiceConfiguration.java
@@ -5,6 +5,8 @@
 
 package io.enmasse.iot.registry.infinispan.config;
 
+import org.eclipse.hono.auth.HonoPasswordEncoder;
+import org.eclipse.hono.auth.SpringBasedHonoPasswordEncoder;
 import org.eclipse.hono.service.credentials.CredentialsAmqpEndpoint;
 import org.eclipse.hono.service.management.credentials.CredentialsManagementHttpEndpoint;
 import org.eclipse.hono.service.management.credentials.CredentialsManagementService;
@@ -80,4 +82,15 @@ public class DeviceServiceConfiguration {
         return new DeviceRegistryTokenAuthHandler(new DeviceRegistryTokenAuthProvider());
     }
 
+    /**
+     * Exposes a password encoder to use for encoding clear text passwords
+     * and for matching password hashes.
+     *
+     * @return The encoder.
+     */
+    @Bean
+    @Autowired
+    public HonoPasswordEncoder passwordEncoder(DeviceServiceProperties deviceServiceProperties) {
+        return new SpringBasedHonoPasswordEncoder(deviceServiceProperties.getMaxBcryptIterations());
+    }
 }

--- a/iot/iot-device-registry-infinispan/src/main/java/io/enmasse/iot/registry/infinispan/config/DeviceServiceProperties.java
+++ b/iot/iot-device-registry-infinispan/src/main/java/io/enmasse/iot/registry/infinispan/config/DeviceServiceProperties.java
@@ -18,9 +18,13 @@ public class DeviceServiceProperties {
 
     private static final int DEFAULT_TASK_EXECUTOR_QUEUE_SIZE = 1024;
     private static final Duration DEFAULT_CREDENTIALS_TTL = Duration.ofMinutes(1);
+    private static final int DEFAULT_MAX_BCRYPT_ITERATIONS = 10;
 
     private int taskExecutorQueueSize = DEFAULT_TASK_EXECUTOR_QUEUE_SIZE;
     private Duration credentialsTtl = DEFAULT_CREDENTIALS_TTL;
+
+    private int maxBcryptIterations = DEFAULT_MAX_BCRYPT_ITERATIONS;
+
 
     public int getTaskExecutorQueueSize() {
         return this.taskExecutorQueueSize;
@@ -41,4 +45,32 @@ public class DeviceServiceProperties {
         this.credentialsTtl = credentialsTtl;
     }
 
+    /**
+     * Gets the maximum number of iterations to use for bcrypt
+     * password hashes.
+     * <p>
+     * The default value of this property is 10.
+     *
+     * @return The maximum number.
+     */
+    public int getMaxBcryptIterations() {
+        return maxBcryptIterations;
+    }
+
+    /**
+     * Sets the maximum number of iterations to use for bcrypt
+     * password hashes.
+     * <p>
+     * The default value of this property is 10.
+     *
+     * @param iterations The maximum number.
+     * @throws IllegalArgumentException if iterations is &lt; 4 or &gt; 31.
+     */
+    public void setMaxBcryptIterations(final int iterations) {
+        if (iterations < 4 || iterations > 31) {
+            throw new IllegalArgumentException("iterations must be > 3 and < 32");
+        } else {
+            maxBcryptIterations = iterations;
+        }
+    }
 }

--- a/iot/iot-device-registry-infinispan/src/main/java/io/enmasse/iot/registry/infinispan/device/impl/CredentialsManagementServiceImpl.java
+++ b/iot/iot-device-registry-infinispan/src/main/java/io/enmasse/iot/registry/infinispan/device/impl/CredentialsManagementServiceImpl.java
@@ -28,9 +28,12 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
+import org.eclipse.hono.auth.HonoPasswordEncoder;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.service.management.OperationResult;
 import org.eclipse.hono.service.management.credentials.CommonCredential;
+import org.eclipse.hono.service.management.credentials.PasswordCredential;
+import org.eclipse.hono.service.management.credentials.PasswordSecret;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -46,6 +49,13 @@ import io.opentracing.Span;
 
 @Component
 public class CredentialsManagementServiceImpl extends AbstractCredentialsManagementService {
+
+    private HonoPasswordEncoder passwordEncoder;
+
+    @Autowired
+    public void setPasswordEncoder(final HonoPasswordEncoder passwordEncoder) {
+        this.passwordEncoder = passwordEncoder;
+    }
 
     @Autowired
     public CredentialsManagementServiceImpl(final DeviceManagementCacheProvider managementProvider, final AdapterCredentialsCacheProvider adapterProvider) {
@@ -70,6 +80,13 @@ public class CredentialsManagementServiceImpl extends AbstractCredentialsManagem
                     }
 
                     final DeviceInformation newValue = currentValue.getValue().newVersion();
+                    for(CommonCredential credential : credentials){
+                        try {
+                            checkCredential(credential);
+                        } catch (IllegalStateException e){
+                            return completedFuture(OperationResult.empty(HTTP_BAD_REQUEST));
+                        }
+                    }
                     newValue.setCredentials(toInternal(credentials));
 
                     final Collection<CredentialKey> affectedKeys;
@@ -204,4 +221,19 @@ public class CredentialsManagementServiceImpl extends AbstractCredentialsManagem
 
     }
 
+    /**
+     * Validate a secret and hash the password if necessary.
+     *
+     * @param credential The secret to validate.
+     * @throws IllegalStateException if the secret is not valid.
+     */
+    private void checkCredential(final CommonCredential credential) {
+        credential.checkValidity();
+        if (credential instanceof PasswordCredential) {
+            for (final PasswordSecret passwordSecret : ((PasswordCredential) credential).getSecrets()) {
+                passwordSecret.encode(passwordEncoder);
+                passwordSecret.checkValidity();
+            }
+        }
+    }
 }

--- a/iot/iot-device-registry-infinispan/src/main/java/io/enmasse/iot/registry/infinispan/util/Credentials.java
+++ b/iot/iot-device-registry-infinispan/src/main/java/io/enmasse/iot/registry/infinispan/util/Credentials.java
@@ -6,6 +6,7 @@
 package io.enmasse.iot.registry.infinispan.util;
 
 import static io.vertx.core.json.Json.decodeValue;
+import java.util.ArrayList;
 import static java.util.Arrays.asList;
 import static java.util.Arrays.stream;
 import static java.util.Collections.emptyList;
@@ -18,6 +19,8 @@ import java.util.stream.Stream;
 
 import org.eclipse.hono.service.management.credentials.CommonCredential;
 import org.eclipse.hono.service.management.credentials.GenericCredential;
+import org.eclipse.hono.service.management.credentials.PasswordCredential;
+import org.eclipse.hono.service.management.credentials.PasswordSecret;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.CredentialsConstants;
 
@@ -155,7 +158,30 @@ public final class Credentials {
         return credentials
                 .stream()
                 .map(Credentials::fromInternal)
+                // this breaks the gut - > put operation flows.
+                // This should be re-enabled when the `id` feature for secret is implemented.
+                //.map(Credentials::removePasswordDetails)
                 .collect(Collectors.toList());
 
+    }
+
+    /**
+     * Strips the hashed-password details from the secret if needed.
+     */
+    private static CommonCredential removePasswordDetails(final CommonCredential credential) {
+
+        if (JsonObject.mapFrom(credential).getString(CredentialsConstants.FIELD_TYPE).equals(CredentialsConstants.SECRETS_TYPE_HASHED_PASSWORD)) {
+            final PasswordCredential passwordCredential = (PasswordCredential) credential;
+            passwordCredential.getSecrets().forEach(secret -> {
+                secret.setHashFunction(null);
+                secret.setPasswordHash(null);
+                secret.setPasswordPlain(null);
+                secret.setSalt(null);
+            });
+
+                return passwordCredential;
+        } else {
+            return credential;
+        }
     }
 }

--- a/systemtests/src/main/java/io/enmasse/systemtest/iot/CredentialsRegistryClient.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/iot/CredentialsRegistryClient.java
@@ -128,6 +128,29 @@ public class CredentialsRegistryClient extends HonoApiClient {
         }
     }
 
+    static PasswordSecret createPlainPasswordSecret(final String authId, final String password, final Instant notAfter) {
+
+        final PasswordSecret secret = new PasswordSecret();
+        secret.setPasswordPlain(password);
+        secret.setNotAfter(notAfter);
+
+        return secret;
+    }
+
+    static PasswordCredential createPlainPasswordCredentialsObject(final String authId, final String password, final Instant notAfter) {
+
+        var secret = createPlainPasswordSecret(authId, password, notAfter);
+
+        // create credentials
+
+        var credentials = new PasswordCredential();
+        credentials.setAuthId(authId);
+        credentials.setSecrets(Collections.singletonList(secret));
+
+        return credentials;
+
+    }
+
     static PasswordCredential createCredentialsObject(final String authId, final String password, final Instant notAfter) {
 
         var secret = createPasswordSecret(authId, password, notAfter);
@@ -142,8 +165,16 @@ public class CredentialsRegistryClient extends HonoApiClient {
 
     }
 
+    public void addPlainPasswordCredentials(final String tenantId, final String deviceId, final String authId, final String password) throws Exception {
+        addPlainPasswordCredentials(tenantId, deviceId, authId, password, null);
+    }
+
     public void addCredentials(final String tenantId, final String deviceId, final String authId, final String password) throws Exception {
         addCredentials(tenantId, deviceId, authId, password, null);
+    }
+
+    public void addPlainPasswordCredentials(final String tenantId, final String deviceId, final String authId, final String password, final Instant notAfter) throws Exception {
+        addCredentials(tenantId, deviceId, Collections.singletonList(createPlainPasswordCredentialsObject(authId, password, notAfter)));
     }
 
     public void addCredentials(final String tenantId, final String deviceId, final String authId, final String password, final Instant notAfter) throws Exception {

--- a/systemtests/src/test/java/io/enmasse/systemtest/iot/isolated/registry/FileDeviceRegistryTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/iot/isolated/registry/FileDeviceRegistryTest.java
@@ -5,6 +5,7 @@
 package io.enmasse.systemtest.iot.isolated.registry;
 
 import io.enmasse.iot.model.v1.IoTConfigBuilder;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static io.enmasse.systemtest.iot.DefaultDeviceRegistry.newFileBased;
@@ -46,6 +47,16 @@ class FileDeviceRegistryTest extends DeviceRegistryTest {
         super.doTestDeviceCredentials();
     }
 
+    @Test
+    void testDeviceCredentialsPlainPassword() throws Exception {
+        super.doTestDeviceCredentialsPlainPassword();
+    }
+
+    @Test
+    @Disabled("Fixed in hono/pull/1565")
+    void testDeviceCredentialsDoesNotContainsPasswordDetails() throws Exception {
+        super.doTestDeviceCredentialsDoesNotContainsPasswordDetails();
+    }
     @Test
     void testSetExpiryForCredentials() throws Exception {
         super.doTestSetExpiryForCredentials();

--- a/systemtests/src/test/java/io/enmasse/systemtest/iot/isolated/registry/InfinispanDeviceRegistryTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/iot/isolated/registry/InfinispanDeviceRegistryTest.java
@@ -48,6 +48,17 @@ class InfinispanDeviceRegistryTest extends DeviceRegistryTest {
     }
 
     @Test
+    void testDeviceCredentialsPlainPassword() throws Exception {
+        super.doTestDeviceCredentialsPlainPassword();
+    }
+
+    @Test
+    @Disabled("Fixed in hono/pull/1565")
+    void testDeviceCredentialsDoesNotContainsPasswordDetails() throws Exception {
+        super.doTestDeviceCredentialsDoesNotContainsPasswordDetails();
+    }
+
+    @Test
     @Disabled("Caches expire a bit unpredictably")
     void testCacheExpiryForCredentials() throws Exception {
         super.doTestCacheExpiryForCredentials();


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

Use hono's  `SpringBasedHonoPasswordEncoder` to hash passwords in the device registry.
This should fix https://issues.jboss.org/browse/ENTMQMAAS-1388

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
