### PR TITLE
Bump application monitoring operator to 0.0.27

### DIFF
--- a/Makefile.env.mk
+++ b/Makefile.env.mk
@@ -37,7 +37,7 @@ CONSOLE_HTTPD_IMAGE ?= $(DOCKER_REGISTRY_PREFIX)$(DOCKER_ORG)/console-httpd:$(IM
 PROMETHEUS_IMAGE ?= prom/prometheus:v2.4.3
 ALERTMANAGER_IMAGE ?= prom/alertmanager:v0.15.2
 GRAFANA_IMAGE ?= grafana/grafana:5.3.1
-APPLICATION_MONITORING_OPERATOR_IMAGE ?= quay.io/integreatly/application-monitoring-operator:0.0.25
+APPLICATION_MONITORING_OPERATOR_IMAGE ?= quay.io/integreatly/application-monitoring-operator:0.0.27
 KUBE_STATE_METRICS_IMAGE ?= quay.io/coreos/kube-state-metrics:v1.4.0
 BROKER_IMAGE ?= quay.io/enmasse/artemis-base:2.10.1
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Bumped the application monitoring operator to version 0.0.27. This ensures that the v0.33.0 of the Prometheus operator is deployed, including the fix for the following bug:
[https://bugzilla.redhat.com/show_bug.cgi?id=1735691](https://bugzilla.redhat.com/show_bug.cgi?id=1735691)
