### PR TITLE
Resolve router deprecation warning logged during autolink creation

### DIFF
--- a/agent/lib/router_config.js
+++ b/agent/lib/router_config.js
@@ -41,7 +41,7 @@ function address_describe (a) {
 }
 
 function autolink_compare (a, b) {
-    return myutils.string_compare(a.addr, b.addr) || myutils.string_compare(a.direction, b.direction) || myutils.string_compare(a.containerId, b.containerId);
+    return myutils.string_compare(a.address, b.address) || myutils.string_compare(a.direction, b.direction) || myutils.string_compare(a.containerId, b.containerId);
 }
 
 function is_not_defined (a) {
@@ -55,11 +55,11 @@ function equivalent_container_id(a, b) {
 }
 
 function same_autolink_definition (a, b) {
-    return a.addr === b.addr && a.direction === b.direction && equivalent_container_id(a.containerId, b.containerId);
+    return a.address === b.address && a.direction === b.direction && equivalent_container_id(a.containerId, b.containerId);
 }
 
 function autolink_describe (a) {
-    return 'autolink ' + a.name + ' (dir: ' + a.direction + ', addr: ' + a.addr + ')';
+    return 'autolink ' + a.name + ' (dir: ' + a.direction + ', address: ' + a.address + ')';
 }
 
 function linkroute_compare (a, b) {
@@ -162,7 +162,7 @@ RouterConfig.prototype.add_address = function (a) {
 };
 
 RouterConfig.prototype.add_autolink = function (a) {
-    this.autolinks.push(myutils.merge({name: this.prefix + a.addr + '-' + a.containerId}, a));
+    this.autolinks.push(myutils.merge({name: this.prefix + a.address + '-' + a.containerId}, a));
 };
 
 RouterConfig.prototype.add_listener = function (a) {
@@ -374,16 +374,16 @@ function desired_address_config(high_level_address_definitions) {
                 for (var j in def.allocated_to) {
                     var brokerStatus = def.allocated_to[j];
                     if (brokerStatus.state === 'Active') {
-                        config.add_autolink_pair({addr:def.address, containerId: brokerStatus.containerId});
+                        config.add_autolink_pair({address:def.address, containerId: brokerStatus.containerId});
                     } else if (brokerStatus.state === 'Migrating') {
-                        config.add_autolink_pair({addr:def.address, containerId: brokerStatus.containerId});
+                        config.add_autolink_pair({address:def.address, containerId: brokerStatus.containerId});
                     } else if (brokerStatus.state === 'Draining') {
-                        config.add_autolink_in({addr:def.address, containerId: brokerStatus.containerId});
+                        config.add_autolink_in({address:def.address, containerId: brokerStatus.containerId});
                     }
                 }
             } else {
                 log.debug("Constructing old config for queue %s", def.address);
-                config.add_autolink_pair({addr:def.address, containerId: def.address});
+                config.add_autolink_pair({address:def.address, containerId: def.address});
             }
         } else if (def.type === 'topic') {
             if (def.allocated_to) {

--- a/agent/test/ragent.js
+++ b/agent/test/ragent.js
@@ -93,12 +93,12 @@ function verify_queue(name, all_addresses, all_autolinks, allocated_to) {
     assert.equal(addresses[0].distribution, 'balanced');
     assert.equal(addresses[0].waypoint, true);
 
-    var autolinks = remove(all_autolinks, function (o) { return o.addr === name; });
+    var autolinks = remove(all_autolinks, function (o) { return o.address === name; });
     if (allocated_to !== undefined) {
         if (allocated_to[0].state === 'Active') {
             assert.equal(autolinks.length, 2, 'did not find required autolinks for queue ' + name);
-            assert.equal(autolinks[0].addr, name);
-            assert.equal(autolinks[1].addr, name);
+            assert.equal(autolinks[0].address, name);
+            assert.equal(autolinks[1].address, name);
             if (autolinks[0].direction === 'in') {
                 assert.equal(autolinks[1].direction, 'out');
                 assert.equal(autolinks[0].containerId, util.format('%s-in', allocated_to[0].containerId));
@@ -116,8 +116,8 @@ function verify_queue(name, all_addresses, all_autolinks, allocated_to) {
         }
     } else {
         assert.equal(autolinks.length, 2, 'did not find required autolinks for queue ' + name);
-        assert.equal(autolinks[0].addr, name);
-        assert.equal(autolinks[1].addr, name);
+        assert.equal(autolinks[0].address, name);
+        assert.equal(autolinks[1].address, name);
         if (autolinks[0].direction === 'in') {
             assert.equal(autolinks[1].direction, 'out');
             assert.equal(autolinks[0].containerId, util.format('%s-in', name));
@@ -407,14 +407,14 @@ describe('basic router configuration', function() {
        function (router) {
            router.create_object('org.apache.qpid.dispatch.router.config.address', 'ragent-foo', {prefix:'foo', distribution:'closest', 'waypoint':false});
            router.create_object('org.apache.qpid.dispatch.router.config.linkRoute', 'ragent-bar', {prefix:'bar', direction:'in'});
-           router.create_object('org.apache.qpid.dispatch.router.config.autoLink', 'ragent-baz', {addr:'baz', direction:'out', containerId: 'baz'});
+           router.create_object('org.apache.qpid.dispatch.router.config.autoLink', 'ragent-baz', {address:'baz', direction:'out', containerId: 'baz'});
        }));
     it('removes or updates address config', simple_address_test([{address:'a',type:'topic'}, {address:'b',type:'queue'}, {address:'c',type:'anycast'}, {address:'d',type:'multicast'}], undefined,
        function (router) {
            router.create_object('org.apache.qpid.dispatch.router.config.address', 'ragent-a', {prefix:'a', distribution:'closest', 'waypoint':false});
            router.create_object('org.apache.qpid.dispatch.router.config.linkRoute', 'ragent-b-in', {prefix:'b', direction:'in'});
            router.create_object('org.apache.qpid.dispatch.router.config.linkRoute', 'ragent-b-out', {prefix:'b', direction:'out'});
-           router.create_object('org.apache.qpid.dispatch.router.config.autoLink', 'ragent-baz', {addr:'baz', direction:'out', containerId: 'baz'});
+           router.create_object('org.apache.qpid.dispatch.router.config.autoLink', 'ragent-baz', {address:'baz', direction:'out', containerId: 'baz'});
        }));
     it('configures addresses on multiple routers', multi_router_address_test(3, [{address:'a',type:'topic'}, {address:'b',type:'queue'}, {address:'c',type:'anycast'}, {address:'d',type:'multicast'}]));
     it('configures multiple routers into a full mesh', multi_router_address_test(6, [], function (routers) {

--- a/agent/test/router_stats.js
+++ b/agent/test/router_stats.js
@@ -100,7 +100,7 @@ function MockRouter (name) {
     this.name = name || router_names.next();
     events.EventEmitter.call(this);
     this.objects = {};
-    this.create_object('listener', 'default', {name:'default', addr:name, port:55672, role:'inter-router'});
+    this.create_object('listener', 'default', {name:'default', address:name, port:55672, role:'inter-router'});
     this.container = rhea.create_container({id:this.name});
     this.container.on('message', this.on_message.bind(this));
     var self = this;


### PR DESCRIPTION
The agent currently causes the Router to log a deprecation warning during auto link
creation.  This PR resolves that issue.

`The 'addr' attribute of autoLink has been deprecated. Use 'address' instead`

### Type of change

- Refactoring

### Description

As above.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
