### PR TITLE
systemtests detect disabled tests in TestInfo#tests

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/info/FakeExtensionContext.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/info/FakeExtensionContext.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2019, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.systemtest.info;
+
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestInstances;
+
+public class FakeExtensionContext implements ExtensionContext{
+
+    private Optional<Method> method;
+
+    public FakeExtensionContext(Optional<Method> method) throws ClassNotFoundException {
+        this.method = method;
+    }
+
+    @Override
+    public Optional<ExtensionContext> getParent() {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public ExtensionContext getRoot() {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public String getUniqueId() {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public String getDisplayName() {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public Set<String> getTags() {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public Optional<AnnotatedElement> getElement() {
+        return this.method.map(m -> (AnnotatedElement)m);
+    }
+
+    @Override
+    public Optional<Class<?>> getTestClass() {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public Optional<Lifecycle> getTestInstanceLifecycle() {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public Optional<Object> getTestInstance() {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public Optional<TestInstances> getTestInstances() {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public Optional<Method> getTestMethod() {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public Optional<Throwable> getExecutionException() {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public Optional<String> getConfigurationParameter(String key) {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public void publishReportEntry(Map<String, String> map) {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public Store getStore(Namespace namespace) {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+}

--- a/systemtests/src/main/java/io/enmasse/systemtest/info/MethodBasedExtensionContext.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/info/MethodBasedExtensionContext.java
@@ -14,11 +14,11 @@ import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestInstances;
 
-public class FakeExtensionContext implements ExtensionContext{
+public class MethodBasedExtensionContext implements ExtensionContext{
 
     private Optional<Method> method;
 
-    public FakeExtensionContext(Optional<Method> method) throws ClassNotFoundException {
+    public MethodBasedExtensionContext(Optional<Method> method) throws ClassNotFoundException {
         this.method = method;
     }
 

--- a/systemtests/src/main/java/io/enmasse/systemtest/info/TestInfo.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/info/TestInfo.java
@@ -56,7 +56,7 @@ public class TestInfo {
                     MethodSource testSource = (MethodSource) test.getSource().get();
                     try {
                         Optional<Method> testMethod = ReflectionUtils.findMethod(Class.forName(testSource.getClassName()), testSource.getMethodName(), testSource.getMethodParameterTypes());
-                        FakeExtensionContext fakeExtensionContext = new FakeExtensionContext(testMethod);
+                        MethodBasedExtensionContext fakeExtensionContext = new MethodBasedExtensionContext(testMethod);
                         if (testMethod.isPresent()) {
                             Optional<Disabled> disabled = AnnotationSupport.findAnnotation(testMethod.get(), Disabled.class);
                             ConditionEvaluationResult kubernetesDisabled = new AssumeKubernetesCondition().evaluateExecutionCondition(fakeExtensionContext);
@@ -89,12 +89,14 @@ public class TestInfo {
         }
     }
 
-    public boolean isAddressSpaceDeletable() {
+    public boolean isAddressSpaceDeleteable() {
+        boolean isDeleteable = true;
         int currentTestIndex = getCurrentTestIndex();
         if (currentTestIndex + 1 < tests.size()) {
-            return !isSameSharedTag(tests.get(currentTestIndex + 1), currentTest);
+            isDeleteable = !isSameSharedTag(tests.get(currentTestIndex + 1), currentTest);
         }
-        return true;
+        LOGGER.info("AddressSpace isDeleteable: {}", isDeleteable);
+        return isDeleteable;
     }
 
     public ExtensionContext getActualTest() {

--- a/systemtests/src/main/java/io/enmasse/systemtest/info/TestInfo.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/info/TestInfo.java
@@ -5,17 +5,27 @@
 package io.enmasse.systemtest.info;
 
 import io.enmasse.systemtest.TestTag;
+import io.enmasse.systemtest.condition.AssumeKubernetesCondition;
+import io.enmasse.systemtest.condition.AssumeOpenshiftCondition;
 import io.enmasse.systemtest.logs.CustomLogger;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.support.AnnotationSupport;
+import org.junit.platform.commons.util.ReflectionUtils;
+import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
 import org.slf4j.Logger;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
-
 /*
 Class for store and query information about test plan and tests
  */
@@ -24,8 +34,8 @@ public class TestInfo {
     private static TestInfo testInfo = null;
     private List<TestIdentifier> testClasses;
     private List<TestIdentifier> tests;
-    private ExtensionContext actualTest;
-    private ExtensionContext actualTestClass;
+    private ExtensionContext currentTest;
+    private ExtensionContext currentTestClass;
 
     public static synchronized TestInfo getInstance() {
         if (testInfo == null) {
@@ -36,10 +46,36 @@ public class TestInfo {
 
     public void setTestPlan(TestPlan testPlan) {
         LOGGER.info("Setting testplan");
+        tests = new ArrayList<>();
         testClasses = Arrays.asList(testPlan.getChildren(testPlan.getRoots()
                 .toArray(new TestIdentifier[0])[0]).toArray(new TestIdentifier[0]));
-        tests = new ArrayList<>();
-        testClasses.forEach(testIdentifier -> tests.addAll(testPlan.getChildren(testIdentifier)));
+        testClasses.forEach(testIdentifier -> {
+            testPlan.getChildren(testIdentifier)
+            .forEach(test -> {
+                if (test.getSource().isPresent() && test.getSource().get() instanceof MethodSource) {
+                    MethodSource testSource = (MethodSource) test.getSource().get();
+                    try {
+                        Optional<Method> testMethod = ReflectionUtils.findMethod(Class.forName(testSource.getClassName()), testSource.getMethodName(), testSource.getMethodParameterTypes());
+                        FakeExtensionContext fakeExtensionContext = new FakeExtensionContext(testMethod);
+                        if (testMethod.isPresent()) {
+                            Optional<Disabled> disabled = AnnotationSupport.findAnnotation(testMethod.get(), Disabled.class);
+                            ConditionEvaluationResult kubernetesDisabled = new AssumeKubernetesCondition().evaluateExecutionCondition(fakeExtensionContext);
+                            ConditionEvaluationResult openshiftDisabled = new AssumeOpenshiftCondition().evaluateExecutionCondition(fakeExtensionContext);
+                            if (disabled.isPresent() || kubernetesDisabled.isDisabled() || openshiftDisabled.isDisabled()) {
+                                LOGGER.debug("Test {}.{} is disabled", testSource.getClassName(), testSource.getMethodName());
+                            } else {
+                                tests.add(test);
+                            }
+                        }
+                    } catch ( ClassNotFoundException e ) {
+                        throw new IllegalArgumentException(e);
+                    }
+                } else {
+                    LOGGER.warn("Test {} doesn't have MethodSource", test.getUniqueId());
+                }
+            });
+        });
+        LOGGER.debug("Final tests are {}", tests);
     }
 
     public void printTestClasses() {
@@ -54,52 +90,38 @@ public class TestInfo {
     }
 
     public boolean isAddressSpaceDeletable() {
-        if (tests.size() > 0) {
-            int currentTestIndex = getCurrentTestIndex();
-            if (!(currentTestIndex == tests.size() - 1)) {
-                return !isSameSharedTag(tests.get(currentTestIndex + 1), actualTest);
-            }
+        int currentTestIndex = getCurrentTestIndex();
+        if (currentTestIndex + 1 < tests.size()) {
+            return !isSameSharedTag(tests.get(currentTestIndex + 1), currentTest);
         }
         return true;
     }
 
-    public boolean isSameClass(TestIdentifier test1, ExtensionContext test2) {
-        return test1 != null && test2 != null && test1.getUniqueId().contains(test2.getRequiredTestClass().getName());
+    public ExtensionContext getActualTest() {
+        return currentTest;
     }
 
-    public boolean isSameTestMethod(TestIdentifier test1, ExtensionContext test2) {
-        return test1 != null && test2 != null && test1.getLegacyReportingName().replaceAll("\\(.*\\)", "").equals(test2.getRequiredTestMethod().getName());
+    public void setCurrentTest(ExtensionContext test) {
+        currentTest = test;
     }
 
-    public List<String> getTags(TestIdentifier test) {
-        return test.getTags().stream().map(org.junit.platform.engine.TestTag::getName).collect(Collectors.toList());
-    }
-
-    public boolean isSameSharedTag(TestIdentifier test1, ExtensionContext test2) {
-        List<String> nextTestTags = getTags(test1);
-        List<String> currentTestTags = new ArrayList<>(test2.getTags());
-
-        return (nextTestTags.contains(TestTag.SHARED_BROKERED) && currentTestTags.contains(TestTag.SHARED_BROKERED))
-                || ((nextTestTags.contains(TestTag.SHARED_STANDARD) && !nextTestTags.contains(TestTag.SHARED_MQTT))
-                && (currentTestTags.contains(TestTag.SHARED_STANDARD) && !currentTestTags.contains(TestTag.SHARED_MQTT)))
-                || (nextTestTags.contains(TestTag.SHARED_MQTT) && currentTestTags.contains(TestTag.SHARED_MQTT))
-                || (nextTestTags.contains(TestTag.SHARED_IOT) && currentTestTags.contains(TestTag.SHARED_IOT));
+    public void setCurrentTestClass(ExtensionContext testClass) {
+        currentTestClass = testClass;
     }
 
     public boolean isTestShared() {
-        for (String tag : actualTest.getTags()) {
+        for (String tag : currentTest.getTags()) {
             if (TestTag.SHARED_TAGS.contains(tag)) {
                 LOGGER.info("Test is shared");
                 return true;
             }
         }
-
         LOGGER.info("Test is not shared!");
         return false;
     }
 
     public boolean isTestIoT() {
-        for (String tag : actualTest.getTags()) {
+        for (String tag : currentTest.getTags()) {
             if (TestTag.IOT_TAGS.contains(tag)) {
                 LOGGER.info("Test is IoT");
                 return true;
@@ -110,75 +132,71 @@ public class TestInfo {
     }
 
     public boolean isClassIoT() {
-        for (String tag : new ArrayList<>(actualTestClass.getTags())) {
-            if (TestTag.IOT_TAGS.contains(tag)) {
-                return true;
-            }
-        }
-        return false;
+        return currentTestClass.getTags().stream().anyMatch(tag -> TestTag.IOT_TAGS.contains(tag));
     }
 
     public boolean isEndOfIotTests() {
-        if (tests.size() > 0 && getCurrentTestIndex() + 1 < tests.size()) {
-            for (String tag : getTags(tests.get(getCurrentTestIndex() + 1))) {
-                if (TestTag.IOT_TAGS.contains(tag)) {
-                    return false;
-                }
-            }
+        int currentTestIndex = getCurrentTestIndex();
+        if (currentTestIndex + 1 < tests.size()) {
+            return getTags(tests.get(currentTestIndex + 1)).stream().anyMatch(tag -> TestTag.IOT_TAGS.contains(tag));
         }
         return true;
     }
 
     public boolean isUpgradeTest() {
-        for (String tag : new ArrayList<>(actualTestClass.getTags())) {
-            if (tag.equals(TestTag.UPGRADE)) {
-                return true;
-            }
-        }
-        return false;
+        return currentTestClass.getTags().stream().anyMatch(TestTag.UPGRADE::equals);
     }
 
     public boolean isNextTestUpgrade() {
-        if (testClasses.size() > 0 && getCurrentClassIndex() + 1 < testClasses.size()) {
-            for (String tag : new ArrayList<>(getTags(testClasses.get(getCurrentClassIndex() + 1)))) {
-                if (tag.equals(TestTag.UPGRADE)) {
-                    return true;
-                }
-            }
+        int currentClassIndex = getCurrentClassIndex();
+        if (currentClassIndex + 1 < testClasses.size()) {
+            return getTags(testClasses.get(currentClassIndex + 1)).stream().anyMatch(TestTag.UPGRADE::equals);
         }
         return false;
     }
 
-    public int getCurrentTestIndex() {
-        if (actualTest != null && tests.size() > 0) {
-            TestIdentifier test = tests.stream().filter(testIdentifier -> isSameTestMethod(testIdentifier, actualTest)
-                    && isSameClass(testIdentifier, actualTest)).findFirst().get();
+    private List<String> getTags(TestIdentifier test) {
+        return test.getTags().stream().map(org.junit.platform.engine.TestTag::getName).collect(Collectors.toList());
+    }
+
+    private boolean isSameSharedTag(TestIdentifier test1, ExtensionContext test2) {
+        List<String> nextTestTags = getTags(test1);
+        Set<String> currentTestTags = test2.getTags();
+
+        return (nextTestTags.contains(TestTag.SHARED_BROKERED) && currentTestTags.contains(TestTag.SHARED_BROKERED))
+                || (nextTestTags.contains(TestTag.SHARED_STANDARD) && currentTestTags.contains(TestTag.SHARED_STANDARD))
+                || (nextTestTags.contains(TestTag.SHARED_MQTT) && currentTestTags.contains(TestTag.SHARED_MQTT))
+                || (nextTestTags.contains(TestTag.SHARED_IOT) && currentTestTags.contains(TestTag.SHARED_IOT));
+    }
+
+    private int getCurrentTestIndex() {
+        if (currentTest != null && tests.size() > 0) {
+            TestIdentifier test = tests.stream()
+                    .filter(testIdentifier -> isSameTestMethod(testIdentifier, currentTest) && isSameClass(testIdentifier, currentTest))
+                    .findFirst()
+                    .get();
             return tests.indexOf(test);
         }
         return 0;
     }
 
-    public int getCurrentClassIndex() {
-        if (actualTestClass != null && testClasses.size() > 0) {
-            TestIdentifier test = testClasses.stream().filter(testClass -> isSameClass(testClass, actualTestClass)).findFirst().get();
+    private int getCurrentClassIndex() {
+        if (currentTestClass != null && testClasses.size() > 0) {
+            TestIdentifier test = testClasses.stream()
+                    .filter(testClass -> isSameClass(testClass, currentTestClass))
+                    .findFirst()
+                    .get();
             return testClasses.indexOf(test);
         }
         return 0;
     }
 
-    public List<TestIdentifier> getTests() {
-        return tests;
+    private boolean isSameClass(TestIdentifier test1, ExtensionContext test2) {
+        return test1 != null && test2 != null && test1.getUniqueId().contains(test2.getRequiredTestClass().getName());
     }
 
-    public ExtensionContext getActualTest() {
-        return actualTest;
+    private boolean isSameTestMethod(TestIdentifier test1, ExtensionContext test2) {
+        return test1 != null && test2 != null && test1.getDisplayName().equals(test2.getDisplayName());
     }
 
-    public void setActualTest(ExtensionContext test) {
-        actualTest = test;
-    }
-
-    public void setActualTestClass(ExtensionContext testClass) {
-        actualTestClass = testClass;
-    }
 }

--- a/systemtests/src/main/java/io/enmasse/systemtest/info/TestInfo.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/info/TestInfo.java
@@ -56,11 +56,11 @@ public class TestInfo {
                     MethodSource testSource = (MethodSource) test.getSource().get();
                     try {
                         Optional<Method> testMethod = ReflectionUtils.findMethod(Class.forName(testSource.getClassName()), testSource.getMethodName(), testSource.getMethodParameterTypes());
-                        MethodBasedExtensionContext fakeExtensionContext = new MethodBasedExtensionContext(testMethod);
+                        MethodBasedExtensionContext extensionContext = new MethodBasedExtensionContext(testMethod);
                         if (testMethod.isPresent()) {
                             Optional<Disabled> disabled = AnnotationSupport.findAnnotation(testMethod.get(), Disabled.class);
-                            ConditionEvaluationResult kubernetesDisabled = new AssumeKubernetesCondition().evaluateExecutionCondition(fakeExtensionContext);
-                            ConditionEvaluationResult openshiftDisabled = new AssumeOpenshiftCondition().evaluateExecutionCondition(fakeExtensionContext);
+                            ConditionEvaluationResult kubernetesDisabled = new AssumeKubernetesCondition().evaluateExecutionCondition(extensionContext);
+                            ConditionEvaluationResult openshiftDisabled = new AssumeOpenshiftCondition().evaluateExecutionCondition(extensionContext);
                             if (disabled.isPresent() || kubernetesDisabled.isDisabled() || openshiftDisabled.isDisabled()) {
                                 LOGGER.debug("Test {}.{} is disabled", testSource.getClassName(), testSource.getMethodName());
                             } else {

--- a/systemtests/src/main/java/io/enmasse/systemtest/listener/JunitCallbackListener.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/listener/JunitCallbackListener.java
@@ -94,7 +94,7 @@ public class JunitCallbackListener implements TestExecutionExceptionHandler, Lif
     }
 
     private void tearDownSharedResources() throws Exception {
-        if (testInfo.isAddressSpaceDeletable() || testInfo.getActualTest().getExecutionException().isPresent()) {
+        if (testInfo.isAddressSpaceDeleteable() || testInfo.getActualTest().getExecutionException().isPresent()) {
             if (testInfo.isTestIoT()) {
                 LOGGER.info("Teardown shared IoT!");
                 sharedIoTManager.tearDown(testInfo.getActualTest());

--- a/systemtests/src/main/java/io/enmasse/systemtest/listener/JunitCallbackListener.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/listener/JunitCallbackListener.java
@@ -44,7 +44,7 @@ public class JunitCallbackListener implements TestExecutionExceptionHandler, Lif
 
     @Override
     public void beforeAll(ExtensionContext context) throws Exception {
-        testInfo.setActualTestClass(context);
+        testInfo.setCurrentTestClass(context);
         if (!operatorManager.isEnmasseBundleDeployed() && !testInfo.isUpgradeTest()) {
             operatorManager.installEnmasseBundle();
         }
@@ -69,7 +69,7 @@ public class JunitCallbackListener implements TestExecutionExceptionHandler, Lif
 
     @Override
     public void beforeEach(ExtensionContext context) throws Exception {
-        testInfo.setActualTest(context);
+        testInfo.setCurrentTest(context);
     }
 
     @Override

--- a/systemtests/src/main/java/io/enmasse/systemtest/manager/SharedResourceManager.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/manager/SharedResourceManager.java
@@ -133,7 +133,7 @@ public class SharedResourceManager extends ResourceManager {
     }
 
     public void deleteSharedAddressSpace() {
-        if (sharedAddressSpace != null && TestInfo.getInstance().isAddressSpaceDeletable()) {
+        if (sharedAddressSpace != null && TestInfo.getInstance().isAddressSpaceDeleteable()) {
             LOGGER.info("Shared address {} space will be removed", sharedAddressSpace.getMetadata().getName());
             Environment env = Environment.getInstance();
             if (!env.skipCleanup()) {

--- a/systemtests/src/main/java/io/enmasse/systemtest/selenium/page/ConsoleWebPage.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/selenium/page/ConsoleWebPage.java
@@ -378,14 +378,6 @@ public class ConsoleWebPage implements IWebPage {
         return selenium.getWebElement(() -> selenium.getDriver().findElement(By.className("pficon-close")));
     }
 
-    private WebElement getNextButton() {
-        return getModalWindow().findElement(By.id("nextButton"));
-    }
-
-    private WebElement getModalWindow() {
-        return selenium.getDriver().findElement(By.className("modal-content"));
-    }
-
     /**
      * get the radio button for the destination
      */
@@ -449,7 +441,8 @@ public class ConsoleWebPage implements IWebPage {
     }
 
     public void next() throws Exception {
-        selenium.clickOnItem(getNextButton());
+        WebElement nextButton = selenium.getWebElement(() -> selenium.getDriver().findElement(By.id("nextButton")));
+        selenium.clickOnItem(nextButton);
     }
 
     public void clickOnAddressModalPageByNumber(Integer pageNumber) throws Exception {


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description
This PR fix an issue because of the incorrect tracking of the executed tests that made systemtests share address spaces wrongly between brokered and standard address space tests.

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
