### PR TITLE
Stop removing iot project after every test

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/manager/IsolatedIoTManager.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/manager/IsolatedIoTManager.java
@@ -70,7 +70,6 @@ public class IsolatedIoTManager extends ResourceManager {
                 tearDownProjects();
                 tearDownConfigs();
                 SystemtestsKubernetesApps.deleteInfinispanServer(kubernetes.getInfraNamespace());
-                kubernetes.deleteNamespace(IOT_PROJECT_NAMESPACE);
             } catch (Exception e) {
                 LOGGER.error("Error tearing down iot test: {}", e.getMessage());
                 throw e;

--- a/systemtests/src/main/java/io/enmasse/systemtest/manager/SharedIoTManager.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/manager/SharedIoTManager.java
@@ -74,7 +74,6 @@ public class SharedIoTManager extends ResourceManager {
             }
             tearDownSharedIoTConfig();
             SystemtestsKubernetesApps.deleteInfinispanServer(kubernetes.getInfraNamespace());
-            kubernetes.deleteNamespace(IOT_PROJECT_NAMESPACE);
         } else {
             LOGGER.info("Skip cleanup is set, no cleanup process");
         }


### PR DESCRIPTION
Kubernetes and ocp clusters has problems when we remove and create same namespace in evenry test. This should fix this problem.