### PR TITLE
try to fix racey test testMessagingDuringRestartComponents

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/amqp/AmqpClient.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/amqp/AmqpClient.java
@@ -149,6 +149,11 @@ public class AmqpClient implements AutoCloseable {
                 clients.remove(vertx);
                 closeVertxAndWait(Arrays.asList(vertx));
             }
+
+            @Override
+            public void closeGracefully() {
+                receiver.closeGracefully();
+            }
         };
     }
 

--- a/systemtests/src/main/java/io/enmasse/systemtest/amqp/ReceiverStatus.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/amqp/ReceiverStatus.java
@@ -13,4 +13,6 @@ public interface ReceiverStatus extends AutoCloseable {
     Future<List<Message>> getResult();
 
     int getNumReceived();
+
+    void closeGracefully();
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

test CommonTest#testMessagingDuringRestartComponents has a possible race condition in the way the sender and receiver are stopped. This PR tries to fix that introducing a wait between the stop of those two. Other solution could be changing the assertion and not focus on exact messages sent and received, we can discuss that.
