### PR TITLE
Stop adding service ports to network policy rule by default

### DIFF
--- a/address-space-controller/src/main/java/io/enmasse/controller/AddressSpaceController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/AddressSpaceController.java
@@ -90,7 +90,7 @@ public class AddressSpaceController {
         controllerChain.addController(new CreateController(kubernetes, schemaProvider, infraResourceFactory, eventLogger, authController.getDefaultCertProvider(), options.getVersion(), addressSpaceApi));
         controllerChain.addController(new RouterConfigController(controllerClient, controllerClient.getNamespace(), authenticationServiceResolver));
         controllerChain.addController(new RealmController(keycloakUserApi, authenticationServiceRegistry));
-        controllerChain.addController(new NetworkPolicyController(controllerClient, schemaProvider));
+        controllerChain.addController(new NetworkPolicyController(controllerClient));
         controllerChain.addController(new StatusController(kubernetes, schemaProvider, infraResourceFactory, authenticationServiceRegistry, userApi));
         controllerChain.addController(new RouterStatusController(controllerClient, controllerClient.getNamespace(), options));
         controllerChain.addController(new EndpointController(controllerClient, options.isExposeEndpointsByDefault(), isOpenShift));

--- a/address-space-controller/src/test/java/io/enmasse/controller/NetworkPolicyControllerTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/NetworkPolicyControllerTest.java
@@ -63,7 +63,7 @@ public class NetworkPolicyControllerTest extends JULInitializingTest {
         InfraConfig infraConfig = createTestInfra(createTestPolicy("my", "label"));
         AddressSpace addressSpace = createTestSpace(infraConfig, null);
 
-        NetworkPolicyController controller = new NetworkPolicyController(client, new TestSchemaProvider());
+        NetworkPolicyController controller = new NetworkPolicyController(client);
         controller.reconcile(addressSpace);
 
         assertEquals(1, client.network().networkPolicies().list().getItems().size());
@@ -80,7 +80,7 @@ public class NetworkPolicyControllerTest extends JULInitializingTest {
         InfraConfig infraConfig = createTestInfra(null);
         AddressSpace addressSpace = createTestSpace(infraConfig, createTestPolicy("my", "label"));
 
-        NetworkPolicyController controller = new NetworkPolicyController(client, new TestSchemaProvider());
+        NetworkPolicyController controller = new NetworkPolicyController(client);
         controller.reconcile(addressSpace);
 
         assertEquals(1, client.network().networkPolicies().list().getItems().size());
@@ -97,7 +97,7 @@ public class NetworkPolicyControllerTest extends JULInitializingTest {
         InfraConfig infraConfig = createTestInfra(createTestPolicy("my", "label"));
         AddressSpace addressSpace = createTestSpace(infraConfig, createTestPolicy("my", "overridden"));
 
-        NetworkPolicyController controller = new NetworkPolicyController(client, new TestSchemaProvider());
+        NetworkPolicyController controller = new NetworkPolicyController(client);
         controller.reconcile(addressSpace);
 
         assertEquals(1, client.network().networkPolicies().list().getItems().size());
@@ -116,7 +116,7 @@ public class NetworkPolicyControllerTest extends JULInitializingTest {
         AddressSpace addressSpace = createTestSpace(infraConfig,
                 createTestPolicy("my", "label1"));
 
-        NetworkPolicyController controller = new NetworkPolicyController(client, new TestSchemaProvider());
+        NetworkPolicyController controller = new NetworkPolicyController(client);
         controller.reconcile(addressSpace);
 
         assertEquals(1, client.network().networkPolicies().list().getItems().size());
@@ -149,7 +149,7 @@ public class NetworkPolicyControllerTest extends JULInitializingTest {
         InfraConfig infraConfig = createTestInfra(null);
         AddressSpace addressSpace = createTestSpace(infraConfig, createTestPolicy("my", "label"));
 
-        NetworkPolicyController controller = new NetworkPolicyController(client, new TestSchemaProvider());
+        NetworkPolicyController controller = new NetworkPolicyController(client);
         controller.reconcile(addressSpace);
 
         assertEquals(1, client.network().networkPolicies().list().getItems().size());


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

This prevents the user from deliberately opening all ports if desired.
The current list is in any case not sufficient to allow internal
components to talk to eachother.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
