### PR TITLE
Expose OkHttp3 read/write/connect timeouts for configuration

### DIFF
--- a/address-space-controller/src/main/java/io/enmasse/controller/AddressSpaceControllerOptions.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/AddressSpaceControllerOptions.java
@@ -35,6 +35,10 @@ public final class AddressSpaceControllerOptions {
     private Duration managementQueryTimeout;
     private Duration managementConnectTimeout;
 
+    private Duration kubernetesApiConnectTimeout;
+    private Duration kubernetesApiReadTimeout;
+    private Duration kubernetesApiWriteTimeout;
+
     public File getTemplateDir() {
         return templateDir;
     }
@@ -108,6 +112,19 @@ public final class AddressSpaceControllerOptions {
         options.setManagementConnectTimeout(getEnv(env, "MANAGEMENT_CONNECT_TIMEOUT")
                 .map(i -> Duration.ofSeconds(Long.parseLong(i)))
                 .orElse(Duration.ofSeconds(30)));
+
+        options.setKubernetesApiConnectTimeout(getEnv(env, "KUBERNETES_API_CONNECT_TIMEOUT")
+                .map(i -> Duration.ofSeconds(Long.parseLong(i)))
+                .orElse(Duration.ofSeconds(30)));
+
+        options.setKubernetesApiReadTimeout(getEnv(env, "KUBERNETES_API_READ_TIMEOUT")
+                .map(i -> Duration.ofSeconds(Long.parseLong(i)))
+                .orElse(Duration.ofSeconds(30)));
+
+        options.setKubernetesApiWriteTimeout(getEnv(env, "KUBERNETES_API_WRITE_TIMEOUT")
+                .map(i -> Duration.ofSeconds(Long.parseLong(i)))
+                .orElse(Duration.ofSeconds(30)));
+
 
         options.setVersion(getEnvOrThrow(env, "VERSION"));
         return options;
@@ -210,6 +227,9 @@ public final class AddressSpaceControllerOptions {
                 ", standardAuthserviceCertSecretName='" + standardAuthserviceCertSecretName + '\'' +
                 ", managementQueryTimeout='" + managementQueryTimeout + '\'' +
                 ", managementConnectTimeout='" + managementConnectTimeout + '\'' +
+                ", kubernetesApiConnectTimeout='" + kubernetesApiConnectTimeout + '\'' +
+                ", kubernetesApiReadTimeout='" + kubernetesApiReadTimeout + '\'' +
+                ", kubernetesApiWriteTimeout='" + kubernetesApiWriteTimeout + '\'' +
                 '}';
     }
 
@@ -236,4 +256,29 @@ public final class AddressSpaceControllerOptions {
     public void setManagementConnectTimeout(Duration managementConnectTimeout) {
         this.managementConnectTimeout = managementConnectTimeout;
     }
+
+    public Duration getKubernetesApiConnectTimeout() {
+        return kubernetesApiConnectTimeout;
+    }
+
+    public void setKubernetesApiConnectTimeout(Duration kubernetesApiConnectTimeout) {
+        this.kubernetesApiConnectTimeout = kubernetesApiConnectTimeout;
+    }
+
+    public Duration getKubernetesApiReadTimeout() {
+        return kubernetesApiReadTimeout;
+    }
+
+    public void setKubernetesApiReadTimeout(Duration kubernetesApiReadTimeout) {
+        this.kubernetesApiReadTimeout = kubernetesApiReadTimeout;
+    }
+
+    public Duration getKubernetesApiWriteTimeout() {
+        return kubernetesApiWriteTimeout;
+    }
+
+    public void setKubernetesApiWriteTimeout(Duration kubernetesApiWriteTimeout) {
+        this.kubernetesApiWriteTimeout = kubernetesApiWriteTimeout;
+    }
+
 }

--- a/api-server/src/main/java/io/enmasse/api/server/ApiServerOptions.java
+++ b/api-server/src/main/java/io/enmasse/api/server/ApiServerOptions.java
@@ -21,6 +21,9 @@ public class ApiServerOptions {
     private String apiserverClientCaConfigName;
     private String apiserverClientCaConfigNamespace;
     private Duration userApiTimeout;
+    private Duration kubernetesApiConnectTimeout;
+    private Duration kubernetesApiReadTimeout;
+    private Duration kubernetesApiWriteTimeout;
     private String version;
 
     public static ApiServerOptions fromEnv(Map<String, String> env) {
@@ -39,6 +42,18 @@ public class ApiServerOptions {
         options.setUserApiTimeout(getEnv(env, "USER_API_TIMEOUT")
                 .map(i -> Duration.ofSeconds(Long.parseLong(i)))
                 .orElse(Duration.ofSeconds(10)));
+
+        options.setKubernetesApiConnectTimeout(getEnv(env, "KUBERNETES_API_CONNECT_TIMEOUT")
+                .map(i -> Duration.ofSeconds(Long.parseLong(i)))
+                .orElse(Duration.ofSeconds(30)));
+
+        options.setKubernetesApiReadTimeout(getEnv(env, "KUBERNETES_API_READ_TIMEOUT")
+                .map(i -> Duration.ofSeconds(Long.parseLong(i)))
+                .orElse(Duration.ofSeconds(30)));
+
+        options.setKubernetesApiWriteTimeout(getEnv(env, "KUBERNETES_API_WRITE_TIMEOUT")
+                .map(i -> Duration.ofSeconds(Long.parseLong(i)))
+                .orElse(Duration.ofSeconds(30)));
 
         options.setEnableRbac(Boolean.parseBoolean(getEnv(env, "ENABLE_RBAC").orElse("false")));
 
@@ -130,5 +145,46 @@ public class ApiServerOptions {
 
     public void setVersion(String version) {
         this.version = version;
+    }
+
+    public Duration getKubernetesApiConnectTimeout() {
+        return kubernetesApiConnectTimeout;
+    }
+
+    public void setKubernetesApiConnectTimeout(Duration kubernetesApiConnectTimeout) {
+        this.kubernetesApiConnectTimeout = kubernetesApiConnectTimeout;
+    }
+
+    public Duration getKubernetesApiReadTimeout() {
+        return kubernetesApiReadTimeout;
+    }
+
+    public void setKubernetesApiReadTimeout(Duration kubernetesApiReadTimeout) {
+        this.kubernetesApiReadTimeout = kubernetesApiReadTimeout;
+    }
+
+    public Duration getKubernetesApiWriteTimeout() {
+        return kubernetesApiWriteTimeout;
+    }
+
+    public void setKubernetesApiWriteTimeout(Duration kubernetesApiWriteTimeout) {
+        this.kubernetesApiWriteTimeout = kubernetesApiWriteTimeout;
+    }
+
+    @Override
+    public String toString() {
+        return "ApiServerOptions{" +
+                "namespace='" + namespace + '\'' +
+                ", certDir='" + certDir + '\'' +
+                ", resyncInterval=" + resyncInterval +
+                ", enableRbac=" + enableRbac +
+                ", apiserverClientCaConfigName='" + apiserverClientCaConfigName + '\'' +
+                ", apiserverClientCaConfigNamespace='" + apiserverClientCaConfigNamespace + '\'' +
+                ", userApiTimeout=" + userApiTimeout +
+                ", kubernetesApiConnectTimeout=" + kubernetesApiConnectTimeout +
+                ", kubernetesApiReadTimeout=" + kubernetesApiReadTimeout +
+                ", kubernetesApiWriteTimeout=" + kubernetesApiWriteTimeout +
+                ", version='" + version + '\'' +
+                '}';
     }
 }

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/StandardController.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/StandardController.java
@@ -13,6 +13,10 @@ import io.enmasse.config.AnnotationKeys;
 import io.enmasse.k8s.api.*;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.utils.HttpClientUtils;
+import okhttp3.OkHttpClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,7 +71,14 @@ public class StandardController {
     private HTTPServer httpServer;
 
     public StandardController(StandardControllerOptions options) {
-        this.kubeClient = new DefaultKubernetesClient();
+        Config config = new ConfigBuilder().build();
+        OkHttpClient httpClient = HttpClientUtils.createHttpClient(config);
+        httpClient = httpClient.newBuilder()
+                .connectTimeout(options.getKubernetesApiConnectTimeout())
+                .writeTimeout(options.getKubernetesApiWriteTimeout())
+                .readTimeout(options.getKubernetesApiReadTimeout())
+                .build();
+        this.kubeClient = new DefaultKubernetesClient(httpClient, config);
         this.options = options;
     }
 

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/StandardControllerOptions.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/StandardControllerOptions.java
@@ -28,6 +28,9 @@ public class StandardControllerOptions {
     private String authenticationServiceSaslInitHost;
     private Duration managementQueryTimeout;
     private Duration managementConnectTimeout;
+    private Duration kubernetesApiConnectTimeout;
+    private Duration kubernetesApiReadTimeout;
+    private Duration kubernetesApiWriteTimeout;
 
     public String getCertDir() {
         return certDir;
@@ -178,6 +181,18 @@ public class StandardControllerOptions {
                 .map(i -> Duration.ofSeconds(Long.parseLong(i)))
                 .orElse(Duration.ofSeconds(30)));
 
+        options.setKubernetesApiConnectTimeout(getEnv(env, "KUBERNETES_API_CONNECT_TIMEOUT")
+                .map(i -> Duration.ofSeconds(Long.parseLong(i)))
+                .orElse(Duration.ofSeconds(30)));
+
+        options.setKubernetesApiReadTimeout(getEnv(env, "KUBERNETES_API_READ_TIMEOUT")
+                .map(i -> Duration.ofSeconds(Long.parseLong(i)))
+                .orElse(Duration.ofSeconds(30)));
+
+        options.setKubernetesApiWriteTimeout(getEnv(env, "KUBERNETES_API_WRITE_TIMEOUT")
+                .map(i -> Duration.ofSeconds(Long.parseLong(i)))
+                .orElse(Duration.ofSeconds(30)));
+
         return options;
     }
 
@@ -225,6 +240,9 @@ public class StandardControllerOptions {
                 ", authenticationServiceSaslInitHost='" + authenticationServiceSaslInitHost + '\'' +
                 ", managementQueryTimeout='" + managementQueryTimeout + '\'' +
                 ", managementConnectTimeout='" + managementConnectTimeout + '\'' +
+                ", kubernetesApiConnectTimeout='" + kubernetesApiConnectTimeout + '\'' +
+                ", kubernetesApiReadTimeout='" + kubernetesApiReadTimeout + '\'' +
+                ", kubernetesApiWriteTimeout='" + kubernetesApiWriteTimeout + '\'' +
                 '}';
     }
 
@@ -255,4 +273,29 @@ public class StandardControllerOptions {
     public void setStatusCheckInterval(Duration statusCheckInterval) {
         this.statusCheckInterval = statusCheckInterval;
     }
+
+    public Duration getKubernetesApiConnectTimeout() {
+        return kubernetesApiConnectTimeout;
+    }
+
+    public void setKubernetesApiConnectTimeout(Duration kubernetesApiConnectTimeout) {
+        this.kubernetesApiConnectTimeout = kubernetesApiConnectTimeout;
+    }
+
+    public Duration getKubernetesApiReadTimeout() {
+        return kubernetesApiReadTimeout;
+    }
+
+    public void setKubernetesApiReadTimeout(Duration kubernetesApiReadTimeout) {
+        this.kubernetesApiReadTimeout = kubernetesApiReadTimeout;
+    }
+
+    public Duration getKubernetesApiWriteTimeout() {
+        return kubernetesApiWriteTimeout;
+    }
+
+    public void setKubernetesApiWriteTimeout(Duration kubernetesApiWriteTimeout) {
+        this.kubernetesApiWriteTimeout = kubernetesApiWriteTimeout;
+    }
+
 }

--- a/systemtests/pom.xml
+++ b/systemtests/pom.xml
@@ -106,6 +106,13 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
+            <exclusions>
+                <!-- Prevent Selenium dependency managing okhttp3 back to 3.11.  Remove on upgrade to Selenium 4 -->
+                <exclusion>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.paulhammant</groupId>

--- a/systemtests/src/main/java/io/enmasse/systemtest/Environment.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/Environment.java
@@ -10,6 +10,8 @@ import io.fabric8.kubernetes.client.Config;
 import org.slf4j.Logger;
 
 import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.Optional;
 
 public class Environment {
     public static final String KEYCLOAK_ADMIN_PASSWORD_ENV = "KEYCLOAK_ADMIN_PASSWORD";
@@ -20,6 +22,9 @@ public class Environment {
     public static final String K8S_API_TOKEN_ENV = "KUBERNETES_API_TOKEN";
     public static final String ENMASSE_VERSION_SYSTEM_PROPERTY = "enmasse.version";
     public static final String K8S_DOMAIN_ENV = "KUBERNETES_DOMAIN";
+    public static final String K8S_API_CONNECT_TIMEOUT = "KUBERNETES_API_CONNECT_TIMEOUT";
+    public static final String K8S_API_READ_TIMEOUT = "KUBERNETES_API_READ_TIMEOUT";
+    public static final String K8S_API_WRITE_TIMEOUT = "KUBERNETES_API_WRITE_TIMEOUT";
     public static final String UPGRADE_TEPLATES_ENV = "UPGRADE_TEMPLATES";
     public static final String START_TEMPLATES_ENV = "START_TEMPLATES";
     public static final String TEMPLATES_PATH = "TEMPLATES";
@@ -50,6 +55,10 @@ public class Environment {
     private final String appName = System.getenv().getOrDefault(APP_NAME_ENV, "enmasse");
     private final boolean skipSaveState = Boolean.parseBoolean(System.getenv(SKIP_SAVE_STATE));
     private final boolean skipDeployInfinispan = Boolean.parseBoolean(System.getenv(SKIP_DEPLOY_INFINISPAN));
+    private final Duration kubernetesApiConnectTimeout = Optional.ofNullable(System.getenv().get(K8S_API_CONNECT_TIMEOUT)).map(i -> Duration.ofSeconds(Long.parseLong(i))).orElse(Duration.ofSeconds(60));
+    private final Duration kubernetesApiReadTimeout = Optional.ofNullable(System.getenv().get(K8S_API_READ_TIMEOUT)).map(i -> Duration.ofSeconds(Long.parseLong(i))).orElse(Duration.ofSeconds(60));
+    private final Duration kubernetesApiWriteTimeout = Optional.ofNullable(System.getenv().get(K8S_API_WRITE_TIMEOUT)).map(i -> Duration.ofSeconds(Long.parseLong(i))).orElse(Duration.ofSeconds(60));
+
     protected String templatesPath = System.getenv().getOrDefault(TEMPLATES_PATH,
             Paths.get(System.getProperty("user.dir"), "..", "templates", "build", "enmasse-latest").toString());
     protected UserCredentials managementCredentials = new UserCredentials(null, null);
@@ -188,5 +197,17 @@ public class Environment {
 
     public String getTemplatesPath() {
         return templatesPath;
+    }
+
+    public Duration getKubernetesApiConnectTimeout() {
+        return kubernetesApiConnectTimeout;
+    }
+
+    public Duration getKubernetesApiReadTimeout() {
+        return kubernetesApiReadTimeout;
+    }
+
+    public Duration getKubernetesApiWriteTimeout() {
+        return kubernetesApiWriteTimeout;
     }
 }

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/Minikube.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/Minikube.java
@@ -5,6 +5,7 @@
 package io.enmasse.systemtest.platform;
 
 import io.enmasse.systemtest.Endpoint;
+import io.enmasse.systemtest.Environment;
 import io.enmasse.systemtest.executor.Exec;
 import io.enmasse.systemtest.logs.CustomLogger;
 import io.fabric8.kubernetes.api.model.Service;
@@ -26,12 +27,17 @@ public class Minikube extends Kubernetes {
 
     protected Minikube(String globalNamespace) {
         super(globalNamespace, () -> {
+            final Environment instance = Environment.getInstance();
             Config config = new ConfigBuilder().build();
 
             OkHttpClient httpClient = HttpClientUtils.createHttpClient(config);
             // Workaround https://github.com/square/okhttp/issues/3146
-            httpClient = httpClient.newBuilder().protocols(Collections.singletonList(Protocol.HTTP_1_1)).build();
-
+            httpClient = httpClient.newBuilder()
+                    .protocols(Collections.singletonList(Protocol.HTTP_1_1))
+                    .connectTimeout(instance.getKubernetesApiConnectTimeout())
+                    .writeTimeout(instance.getKubernetesApiWriteTimeout())
+                    .readTimeout(instance.getKubernetesApiReadTimeout())
+                    .build();
             return new DefaultKubernetesClient(httpClient, config);
         });
     }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

In slow CI environments we see sporadic failures with kubernetes API interactions. Raising the
timeouts seems to help.  This changes exposse OkHttp3 read/write/connect timeouts for configuration for both production and test use-cases.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
