### PR TITLE
Ensure proper tear down of testRestartComponents

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/KubeCMDClient.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/KubeCMDClient.java
@@ -243,9 +243,9 @@ public class KubeCMDClient {
         return Exec.execute(runCmd, DEFAULT_SYNC_TIMEOUT, false);
     }
 
-    public static ExecutionResultData runQDstat(String podName, String... args) {
+    public static ExecutionResultData runQDstat(String namespace, String podName, String... args) {
         List<String> runCmd = new ArrayList<>();
-        String[] base = new String[]{CMD, "exec", podName, "--", "qdstat", "-t 20"};
+        String[] base = new String[]{CMD, "exec", podName, "-n", namespace, "--", "qdstat", "-t 20"};
         Collections.addAll(runCmd, base);
         Collections.addAll(runCmd, args);
         return Exec.execute(runCmd, ONE_MINUTE_TIMEOUT, true);

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/CommonTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/CommonTest.java
@@ -353,9 +353,9 @@ class CommonTest extends TestBase implements ITestBaseIsolated {
         String qdRouterName = TestUtils.listRunningPods(kubernetes, standard).stream()
                 .filter(pod -> pod.getMetadata().getName().contains("qdrouter"))
                 .collect(Collectors.toList()).get(0).getMetadata().getName();
-        assertTrue(KubeCMDClient.runQDstat(qdRouterName, "-c", "--sasl-username=jenda", "--sasl-password=cenda").getRetCode());
-        assertTrue(KubeCMDClient.runQDstat(qdRouterName, "-a", "--sasl-username=jenda", "--sasl-password=cenda").getRetCode());
-        assertTrue(KubeCMDClient.runQDstat(qdRouterName, "-l", "--sasl-username=jenda", "--sasl-password=cenda").getRetCode());
+        assertTrue(KubeCMDClient.runQDstat(kubernetes.getInfraNamespace(), qdRouterName, "-c", "--sasl-username=jenda", "--sasl-password=cenda").getRetCode());
+        assertTrue(KubeCMDClient.runQDstat(kubernetes.getInfraNamespace(), qdRouterName, "-a", "--sasl-username=jenda", "--sasl-password=cenda").getRetCode());
+        assertTrue(KubeCMDClient.runQDstat(kubernetes.getInfraNamespace(), qdRouterName, "-l", "--sasl-username=jenda", "--sasl-password=cenda").getRetCode());
     }
 
     @Test

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/CommonTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/CommonTest.java
@@ -183,28 +183,33 @@ class CommonTest extends TestBase implements ITestBaseIsolated {
         List<Pod> pods = kubernetes.listPods();
         int runningPodsBefore = pods.size();
         log.info("Number of running pods before restarting any: {}", runningPodsBefore);
+        try {
+            for (Label label : labels) {
+                log.info("Restarting {}", label.labelValue);
+                KubeCMDClient.deletePodByLabel(label.getLabelName(), label.getLabelValue());
+                Thread.sleep(30_000);
+                TestUtils.waitForExpectedReadyPods(kubernetes, kubernetes.getInfraNamespace(), runningPodsBefore, new TimeoutBudget(10, TimeUnit.MINUTES));
+                assertSystemWorks(brokered, standard, user, brokeredAddresses, standardAddresses);
+            }
 
-        for (Label label : labels) {
-            log.info("Restarting {}", label.labelValue);
-            KubeCMDClient.deletePodByLabel(label.getLabelName(), label.getLabelValue());
-            Thread.sleep(30_000);
+            log.info("Restarting whole enmasse");
+            KubeCMDClient.deletePodByLabel("app", kubernetes.getEnmasseAppLabel());
+            Thread.sleep(180_000);
             TestUtils.waitForExpectedReadyPods(kubernetes, kubernetes.getInfraNamespace(), runningPodsBefore, new TimeoutBudget(10, TimeUnit.MINUTES));
+            AddressUtils.waitForDestinationsReady(new TimeoutBudget(10, TimeUnit.MINUTES),
+                    standardAddresses.toArray(new Address[0]));
             assertSystemWorks(brokered, standard, user, brokeredAddresses, standardAddresses);
+
+            //TODO: Uncomment when #2127 will be fixedy
+
+//            Pod qdrouter = pods.stream().filter(pod -> pod.getMetadata().getName().contains("qdrouter")).collect(Collectors.toList()).get(0);
+//            kubernetes.deletePod(environment.namespace(), qdrouter.getMetadata().getName());
+//            assertSystemWorks(brokered, standard, user, brokeredAddresses, standardAddresses);
+        } finally {
+            // Ensure that EnMasse's API services are finished re-registering (after api-server restart) before ending
+            // the test otherwise test clean-up will fail.
+            assertWaitForValue(true, () -> KubeCMDClient.getApiServices("v1beta1.enmasse.io").getRetCode(), new TimeoutBudget(90, TimeUnit.SECONDS));
         }
-
-        log.info("Restarting whole enmasse");
-        KubeCMDClient.deletePodByLabel("app", kubernetes.getEnmasseAppLabel());
-        Thread.sleep(180_000);
-        TestUtils.waitForExpectedReadyPods(kubernetes, kubernetes.getInfraNamespace(), runningPodsBefore, new TimeoutBudget(10, TimeUnit.MINUTES));
-        AddressUtils.waitForDestinationsReady(new TimeoutBudget(10, TimeUnit.MINUTES),
-                standardAddresses.toArray(new Address[0]));
-        assertSystemWorks(brokered, standard, user, brokeredAddresses, standardAddresses);
-
-        //TODO: Uncomment when #2127 will be fixedy
-
-//        Pod qdrouter = pods.stream().filter(pod -> pod.getMetadata().getName().contains("qdrouter")).collect(Collectors.toList()).get(0);
-//        kubernetes.deletePod(environment.namespace(), qdrouter.getMetadata().getName());
-//        assertSystemWorks(brokered, standard, user, brokeredAddresses, standardAddresses);
     }
 
     //https://github.com/EnMasseProject/enmasse/issues/3098

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/CommonTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/CommonTest.java
@@ -8,6 +8,7 @@ import io.enmasse.address.model.Address;
 import io.enmasse.address.model.AddressBuilder;
 import io.enmasse.address.model.AddressSpace;
 import io.enmasse.address.model.AddressSpaceBuilder;
+import io.enmasse.address.model.CoreCrd;
 import io.enmasse.systemtest.UserCredentials;
 import io.enmasse.systemtest.amqp.AmqpClient;
 import io.enmasse.systemtest.bases.TestBase;
@@ -187,14 +188,12 @@ class CommonTest extends TestBase implements ITestBaseIsolated {
             for (Label label : labels) {
                 log.info("Restarting {}", label.labelValue);
                 KubeCMDClient.deletePodByLabel(label.getLabelName(), label.getLabelValue());
-                Thread.sleep(30_000);
                 TestUtils.waitForExpectedReadyPods(kubernetes, kubernetes.getInfraNamespace(), runningPodsBefore, new TimeoutBudget(10, TimeUnit.MINUTES));
                 assertSystemWorks(brokered, standard, user, brokeredAddresses, standardAddresses);
             }
 
             log.info("Restarting whole enmasse");
             KubeCMDClient.deletePodByLabel("app", kubernetes.getEnmasseAppLabel());
-            Thread.sleep(180_000);
             TestUtils.waitForExpectedReadyPods(kubernetes, kubernetes.getInfraNamespace(), runningPodsBefore, new TimeoutBudget(10, TimeUnit.MINUTES));
             AddressUtils.waitForDestinationsReady(new TimeoutBudget(10, TimeUnit.MINUTES),
                     standardAddresses.toArray(new Address[0]));
@@ -208,7 +207,7 @@ class CommonTest extends TestBase implements ITestBaseIsolated {
         } finally {
             // Ensure that EnMasse's API services are finished re-registering (after api-server restart) before ending
             // the test otherwise test clean-up will fail.
-            assertWaitForValue(true, () -> KubeCMDClient.getApiServices("v1beta1.enmasse.io").getRetCode(), new TimeoutBudget(90, TimeUnit.SECONDS));
+            assertWaitForValue(true, () -> KubeCMDClient.getApiServices(String.format("%s.%s", CoreCrd.VERSION, CoreCrd.GROUP)).getRetCode(), new TimeoutBudget(90, TimeUnit.SECONDS));
         }
     }
 
@@ -437,7 +436,7 @@ class CommonTest extends TestBase implements ITestBaseIsolated {
         } finally {
             // Ensure that EnMasse's API services are finished re-registering (after api-server restart) before ending
             // the test otherwise test clean-up will fail.
-            assertWaitForValue(true, () -> KubeCMDClient.getApiServices("v1beta1.enmasse.io").getRetCode(), new TimeoutBudget(90, TimeUnit.SECONDS));
+            assertWaitForValue(true, () -> KubeCMDClient.getApiServices(String.format("%s.%s", CoreCrd.VERSION, CoreCrd.GROUP)).getRetCode(), new TimeoutBudget(90, TimeUnit.SECONDS));
         }
 
     }


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

This PR adds to testRestartComponents the same wait we added in the past to testMessagingDuringRestartComponents because after restarting the api-server we need to ensure the api services are up again or if not next tests will faill because of this

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
