### PR TITLE
Docs: Operator installation method into specific namespace

### DIFF
--- a/documentation/assemblies/assembly-configuring-olm.adoc
+++ b/documentation/assemblies/assembly-configuring-olm.adoc
@@ -8,7 +8,7 @@
 [id='assembly-configuring-olm-{context}']
 = Configuring {ProductName} using the {KubePlatform} console
 
-After installing {ProductName} from the OperatorHub using the {KubePlatform} console, create a new instance of a custom resource for the following items within the `openshift-operators` project:
+After installing {ProductName} from the OperatorHub using the {KubePlatform} console, create a new instance of a custom resource for the following items within the `{ProductNamespace}` project:
 
 * an authentication service
 * infrastructure configuration for an address space type (the example uses the standard address space type)

--- a/documentation/modules/proc-create-address-plan-custom-resource-olm-ui.adoc
+++ b/documentation/modules/proc-create-address-plan-custom-resource-olm-ui.adoc
@@ -10,7 +10,7 @@ You must create an address plan custom resource to use {ProductName}. This proce
 
 .Procedure
 
-. From the dropdown menu, select the `openshift-operators` project.
+. From the dropdown menu, select the `{ProductNamespace}` project.
 
 . Click *Catalog > Installed Operators*.
 

--- a/documentation/modules/proc-create-address-space-plan-custom-resource-olm-ui.adoc
+++ b/documentation/modules/proc-create-address-space-plan-custom-resource-olm-ui.adoc
@@ -10,7 +10,7 @@ You must create an address space plan custom resource to use {ProductName}. This
 
 .Procedure
 
-. From the dropdown menu, select the `openshift-operators` project.
+. From the dropdown menu, select the `{ProductNamespace}` project.
 
 . Click *Catalog > Installed Operators*.
 

--- a/documentation/modules/proc-create-auth-service-custom-resource-olm-ui.adoc
+++ b/documentation/modules/proc-create-auth-service-custom-resource-olm-ui.adoc
@@ -10,7 +10,7 @@ You must create a custom resource for an authentication service to use {ProductN
 
 .Procedure
 
-. From the dropdown menu, select the `openshift-operators` project.
+. From the dropdown menu, select the `{ProductNamespace}` project.
 
 . Click *Catalog > Installed Operators*.
 

--- a/documentation/modules/proc-create-infraconfig-custom-resource-olm-ui.adoc
+++ b/documentation/modules/proc-create-infraconfig-custom-resource-olm-ui.adoc
@@ -10,7 +10,7 @@ You must create an infrastructure configuration custom resource to use {ProductN
 
 .Procedure
 
-. From the dropdown menu, select the `openshift-operators` project.
+. From the dropdown menu, select the `{ProductNamespace}` project.
 
 . Click *Catalog > Installed Operators*.
 

--- a/documentation/modules/proc-olm-installing-from-operatorhub-using-console.adoc
+++ b/documentation/modules/proc-olm-installing-from-operatorhub-using-console.adoc
@@ -7,11 +7,6 @@
 
 You can install the {ProductName} Operator on an {KubePlatform} 4.x cluster by using OperatorHub in the {KubePlatform} console.
 
-[NOTE]
-====
-For {KubePlatform} 4.1 only, you must install and deploy the {ProductName} Operator in the `{OperatorNamespace}` project.
-====
-
 .Prerequisites
 
 * Access to an {KubePlatform} 4.x cluster and an account with `cluster-admin` permissions.
@@ -28,28 +23,13 @@ For {KubePlatform} 4.1 only, you must install and deploy the {ProductName} Opera
 
 . Read the information about the Operator and click *Install*. The Create Operator Subscription page opens.
 
-. ({KubePlatform} 4.1 only) On the *Create Operator Subscription* page, accept all of the default selections and click *Subscribe*.
-+
-NOTE:
-{KubePlatform} 4.1 only: *All namespaces on the cluster (default)* installs the Operator in the default *{OperatorNamespace}* project and makes the Operator available to all projects
-in the cluster.
-+
-({KubePlatform} 4.2 only) On the *Create Operator Subscription* page, select *A specific namespace on the cluster*, select the *{ProductNamespace}* project, and then click *Subscribe*.
-+
-NOTE:
-{KubePlatform} 4.2 only: By choosing *A specific namespace on the cluster* you can install the  Operator into a specific, single project. The Operator only watches and is made available for use in this project.
+. On the *Create Operator Subscription* page, for *Installation Mode*, click *A specific namespace on the cluster*, and then select the *{ProductNamespace}* namespace from the drop-down list.
 
+. Accept all of the remaining default selections and click *Subscribe*.
 +
 The *{ProductBundleName}* page is displayed, where you can monitor the installation progress of the {ProductName} Operator subscription.
 
 . After the subscription upgrade status is shown as *Up to date*, click *Catalog > Installed Operators* to verify that the *{ProductName}* ClusterServiceVersion (CSV) is displayed and its *Status* ultimately resolves to *InstallSucceeded* in the *{OperatorNamespace}* or *{ProductNamespace}* project.
-+
-[NOTE]
-====
-For the *All namespaces...* installation mode, the status resolves to
-*InstallSucceeded* in the *{OperatorNamespace}* project, but the status is
-*Copied* if you view other projects.
-====
 +
 For troubleshooting information, see the link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html/applications/operators#olm-installing-operators-from-operatorhub_olm-adding-operators-to-a-cluster[{KubePlatform} documentation].
 

--- a/documentation/modules/proc-olm-installing-from-operatorhub-using-console.adoc
+++ b/documentation/modules/proc-olm-installing-from-operatorhub-using-console.adoc
@@ -29,7 +29,7 @@ You can install the {ProductName} Operator on an {KubePlatform} 4.x cluster by u
 +
 The *{ProductBundleName}* page is displayed, where you can monitor the installation progress of the {ProductName} Operator subscription.
 
-. After the subscription upgrade status is shown as *Up to date*, click *Catalog > Installed Operators* to verify that the *{ProductName}* ClusterServiceVersion (CSV) is displayed and its *Status* ultimately resolves to *InstallSucceeded* in the *{OperatorNamespace}* or *{ProductNamespace}* project.
+. After the subscription upgrade status is shown as *Up to date*, click *Catalog > Installed Operators* to verify that the *{ProductName}* ClusterServiceVersion (CSV) is displayed and its *Status* ultimately resolves to *InstallSucceeded* in the *{ProductNamespace}* namespace.
 +
 For troubleshooting information, see the link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html/applications/operators#olm-installing-operators-from-operatorhub_olm-adding-operators-to-a-cluster[{KubePlatform} documentation].
 

--- a/documentation/modules/proc-olm-installing-from-operatorhub-using-console.adoc
+++ b/documentation/modules/proc-olm-installing-from-operatorhub-using-console.adoc
@@ -9,16 +9,16 @@ You can install the {ProductName} Operator on an {KubePlatform} 4.x cluster by u
 
 [NOTE]
 ====
-You must install and deploy the {ProductName} Operator in the `openshift-operator` project.
+For {KubePlatform} 4.1 only, you must install and deploy the {ProductName} Operator in the `{OperatorNamespace}` project.
 ====
 
 .Prerequisites
 
-* Access to an {KubePlatform} 4.x cluster using an account with `cluster-admin` permissions.
+* Access to an {KubePlatform} 4.x cluster and an account with `cluster-admin` permissions.
 
 .Procedure
 
-. In the {KubePlatform} console, log in using an account with `cluster-admin` privileges.
+. In the {KubePlatform} 4.x console, log in using an account with `cluster-admin` privileges.
 
 . Click *Catalog > OperatorHub*.
 
@@ -28,23 +28,26 @@ You must install and deploy the {ProductName} Operator in the `openshift-operato
 
 . Read the information about the Operator and click *Install*. The Create Operator Subscription page opens.
 
-. On the *Create Operator Subscription* page, accept all of the default selections and click *Subscribe*.
+. ({KubePlatform} 4.1 only) On the *Create Operator Subscription* page, accept all of the default selections and click *Subscribe*.
 +
-[NOTE]
-====
-*All namespaces on the cluster (default)* installs the Operator in the default
-*openshift-operators* project and makes the Operator available to all projects
+NOTE:
+{KubePlatform} 4.1 only: *All namespaces on the cluster (default)* installs the Operator in the default *{OperatorNamespace}* project and makes the Operator available to all projects
 in the cluster.
-====
++
+({KubePlatform} 4.2 only) On the *Create Operator Subscription* page, select *A specific namespace on the cluster*, select the *{ProductNamespace}* project, and then click *Subscribe*.
++
+NOTE:
+{KubePlatform} 4.2 only: By choosing *A specific namespace on the cluster* you can install the  Operator into a specific, single project. The Operator only watches and is made available for use in this project.
+
 +
 The *{ProductBundleName}* page is displayed, where you can monitor the installation progress of the {ProductName} Operator subscription.
 
-. After the subscription upgrade status is shown as *Up to date*, click *Catalog > Installed Operators* to verify that the *{ProductName}* ClusterServiceVersion (CSV) is displayed and its *Status* ultimately resolves to *InstallSucceeded* in the *openshift-operators* project.
+. After the subscription upgrade status is shown as *Up to date*, click *Catalog > Installed Operators* to verify that the *{ProductName}* ClusterServiceVersion (CSV) is displayed and its *Status* ultimately resolves to *InstallSucceeded* in the *{OperatorNamespace}* or *{ProductNamespace}* project.
 +
 [NOTE]
 ====
 For the *All namespaces...* installation mode, the status resolves to
-*InstallSucceeded* in the *openshift-operators* project, but the status is
+*InstallSucceeded* in the *{OperatorNamespace}* project, but the status is
 *Copied* if you view other projects.
 ====
 +

--- a/documentation/modules/proc-olm-installing-from-operatorhub-using-console.adoc
+++ b/documentation/modules/proc-olm-installing-from-operatorhub-using-console.adoc
@@ -15,6 +15,10 @@ You can install the {ProductName} Operator on an {KubePlatform} 4.x cluster by u
 
 . In the {KubePlatform} 4.x console, log in using an account with `cluster-admin` privileges.
 
+. To create the project where you want to deploy {ProductName}, click *Home > Projects*, and then click *Create Project*. The Create Project window opens.
+
+. In the *Name* field, type `{ProductNamespace}` and click *Create*. The `{ProductNamespace}` project is created.
+
 . Click *Catalog > OperatorHub*.
 
 . In the *Filter by keyword* box, type `{ProductName}` to find the {ProductName} Operator.


### PR DESCRIPTION
### Type of change
Documentation

### Description
Document option for OpenShift 4.2 and ability to install into a specific namespace when using the Operator install method

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
