### PR TITLE
Close clients in tear down of shared tests

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/listener/JunitCallbackListener.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/listener/JunitCallbackListener.java
@@ -110,8 +110,7 @@ public class JunitCallbackListener implements TestExecutionExceptionHandler, Lif
                 sharedResourcesManager.tearDown(testInfo.getActualTest());
             }
         } else if (sharedResourcesManager.getSharedAddressSpace() != null) {
-            LOGGER.info("Deleting addresses");
-            sharedResourcesManager.deleteAddresses(sharedResourcesManager.getSharedAddressSpace());
+            sharedResourcesManager.tearDownShared();
         }
     }
 

--- a/systemtests/src/main/java/io/enmasse/systemtest/manager/IsolatedResourcesManager.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/manager/IsolatedResourcesManager.java
@@ -11,7 +11,6 @@ import io.enmasse.admin.model.v1.AuthenticationService;
 import io.enmasse.admin.model.v1.BrokeredInfraConfig;
 import io.enmasse.admin.model.v1.InfraConfig;
 import io.enmasse.admin.model.v1.StandardInfraConfig;
-import io.enmasse.systemtest.Environment;
 import io.enmasse.systemtest.UserCredentials;
 import io.enmasse.systemtest.amqp.AmqpClientFactory;
 import io.enmasse.systemtest.logs.CustomLogger;
@@ -95,9 +94,9 @@ public class IsolatedResourcesManager extends ResourceManager {
     @Override
     public void tearDown(ExtensionContext context) throws Exception {
         LOGGER.info("Reuse addressspace: " + reuseAddressSpace);
-        LOGGER.info("Environment cleanup: " + Environment.getInstance().skipCleanup());
+        LOGGER.info("Environment cleanup: " + environment.skipCleanup());
 
-        if (!Environment.getInstance().skipCleanup() && !reuseAddressSpace) {
+        if (!environment.skipCleanup() && !reuseAddressSpace) {
             for (AddressSpacePlan addressSpacePlan : addressSpacePlans) {
                 Kubernetes.getInstance().getAddressSpacePlanClient().withName(addressSpacePlan.getMetadata().getName()).cascading(true).delete();
                 LOGGER.info("AddressSpace plan {} deleted", addressSpacePlan.getMetadata().getName());
@@ -303,14 +302,14 @@ public class IsolatedResourcesManager extends ResourceManager {
     }
 
     public void deleteAddressspacesFromList() throws Exception {
-        if (!Environment.getInstance().skipCleanup()) {
+        if (environment.skipCleanup()) {
+            LOGGER.warn("No address space is deleted, SKIP_CLEANUP is set");
+        } else {
             LOGGER.info("All addressspaces will be removed");
             for (AddressSpace addressSpace : currentAddressSpaces) {
                 deleteAddressSpace(addressSpace);
             }
             currentAddressSpaces.clear();
-        } else {
-            LOGGER.warn("No address space is deleted, SKIP_CLEANUP is set");
         }
     }
 


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

This PR adds proper tear down of shared tests when test successfully pass and the environment is shared with the next test. We were missing the closing of clients.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
