### PR TITLE
Check router mesh connectivity

### DIFF
--- a/address-space-controller/src/main/java/io/enmasse/controller/RouterStatusController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/RouterStatusController.java
@@ -47,15 +47,18 @@ public class RouterStatusController implements Controller {
 
         if (infraConfig instanceof StandardInfraConfig) {
             if (!addressSpace.getStatus().getConnectors().isEmpty()) {
-                checkConnectorStatuses(addressSpace);
+                checkRouterStatus(addressSpace, connection, node);
+            } else {
+                checkRouterStatus(addressSpace, node);
             }
         }
         return addressSpace;
     }
 
     private static final RouterEntity connection = new RouterEntity( "org.apache.qpid.dispatch.connection", "operStatus", "opened", "host");
+    private static final RouterEntity node = new RouterEntity("org.apache.qpid.dispatch.router.node", "id");
 
-    private void checkConnectorStatuses(AddressSpace addressSpace) {
+    private void checkRouterStatus(AddressSpace addressSpace, RouterEntity ... entities) {
         String addressSpaceCaSecretName = KubeUtil.getAddressSpaceCaSecretName(addressSpace);
         Secret addressSpaceCa = client.secrets().inNamespace(namespace).withName(addressSpaceCaSecretName).get();
         if (addressSpaceCa == null) {
@@ -79,42 +82,53 @@ public class RouterStatusController implements Controller {
         RouterManagement routerManagement = RouterManagement.withCerts(vertx, "address-space-controller", connectTimeout, queryTimeout, cert, cert, key);
 
         String infraUuid = addressSpace.getAnnotation(AnnotationKeys.INFRA_UUID);
-        List<Pod> routerPods = client.pods().withLabel(LabelKeys.CAPABILITY, "router").withLabel(LabelKeys.INFRA_UUID, infraUuid).list().getItems();
-        Map<String, List<List>> results = new HashMap<>();
+        Map<RouterEntity, Map<String, List<List>>> results = new HashMap<>();
+
+        List<Pod> routerPods = client.pods().withLabel(LabelKeys.CAPABILITY, "router").withLabel(LabelKeys.INFRA_UUID, infraUuid).list().getItems().stream()
+                .filter(Readiness::isPodReady)
+                .collect(Collectors.toList());
 
         for (Pod router : routerPods) {
-            if (Readiness.isPodReady(router)) {
-                try {
-                    int port = 0;
-                    for (Container container : router.getSpec().getContainers()) {
-                        if (container.getName().equals("router")) {
-                            for (ContainerPort containerPort : container.getPorts()) {
-                                if (containerPort.getName().equals("amqps-normal")) {
-                                    port = containerPort.getContainerPort();
-                                }
+            try {
+                int port = 0;
+                for (Container container : router.getSpec().getContainers()) {
+                    if (container.getName().equals("router")) {
+                        for (ContainerPort containerPort : container.getPorts()) {
+                            if (containerPort.getName().equals("amqps-normal")) {
+                                port = containerPort.getContainerPort();
                             }
                         }
                     }
-
-                    if (port != 0) {
-                        // Until the connector entity allows querying for the status, we have to list
-                        // all connections and match with the connector host.
-                        Map<RouterEntity, List<List>> response = routerManagement.query(router.getStatus().getPodIP(), port, connection);
-                        results.put(router.getMetadata().getName(), response.get(connection));
-                    }
-                } catch (Exception e) {
-                    log.info("Error requesting registered topics from {}. Ignoring", router.getMetadata().getName(), e);
                 }
+
+                if (port != 0) {
+                    // Until the connector entity allows querying for the status, we have to list
+                    // all connections and match with the connector host.
+                    Map<RouterEntity, List<List>> response = routerManagement.query(router.getStatus().getPodIP(), port, entities);
+                    for (RouterEntity entity : entities) {
+                        Map<String, List<List>> entityResponse = results.computeIfAbsent(entity, e -> new HashMap<>());
+                        entityResponse.put(router.getMetadata().getName(), response.get(entity));
+                    }
+                }
+            } catch (Exception e) {
+                log.info("Error requesting registered topics from {}. Ignoring", router.getMetadata().getName(), e);
             }
         }
 
-        Map<String, AddressSpaceSpecConnector> connectorMap = new HashMap<>();
-        for (AddressSpaceSpecConnector connector : addressSpace.getSpec().getConnectors()) {
-            connectorMap.put(connector.getName(), connector);
+        if (results.containsKey(connection)) {
+            Map<String, AddressSpaceSpecConnector> connectorMap = new HashMap<>();
+            for (AddressSpaceSpecConnector connector : addressSpace.getSpec().getConnectors()) {
+                connectorMap.put(connector.getName(), connector);
+            }
+
+            for (AddressSpaceStatusConnector connector : addressSpace.getStatus().getConnectors()) {
+                checkConnectorStatus(connector, connectorMap.get(connector.getName()), results.get(connection));
+            }
         }
 
-        for (AddressSpaceStatusConnector connector : addressSpace.getStatus().getConnectors()) {
-            checkConnectorStatus(connector, connectorMap.get(connector.getName()), results);
+        if (results.containsKey(node)) {
+            Map<String, List<List>> response = results.get(node);
+            checkRouterMesh(addressSpace, routerPods.stream().map(pod -> pod.getMetadata().getName()).collect(Collectors.toList()), response);
         }
     }
 
@@ -181,6 +195,27 @@ public class RouterStatusController implements Controller {
             connectorStatus.appendMessage("Unable to find connection in the opened state for connector '" + connector.getName() + "'");
         }
     }
+
+    private void checkRouterMesh(AddressSpace addressSpace, List<String> routerIds, Map<String, List<List>> response) {
+        for (String routerId : routerIds) {
+            List<List> routerResponse = response.get(routerId);
+            if (routerResponse == null) {
+                log.warn("No response received from router {}. Will not check mesh connectivity.", routerId);
+                continue;
+            }
+            List<String> neighbours = filterOnAttribute(String.class, 0, routerResponse);
+            log.info("Router {} has neighbours: {}", routerId, neighbours);
+            if (!neighbours.containsAll(routerIds)) {
+                Set<String> missing = new HashSet<>(routerIds);
+                missing.removeAll(neighbours);
+                String msg = String.format("Router %s is missing connection to %s", routerId, missing);
+                log.warn(msg);
+                addressSpace.getStatus().setReady(false);
+                addressSpace.getStatus().appendMessage(msg);
+            }
+        }
+    }
+
 
     private static <T> List<T> filterOnAttribute(Class<T> type, int attrNum, List<List> list) {
         List<T> filtered = new ArrayList<>();

--- a/address-space-controller/src/main/java/io/enmasse/controller/RouterStatusController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/RouterStatusController.java
@@ -204,7 +204,7 @@ public class RouterStatusController implements Controller {
                 continue;
             }
             List<String> neighbours = filterOnAttribute(String.class, 0, routerResponse);
-            log.info("Router {} has neighbours: {}", routerId, neighbours);
+            log.debug("Router {} has neighbours: {}", routerId, neighbours);
             if (!neighbours.containsAll(routerIds)) {
                 Set<String> missing = new HashSet<>(routerIds);
                 missing.removeAll(neighbours);


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description


This adds a check for router mesh connectivity by querying the routers
for its connected nodes in the router network. If the list of nodes does
not contain the number of ready router pods, the address space status is
set to false, and an error message is added to the status and in the
log.

Fixes #3355

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
