### PR TITLE
Handle multiple API server requests in parallel

### DIFF
--- a/api-server/src/main/java/io/enmasse/api/server/ApiServerOptions.java
+++ b/api-server/src/main/java/io/enmasse/api/server/ApiServerOptions.java
@@ -24,6 +24,7 @@ public class ApiServerOptions {
     private Duration kubernetesApiConnectTimeout;
     private Duration kubernetesApiReadTimeout;
     private Duration kubernetesApiWriteTimeout;
+    private int numWorkerThreads;
     private String version;
 
     public static ApiServerOptions fromEnv(Map<String, String> env) {
@@ -55,6 +56,9 @@ public class ApiServerOptions {
                 .map(i -> Duration.ofSeconds(Long.parseLong(i)))
                 .orElse(Duration.ofSeconds(30)));
 
+        options.setNumWorkerThreads(getEnv(env, "NUM_WORKER_THREADS")
+                .map(Integer::parseInt)
+                .orElse(Runtime.getRuntime().availableProcessors() * 4));
         options.setEnableRbac(Boolean.parseBoolean(getEnv(env, "ENABLE_RBAC").orElse("false")));
 
         options.setApiserverClientCaConfigName(getEnv(env, "APISERVER_CLIENT_CA_CONFIG_NAME").orElse(null));
@@ -178,6 +182,7 @@ public class ApiServerOptions {
                 ", certDir='" + certDir + '\'' +
                 ", resyncInterval=" + resyncInterval +
                 ", enableRbac=" + enableRbac +
+                ", numWorkerThreads=" + numWorkerThreads +
                 ", apiserverClientCaConfigName='" + apiserverClientCaConfigName + '\'' +
                 ", apiserverClientCaConfigNamespace='" + apiserverClientCaConfigNamespace + '\'' +
                 ", userApiTimeout=" + userApiTimeout +
@@ -186,5 +191,13 @@ public class ApiServerOptions {
                 ", kubernetesApiWriteTimeout=" + kubernetesApiWriteTimeout +
                 ", version='" + version + '\'' +
                 '}';
+    }
+
+    public int getNumWorkerThreads() {
+        return numWorkerThreads;
+    }
+
+    public void setNumWorkerThreads(int numWorkerThreads) {
+        this.numWorkerThreads = numWorkerThreads;
     }
 }

--- a/api-server/src/main/java/io/enmasse/api/server/HTTPServer.java
+++ b/api-server/src/main/java/io/enmasse/api/server/HTTPServer.java
@@ -5,28 +5,6 @@
 
 package io.enmasse.api.server;
 
-import io.enmasse.api.auth.AllowAllAuthInterceptor;
-import io.enmasse.api.auth.ApiHeaderConfig;
-import io.enmasse.api.auth.AuthApi;
-import io.enmasse.api.auth.AuthInterceptor;
-import io.enmasse.api.common.DefaultExceptionMapper;
-import io.enmasse.api.v1.http.HttpAddressService;
-import io.enmasse.api.v1.http.HttpAddressSpaceService;
-import io.enmasse.api.v1.http.HttpApiRootService;
-import io.enmasse.api.v1.http.HttpClusterAddressService;
-import io.enmasse.api.v1.http.HttpClusterAddressSpaceService;
-import io.enmasse.api.v1.http.HttpClusterUserService;
-import io.enmasse.api.v1.http.HttpNestedAddressService;
-import io.enmasse.api.v1.http.HttpOpenApiService;
-import io.enmasse.api.v1.http.HttpRootService;
-import io.enmasse.api.v1.http.HttpSchemaService;
-import io.enmasse.api.v1.http.HttpUserService;
-import io.enmasse.api.v1.http.SwaggerSpecEndpoint;
-import io.enmasse.k8s.api.AddressSpaceApi;
-import io.enmasse.k8s.api.AuthenticationServiceRegistry;
-import io.enmasse.k8s.api.SchemaProvider;
-import io.enmasse.metrics.api.Metrics;
-import io.enmasse.user.api.UserApi;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -38,7 +16,6 @@ import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.net.JksOptions;
 import io.vertx.core.net.PemTrustOptions;
 import org.jboss.resteasy.plugins.server.vertx.VertxRequestHandler;
-import org.jboss.resteasy.plugins.server.vertx.VertxResteasyDeployment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +24,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
-import java.time.Clock;
 import java.util.Deque;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
@@ -59,106 +35,38 @@ public class HTTPServer extends AbstractVerticle {
     public static final int SECURE_PORT = 8443;
     private static final int PROCESS_LINE_BUFFER_SIZE = 10;
     private static final Logger log = LoggerFactory.getLogger(HTTPServer.class.getName());
-    private final AddressSpaceApi addressSpaceApi;
-    private final SchemaProvider schemaProvider;
     private final String certDir;
     private final String clientCa;
     private final String requestHeaderClientCa;
-    private final AuthApi authApi;
-    private final UserApi userApi;
-    private final boolean isRbacEnabled;
-    private final Clock clock;
-    private final AuthenticationServiceRegistry authenticationServiceRegistry;
+    private final ResteasyDeploymentFactory resteasyDeploymentFactory;
+
     private final int port;
-    private final ApiHeaderConfig apiHeaderConfig;
-    private final Metrics metrics;
 
     private HttpServer httpServer;
 
-    public HTTPServer(AddressSpaceApi addressSpaceApi,
-                      SchemaProvider schemaProvider,
-                      AuthApi authApi,
-                      UserApi userApi,
-                      ApiServerOptions options,
+    public HTTPServer(ApiServerOptions options,
+                      ResteasyDeploymentFactory resteasyDeploymentFactory,
                       String clientCa,
-                      String requestHeaderClientCa,
-                      Clock clock,
-                      AuthenticationServiceRegistry authenticationServiceRegistry,
-                      ApiHeaderConfig apiHeaderConfig,
-                      Metrics metrics) {
-        this(addressSpaceApi,
-                schemaProvider,
-                authApi,
-                userApi,
-                options,
-                clientCa,
-                requestHeaderClientCa,
-                clock,
-                authenticationServiceRegistry,
-                SECURE_PORT,
-                apiHeaderConfig,
-                metrics);
+                      String requestHeaderClientCa) {
+        this(options, resteasyDeploymentFactory, clientCa, requestHeaderClientCa, SECURE_PORT);
     }
 
-    public HTTPServer(AddressSpaceApi addressSpaceApi,
-            SchemaProvider schemaProvider,
-            AuthApi authApi,
-            UserApi userApi,
-            ApiServerOptions options,
+    public HTTPServer(ApiServerOptions options,
+            ResteasyDeploymentFactory resteasyDeploymentFactory,
             String clientCa,
             String requestHeaderClientCa,
-            Clock clock,
-            AuthenticationServiceRegistry authenticationServiceRegistry,
-            int port,
-            ApiHeaderConfig apiHeaderConfig,
-            Metrics metrics) {
-        this.addressSpaceApi = addressSpaceApi;
-        this.schemaProvider = schemaProvider;
+            int port) {
         this.certDir = options.getCertDir();
         this.clientCa = clientCa;
         this.requestHeaderClientCa = requestHeaderClientCa;
-        this.authApi = authApi;
-        this.userApi = userApi;
-        this.isRbacEnabled = options.isEnableRbac();
-        this.clock = clock;
-        this.authenticationServiceRegistry = authenticationServiceRegistry;
         this.port = port;
-        this.apiHeaderConfig = apiHeaderConfig;
-        this.metrics = metrics;
+        this.resteasyDeploymentFactory = resteasyDeploymentFactory;
     }
 
     @Override
     public void start(Future<Void> startPromise) {
-        VertxResteasyDeployment deployment = new VertxResteasyDeployment();
-        deployment.start();
 
-        RequestLogger requestLogger = new RequestLogger(metrics);
-        deployment.getProviderFactory().registerProvider(DefaultExceptionMapper.class);
-        deployment.getProviderFactory().registerProviderInstance(requestLogger);
-
-        if (isRbacEnabled) {
-            log.info("Enabling RBAC for REST API");
-            deployment.getProviderFactory().registerProviderInstance(new AuthInterceptor(authApi, apiHeaderConfig, path -> path.equals("/swagger.json")));
-        } else {
-            log.info("Disabling authentication and authorization for REST API");
-            deployment.getProviderFactory().registerProviderInstance(new AllowAllAuthInterceptor());
-        }
-
-
-        deployment.getRegistry().addSingletonResource(new SwaggerSpecEndpoint());
-        deployment.getRegistry().addSingletonResource(new HttpOpenApiService());
-        deployment.getRegistry().addSingletonResource(new HttpNestedAddressService(addressSpaceApi, schemaProvider, clock));
-        deployment.getRegistry().addSingletonResource(new HttpAddressService(addressSpaceApi, schemaProvider, clock));
-        deployment.getRegistry().addSingletonResource(new HttpClusterAddressService(addressSpaceApi, schemaProvider, clock));
-        deployment.getRegistry().addSingletonResource(new HttpSchemaService(schemaProvider));
-        deployment.getRegistry().addSingletonResource(new HttpAddressSpaceService(addressSpaceApi, schemaProvider, clock, authenticationServiceRegistry));
-        deployment.getRegistry().addSingletonResource(new HttpClusterAddressSpaceService(addressSpaceApi, clock));
-        deployment.getRegistry().addSingletonResource(new HttpUserService(addressSpaceApi, userApi, authenticationServiceRegistry, clock));
-        deployment.getRegistry().addSingletonResource(new HttpClusterUserService(userApi, authenticationServiceRegistry, clock));
-        deployment.getRegistry().addSingletonResource(new HttpRootService());
-        deployment.getRegistry().addSingletonResource(new HttpApiRootService());
-
-        VertxRequestHandler vertxRequestHandler = new VertxRequestHandler(vertx, deployment);
+        VertxRequestHandler vertxRequestHandler = new VertxRequestHandler(vertx, resteasyDeploymentFactory.getInstance());
 
         createSecureServer(vertxRequestHandler, startPromise);
     }

--- a/api-server/src/main/java/io/enmasse/api/server/ResteasyDeploymentFactory.java
+++ b/api-server/src/main/java/io/enmasse/api/server/ResteasyDeploymentFactory.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.api.server;
+
+import io.enmasse.api.auth.AllowAllAuthInterceptor;
+import io.enmasse.api.auth.ApiHeaderConfig;
+import io.enmasse.api.auth.AuthApi;
+import io.enmasse.api.auth.AuthInterceptor;
+import io.enmasse.api.common.DefaultExceptionMapper;
+import io.enmasse.api.v1.http.HttpAddressService;
+import io.enmasse.api.v1.http.HttpAddressSpaceService;
+import io.enmasse.api.v1.http.HttpApiRootService;
+import io.enmasse.api.v1.http.HttpClusterAddressService;
+import io.enmasse.api.v1.http.HttpClusterAddressSpaceService;
+import io.enmasse.api.v1.http.HttpClusterUserService;
+import io.enmasse.api.v1.http.HttpNestedAddressService;
+import io.enmasse.api.v1.http.HttpOpenApiService;
+import io.enmasse.api.v1.http.HttpRootService;
+import io.enmasse.api.v1.http.HttpSchemaService;
+import io.enmasse.api.v1.http.HttpUserService;
+import io.enmasse.api.v1.http.SwaggerSpecEndpoint;
+import io.enmasse.k8s.api.AddressSpaceApi;
+import io.enmasse.k8s.api.AuthenticationServiceRegistry;
+import io.enmasse.k8s.api.SchemaProvider;
+import io.enmasse.metrics.api.Metrics;
+import io.enmasse.user.api.UserApi;
+import org.jboss.resteasy.plugins.server.vertx.VertxResteasyDeployment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.container.ContainerRequestFilter;
+import java.time.Clock;
+
+public class ResteasyDeploymentFactory {
+    private static final Logger log = LoggerFactory.getLogger(ResteasyDeploymentFactory.class);
+
+    private final RequestLogger requestLogger;
+    private final ContainerRequestFilter authInterceptor;
+    private final SwaggerSpecEndpoint swaggerSpecEndpoint;
+    private final HttpOpenApiService openApiService;
+    private final HttpNestedAddressService nestedAddressService;
+    private final HttpAddressService addressService;
+    private final HttpClusterAddressService clusterAddressService;
+    private final HttpSchemaService schemaService;
+    private final HttpAddressSpaceService addressSpaceService;
+    private final HttpClusterAddressSpaceService clusterAddressSpaceService;
+    private final HttpUserService userService;
+    private final HttpClusterUserService clusterUserService;
+    private final HttpRootService rootService;
+    private final HttpApiRootService apiRootService;
+
+
+    public ResteasyDeploymentFactory(AddressSpaceApi addressSpaceApi, SchemaProvider schemaProvider, AuthApi authApi, UserApi userApi, Clock clock, AuthenticationServiceRegistry authenticationServiceRegistry, ApiHeaderConfig apiHeaderConfig, Metrics metrics, boolean isRbacEnabled) {
+        requestLogger = new RequestLogger(metrics);
+
+        if (isRbacEnabled) {
+            log.info("Enabling RBAC for REST API");
+            authInterceptor = new AuthInterceptor(authApi, apiHeaderConfig, path -> path.equals("/swagger.json"));
+        } else {
+            log.info("Disabling authentication and authorization for REST API");
+            authInterceptor = new AllowAllAuthInterceptor();
+        }
+
+        swaggerSpecEndpoint = new SwaggerSpecEndpoint();
+        openApiService = new HttpOpenApiService();
+        nestedAddressService = new HttpNestedAddressService(addressSpaceApi, schemaProvider, clock);
+        addressService = new HttpAddressService(addressSpaceApi, schemaProvider, clock);
+        clusterAddressService = new HttpClusterAddressService(addressSpaceApi, schemaProvider, clock);
+        schemaService = new HttpSchemaService(schemaProvider);
+        addressSpaceService = new HttpAddressSpaceService(addressSpaceApi, schemaProvider, clock, authenticationServiceRegistry);
+        clusterAddressSpaceService = new HttpClusterAddressSpaceService(addressSpaceApi, clock);
+        userService = new HttpUserService(addressSpaceApi, userApi, authenticationServiceRegistry, clock);
+        clusterUserService = new HttpClusterUserService(userApi, authenticationServiceRegistry, clock);
+        rootService = new HttpRootService();
+        apiRootService = new HttpApiRootService();
+    }
+
+    public org.jboss.resteasy.spi.ResteasyDeployment getInstance() {
+        VertxResteasyDeployment deployment = new VertxResteasyDeployment();
+        deployment.start();
+
+        deployment.getProviderFactory().registerProvider(DefaultExceptionMapper.class);
+        deployment.getProviderFactory().registerProviderInstance(requestLogger);
+        deployment.getProviderFactory().registerProviderInstance(authInterceptor);
+        deployment.getRegistry().addSingletonResource(swaggerSpecEndpoint);
+        deployment.getRegistry().addSingletonResource(openApiService);
+        deployment.getRegistry().addSingletonResource(nestedAddressService);
+        deployment.getRegistry().addSingletonResource(addressService);
+        deployment.getRegistry().addSingletonResource(clusterAddressService);
+        deployment.getRegistry().addSingletonResource(schemaService);
+        deployment.getRegistry().addSingletonResource(addressSpaceService);
+        deployment.getRegistry().addSingletonResource(clusterAddressSpaceService);
+        deployment.getRegistry().addSingletonResource(userService);
+        deployment.getRegistry().addSingletonResource(clusterUserService);
+        deployment.getRegistry().addSingletonResource(rootService);
+        deployment.getRegistry().addSingletonResource(apiRootService);
+        return deployment;
+    }
+}

--- a/api-server/src/test/java/io/enmasse/api/server/HTTPServerTest.java
+++ b/api-server/src/test/java/io/enmasse/api/server/HTTPServerTest.java
@@ -120,7 +120,8 @@ public class HTTPServerTest {
         when(authenticationServiceRegistry.resolveDefaultAuthenticationService()).thenReturn(Optional.of(authenticationService));
         when(authenticationServiceRegistry.listAuthenticationServices()).thenReturn(Collections.singletonList(authenticationService));
 
-        this.server = new HTTPServer(addressSpaceApi, new TestSchemaProvider(), authApi, userApi, options, null, null, Clock.systemUTC(), authenticationServiceRegistry, 0, ApiHeaderConfig.DEFAULT_HEADERS_CONFIG, new Metrics());
+        ResteasyDeploymentFactory resteasyDeploymentFactory = new ResteasyDeploymentFactory(addressSpaceApi, new TestSchemaProvider(), authApi, userApi, Clock.systemUTC(), authenticationServiceRegistry, ApiHeaderConfig.DEFAULT_HEADERS_CONFIG, new Metrics(), false);
+        this.server = new HTTPServer(options, resteasyDeploymentFactory, null, null, 0);
         vertx.deployVerticle(this.server, context.succeeding(arg -> context.completeNow()));
     }
 


### PR DESCRIPTION
### Type of change

- Enhancement 

### Description

Create multiple instances of HTTP servers while keeping the service
handlers and request filters singletons.

Set the number of HTTP server instances based on the number of CPUs,
optionally via an environment variable.

Fixes #3392 

Co-authored-by: Keith Wall <kwall@apache.org>

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
