### PR TITLE
Use SASL plain for the Serviceaccount authentication type

### DIFF
--- a/documentation/modules/con-user-model.adoc
+++ b/documentation/modules/con-user-model.adoc
@@ -46,7 +46,7 @@ bXktcGFzc3dvcmQ=
 
 === Serviceaccount authentication type
 
-For the `serviceaccount` type, the `username` field must contain the {KubePlatform} serviceaccount name that will be used to authenticate. When connecting with the messaging client, use the string `@@serviceaccount@@` as the username, and the service account token as the password.  The AMQP client used by the applictaion must be configured to use the SASL mechanism type `PLAIN`.
+For the `serviceaccount` type, the `username` field must contain the {KubePlatform} serviceaccount name that will be used to authenticate. When connecting with the messaging client, use the string `@@serviceaccount@@` as the username, and the service account token as the password.  The AMQP client used by the application must be configured to use the SASL mechanism type `PLAIN`.
 
 == Authorization
 

--- a/documentation/modules/con-user-model.adoc
+++ b/documentation/modules/con-user-model.adoc
@@ -46,7 +46,7 @@ bXktcGFzc3dvcmQ=
 
 === Serviceaccount authentication type
 
-For the `serviceaccount` type, the `username` field must contain the {KubePlatform} serviceaccount name that will be used to authenticate. When connecting with the messaging client, use the string `@@serviceaccount@@` as the username, and the service account token as the password.
+For the `serviceaccount` type, the `username` field must contain the {KubePlatform} serviceaccount name that will be used to authenticate. When connecting with the messaging client, use the string `@@serviceaccount@@` as the username, and the service account token as the password.  The AMQP client used by the applictaion must be configured to use the SASL mechanism type `PLAIN`.
 
 == Authorization
 


### PR DESCRIPTION


### Type of change

- Documentation

### Description

The application's AMQP client must be configured to use SASL plain when using this authentication type.
### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
