### PR TITLE
Workaround Fabric8 NPE that may erronously occur whilst awaiting pods

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
@@ -246,7 +246,7 @@ public class TestUtils {
                 } catch (NullPointerException | IllegalArgumentException e) {
                     // TODO: remove NPE guard once upgrade to Fabric8 kubernetes-client 4.6.0 or beyond is complete.
                     // (kubernetes-client 450b94745b68403293a55956be2aa7ec483c0a6c)
-                    log.warn("Failed to await pod %s", e);
+                    log.warn("Failed to await pod %s", pod, e);
                     shouldRetry = true;
                     break;
                 }


### PR DESCRIPTION
### Type of change

- Bugfix to test code

### Description

Works around Kubernetes Client issue where a NPE may occur when awaiting pods.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
