### PR TITLE
Soak suite cleanup, add load test, add create address spaces method

### DIFF
--- a/systemtests/pom.xml
+++ b/systemtests/pom.xml
@@ -181,14 +181,14 @@
             <id>systemtests</id>
             <properties>
                 <skip.tests>false</skip.tests>
-                <groups>(shared-standard | shared-brokered | shared-mqtt | isolated | marathon | shared-iot | isolated-iot) &amp; !upgrade</groups>
+                <groups>(shared-standard | shared-brokered | shared-mqtt | isolated | soak | shared-iot | isolated-iot) &amp; !upgrade</groups>
             </properties>
         </profile>
         <profile>
             <id>shared</id>
             <properties>
                 <skip.tests>false</skip.tests>
-                <groups>(shared-standard | shared-brokered | shared-mqtt) &amp; !isolated &amp; !smoke &amp; !marathon
+                <groups>(shared-standard | shared-brokered | shared-mqtt) &amp; !isolated &amp; !smoke &amp; !soak
                     &amp; !shared-iot &amp; !olm &amp; !upgrade
                 </groups>
             </properties>
@@ -196,7 +196,7 @@
         <profile>
             <id>isolated</id>
             <properties>
-                <groups>(isolated | isolated-broker | isolated-standard) &amp; !marathon &amp; !shared-iot &amp; !olm &amp; !upgrade</groups>
+                <groups>(isolated | isolated-broker | isolated-standard) &amp; !soak &amp; !shared-iot &amp; !olm &amp; !upgrade</groups>
                 <skip.tests>false</skip.tests>
             </properties>
         </profile>
@@ -204,7 +204,7 @@
             <id>pr</id>
             <properties>
                 <skip.tests>false</skip.tests>
-                <groups>(shared-standard | shared-brokered | shared-mqtt | isolated) &amp; !nonPR &amp; !smoke &amp; !marathon
+                <groups>(shared-standard | shared-brokered | shared-mqtt | isolated) &amp; !nonPR &amp; !smoke &amp; !soak
                     &amp; !shared-iot &amp; !olm &amp; !upgrade
                 </groups>
             </properties>
@@ -212,56 +212,56 @@
         <profile>
             <id>iot</id>
             <properties>
-                <groups>(isolated-iot | shared-iot) &amp; !marathon &amp; !olm &amp; !upgrade</groups>
+                <groups>(isolated-iot | shared-iot) &amp; !soak &amp; !olm &amp; !upgrade</groups>
                 <skip.tests>false</skip.tests>
             </properties>
         </profile>
         <profile>
             <id>shared-iot</id>
             <properties>
-                <groups>shared-iot &amp; !marathon &amp; !olm &amp; !upgrade</groups>
+                <groups>shared-iot &amp; !soak &amp; !olm &amp; !upgrade</groups>
                 <skip.tests>false</skip.tests>
             </properties>
         </profile>
         <profile>
             <id>isolated-iot</id>
             <properties>
-                <groups>isolated-iot &amp; !marathon &amp; !olm &amp; !upgrade</groups>
+                <groups>isolated-iot &amp; !soak &amp; !olm &amp; !upgrade</groups>
                 <skip.tests>false</skip.tests>
             </properties>
         </profile>
         <profile>
             <id>smoke-iot</id>
             <properties>
-                <groups>(shared-iot | isolated-iot) &amp; smoke &amp; !marathon &amp; !olm &amp; !upgrade</groups>
+                <groups>(shared-iot | isolated-iot) &amp; smoke &amp; !soak &amp; !olm &amp; !upgrade</groups>
                 <skip.tests>false</skip.tests>
             </properties>
         </profile>
         <profile>
-            <id>marathon</id>
+            <id>soak</id>
             <properties>
-                <groups>marathon</groups>
+                <groups>soak</groups>
                 <skip.tests>false</skip.tests>
             </properties>
         </profile>
         <profile>
             <id>smoke</id>
             <properties>
-                <groups>smoke &amp; !shared-iot &amp; !isolated-iot &amp; !marathon &amp; !olm &amp; !upgrade</groups>
+                <groups>smoke &amp; !shared-iot &amp; !isolated-iot &amp; !soak &amp; !olm &amp; !upgrade</groups>
                 <skip.tests>false</skip.tests>
             </properties>
         </profile>
         <profile>
             <id>upgrade</id>
             <properties>
-                <groups>upgrade &amp; !marathon &amp; !olm</groups>
+                <groups>upgrade &amp; !soak &amp; !olm</groups>
                 <skip.tests>false</skip.tests>
             </properties>
         </profile>
         <profile>
             <id>iot-release</id>
             <properties>
-                <groups>(shared-iot | isolated-iot) &amp; !noneAuth &amp; !smoke &amp; !marathon &amp; !olm &amp; !upgrade</groups>
+                <groups>(shared-iot | isolated-iot) &amp; !noneAuth &amp; !smoke &amp; !soak &amp; !olm &amp; !upgrade</groups>
                 <skip.tests>false</skip.tests>
             </properties>
         </profile>
@@ -269,7 +269,7 @@
             <id>olm</id>
             <properties>
                 <groups>olm &amp; !shared-standard &amp; !shared-brokered &amp; !shared-mqtt &amp; !noneAuth &amp;
-                    !smoke &amp; !marathon &amp; !shared-iot &amp; !smoke-iot &amp; !isolated &amp; !upgrade
+                    !smoke &amp; !soak &amp; !shared-iot &amp; !smoke-iot &amp; !isolated &amp; !upgrade
                 </groups>
                 <skip.tests>false</skip.tests>
             </properties>
@@ -277,7 +277,7 @@
         <profile>
             <id>acceptance</id>
             <properties>
-                <groups>acceptance &amp; !marathon &amp; !olm &amp; !upgrade</groups>
+                <groups>acceptance &amp; !soak &amp; !olm &amp; !upgrade</groups>
                 <skip.tests>false</skip.tests>
             </properties>
         </profile>

--- a/systemtests/src/main/java/io/enmasse/systemtest/TestTag.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/TestTag.java
@@ -17,7 +17,7 @@ public class TestTag {
     public static final String SHARED_MQTT = "shared-mqtt";
     public static final String SHARED_IOT = "shared-iot";
     public static final String ISOLATED_IOT = "isolated-iot";
-    public static final String MARATHON = "marathon";
+    public static final String SOAK = "soak";
     public static final String NON_PR = "nonPR";
     public static final String UPGRADE = "upgrade";
     public static final String NONE_AUTH = "noneAuth";

--- a/systemtests/src/main/java/io/enmasse/systemtest/manager/ResourceManager.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/manager/ResourceManager.java
@@ -243,6 +243,23 @@ public abstract class ResourceManager {
         syncAddressSpaceAndCollectLogs(addressSpace, operationID);
     }
 
+    public void createAddressSpace(AddressSpace... addressSpaces) throws Exception {
+        String operationID = TimeMeasuringSystem.startOperation(SystemtestsOperation.CREATE_ADDRESS_SPACE);
+        for (AddressSpace addressSpace : addressSpaces) {
+            if (!AddressSpaceUtils.existAddressSpace(addressSpace.getMetadata().getNamespace(), addressSpace.getMetadata().getName())) {
+                LOGGER.info("Address space '{}' doesn't exist and will be created.", addressSpace);
+                kubernetes.getAddressSpaceClient(addressSpace.getMetadata().getNamespace()).createOrReplace(addressSpace);
+            } else {
+                LOGGER.info("Address space '" + addressSpace + "' already exists.");
+            }
+        }
+        for (AddressSpace addressSpace : addressSpaces) {
+            AddressSpaceUtils.waitForAddressSpaceReady(addressSpace);
+            AddressSpaceUtils.syncAddressSpaceObject(addressSpace);
+            syncAddressSpaceAndCollectLogs(addressSpace, operationID);
+        }
+    }
+
     public void waitForAddressSpaceReady(AddressSpace addressSpace) throws Exception {
         LOGGER.info("Waiting for address space ready");
         String operationID = TimeMeasuringSystem.startOperation(SystemtestsOperation.CREATE_ADDRESS_SPACE);

--- a/systemtests/src/main/java/io/enmasse/systemtest/utils/AddressUtils.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/utils/AddressUtils.java
@@ -178,11 +178,10 @@ public class AddressUtils {
 
     private static FilterWatchListMultiDeletable<Address, AddressList, Boolean, Watch, Watcher<Address>> getAddressClient(Address... destinations) {
         List<String> namespaces = Stream.of(destinations)
-                .map(Address::getMetadata)
-                .map(ObjectMeta::getNamespace)
+                .map(address -> address.getMetadata().getNamespace())
                 .distinct()
                 .collect(Collectors.toList());
-        if (namespaces.size() != 1) {
+        if (namespaces.size() > 1) {
             return Kubernetes.getInstance().getAddressClient().inAnyNamespace();
         } else {
             return Kubernetes.getInstance().getAddressClient(namespaces.get(0));
@@ -239,7 +238,7 @@ public class AddressUtils {
         Map<String, Address> notMatchingAddresses = new HashMap<>();
         for (Address destination : destinations) {
             Optional<Address> lookupAddressResult = addressList.stream()
-                    .filter(addr -> addr.getSpec().getAddress().equals(destination.getSpec().getAddress()))
+                    .filter(addr -> addr.getMetadata().getName().equals(destination.getMetadata().getName()))
                     .findFirst();
             if (lookupAddressResult.isEmpty()) {
                 notMatchingAddresses.put(destination.getSpec().getAddress(), null);

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/soak/SoakTestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/soak/SoakTestBase.java
@@ -2,21 +2,22 @@
  * Copyright 2019, EnMasse authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.enmasse.systemtest.bases.marathon;
+package io.enmasse.systemtest.bases.soak;
 
 import io.enmasse.address.model.Address;
 import io.enmasse.address.model.AddressBuilder;
 import io.enmasse.address.model.AddressSpace;
+import io.enmasse.address.model.AddressSpaceBuilder;
+import io.enmasse.admin.model.v1.AddressSpacePlan;
 import io.enmasse.systemtest.SysytemTestsErrorCollector;
 import io.enmasse.systemtest.UserCredentials;
 import io.enmasse.systemtest.amqp.AmqpClient;
-import io.enmasse.systemtest.bases.ThrowableRunner;
 import io.enmasse.systemtest.bases.TestBase;
+import io.enmasse.systemtest.bases.ThrowableRunner;
 import io.enmasse.systemtest.logs.CustomLogger;
 import io.enmasse.systemtest.model.address.AddressType;
-import io.enmasse.systemtest.selenium.SeleniumManagement;
-import io.enmasse.systemtest.selenium.SeleniumProvider;
-import io.enmasse.systemtest.selenium.page.ConsoleWebPage;
+import io.enmasse.systemtest.model.addressspace.AddressSpacePlans;
+import io.enmasse.systemtest.model.addressspace.AddressSpaceType;
 import io.enmasse.systemtest.shared.standard.QueueTest;
 import io.enmasse.systemtest.shared.standard.TopicTest;
 import io.enmasse.systemtest.utils.AddressUtils;
@@ -26,23 +27,28 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.slf4j.Logger;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static io.enmasse.systemtest.TestTag.MARATHON;
+import static io.enmasse.systemtest.TestTag.SOAK;
 import static org.hamcrest.CoreMatchers.is;
 
-@Tag(MARATHON)
-public abstract class MarathonTestBase extends TestBase {
+@Tag(SOAK)
+public abstract class SoakTestBase extends TestBase {
     private static Logger log = CustomLogger.getLogger();
     private ArrayList<AmqpClient> clients = new ArrayList<>();
-    private ConsoleWebPage consoleWebPage;
     private SysytemTestsErrorCollector collector = new SysytemTestsErrorCollector();
 
     @BeforeEach
@@ -97,37 +103,6 @@ public abstract class MarathonTestBase extends TestBase {
     //========================================================================================================
     // Tests methods
     //========================================================================================================
-
-    protected void doTestCreateDeleteAddressSpaceLong(Supplier<AddressSpace> supplier) throws Exception {
-        runTestInLoop(30, () -> {
-            UserCredentials cred = new UserCredentials("david", "kornelius");
-            AddressSpace addressSpace = supplier.get();
-            resourcesManager.createAddressSpace(addressSpace);
-            resourcesManager.createOrUpdateUser(addressSpace, cred);
-
-            log.info("Address space created");
-
-            doAddressTest(addressSpace, "test-topic-createdelete-brokered-%d",
-                    "test-queue-createdelete-brokered-%d", cred);
-
-            resourcesManager.deleteAddressSpace(addressSpace);
-            log.info("Address space removed");
-        });
-    }
-
-    protected void doTestCreateDeleteAddressesWithAuthLong(AddressSpace addressSpace) throws Exception {
-        log.info("test testCreateDeleteAddressesWithAuthLong");
-        resourcesManager.createAddressSpace(addressSpace);
-
-        UserCredentials user = new UserCredentials("test-user", "test-user");
-        resourcesManager.createOrUpdateUser(addressSpace, user);
-
-        runTestInLoop(30, () -> {
-            doAddressTest(addressSpace, "test-topic-createdelete-auth-brokered-%d",
-                    "test-queue-createdelete-auth-brokered-%d", user);
-        });
-    }
-
     protected void doTestQueueSendReceiveLong(AddressSpace addressSpace) throws Exception {
         resourcesManager.createAddressSpace(addressSpace);
 
@@ -159,7 +134,7 @@ public abstract class MarathonTestBase extends TestBase {
         UserCredentials credentials = new UserCredentials("test", "test");
         resourcesManager.createOrUpdateUser(addressSpace, credentials);
 
-        runTestInLoop(30, () -> {
+        runTestInLoop(10, () -> {
             //create client
             AmqpClient client = resourcesManager.getAmqpClientFactory().createQueueClient(addressSpace);
             client.getConnectOptions().setCredentials(credentials);
@@ -276,40 +251,6 @@ public abstract class MarathonTestBase extends TestBase {
         });
     }
 
-    protected void doTestCreateDeleteAddressesViaAgentLong(AddressSpace addressSpace, String className, String testName) throws Exception {
-        log.info("testCreateDeleteAddressesViaAgentLong start");
-        resourcesManager.createAddressSpace(addressSpace);
-        log.info("Address space '{}'created", addressSpace);
-        SeleniumManagement.deployFirefoxApp();
-
-        UserCredentials user = new UserCredentials("test", "test");
-        resourcesManager.createOrUpdateUser(addressSpace, user);
-
-        int addressCount = 5;
-        ArrayList<Address> addresses = generateQueueTopicList(addressSpace, "via-web", IntStream.range(0, addressCount));
-
-        runTestInLoop(30, () -> {
-            SeleniumProvider selenium = SeleniumProvider.getInstance();
-            selenium.setupDriver(TestUtils.getFirefoxDriver());
-            consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(addressSpace), addressSpace, clusterUser);
-            consoleWebPage.openWebConsolePage(user);
-            try {
-                consoleWebPage.createAddressesWebConsole(addresses.toArray(new Address[0]));
-                consoleWebPage.deleteAddressesWebConsole(addresses.toArray(new Address[0]));
-                Thread.sleep(5000);
-                selenium.saveScreenShots(className, testName);
-                selenium.tearDownDrivers();
-            } catch (Exception ex) {
-                selenium.setupDriver(TestUtils.getFirefoxDriver());
-                consoleWebPage = new ConsoleWebPage(selenium, getConsoleRoute(addressSpace), addressSpace, clusterUser);
-                consoleWebPage.openWebConsolePage(user);
-                throw new Exception(ex);
-            }
-        });
-        log.info("testCreateDeleteAddressesViaAgentLong finished");
-    }
-
-
     //========================================================================================================
     // Help methods
     //========================================================================================================
@@ -372,4 +313,69 @@ public abstract class MarathonTestBase extends TestBase {
         resourcesManager.deleteAddresses(topicList.toArray(new Address[0]));
         Thread.sleep(15000);
     }
+
+    protected void doTestLoad(AddressSpaceType type, String addressSpacePlans, String addressPlan) throws Exception {
+
+        runTestInLoop(5, () -> {
+            int count = 5;
+            AmqpClient queueClient;
+            Map<Address, AmqpClient> pairs = new HashMap<Address, AmqpClient>();
+
+
+            List<AddressSpace> addressSpaceList = IntStream.range(0, count).mapToObj(i ->
+                    new AddressSpaceBuilder()
+                            .withNewMetadata()
+                            .withName("test-address-space-" + i)
+                            .withNamespace(kubernetes.getInfraNamespace())
+                            .endMetadata()
+                            .withNewSpec()
+                            .withType(type.toString())
+                            .withPlan(addressSpacePlans)
+                            .withNewAuthenticationService()
+                            .withName("standard-authservice")
+                            .endAuthenticationService()
+                            .endSpec()
+                            .build()).collect(Collectors.toList());
+
+            resourcesManager.createAddressSpace(addressSpaceList.toArray(new AddressSpace[0]));
+            List<Address> addresses = new LinkedList<>();
+            for (AddressSpace space : addressSpaceList) {
+                UserCredentials credentials = new UserCredentials("test", "test");
+                resourcesManager.createOrUpdateUser(space, credentials);
+                queueClient = resourcesManager.getAmqpClientFactory().createQueueClient(space);
+                queueClient.getConnectOptions().setCredentials(credentials);
+                clients.add(queueClient);
+
+                for (int i = 0; i < count; i++) {
+                    addresses.add(new AddressBuilder()
+                            .withNewMetadata()
+                            .withNamespace(space.getMetadata().getNamespace())
+                            .withName(AddressUtils.generateAddressMetadataName(space, "test-address-" + i))
+                            .endMetadata()
+                            .withNewSpec()
+                            .withType("queue")
+                            .withAddress("test-address-" + i)
+                            .withPlan(addressPlan)
+                            .endSpec()
+                            .build());
+                    pairs.put(addresses.get(i), queueClient);
+                }
+            }
+            resourcesManager.setAddresses(addresses.toArray(new Address[0]));
+            for (Map.Entry<Address, AmqpClient> pair : pairs.entrySet()) {
+                QueueTest.runQueueTest(pair.getValue(), pair.getKey(), 1024);
+            }
+
+            for (AddressSpace space : addressSpaceList) {
+                resourcesManager.deleteAddressSpace(space);
+            }
+        });
+    }
 }
+
+
+
+
+
+
+

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/soak/SoakTestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/soak/SoakTestBase.java
@@ -134,7 +134,7 @@ public abstract class SoakTestBase extends TestBase {
         UserCredentials credentials = new UserCredentials("test", "test");
         resourcesManager.createOrUpdateUser(addressSpace, credentials);
 
-        runTestInLoop(10, () -> {
+        runTestInLoop(30, () -> {
             //create client
             AmqpClient client = resourcesManager.getAmqpClientFactory().createQueueClient(addressSpace);
             client.getConnectOptions().setCredentials(credentials);
@@ -316,7 +316,7 @@ public abstract class SoakTestBase extends TestBase {
 
     protected void doTestLoad(AddressSpaceType type, String addressSpacePlans, String addressPlan) throws Exception {
 
-        runTestInLoop(5, () -> {
+        runTestInLoop(120, () -> {
             int count = 5;
             AmqpClient queueClient;
             Map<Address, AmqpClient> pairs = new HashMap<Address, AmqpClient>();

--- a/systemtests/src/test/java/io/enmasse/systemtest/soak/BrokeredSoakTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/soak/BrokeredSoakTest.java
@@ -2,53 +2,18 @@
  * Copyright 2018, EnMasse authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.enmasse.systemtest.marathon;
+package io.enmasse.systemtest.soak;
 
 import io.enmasse.address.model.AddressSpaceBuilder;
 import io.enmasse.systemtest.bases.isolated.ITestIsolatedBrokered;
-import io.enmasse.systemtest.bases.marathon.MarathonTestBase;
+import io.enmasse.systemtest.bases.soak.SoakTestBase;
+import io.enmasse.systemtest.model.addressplan.DestinationPlan;
 import io.enmasse.systemtest.model.addressspace.AddressSpacePlans;
 import io.enmasse.systemtest.model.addressspace.AddressSpaceType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
-class BrokeredMarathonTest extends MarathonTestBase implements ITestIsolatedBrokered {
-
-    @Test
-    void testCreateDeleteAddressSpaceLong() throws Exception {
-        doTestCreateDeleteAddressSpaceLong(() ->
-                new AddressSpaceBuilder()
-                        .withNewMetadata()
-                        .withName("test-create-delete-addr-space")
-                        .withNamespace(kubernetes.getInfraNamespace())
-                        .endMetadata()
-                        .withNewSpec()
-                        .withType(AddressSpaceType.BROKERED.toString())
-                        .withPlan(AddressSpacePlans.BROKERED)
-                        .withNewAuthenticationService()
-                        .withName("standard-authservice")
-                        .endAuthenticationService()
-                        .endSpec()
-                        .build());
-    }
-
-    @Test
-    void testCreateDeleteAddressesWithAuthLong() throws Exception {
-        doTestCreateDeleteAddressesWithAuthLong(
-                new AddressSpaceBuilder()
-                        .withNewMetadata()
-                        .withName("test-create-delete-addresses")
-                        .withNamespace(kubernetes.getInfraNamespace())
-                        .endMetadata()
-                        .withNewSpec()
-                        .withType(AddressSpaceType.BROKERED.toString())
-                        .withPlan(AddressSpacePlans.BROKERED)
-                        .withNewAuthenticationService()
-                        .withName("standard-authservice")
-                        .endAuthenticationService()
-                        .endSpec()
-                        .build());
-    }
+class BrokeredSoakTest extends SoakTestBase implements ITestIsolatedBrokered {
 
     @Test
     void testQueueSendReceiveLong() throws Exception {
@@ -105,21 +70,7 @@ class BrokeredMarathonTest extends MarathonTestBase implements ITestIsolatedBrok
     }
 
     @Test
-    void testCreateDeleteAddressesViaAgentLong(TestInfo info) throws Exception {
-        doTestCreateDeleteAddressesViaAgentLong(
-                new AddressSpaceBuilder()
-                        .withNewMetadata()
-                        .withName("brokered-marathon-web-console")
-                        .withNamespace(kubernetes.getInfraNamespace())
-                        .endMetadata()
-                        .withNewSpec()
-                        .withType(AddressSpaceType.BROKERED.toString())
-                        .withPlan(AddressSpacePlans.BROKERED)
-                        .withNewAuthenticationService()
-                        .withName("standard-authservice")
-                        .endAuthenticationService()
-                        .endSpec()
-                        .build(),
-                info.getTestClass().get().getName(), info.getTestMethod().get().getName());
+    void testTestLoadLong() throws Exception {
+        doTestLoad(AddressSpaceType.BROKERED, AddressSpacePlans.BROKERED, DestinationPlan.BROKERED_QUEUE);
     }
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/soak/PlansSoakTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/soak/PlansSoakTest.java
@@ -2,7 +2,7 @@
  * Copyright 2018, EnMasse authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.enmasse.systemtest.marathon;
+package io.enmasse.systemtest.soak;
 
 import io.enmasse.address.model.Address;
 import io.enmasse.address.model.AddressBuilder;
@@ -15,7 +15,7 @@ import io.enmasse.admin.model.v1.ResourceRequest;
 import io.enmasse.systemtest.UserCredentials;
 import io.enmasse.systemtest.amqp.AmqpClient;
 import io.enmasse.systemtest.bases.isolated.ITestIsolatedStandard;
-import io.enmasse.systemtest.bases.marathon.MarathonTestBase;
+import io.enmasse.systemtest.bases.soak.SoakTestBase;
 import io.enmasse.systemtest.model.address.AddressType;
 import io.enmasse.systemtest.model.addressspace.AddressSpaceType;
 import io.enmasse.systemtest.shared.standard.QueueTest;
@@ -29,7 +29,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-class PlansMarathonTest extends MarathonTestBase implements ITestIsolatedStandard {
+class PlansSoakTest extends SoakTestBase implements ITestIsolatedStandard {
 
     @AfterEach
     void tearDown() throws Exception {

--- a/systemtests/src/test/java/io/enmasse/systemtest/soak/StandardSoakTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/soak/StandardSoakTest.java
@@ -2,53 +2,18 @@
  * Copyright 2018, EnMasse authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.enmasse.systemtest.marathon;
+package io.enmasse.systemtest.soak;
 
 import io.enmasse.address.model.AddressSpaceBuilder;
 import io.enmasse.systemtest.bases.isolated.ITestIsolatedStandard;
-import io.enmasse.systemtest.bases.marathon.MarathonTestBase;
+import io.enmasse.systemtest.bases.soak.SoakTestBase;
+import io.enmasse.systemtest.model.addressplan.DestinationPlan;
 import io.enmasse.systemtest.model.addressspace.AddressSpacePlans;
 import io.enmasse.systemtest.model.addressspace.AddressSpaceType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
-class StandardMarathonTest extends MarathonTestBase implements ITestIsolatedStandard {
-
-    @Test
-    void testCreateDeleteAddressSpaceLong() throws Exception {
-        doTestCreateDeleteAddressSpaceLong(() ->
-                new AddressSpaceBuilder()
-                        .withNewMetadata()
-                        .withName("test-create-delete-addr-space")
-                        .withNamespace(kubernetes.getInfraNamespace())
-                        .endMetadata()
-                        .withNewSpec()
-                        .withType(AddressSpaceType.STANDARD.toString())
-                        .withPlan(AddressSpacePlans.STANDARD_MEDIUM)
-                        .withNewAuthenticationService()
-                        .withName("standard-authservice")
-                        .endAuthenticationService()
-                        .endSpec()
-                        .build());
-    }
-
-    @Test
-    void testCreateDeleteAddressesWithAuthLong() throws Exception {
-        doTestCreateDeleteAddressesWithAuthLong(
-                new AddressSpaceBuilder()
-                        .withNewMetadata()
-                        .withName("test-create-delete-addresses")
-                        .withNamespace(kubernetes.getInfraNamespace())
-                        .endMetadata()
-                        .withNewSpec()
-                        .withType(AddressSpaceType.STANDARD.toString())
-                        .withPlan(AddressSpacePlans.STANDARD_MEDIUM)
-                        .withNewAuthenticationService()
-                        .withName("standard-authservice")
-                        .endAuthenticationService()
-                        .endSpec()
-                        .build());
-    }
+class StandardSoakTest extends SoakTestBase implements ITestIsolatedStandard {
 
     @Test
     void testQueueSendReceiveLong() throws Exception {
@@ -105,21 +70,7 @@ class StandardMarathonTest extends MarathonTestBase implements ITestIsolatedStan
     }
 
     @Test
-    void testCreateDeleteAddressesViaAgentLong(TestInfo info) throws Exception {
-        doTestCreateDeleteAddressesViaAgentLong(
-                new AddressSpaceBuilder()
-                        .withNewMetadata()
-                        .withName("standard-marathon-web-console")
-                        .withNamespace(kubernetes.getInfraNamespace())
-                        .endMetadata()
-                        .withNewSpec()
-                        .withType(AddressSpaceType.STANDARD.toString())
-                        .withPlan(AddressSpacePlans.STANDARD_MEDIUM)
-                        .withNewAuthenticationService()
-                        .withName("standard-authservice")
-                        .endAuthenticationService()
-                        .endSpec()
-                        .build(),
-                info.getTestClass().get().getName(), info.getTestMethod().get().getName());
+    void testTestLoadLong() throws Exception {
+        doTestLoad(AddressSpaceType.STANDARD, AddressSpacePlans.STANDARD_MEDIUM, DestinationPlan.STANDARD_SMALL_QUEUE);
     }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Refactoring

### Description

Changed "marathon" suite to "soak", deleted unneeded tests. Added load test that creates several address spaces with several addresses for both (standard, brokered) address space types.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./documentation/design`
- [X] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
