### PR TITLE
Fix 404 when using a tenant outside of the enmasse namespace

### DIFF
--- a/iot/iot-service-base/src/main/java/io/enmasse/iot/service/base/AbstractProjectBasedService.java
+++ b/iot/iot-service-base/src/main/java/io/enmasse/iot/service/base/AbstractProjectBasedService.java
@@ -56,7 +56,7 @@ public abstract class AbstractProjectBasedService extends AbstractKubernetesBase
         log.info("Starting project watcher");
 
         this.watcher = IoTProjects.clientForProject(getClient())
-
+                .inAnyNamespace()
                 .watch(new Watcher<>() {
 
                     @Override

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/apps/SystemtestsKubernetesApps.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/apps/SystemtestsKubernetesApps.java
@@ -394,7 +394,12 @@ public class SystemtestsKubernetesApps {
     }
 
     public static void deleteDirectories(final Function<InputStream, InputStream> streamManipulator, final Path... paths) throws Exception {
-        loadDirectories(streamManipulator, Deletable::delete, paths);
+        loadDirectories(streamManipulator, o -> {
+            o.fromServer().get().forEach(item -> {
+                // Workaround for https://github.com/fabric8io/kubernetes-client/issues/1856
+                Kubernetes.getInstance().getClient().resource(item).cascading(true).delete();
+            });
+        }, paths);
     }
 
     public static void loadDirectories(final Function<InputStream, InputStream> streamManipulator, Consumer<ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean>> consumer, final Path... paths) throws Exception {


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

Since the upgrade to fabric8, all IoT tests fail due to unknown tenants. It looks
like fabric8 changed it behavior, to apply a default namespace ot the client, which
makes the client only watch for tenants in the current namespace of the infrastructure.

This change explicitly enables "any" namespace.

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [X] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
