### PR TITLE
Scale explicitly back up to 1 api-server

### DIFF
--- a/pkg/controller/address_space_controller_deployer/deployer.go
+++ b/pkg/controller/address_space_controller_deployer/deployer.go
@@ -127,7 +127,6 @@ func (d *AddressSpaceControllerDeployment) performUpgrade(deployment *appsv1.Dep
 		return err
 	}
 	log.Info("Downscaling api-server", "deployment", apiServerDeployment.Name)
-	apiServerReplicas := *apiServerDeployment.Spec.Replicas
 	apiServerDeployment.Spec.Replicas = &zero
 	_, err = deploymentClient.Update(apiServerDeployment)
 	if err != nil {
@@ -215,12 +214,13 @@ func (d *AddressSpaceControllerDeployment) performUpgrade(deployment *appsv1.Dep
 
 	// Scale api-server back up
 	log.Info("Scaling up api-server", "deployment", apiServerDeployment.Name)
-	apiServerDeployment.Spec.Replicas = &apiServerReplicas
+	var one int32 = 1
+	apiServerDeployment.Spec.Replicas = &one
 	_, err = deploymentClient.Update(apiServerDeployment)
 	if err != nil {
 		return err
 	}
-	err = waitForReplicas(podClient, apiServerDeployment, int(apiServerReplicas))
+	err = waitForReplicas(podClient, apiServerDeployment, int(one))
 	if err != nil {
 		return err
 	}

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/upgrade/UpgradeTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/upgrade/UpgradeTest.java
@@ -288,7 +288,7 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
                 log.info("*********************************************");
             });
             return ready.get();
-        }, new TimeoutBudget(5, TimeUnit.MINUTES));
+        }, new TimeoutBudget(10, TimeUnit.MINUTES));
         TestUtils.waitUntilDeployed(kubernetes.getInfraNamespace());
     }
 


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description
This avoids the cause found by upgrade tests, where the enmasse-operator
was restarted after failing to replace address-space-controller
deployment and not scaling api-server back up.


<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md