### PR TITLE
Restructure IoT documentation

### DIFF
--- a/documentation/assemblies/assembly-iot-getting-started.adoc
+++ b/documentation/assemblies/assembly-iot-getting-started.adoc
@@ -1,0 +1,32 @@
+// This assembly is included in the following assemblies:
+//
+// assembly-getting-started.adoc
+
+:context: {context}-iot
+
+[id='iot-getting-started-{context}]
+= Getting started using IoT
+
+The following information describes how to set up and manage {ProductName} IoT features.
+
+include::../modules/proc-installing-using-bundle.adoc[leveloffset=+1]
+
+include::../modules/proc-iot-installing-services.adoc[leveloffset=+1]
+
+include::../modules/proc-iot-creating-project.adoc[leveloffset=+1]
+
+include::../modules/proc-iot-creating-device.adoc[leveloffset=+1]
+
+=== Installing command-line client
+
+include::../modules/proc-iot-configure-hono-cli.adoc[leveloffset=+1]
+
+:api: telemetry
+
+=== Starting telemetry consumer
+
+include::../modules/snip-iot-customer-api.adoc[leveloffset=+2]
+
+=== Sending HTTP telemetry message
+
+include::../modules/snip-iot-http-api.adoc[leveloffset=+2]

--- a/documentation/assemblies/assembly-iot-guide.adoc
+++ b/documentation/assemblies/assembly-iot-guide.adoc
@@ -11,23 +11,10 @@ The IoT guide provides resources on how to set up and manage {ProductName} IoT f
 
 include::../modules/con-iot-concepts.adoc[leveloffset=+1]
 
-include::../modules/proc-installing-using-bundle.adoc[leveloffset=+1]
+include::../assemblies/assembly-iot-getting-started.adoc[leveloffset=+1]
 
-include::../modules/proc-iot-installing-services.adoc[leveloffset=+1]
+include::../assemblies/assembly-iot-service-admin-guide.adoc[leveloffset=+1]
 
-include::../modules/proc-iot-creating-project.adoc[leveloffset=+1]
-
-include::../modules/proc-iot-creating-device.adoc[leveloffset=+1]
-
-include::../modules/proc-iot-configuring-sigfox.adoc[leveloffset=+1]
-
-:api: telemetry
-
-include::../modules/proc-iot-api.adoc[leveloffset=+1]
-
-:api: event
-
-include::../modules/proc-iot-api.adoc[leveloffset=+1]
+include::../assemblies/assembly-iot-tenant-guide.adoc[leveloffset=+1]
 
 :context: {parent-context}
-

--- a/documentation/assemblies/assembly-iot-service-admin-guide.adoc
+++ b/documentation/assemblies/assembly-iot-service-admin-guide.adoc
@@ -1,0 +1,10 @@
+// This assembly is included in the following assemblies:
+//
+// assembly-iot-guide.adoc
+
+:context: {context}-iot
+
+[id='iot-service-admin-{context}]
+= IoT for service administrators 
+
+include::../modules/proc-iot-configuring-sigfox.adoc[leveloffset=+1]

--- a/documentation/assemblies/assembly-iot-tenant-guide.adoc
+++ b/documentation/assemblies/assembly-iot-tenant-guide.adoc
@@ -1,0 +1,55 @@
+// This assembly is included in the following assemblies:
+//
+// assembly-tenant-guide.adoc
+
+:context: {context}-iot
+
+[id='iot-tenant-{context}]
+= IoT for messaging tenants
+
+
+== Customer applications
+
+include::../modules/proc-iot-configure-hono-cli.adoc[leveloffset=+1]
+
+:api: telemetry
+
+=== Telemetry
+
+include::../modules/snip-iot-customer-api.adoc[leveloffset=+1]
+
+:api: events
+
+=== Events
+
+include::../modules/snip-iot-customer-api.adoc[leveloffset=+1]
+
+== Device applications
+
+=== HTTP
+
+.Telemetry
+
+:api: telemetry
+
+include::../modules/snip-iot-http-api.adoc[leveloffset=+2]
+
+:api: events
+
+.Events
+
+include::../modules/snip-iot-http-api.adoc[leveloffset=+2]
+
+=== MQTT
+
+:api: telemetry
+
+.Telemetry
+
+include::../modules/snip-iot-mqtt-api.adoc[leveloffset=+2]
+
+:api: events
+
+.Events
+
+include::../modules/snip-iot-mqtt-api.adoc[leveloffset=+2]

--- a/documentation/modules/proc-iot-configure-hono-cli.adoc
+++ b/documentation/modules/proc-iot-configure-hono-cli.adoc
@@ -1,0 +1,54 @@
+// Module included in the following assemblies:
+//
+// assembly-iot-getting-started.adoc
+// assembly-iot-tenant-guide.adoc
+
+[id='iot-installing-cli-{context}']
+
+ifeval::["{cmdcli}" == "oc"]
+:http-adapter: $(oc -n enmasse-infra get routes iot-http-adapter --template='{{ .spec.host }}')
+:mqtt-adapter: $(oc -n enmasse-infra get routes iot-mqtt-adapter --template='{{ .spec.host }}')
+:mqtt-port: 443
+endif::[]
+ifeval::["{cmdcli}" == "kubectl"]
+:http-adapter: $(kubectl -n enmasse-infra get service iot-http-adapter-external -o jsonpath={.status.loadBalancer.ingress[0].hostname}):30443
+:mqtt-adapter: $(kubectl -n enmasse-infra get service iot-mqtt-adapter-external -o jsonpath={.status.loadBalancer.ingress[0].hostname})
+:mqtt-port: 30883
+endif::[]
+
+= Installing the Eclipse Hono command-line client
+
+.Prerequisites
+* link:{BookUrlBase}{BaseProductVersion}{BookNameUrl}#installing-services-messaging-iot[The IoT services are installed].
+* link:{BookUrlBase}{BaseProductVersion}{BookNameUrl}#iot-creating-project-messaging-iot[An IoT project is created].
+* link:{BookUrlBase}{BaseProductVersion}{BookNameUrl}#iot-creating-device-messaging-iot[An IoT device is created].
+
+.Procedure
+
+. Download the link:https://www.eclipse.org/hono/downloads/[Eclipse Hono command-line client].
+. Obtain the messaging endpoint certificate:
++
+[options="nowrap",subs="attributes"]
+----
+{cmdcli} -n myapp get addressspace iot -o jsonpath={.status.caCert} | base64 --decode > tls.crt
+----
+
+. Export the messaging endpoint host and port:
++
+[options="nowrap",subs="attributes"]
+----
+export MESSAGING_HOST=$({cmdcli} -n myapp get addressspace iot -o jsonpath={.status.endpointStatuses[?\(@.name==\'messaging\'\)].externalHost})
+export MESSAGING_PORT=443
+----
+ifeval::["{cmdcli}" == "kubectl"]
++
+[NOTE]
+====
+If you are running Kubernetes in a development environment without a proper load balancer, you need to export the IP address of your local cluster and the port number of the appropriate service, for example:
+[options="nowrap",subs="attributes"]
+----
+export MESSAGING_HOST=localhost
+export MESSAGING_PORT=5671
+----
+====
+endif::[]

--- a/documentation/modules/snip-iot-customer-api.adoc
+++ b/documentation/modules/snip-iot-customer-api.adoc
@@ -1,0 +1,6 @@
+. Run the consumer application to receive {api}:
++
+[options="nowrap",subs="attributes"]
+----
+java -jar hono-cli-*-exec.jar --hono.client.host=$MESSAGING_HOST --hono.client.port=$MESSAGING_PORT --hono.client.username=consumer --hono.client.password=foobar --tenant.id=myapp.iot --hono.client.trustStorePath=tls.crt --message.type={api}
+----

--- a/documentation/modules/snip-iot-http-api.adoc
+++ b/documentation/modules/snip-iot-http-api.adoc
@@ -1,0 +1,6 @@
+. Send {api} using the HTTP protocol:
++
+[options="nowrap",subs="attributes"]
+----
+curl --insecure -X POST -i -u sensor1@myapp.iot:hono-secret -H 'Content-Type: application/json' --data-binary '{"temp": 5}' https://{http-adapter}/{api}
+----

--- a/documentation/modules/snip-iot-mqtt-api.adoc
+++ b/documentation/modules/snip-iot-mqtt-api.adoc
@@ -1,0 +1,6 @@
+. Send {api} using the MQTT protocol:
++
+[options="nowrap",subs="attributes"]
+----
+mosquitto_pub -d -h {mqtt-adapter} -p {mqtt-port} -u 'sensor1@myapp.iot' -P hono-secret -t {api} -m '{"temp": 5}' -i 4711 --cafile install/components/iot/examples/k8s-tls/build/iot-mqtt-adapter-fullchain.pem
+----


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This is the first attempt to restructure the existing material according to #3423 proposal

We are limited by the nesting depth we can go with headlines so the deepest titles are not properly showed in the menu. I'm not sure what's the best way to overcome this. Maybe move everything one level up and lose the general "IoT Guide" level in the main menu, but have "IoT Overview", "IoT service admin guide" and "IoT tenant guide" instead?

Take a look and let me know what you think.
