### PR TITLE
Temporarily disable web console/global console tests

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/console/ChromeGlobalConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/console/ChromeGlobalConsoleTest.java
@@ -10,6 +10,7 @@ import io.enmasse.systemtest.bases.web.GlobalConsoleTest;
 import io.enmasse.systemtest.model.addressspace.AddressSpacePlans;
 import io.enmasse.systemtest.model.addressspace.AddressSpaceType;
 import io.enmasse.systemtest.selenium.SeleniumChrome;
+import org.junit.Ignore;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -17,6 +18,7 @@ import static io.enmasse.systemtest.TestTag.NON_PR;
 
 @Tag(NON_PR)
 @SeleniumChrome
+@Ignore("Ignore whilst 0.31 console refactoring is underway")
 class ChromeGlobalConsoleTest extends GlobalConsoleTest implements ITestIsolatedStandard {
 
     @Test

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/console/ChromeGlobalConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/console/ChromeGlobalConsoleTest.java
@@ -10,7 +10,7 @@ import io.enmasse.systemtest.bases.web.GlobalConsoleTest;
 import io.enmasse.systemtest.model.addressspace.AddressSpacePlans;
 import io.enmasse.systemtest.model.addressspace.AddressSpaceType;
 import io.enmasse.systemtest.selenium.SeleniumChrome;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -18,7 +18,7 @@ import static io.enmasse.systemtest.TestTag.NON_PR;
 
 @Tag(NON_PR)
 @SeleniumChrome
-@Ignore("Ignore whilst 0.31 console refactoring is underway")
+@Disabled("Ignore whilst 0.31 console refactoring is underway")
 class ChromeGlobalConsoleTest extends GlobalConsoleTest implements ITestIsolatedStandard {
 
     @Test

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/console/FirefoxGlobalConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/console/FirefoxGlobalConsoleTest.java
@@ -10,12 +10,14 @@ import io.enmasse.systemtest.bases.web.GlobalConsoleTest;
 import io.enmasse.systemtest.model.addressspace.AddressSpacePlans;
 import io.enmasse.systemtest.model.addressspace.AddressSpaceType;
 import io.enmasse.systemtest.selenium.SeleniumFirefox;
+import org.junit.Ignore;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static io.enmasse.systemtest.TestTag.ACCEPTANCE;
 
 @SeleniumFirefox
+@Ignore("Ignore whilst 0.31 console rework is underway")
 class FirefoxGlobalConsoleTest extends GlobalConsoleTest implements ITestIsolatedStandard {
 
     @Test

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/console/FirefoxGlobalConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/console/FirefoxGlobalConsoleTest.java
@@ -10,14 +10,14 @@ import io.enmasse.systemtest.bases.web.GlobalConsoleTest;
 import io.enmasse.systemtest.model.addressspace.AddressSpacePlans;
 import io.enmasse.systemtest.model.addressspace.AddressSpaceType;
 import io.enmasse.systemtest.selenium.SeleniumFirefox;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static io.enmasse.systemtest.TestTag.ACCEPTANCE;
 
 @SeleniumFirefox
-@Ignore("Ignore whilst 0.31 console rework is underway")
+@Disabled("Ignore whilst 0.31 console rework is underway")
 class FirefoxGlobalConsoleTest extends GlobalConsoleTest implements ITestIsolatedStandard {
 
     @Test

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/plans/web/FirefoxWebConsolePlansTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/plans/web/FirefoxWebConsolePlansTest.java
@@ -7,11 +7,11 @@ package io.enmasse.systemtest.isolated.plans.web;
 import io.enmasse.systemtest.bases.isolated.ITestIsolatedStandard;
 import io.enmasse.systemtest.bases.web.WebConsolePlansTest;
 import io.enmasse.systemtest.selenium.SeleniumFirefox;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 @SeleniumFirefox
-@Ignore("Ignore whilst 0.31 console refactoring is underway")
+@Disabled("Ignore whilst 0.31 console refactoring is underway")
 class FirefoxWebConsolePlansTest extends WebConsolePlansTest implements ITestIsolatedStandard {
 
     @Test

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/plans/web/FirefoxWebConsolePlansTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/plans/web/FirefoxWebConsolePlansTest.java
@@ -7,9 +7,11 @@ package io.enmasse.systemtest.isolated.plans.web;
 import io.enmasse.systemtest.bases.isolated.ITestIsolatedStandard;
 import io.enmasse.systemtest.bases.web.WebConsolePlansTest;
 import io.enmasse.systemtest.selenium.SeleniumFirefox;
+import org.junit.Ignore;
 import org.junit.jupiter.api.Test;
 
 @SeleniumFirefox
+@Ignore("Ignore whilst 0.31 console refactoring is underway")
 class FirefoxWebConsolePlansTest extends WebConsolePlansTest implements ITestIsolatedStandard {
 
     @Test

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/web/ChromeWebConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/web/ChromeWebConsoleTest.java
@@ -12,6 +12,7 @@ import io.enmasse.systemtest.messagingclients.ExternalClients;
 import io.enmasse.systemtest.model.address.AddressType;
 import io.enmasse.systemtest.selenium.SeleniumChrome;
 import io.enmasse.systemtest.utils.AddressUtils;
+import org.junit.Ignore;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -21,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Tag(NON_PR)
 @SeleniumChrome
+@Ignore("Ignore whilst 0.31 console refactoring is underway")
 class ChromeWebConsoleTest extends WebConsoleTest implements ITestSharedBrokered {
 
     @Test

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/web/ChromeWebConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/web/ChromeWebConsoleTest.java
@@ -12,7 +12,6 @@ import io.enmasse.systemtest.messagingclients.ExternalClients;
 import io.enmasse.systemtest.model.address.AddressType;
 import io.enmasse.systemtest.selenium.SeleniumChrome;
 import io.enmasse.systemtest.utils.AddressUtils;
-import org.junit.Ignore;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -22,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Tag(NON_PR)
 @SeleniumChrome
-@Ignore("Ignore whilst 0.31 console refactoring is underway")
+@Disabled("Ignore whilst 0.31 console refactoring is underway")
 class ChromeWebConsoleTest extends WebConsoleTest implements ITestSharedBrokered {
 
     @Test

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/web/FirefoxWebConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/web/FirefoxWebConsoleTest.java
@@ -12,12 +12,14 @@ import io.enmasse.systemtest.messagingclients.ExternalClients;
 import io.enmasse.systemtest.model.address.AddressType;
 import io.enmasse.systemtest.selenium.SeleniumFirefox;
 import io.enmasse.systemtest.utils.AddressUtils;
+import org.junit.Ignore;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SeleniumFirefox
+@Ignore("Ignore whilst 0.31 console refactoring is underway")
 class FirefoxWebConsoleTest extends WebConsoleTest implements ITestSharedBrokered {
 
     @Test

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/web/FirefoxWebConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/web/FirefoxWebConsoleTest.java
@@ -12,14 +12,13 @@ import io.enmasse.systemtest.messagingclients.ExternalClients;
 import io.enmasse.systemtest.model.address.AddressType;
 import io.enmasse.systemtest.selenium.SeleniumFirefox;
 import io.enmasse.systemtest.utils.AddressUtils;
-import org.junit.Ignore;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SeleniumFirefox
-@Ignore("Ignore whilst 0.31 console refactoring is underway")
+@Disabled("Ignore whilst 0.31 console refactoring is underway")
 class FirefoxWebConsoleTest extends WebConsoleTest implements ITestSharedBrokered {
 
     @Test

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/web/ChromeWebConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/web/ChromeWebConsoleTest.java
@@ -13,6 +13,7 @@ import io.enmasse.systemtest.model.address.AddressType;
 import io.enmasse.systemtest.model.addressplan.DestinationPlan;
 import io.enmasse.systemtest.selenium.SeleniumChrome;
 import io.enmasse.systemtest.utils.AddressUtils;
+import org.junit.Ignore;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -22,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Tag(NON_PR)
 @SeleniumChrome
+@Ignore("Ignore whilst 0.31 console refactoring is underway")
 public class ChromeWebConsoleTest extends WebConsoleTest implements ITestSharedStandard {
 
     @Test

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/web/ChromeWebConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/web/ChromeWebConsoleTest.java
@@ -13,7 +13,6 @@ import io.enmasse.systemtest.model.address.AddressType;
 import io.enmasse.systemtest.model.addressplan.DestinationPlan;
 import io.enmasse.systemtest.selenium.SeleniumChrome;
 import io.enmasse.systemtest.utils.AddressUtils;
-import org.junit.Ignore;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -23,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Tag(NON_PR)
 @SeleniumChrome
-@Ignore("Ignore whilst 0.31 console refactoring is underway")
+@Disabled("Ignore whilst 0.31 console refactoring is underway")
 public class ChromeWebConsoleTest extends WebConsoleTest implements ITestSharedStandard {
 
     @Test

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/web/FirefoxWebConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/web/FirefoxWebConsoleTest.java
@@ -13,12 +13,14 @@ import io.enmasse.systemtest.model.address.AddressType;
 import io.enmasse.systemtest.model.addressplan.DestinationPlan;
 import io.enmasse.systemtest.selenium.SeleniumFirefox;
 import io.enmasse.systemtest.utils.AddressUtils;
+import org.junit.Ignore;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SeleniumFirefox
+@Ignore("Ignore whilst 0.31 console refactoring is underway")
 public class FirefoxWebConsoleTest extends WebConsoleTest implements ITestSharedStandard {
 
     @Test

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/web/FirefoxWebConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/web/FirefoxWebConsoleTest.java
@@ -13,14 +13,13 @@ import io.enmasse.systemtest.model.address.AddressType;
 import io.enmasse.systemtest.model.addressplan.DestinationPlan;
 import io.enmasse.systemtest.selenium.SeleniumFirefox;
 import io.enmasse.systemtest.utils.AddressUtils;
-import org.junit.Ignore;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SeleniumFirefox
-@Ignore("Ignore whilst 0.31 console refactoring is underway")
+@Disabled("Ignore whilst 0.31 console refactoring is underway")
 public class FirefoxWebConsoleTest extends WebConsoleTest implements ITestSharedStandard {
 
     @Test


### PR DESCRIPTION
Temporarily exclude the web console and global tests during the console refactoring work.