### PR TITLE
Fix issues of "temporary unavailable"

### DIFF
--- a/pkg/controller/iotconfig/adapter.go
+++ b/pkg/controller/iotconfig/adapter.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/enmasseproject/enmasse/pkg/util/cchange"
+
 	"github.com/enmasseproject/enmasse/pkg/util"
 
 	iotv1alpha1 "github.com/enmasseproject/enmasse/pkg/apis/iot/v1alpha1"
@@ -201,7 +203,7 @@ func AppendHonoAdapterEnvs(config *iotv1alpha1.IoTConfig, container *corev1.Cont
 
 }
 
-func (r *ReconcileIoTConfig) processQdrProxyConfig(ctx context.Context, config *iotv1alpha1.IoTConfig) (reconcile.Result, error) {
+func (r *ReconcileIoTConfig) processQdrProxyConfig(ctx context.Context, config *iotv1alpha1.IoTConfig, configCtx *cchange.ConfigChangeRecorder) (reconcile.Result, error) {
 
 	rc := &recon.ReconcileContext{}
 
@@ -216,6 +218,7 @@ func (r *ReconcileIoTConfig) processQdrProxyConfig(ctx context.Context, config *
 router {
   mode: standalone
   id: Router.Proxy
+  defaultDistribution: unavailable
 }
 
 listener {
@@ -224,6 +227,8 @@ listener {
   saslMechanisms: ANONYMOUS
 }
 `
+			configCtx.AddString(configMap.Data["qdrouterd.conf"])
+
 			return nil
 		})
 	})

--- a/pkg/controller/iotconfig/auth_service.go
+++ b/pkg/controller/iotconfig/auth_service.go
@@ -56,10 +56,7 @@ func (r *ReconcileIoTConfig) reconcileAuthServiceDeployment(config *iotv1alpha1.
 	install.ApplyDeploymentDefaults(deployment, "iot", deployment.Name)
 
 	service := config.Spec.ServicesConfig.Authentication
-	applyDefaultDeploymentConfig(deployment, service.ServiceConfig)
-
-	// set the permissions hash on the pod template to re-deploy, in case the permissions.json changed
-	deployment.Spec.Template.Annotations["iot.enmasse.io/config-hash"] = configCtx.HashString()
+	applyDefaultDeploymentConfig(deployment, service.ServiceConfig, configCtx)
 
 	err := install.ApplyContainerWithError(deployment, "auth-service", func(container *corev1.Container) error {
 

--- a/pkg/controller/iotconfig/file_device_registry.go
+++ b/pkg/controller/iotconfig/file_device_registry.go
@@ -71,7 +71,7 @@ func (r *ReconcileIoTConfig) reconcileFileDeviceRegistryDeployment(config *iotv1
 	deployment.Annotations[RegistryTypeAnnotation] = "file"
 	deployment.Spec.Template.Annotations[RegistryTypeAnnotation] = "file"
 
-	applyDefaultDeploymentConfig(deployment, config.Spec.ServicesConfig.DeviceRegistry.ServiceConfig)
+	applyDefaultDeploymentConfig(deployment, config.Spec.ServicesConfig.DeviceRegistry.ServiceConfig, nil)
 
 	err := install.ApplyFsGroupOverride(deployment)
 

--- a/pkg/controller/iotconfig/infinispan_device_registry.go
+++ b/pkg/controller/iotconfig/infinispan_device_registry.go
@@ -70,7 +70,7 @@ func (r *ReconcileIoTConfig) reconcileInfinispanDeviceRegistryDeployment(config 
 	deployment.Spec.Template.Annotations[RegistryTypeAnnotation] = "infinispan"
 
 	service := config.Spec.ServicesConfig.DeviceRegistry
-	applyDefaultDeploymentConfig(deployment, service.ServiceConfig)
+	applyDefaultDeploymentConfig(deployment, service.ServiceConfig, nil)
 
 	err := install.ApplyContainerWithError(deployment, "device-registry", func(container *corev1.Container) error {
 

--- a/pkg/controller/iotconfig/iotconfig_controller.go
+++ b/pkg/controller/iotconfig/iotconfig_controller.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/enmasseproject/enmasse/pkg/util/cchange"
+
 	"github.com/enmasseproject/enmasse/pkg/util/install"
 
 	"github.com/enmasseproject/enmasse/pkg/util/recon"
@@ -175,8 +177,10 @@ func (r *ReconcileIoTConfig) Reconcile(request reconcile.Request) (reconcile.Res
 
 	// start normal reconcile
 
+	qdrProxyConfigCtx := cchange.NewRecorder()
+
 	rc.Process(func() (reconcile.Result, error) {
-		return r.processQdrProxyConfig(ctx, config)
+		return r.processQdrProxyConfig(ctx, config, qdrProxyConfigCtx)
 	})
 	rc.ProcessSimple(func() error {
 		return r.processCollector(ctx, config)
@@ -201,16 +205,16 @@ func (r *ReconcileIoTConfig) Reconcile(request reconcile.Request) (reconcile.Res
 		}
 	})
 	rc.Process(func() (reconcile.Result, error) {
-		return r.processHttpAdapter(ctx, config)
+		return r.processHttpAdapter(ctx, config, qdrProxyConfigCtx)
 	})
 	rc.Process(func() (reconcile.Result, error) {
-		return r.processMqttAdapter(ctx, config)
+		return r.processMqttAdapter(ctx, config, qdrProxyConfigCtx)
 	})
 	rc.Process(func() (reconcile.Result, error) {
-		return r.processSigfoxAdapter(ctx, config)
+		return r.processSigfoxAdapter(ctx, config, qdrProxyConfigCtx)
 	})
 	rc.Process(func() (reconcile.Result, error) {
-		return r.processLoraWanAdapter(ctx, config)
+		return r.processLoraWanAdapter(ctx, config, qdrProxyConfigCtx)
 	})
 
 	return r.updateFinalStatus(ctx, config, rc)

--- a/pkg/controller/iotconfig/project_operator.go
+++ b/pkg/controller/iotconfig/project_operator.go
@@ -23,7 +23,7 @@ func (r *ReconcileIoTConfig) reconcileProjectOperator(config *iotv1alpha1.IoTCon
 
 	install.ApplyDeploymentDefaults(deployment, "iot", deployment.Name)
 
-	applyDefaultDeploymentConfig(deployment, config.Spec.ServicesConfig.Operator.ServiceConfig)
+	applyDefaultDeploymentConfig(deployment, config.Spec.ServicesConfig.Operator.ServiceConfig, nil)
 
 	deployment.Spec.Template.Spec.ServiceAccountName = "iot-operator"
 

--- a/pkg/controller/iotconfig/tenant_service.go
+++ b/pkg/controller/iotconfig/tenant_service.go
@@ -47,7 +47,7 @@ func (r *ReconcileIoTConfig) reconcileTenantServiceDeployment(config *iotv1alpha
 	install.ApplyDeploymentDefaults(deployment, "iot", deployment.Name)
 
 	service := config.Spec.ServicesConfig.Tenant
-	applyDefaultDeploymentConfig(deployment, service.ServiceConfig)
+	applyDefaultDeploymentConfig(deployment, service.ServiceConfig, nil)
 
 	err := install.ApplyContainerWithError(deployment, "tenant-service", func(container *corev1.Container) error {
 

--- a/pkg/controller/iotconfig/utils.go
+++ b/pkg/controller/iotconfig/utils.go
@@ -8,6 +8,8 @@ package iotconfig
 import (
 	"context"
 
+	"github.com/enmasseproject/enmasse/pkg/util/cchange"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -66,9 +68,14 @@ func AppendStandardHonoJavaOptions(container *corev1.Container) {
 	)
 }
 
-func applyDefaultDeploymentConfig(deployment *appsv1.Deployment, serviceConfig iotv1alpha1.ServiceConfig) {
+func applyDefaultDeploymentConfig(deployment *appsv1.Deployment, serviceConfig iotv1alpha1.ServiceConfig, configCtx *cchange.ConfigChangeRecorder) {
 	deployment.Spec.Replicas = serviceConfig.Replicas
 	deployment.Spec.Strategy.Type = appsv1.RollingUpdateDeploymentStrategyType
+	if configCtx != nil {
+		deployment.Spec.Template.Annotations["iot.enmasse.io/config-hash"] = configCtx.HashString()
+	} else {
+		delete(deployment.Spec.Template.Annotations, "iot.enmasse.io/config-hash")
+	}
 }
 
 func applyContainerConfig(container *corev1.Container, config *iotv1alpha1.ContainerConfig) {

--- a/pkg/util/cchange/change.go
+++ b/pkg/util/cchange/change.go
@@ -50,3 +50,16 @@ func (c ConfigChangeRecorder) Hash() []byte {
 func (c ConfigChangeRecorder) HashString() string {
 	return hex.EncodeToString(c.Hash())
 }
+
+func (c ConfigChangeRecorder) Clone() *ConfigChangeRecorder {
+
+	// start a new hash
+	new := sha256.New()
+	// taking the parent into consideration
+	new.Write(c.hasher.Sum(nil))
+
+	// return the new
+	return &ConfigChangeRecorder{
+		hasher: new,
+	}
+}


### PR DESCRIPTION
This change sets the proxy routers to not created addresses
when the protocol adapters requests them.

Also it does add config tracking to the protocol adapter deployments in
in order to activate the change.

### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [X] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
