### PR TITLE
Prevent continuous updates when project is creating

### DIFF
--- a/pkg/controller/iotproject/managed.go
+++ b/pkg/controller/iotproject/managed.go
@@ -8,6 +8,7 @@ package iotproject
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/enmasseproject/enmasse/pkg/util/install"
@@ -55,7 +56,15 @@ type managedStatus struct {
 func updateFromMap(resources map[string]bool, condition *iotv1alpha1.CommonCondition, reason string) {
 
 	message := ""
-	for k, v := range resources {
+
+	keys := make([]string, 0, len(resources))
+	for k := range resources {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		v := resources[k]
 		if v {
 			continue
 		}


### PR DESCRIPTION
As the map key order is randomized, a change will cause a new order in
the message field, which will cause an update on the object, which will
cause another change, …

### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
