### PR TITLE
Add the missing Phase field to Go AddressSpaceStatus

### DIFF
--- a/pkg/apis/enmasse/v1beta1/types.go
+++ b/pkg/apis/enmasse/v1beta1/types.go
@@ -113,6 +113,7 @@ type ConnectorAddressRule struct {
 
 type AddressSpaceStatus struct {
 	IsReady        bool              `json:"isReady"`
+	Phase          string            `json:"phase,omitempty"`
 	Messages       []string          `json:"messages,omitempty"`
 	CACertificate  []byte            `json:"caCert,omitempty"`
 	EndpointStatus []EndpointStatus  `json:"endpointStatuses,omitempty"`


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Add the missing Phase field to Go AddressSpaceStatus

### Checklist


- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
