### PR TITLE
Fix finalizer logic in address space controller, add unit test

### DIFF
--- a/address-space-controller/src/main/java/io/enmasse/controller/AddressFinalizerController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/AddressFinalizerController.java
@@ -18,7 +18,7 @@ public class AddressFinalizerController extends AbstractFinalizeController {
 
     private static final Logger log = LoggerFactory.getLogger(AddressFinalizerController.class.getName());
 
-    private static final String FINALIZER_ADDRESSES = "enmasse.io/addresses";
+    public static final String FINALIZER_ADDRESSES = "enmasse.io/addresses";
 
     private static final Integer BATCH_SIZE = Integer.getInteger("io.enmasse.controller.AddressFinalizerController.batchSize", 100);
 

--- a/address-space-controller/src/main/java/io/enmasse/controller/ControllerChain.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/ControllerChain.java
@@ -98,7 +98,7 @@ public class ControllerChain implements Watcher<AddressSpace> {
                 for (Controller controller : chain) {
                     log.info("Controller {}", controller);
                     log.debug("Address space input: {}", addressSpace);
-                    addressSpace = controller.reconcileActive(addressSpace);
+                    addressSpace = controller.reconcileAnyState(addressSpace);
                 }
 
                 log.debug("Controller chain output: {}", addressSpace);

--- a/address-space-controller/src/test/java/io/enmasse/controller/AddressFinalizerControllerTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/AddressFinalizerControllerTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2019, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.controller;
+
+import static org.hamcrest.core.IsCollectionContaining.hasItems;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.enmasse.address.model.Address;
+import io.enmasse.address.model.AddressBuilder;
+import io.enmasse.address.model.AddressSpace;
+import io.enmasse.address.model.AddressSpaceBuilder;
+import io.enmasse.k8s.api.AddressApi;
+import io.enmasse.k8s.api.AddressSpaceApi;
+import io.enmasse.k8s.api.TestAddressSpaceApi;
+import io.enmasse.model.CustomResourceDefinitions;
+
+public class AddressFinalizerControllerTest {
+
+    private AddressFinalizerController controller;
+    private AddressSpaceApi addressSpaceApi;
+
+    @BeforeAll
+    public static void init () {
+        CustomResourceDefinitions.registerAll();
+    }
+
+    @BeforeEach
+    public void setup() {
+        this.addressSpaceApi = new TestAddressSpaceApi();
+        this.controller = new AddressFinalizerController(addressSpaceApi);
+    }
+
+    /**
+     * Test calling the finalizer controller with a non-deleted object.
+     */
+    @Test
+    public void testAddingFinalizer () throws Exception {
+
+        // given a non-delete object
+
+        AddressSpace addressSpace = new AddressSpaceBuilder()
+                .withNewMetadata()
+                .withName("foo")
+                .withNamespace("bar")
+                .withFinalizers("foo/bar")
+                .endMetadata()
+                .build();
+
+        // when calling the reconcile method of the finalizer controller
+
+        addressSpace = controller.reconcileAnyState(addressSpace);
+
+        // it should add the finalizer, but not remove existing finalizers
+
+        assertThat(addressSpace, notNullValue());
+        assertThat(addressSpace.getMetadata(), notNullValue());
+        assertThat(addressSpace.getMetadata().getFinalizers(), hasItems("foo/bar", AddressFinalizerController.FINALIZER_ADDRESSES));
+
+    }
+
+    @Test
+    public void testProcessingFinalizer () throws Exception {
+
+        // given a deleted address space, with the finalizer still present
+
+        AddressSpace addressSpace = new AddressSpaceBuilder()
+                .withNewMetadata()
+                .withName("foo")
+                .withNamespace("bar")
+                .withDeletionTimestamp(Instant.now().atZone(ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME))
+                .withFinalizers("foo/bar", AddressFinalizerController.FINALIZER_ADDRESSES)
+                .endMetadata()
+                .build();
+
+        addressSpaceApi.createAddressSpace(addressSpace);
+        AddressApi addressApi = addressSpaceApi.withAddressSpace(addressSpace);
+
+        // and given an existing address for this address space
+
+        Address address = new AddressBuilder()
+                .withNewMetadata()
+                .withName("foo.foo")
+                .withNamespace("bar")
+                .endMetadata()
+                .build();
+
+        addressApi.createAddress(address);
+
+        // and given another address space and address
+
+        AddressSpace otherAddressSpace = new AddressSpaceBuilder()
+                .withNewMetadata()
+                .withName("foo2")
+                .withNamespace("bar")
+                .withFinalizers("foo/bar", AddressFinalizerController.FINALIZER_ADDRESSES)
+                .endMetadata()
+                .build();
+
+        addressSpaceApi.createAddressSpace(otherAddressSpace);
+        AddressApi otherAddressApi = addressSpaceApi.withAddressSpace(otherAddressSpace);
+
+        // and given an existing address for this address space
+
+        Address otherAddress = new AddressBuilder()
+                .withNewMetadata()
+                .withName("foo2.foo")
+                .withNamespace("bar")
+                .endMetadata()
+                .build();
+
+        otherAddressApi.createAddress(otherAddress);
+
+        // ensure that the address spaces and addresses should be found
+
+        assertThat(addressSpaceApi.getAddressSpaceWithName("bar", "foo").orElse(null), notNullValue());
+        assertThat(addressApi.getAddressWithName("bar", "foo.foo").orElse(null), notNullValue());
+        assertThat(addressSpaceApi.getAddressSpaceWithName("bar", "foo2").orElse(null), notNullValue());
+        assertThat(otherAddressApi.getAddressWithName("bar", "foo2.foo").orElse(null), notNullValue());
+
+        // when running the reconcile method
+
+        addressSpace = controller.reconcileAnyState(addressSpace);
+
+        // then the finalizer of this controller should be removed, and the address should be deleted
+
+        assertThat(addressSpace, notNullValue());
+        assertThat(addressSpace.getMetadata(), notNullValue());
+        assertThat(addressSpace.getMetadata().getFinalizers(), hasItems("foo/bar"));
+
+        assertThat(addressSpaceApi.getAddressSpaceWithName("bar", "foo").orElse(null), notNullValue());
+        assertThat(addressApi.getAddressWithName("bar", "foo.foo").orElse(null), nullValue());
+
+        // but not the "other" address
+
+        assertThat(addressSpaceApi.getAddressSpaceWithName("bar", "foo2").orElse(null), notNullValue());
+        assertThat(otherAddressApi.getAddressWithName("bar", "foo2.foo").orElse(null), notNullValue());
+    }
+}

--- a/address-space-controller/src/test/java/io/enmasse/controller/ControllerChainTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/ControllerChainTest.java
@@ -64,14 +64,14 @@ public class ControllerChainTest {
                 .withNewStatus(false)
                 .build();
 
-        when(mockController.reconcileActive(eq(a1))).thenReturn(a1);
-        when(mockController.reconcileActive(eq(a2))).thenReturn(a2);
+        when(mockController.reconcileAnyState(eq(a1))).thenReturn(a1);
+        when(mockController.reconcileAnyState(eq(a2))).thenReturn(a2);
 
         controllerChain.onUpdate(Arrays.asList(a1, a2));
 
-        verify(mockController, times(2)).reconcileActive(any());
-        verify(mockController).reconcileActive(eq(a1));
-        verify(mockController).reconcileActive(eq(a2));
+        verify(mockController, times(2)).reconcileAnyState(any());
+        verify(mockController).reconcileAnyState(eq(a1));
+        verify(mockController).reconcileAnyState(eq(a2));
 
 
     }

--- a/address-space-controller/src/test/java/io/enmasse/controller/CreateControllerTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/CreateControllerTest.java
@@ -75,7 +75,7 @@ public class CreateControllerTest {
         SchemaProvider testSchema = new TestSchemaProvider();
         CreateController createController = new CreateController(kubernetes, testSchema, mockResourceFactory, eventLogger, null, "1.0", new TestAddressSpaceApi());
 
-        createController.reconcileActive(addressSpace);
+        createController.reconcileAnyState(addressSpace);
 
         ArgumentCaptor<KubernetesList> resourceCaptor = ArgumentCaptor.forClass(KubernetesList.class);
         verify(kubernetes).create(resourceCaptor.capture());
@@ -150,7 +150,7 @@ public class CreateControllerTest {
 
         CreateController createController = new CreateController(kubernetes, testSchema, null, eventLogger, null, "1.0", addressSpaceApi);
 
-        addressSpace = createController.reconcileActive(addressSpace);
+        addressSpace = createController.reconcileAnyState(addressSpace);
 
         assertThat(addressSpace.getStatus().getMessages().size(), is(1));
         assertTrue(addressSpace.getStatus().getMessages().iterator().next().contains("quota exceeded for resource broker"));

--- a/address-space-controller/src/test/java/io/enmasse/controller/EndpointControllerTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/EndpointControllerTest.java
@@ -46,7 +46,7 @@ public class EndpointControllerTest extends JULInitializingTest {
     }
 
     @Test
-    public void testRoutesNotCreated() {
+    public void testRoutesNotCreated() throws Exception {
         AddressSpace addressSpace = new AddressSpaceBuilder()
 
                 .withNewMetadata()
@@ -86,7 +86,7 @@ public class EndpointControllerTest extends JULInitializingTest {
 
         EndpointController controller = new EndpointController(client, false, false);
 
-        AddressSpace newspace = controller.reconcileActive(addressSpace);
+        AddressSpace newspace = controller.reconcileAnyState(addressSpace);
 
         assertThat(newspace.getStatus().getEndpointStatuses().size(), is(1));
         assertThat(newspace.getStatus().getEndpointStatuses().get(0).getName(), is("myendpoint"));
@@ -97,7 +97,7 @@ public class EndpointControllerTest extends JULInitializingTest {
     }
 
     @Test
-    public void testExternalLoadBalancerCreated() {
+    public void testExternalLoadBalancerCreated() throws Exception {
         AddressSpace addressSpace = new AddressSpaceBuilder()
 
                 .withNewMetadata()
@@ -142,7 +142,7 @@ public class EndpointControllerTest extends JULInitializingTest {
 
         EndpointController controller = new EndpointController(client, true, false);
 
-        AddressSpace newspace = controller.reconcileActive(addressSpace);
+        AddressSpace newspace = controller.reconcileAnyState(addressSpace);
 
         assertThat(newspace.getStatus().getEndpointStatuses().size(), is(1));
         assertThat(newspace.getStatus().getEndpointStatuses().get(0).getName(), is("myendpoint"));
@@ -151,7 +151,7 @@ public class EndpointControllerTest extends JULInitializingTest {
         assertThat(newspace.getStatus().getEndpointStatuses().get(0).getExternalPorts().size(), is(1));
     }
 
-    public void testExternalRouteCreated() {
+    public void testExternalRouteCreated() throws Exception {
         AddressSpace addressSpace = new AddressSpaceBuilder()
 
                 .withNewMetadata()
@@ -198,7 +198,7 @@ public class EndpointControllerTest extends JULInitializingTest {
 
         EndpointController controller = new EndpointController(client, true, true);
 
-        AddressSpace newspace = controller.reconcileActive(addressSpace);
+        AddressSpace newspace = controller.reconcileAnyState(addressSpace);
 
         assertThat(newspace.getStatus().getEndpointStatuses().size(), is(1));
         assertThat(newspace.getStatus().getEndpointStatuses().get(0).getName(), is("myendpoint"));

--- a/address-space-controller/src/test/java/io/enmasse/controller/ExportsControllerTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/ExportsControllerTest.java
@@ -44,13 +44,13 @@ public class ExportsControllerTest extends JULInitializingTest {
     }
 
     @Test
-    public void testExportConfigMap() {
+    public void testExportConfigMap() throws Exception {
         AddressSpace addressSpace = createTestSpace(new ExportSpecBuilder()
                 .withKind(ExportKind.ConfigMap)
                 .withName("mymap").build());
 
         ExportsController controller = new ExportsController(client);
-        controller.reconcileActive(addressSpace);
+        controller.reconcileAnyState(addressSpace);
 
         ConfigMap configMap = client.configMaps().inNamespace(addressSpace.getMetadata().getNamespace()).withName("mymap").get();
         assertNotNull(configMap);
@@ -63,7 +63,7 @@ public class ExportsControllerTest extends JULInitializingTest {
         assertEquals("mycert", data.get("ca.crt"));
 
         addressSpace.getStatus().getEndpointStatuses().get(0).setServiceHost("messaging2.svc");
-        controller.reconcileActive(addressSpace);
+        controller.reconcileAnyState(addressSpace);
 
         configMap = client.configMaps().inNamespace(addressSpace.getMetadata().getNamespace()).withName("mymap").get();
         assertNotNull(configMap);
@@ -72,14 +72,14 @@ public class ExportsControllerTest extends JULInitializingTest {
     }
 
     @Test
-    public void testExportSecret() {
+    public void testExportSecret() throws Exception {
         AddressSpace addressSpace = createTestSpace(
                 new ExportSpecBuilder()
                         .withKind(ExportKind.Secret)
                         .withName("mysecret")
                         .build());
         ExportsController controller = new ExportsController(client);
-        controller.reconcileActive(addressSpace);
+        controller.reconcileAnyState(addressSpace);
 
         Secret secret = client.secrets().inNamespace(addressSpace.getMetadata().getNamespace()).withName("mysecret").get();
         assertNotNull(secret);
@@ -92,7 +92,7 @@ public class ExportsControllerTest extends JULInitializingTest {
         assertEquals("mycert", data.get("ca.crt"));
 
         addressSpace.getStatus().getEndpointStatuses().get(0).setServiceHost("messaging2.svc");
-        controller.reconcileActive(addressSpace);
+        controller.reconcileAnyState(addressSpace);
 
         secret = client.secrets().inNamespace(addressSpace.getMetadata().getNamespace()).withName("mysecret").get();
         assertNotNull(secret);
@@ -108,7 +108,7 @@ public class ExportsControllerTest extends JULInitializingTest {
                         .withName("myservice")
                         .build());
         ExportsController controller = new ExportsController(client);
-        controller.reconcileActive(addressSpace);
+        controller.reconcileAnyState(addressSpace);
 
         Service service = client.services().inNamespace(addressSpace.getMetadata().getNamespace()).withName("myservice").get();
         assertNotNull(service);
@@ -117,7 +117,7 @@ public class ExportsControllerTest extends JULInitializingTest {
         assertEquals(2, service.getSpec().getPorts().size());
 
         addressSpace.getStatus().getEndpointStatuses().get(0).setServiceHost("messaging2.svc");
-        controller.reconcileActive(addressSpace);
+        controller.reconcileAnyState(addressSpace);
 
         service = client.services().inNamespace(addressSpace.getMetadata().getNamespace()).withName("myservice").get();
         assertNotNull(service);

--- a/address-space-controller/src/test/java/io/enmasse/controller/NetworkPolicyControllerTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/NetworkPolicyControllerTest.java
@@ -64,7 +64,7 @@ public class NetworkPolicyControllerTest extends JULInitializingTest {
         AddressSpace addressSpace = createTestSpace(infraConfig, null);
 
         NetworkPolicyController controller = new NetworkPolicyController(client);
-        controller.reconcileActive(addressSpace);
+        controller.reconcileAnyState(addressSpace);
 
         assertEquals(1, client.network().networkPolicies().list().getItems().size());
         io.fabric8.kubernetes.api.model.networking.NetworkPolicy networkPolicy = client.network().networkPolicies().withName(KubeUtil.getNetworkPolicyName(addressSpace)).get();
@@ -81,7 +81,7 @@ public class NetworkPolicyControllerTest extends JULInitializingTest {
         AddressSpace addressSpace = createTestSpace(infraConfig, createTestPolicy("my", "label"));
 
         NetworkPolicyController controller = new NetworkPolicyController(client);
-        controller.reconcileActive(addressSpace);
+        controller.reconcileAnyState(addressSpace);
 
         assertEquals(1, client.network().networkPolicies().list().getItems().size());
         io.fabric8.kubernetes.api.model.networking.NetworkPolicy networkPolicy = client.network().networkPolicies().withName(KubeUtil.getNetworkPolicyName(addressSpace)).get();
@@ -98,7 +98,7 @@ public class NetworkPolicyControllerTest extends JULInitializingTest {
         AddressSpace addressSpace = createTestSpace(infraConfig, createTestPolicy("my", "overridden"));
 
         NetworkPolicyController controller = new NetworkPolicyController(client);
-        controller.reconcileActive(addressSpace);
+        controller.reconcileAnyState(addressSpace);
 
         assertEquals(1, client.network().networkPolicies().list().getItems().size());
         io.fabric8.kubernetes.api.model.networking.NetworkPolicy networkPolicy = client.network().networkPolicies().withName(KubeUtil.getNetworkPolicyName(addressSpace)).get();
@@ -117,7 +117,7 @@ public class NetworkPolicyControllerTest extends JULInitializingTest {
                 createTestPolicy("my", "label1"));
 
         NetworkPolicyController controller = new NetworkPolicyController(client);
-        controller.reconcileActive(addressSpace);
+        controller.reconcileAnyState(addressSpace);
 
         assertEquals(1, client.network().networkPolicies().list().getItems().size());
         io.fabric8.kubernetes.api.model.networking.NetworkPolicy networkPolicy = client.network().networkPolicies().withName(KubeUtil.getNetworkPolicyName(addressSpace)).get();
@@ -126,7 +126,7 @@ public class NetworkPolicyControllerTest extends JULInitializingTest {
         assertEquals("label1", networkPolicy.getSpec().getIngress().get(0).getFrom().get(0).getPodSelector().getMatchLabels().get("my"));
 
         addressSpace = createTestSpace(infraConfig, createTestPolicy("my", "label2"));
-        controller.reconcileActive(addressSpace);
+        controller.reconcileAnyState(addressSpace);
 
         assertEquals(1, client.network().networkPolicies().list().getItems().size());
         networkPolicy = client.network().networkPolicies().withName(KubeUtil.getNetworkPolicyName(addressSpace)).get();
@@ -135,7 +135,7 @@ public class NetworkPolicyControllerTest extends JULInitializingTest {
         assertEquals("label2", networkPolicy.getSpec().getIngress().get(0).getFrom().get(0).getPodSelector().getMatchLabels().get("my"));
 
         addressSpace = createTestSpace(infraConfig, createTestPolicy("my", "label2", "other", "label3"));
-        controller.reconcileActive(addressSpace);
+        controller.reconcileAnyState(addressSpace);
         networkPolicy = client.network().networkPolicies().withName(KubeUtil.getNetworkPolicyName(addressSpace)).get();
         assertNotNull(networkPolicy);
         assertThat(networkPolicy.getSpec().getPolicyTypes(), hasItem("Ingress"));
@@ -150,7 +150,7 @@ public class NetworkPolicyControllerTest extends JULInitializingTest {
         AddressSpace addressSpace = createTestSpace(infraConfig, createTestPolicy("my", "label"));
 
         NetworkPolicyController controller = new NetworkPolicyController(client);
-        controller.reconcileActive(addressSpace);
+        controller.reconcileAnyState(addressSpace);
 
         assertEquals(1, client.network().networkPolicies().list().getItems().size());
         io.fabric8.kubernetes.api.model.networking.NetworkPolicy networkPolicy = client.network().networkPolicies().withName(KubeUtil.getNetworkPolicyName(addressSpace)).get();
@@ -159,7 +159,7 @@ public class NetworkPolicyControllerTest extends JULInitializingTest {
         assertEquals("label", networkPolicy.getSpec().getIngress().get(0).getFrom().get(0).getPodSelector().getMatchLabels().get("my"));
 
         addressSpace = createTestSpace(infraConfig, null);
-        controller.reconcileActive(addressSpace);
+        controller.reconcileAnyState(addressSpace);
         assertEquals(0, client.network().networkPolicies().list().getItems().size());
         networkPolicy = client.network().networkPolicies().withName(KubeUtil.getNetworkPolicyName(addressSpace)).get();
         assertNull(networkPolicy);

--- a/address-space-controller/src/test/java/io/enmasse/controller/RouterConfigControllerTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/RouterConfigControllerTest.java
@@ -105,7 +105,7 @@ public class RouterConfigControllerTest {
                 .build();
         InfraConfigs.setCurrentInfraConfig(addressSpace, appliedConfig);
 
-        configController.reconcileActive(addressSpace);
+        configController.reconcileAnyState(addressSpace);
 
         ConfigMap routerConfigMap = client.configMaps().inNamespace("test").withName("qdrouterd-config.1234").get();
         assertNotNull(routerConfigMap);
@@ -152,7 +152,7 @@ public class RouterConfigControllerTest {
         appliedConfig.getSpec().getRouter().getPolicy().setMaxConnectionsPerUser(300);
         InfraConfigs.setCurrentInfraConfig(addressSpace, appliedConfig);
 
-        configController.reconcileActive(addressSpace);
+        configController.reconcileAnyState(addressSpace);
 
         routerConfigMap = client.configMaps().inNamespace("test").withName("qdrouterd-config.1234").get();
         assertNotNull(routerConfigMap);
@@ -264,7 +264,7 @@ public class RouterConfigControllerTest {
                 .done();
                 */
 
-        configController.reconcileActive(addressSpace);
+        configController.reconcileAnyState(addressSpace);
 
         AddressSpaceStatusConnector status = addressSpace.getStatus().getConnectors().get(0);
         assertNotNull(status);
@@ -298,7 +298,7 @@ public class RouterConfigControllerTest {
                 .addToData("ca.crt", "ca")
                 .done();
 
-        configController.reconcileActive(addressSpace);
+        configController.reconcileAnyState(addressSpace);
 
 
         routerConfigMap = client.configMaps().inNamespace("test").withName("qdrouterd-config.1234").get();

--- a/address-space-controller/src/test/java/io/enmasse/controller/StatusControllerTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/StatusControllerTest.java
@@ -77,7 +77,7 @@ public class StatusControllerTest {
         when(infraResourceFactory.createInfraResources(eq(addressSpace), any())).thenReturn(Collections.singletonList(deployment));
 
         assertFalse(addressSpace.getStatus().isReady());
-        controller.reconcileActive(addressSpace);
+        controller.reconcileAnyState(addressSpace);
         assertFalse(addressSpace.getStatus().isReady());
     }
 }

--- a/k8s-api-testutil/src/main/java/io/enmasse/k8s/api/TestAddressApi.java
+++ b/k8s-api-testutil/src/main/java/io/enmasse/k8s/api/TestAddressApi.java
@@ -80,7 +80,7 @@ public class TestAddressApi implements AddressApi {
 
     @Override
     public ContinuationResult<Address> listAddresses(String namespace, Integer limit, ContinuationResult<Address> continueValue, Map<String, String> labels) {
-        throw new UnsupportedOperationException();
+        return ContinuationResult.from(listAddresses(namespace), null);
     }
 
     @Override


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

The controller chain called the wrong method (the one processing the "non-deleted" state). In this case the finalizer was never run, and when deleting the object, still all the "active" methods got called.

This change fixes the call, now calling the correct method. And adding a unit test to ensure that the finalizer gets called and properly handles finalizing the address space.

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
