### PR TITLE
Propagate fsGroup environment

### DIFF
--- a/olm-manifest/src/main/resources/latest/enmasse.clusterserviceversion.yaml
+++ b/olm-manifest/src/main/resources/latest/enmasse.clusterserviceversion.yaml
@@ -697,7 +697,7 @@ spec:
                   value: "${env.CONSOLE_PROXY_KUBERNETES_IMAGE}"
                 - name: CONSOLE_HTTPD_IMAGE
                   value: "${env.CONSOLE_HTTPD_IMAGE}"
-                - name: FS_GROUP_OVERRIDE
+                - name: FS_GROUP_STANDARD_AUTHSERVICE_OVERRIDE
                   value: "1000"
       - name: user-api-server
         spec:

--- a/pkg/controller/address_space_controller/controller.go
+++ b/pkg/controller/address_space_controller/controller.go
@@ -31,7 +31,6 @@ import (
 	resource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
-	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	controllertypes "k8s.io/apimachinery/pkg/types"
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
 	kubernetes "k8s.io/client-go/kubernetes"
@@ -139,12 +138,6 @@ func (r *ReconcileAddressSpaceController) ensureDeployment(ctx context.Context, 
 		},
 	}
 
-	deployment.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "apps",
-		Kind:    "Deployment",
-		Version: "v1",
-	})
-
 	_, err := controllerutil.CreateOrUpdate(ctx, r.client, deployment, func() error {
 		return ApplyDeployment(deployment)
 	})
@@ -165,6 +158,12 @@ func ApplyDeployment(deployment *appsv1.Deployment) error {
 		install.ApplyEnvSimple(container, "ENABLE_EVENT_LOGGER", "true")
 		install.ApplyEnvSimple(container, "TEMPLATE_DIR", "/opt/templates")
 		install.ApplyEnvSimple(container, "RESOURCES_DIR", "/opt")
+
+		value, ok := os.LookupEnv("FS_GROUP_OVERRIDE")
+		if ok {
+			install.ApplyEnvSimple(container, "FS_GROUP_OVERRIDE", value)
+		}
+
 		t := true
 		install.ApplyEnvConfigMap(container, "WILDCARD_ENDPOINT_CERT_SECRET", "wildcardEndpointCertSecret", "address-space-controller-config", &t)
 		install.ApplyEnvConfigMap(container, "RESYNC_INTERVAL", "resyncInterval", "address-space-controller-config", &t)
@@ -209,13 +208,6 @@ func ApplyDeployment(deployment *appsv1.Deployment) error {
 	deployment.Spec.Template.Spec.ServiceAccountName = "address-space-controller"
 	deployment.Spec.Replicas = &one
 	install.ApplyNodeAffinity(&deployment.Spec.Template, "node-role.enmasse.io/operator-infra")
-	install.ApplyFsGroupOverride(deployment)
-
-	deployment.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "apps",
-		Kind:    "Deployment",
-		Version: "v1",
-	})
 
 	return nil
 }

--- a/pkg/controller/authenticationservice/standard.go
+++ b/pkg/controller/authenticationservice/standard.go
@@ -106,7 +106,7 @@ func applyStandardAuthServiceDeployment(authservice *adminv1beta1.Authentication
 		return err
 	}
 
-	err := install.ApplyFsGroupOverride("FS_GROUP_STANDARD_AUTHSERVICE_OVERRIDE", deployment)
+	err = install.ApplyFsGroupOverride("FS_GROUP_STANDARD_AUTHSERVICE_OVERRIDE", deployment)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/authenticationservice/standard.go
+++ b/pkg/controller/authenticationservice/standard.go
@@ -101,8 +101,12 @@ func applyStandardAuthServiceDeployment(authservice *adminv1beta1.Authentication
 
 	install.ApplyDeploymentDefaults(deployment, "standard-authservice", *authservice.Spec.Standard.DeploymentName)
 
-	err := install.ApplyFsGroupOverride(deployment)
+	err := install.ApplyFsGroupOverride("FS_GROUP_OVERRIDE", deployment)
+	if err != nil {
+		return err
+	}
 
+	err := install.ApplyFsGroupOverride("FS_GROUP_STANDARD_AUTHSERVICE_OVERRIDE", deployment)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/iotconfig/file_device_registry.go
+++ b/pkg/controller/iotconfig/file_device_registry.go
@@ -73,7 +73,7 @@ func (r *ReconcileIoTConfig) reconcileFileDeviceRegistryDeployment(config *iotv1
 
 	applyDefaultDeploymentConfig(deployment, config.Spec.ServicesConfig.DeviceRegistry.ServiceConfig, nil)
 
-	err := install.ApplyFsGroupOverride(deployment)
+	err := install.ApplyFsGroupOverride("FS_GROUP_OVERRIDE", deployment)
 
 	if err != nil {
 		return err

--- a/pkg/util/install/utils.go
+++ b/pkg/util/install/utils.go
@@ -497,8 +497,8 @@ func ApplyNodeAffinity(template *corev1.PodTemplateSpec, matchKey string) {
 // This is a workaround for a problem that may manifest when EnMasse is deployed into OLM cluster-wide
 // under certain configurations. If https://github.com/operator-framework/operator-lifecycle-manager/issues/927
 // is resolved, this workaround can be removed.
-func ApplyFsGroupOverride(deployment *appsv1.Deployment) error {
-	err := util.ApplyEnv("FS_GROUP_OVERRIDE", func(name string, value string, ok bool) error {
+func ApplyFsGroupOverride(envVar string, deployment *appsv1.Deployment) error {
+	err := util.ApplyEnv(envVar, func(name string, value string, ok bool) error {
 		if ok {
 			fsGroupOverride, err := strconv.ParseInt(value, 10, 0)
 			if deployment.Spec.Template.Spec.SecurityContext == nil {

--- a/templates/enmasse-operator/050-Deployment-enmasse-operator.yaml
+++ b/templates/enmasse-operator/050-Deployment-enmasse-operator.yaml
@@ -111,3 +111,5 @@ spec:
           value: "${CONSOLE_PROXY_KUBERNETES_IMAGE}"
         - name: CONSOLE_HTTPD_IMAGE
           value: "${CONSOLE_HTTPD_IMAGE}"
+        - name: FS_GROUP_STANDARD_AUTHSERVICE_OVERRIDE
+          value: "1000"

--- a/templates/enmasse-operator/050-Deployment-enmasse-operator.yaml
+++ b/templates/enmasse-operator/050-Deployment-enmasse-operator.yaml
@@ -111,5 +111,3 @@ spec:
           value: "${CONSOLE_PROXY_KUBERNETES_IMAGE}"
         - name: CONSOLE_HTTPD_IMAGE
           value: "${CONSOLE_HTTPD_IMAGE}"
-        - name: FS_GROUP_STANDARD_AUTHSERVICE_OVERRIDE
-          value: "1000"


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

Instead of applying the fsgroup environment to the
address-space-controller, propagate it so that it is applied to brokers
etc.

Remove unneeded GVK setting that was added for some debugging earlier.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
