### PR TITLE
Fix crc image localbuild

### DIFF
--- a/.jenkins/Jenkinsfile-pr
+++ b/.jenkins/Jenkinsfile-pr
@@ -81,8 +81,10 @@ pipeline {
                         env.TEST_ONLY = false
                         if (env.OC_VERSION == "4") {
                             env.DOCKER_REGISTRY = 'default-route-openshift-image-registry.apps-crc.testing'
+                            env.INTERNAL_REGISTRY = 'image-registry.openshift-image-registry.svc:5000'
                         } else {
                             env.DOCKER_REGISTRY = '172.30.1.1:5000'
+                            env.INTERNAL_REGISTRY = '172.30.1.1:5000'
                         }
                         env.DOCKER_ORG = 'enmasseci'
                     }
@@ -177,6 +179,7 @@ pipeline {
             environment {
                 UPGRADE_TEMPLATES = "${WORKSPACE}/enmasse/templates/build/enmasse-${env.TAG}"
                 START_TEMPLATES = "${WORKSPACE}/enmasse/templates/build/enmasse-${env.UPGRADE_FROM}"
+                DOCKER_REGISTRY = "${env.INTERNAL_REGISTRY}"
             }
             steps {
                 script {
@@ -193,6 +196,9 @@ pipeline {
         stage('[PR] system tests') {
             when {
                 expression { env.TEST_PROFILE != 'upgrade' }
+            }
+            environment {
+                DOCKER_REGISTRY = "${env.INTERNAL_REGISTRY}"
             }
             steps {
                 dir('enmasse') {

--- a/.jenkins/Jenkinsfile-pr
+++ b/.jenkins/Jenkinsfile-pr
@@ -79,7 +79,11 @@ pipeline {
                         env.DOCKER_ORG = 'enmasse'
                     } else {
                         env.TEST_ONLY = false
-                        env.DOCKER_REGISTRY = '172.30.1.1:5000'
+                        if (env.OC_VERSION == "4") {
+                            env.DOCKER_REGISTRY = 'default-route-openshift-image-registry.apps-crc.testing'
+                        } else {
+                            env.DOCKER_REGISTRY = '172.30.1.1:5000'
+                        }
                         env.DOCKER_ORG = 'enmasseci'
                     }
 
@@ -123,9 +127,8 @@ pipeline {
             }
             steps {
                 dir('enmasse') {
-                    sh 'oc login -u test -p test --server localhost:8443 --insecure-skip-tls-verify'
                     sh 'oc new-project enmasseci'
-                    sh '$DOCKER login -u unused -p `oc whoami -t` $DOCKER_REGISTRY'
+                    sh 'docker login -u unused -p `oc whoami -t` $DOCKER_REGISTRY'
                     sh 'make docker_push'
                 }
             }


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

<!--

_Please describe your pull request_

-->

CRC image localbuild for PR does not work because of different internal registry URL

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
