### PR TITLE
Docs: add admonition to not use self-signed certs in prod environments

### DIFF
--- a/documentation/modules/ref-address-space-example-cert-providers.adoc
+++ b/documentation/modules/ref-address-space-example-cert-providers.adoc
@@ -39,6 +39,8 @@ The `selfsigned` certificate provider can be used to configure endpoints with se
 certificates. The CA for these certificates can be found in the `status.caCert` field of the
 `AddressSpace` resource.
 
+NOTE: Using a self-signed certificate in production environments is not recommended.
+
 [source,yaml,options="nowrap"]
 ----
 apiVersion: enmasse.io/v1beta1


### PR DESCRIPTION
### Type of change
- Documentation

### Description
Add a note about not using self-signed certs in production environments

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
