### PR TITLE
Reduce log output for normal cases

### DIFF
--- a/iot/iot-device-registry-infinispan/src/main/java/io/enmasse/iot/registry/infinispan/util/DeviceRegistryTokenAuthHandler.java
+++ b/iot/iot-device-registry-infinispan/src/main/java/io/enmasse/iot/registry/infinispan/util/DeviceRegistryTokenAuthHandler.java
@@ -20,10 +20,10 @@ import org.slf4j.LoggerFactory;
 
 public class DeviceRegistryTokenAuthHandler extends AuthHandlerImpl {
 
-    protected final Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger log = LoggerFactory.getLogger(DeviceRegistryTokenAuthHandler.class);
 
-    static final HttpStatusException UNAUTHORIZED = new HttpStatusException(401);
-    static final HttpStatusException BAD_REQUEST = new HttpStatusException(400);
+    private static final HttpStatusException UNAUTHORIZED = new HttpStatusException(401);
+    private static final HttpStatusException BAD_REQUEST = new HttpStatusException(400);
 
     static final String BEARER = "Bearer";
     static final String TOKEN = "token";
@@ -63,7 +63,7 @@ public class DeviceRegistryTokenAuthHandler extends AuthHandlerImpl {
             final String[] pathElements = request.path().split("/");
             final String endpoint = pathElements[2];
             final String tenant = pathElements[3];
-            log.info("Authenticating tenant '{}' for endpoint '{}'", tenant, endpoint);
+            log.debug("Authenticating tenant '{}' for endpoint '{}'", tenant, endpoint);
             final JsonObject authInfo = new JsonObject()
                     .put(TOKEN, authorization.substring(idx + 1))
                     .put(ENDPOINT, endpoint)

--- a/iot/iot-device-registry-infinispan/src/main/java/io/enmasse/iot/registry/infinispan/util/DeviceRegistryTokenAuthProvider.java
+++ b/iot/iot-device-registry-infinispan/src/main/java/io/enmasse/iot/registry/infinispan/util/DeviceRegistryTokenAuthProvider.java
@@ -30,9 +30,9 @@ import org.slf4j.LoggerFactory;
 
 public class DeviceRegistryTokenAuthProvider implements AuthProvider {
 
-    protected final Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger log = LoggerFactory.getLogger(DeviceRegistryTokenAuthProvider.class);
 
-    static final HttpStatusException UNAUTHORIZED = new HttpStatusException(401);
+    private static final HttpStatusException UNAUTHORIZED = new HttpStatusException(401);
 
     private final NamespacedKubernetesClient client;
     private final AuthApi authApi;
@@ -65,18 +65,18 @@ public class DeviceRegistryTokenAuthProvider implements AuthProvider {
         final String iotProject = tenant[1];
 
         TokenReview review = authApi.performTokenReview(token);
-        log.info("Authorizing token for '{}' access to '{}' iot project in '{}' namespace", verb, iotProject, namespace);
+        log.debug("Authorizing token for '{}' access to '{}' iot project in '{}' namespace", verb, iotProject, namespace);
         if (review.isAuthenticated()) {
             RbacSecurityContext securityContext = new RbacSecurityContext(review, authApi, null);
             if (!securityContext.isUserInRole(RbacSecurityContext.rbacToRole(namespace, verb, "iotprojects", iotProject, "iot.enmasse.io"))) {
-                log.info("Bearer token not authorized");
+                log.debug("Bearer token not authorized");
                 resultHandler.handle(Future.failedFuture(UNAUTHORIZED));
             }
             // TODO It's possible to cache authorities in the user object implementation based on
             // review.getUserName()
             resultHandler.handle(Future.succeededFuture());
         } else {
-            log.info("Bearer token not authenticated");
+            log.debug("Bearer token not authenticated");
             resultHandler.handle(Future.failedFuture(UNAUTHORIZED));
         }
     }


### PR DESCRIPTION
### Type of change

With the log level being "debug", every call to the device registry will cause two log entries on "info" level.

<!--

_Select the type of your PR_

-->

- Enhancement / new feature

### Description

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
