### PR TITLE
fix ApiServerTest.testReplaceAddressSpace

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/api/ApiServerTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/api/ApiServerTest.java
@@ -61,7 +61,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -458,10 +457,6 @@ class ApiServerTest extends TestBase implements ITestIsolatedStandard {
         resourcesManager.createAddressSpace(addressspace);
         resourcesManager.setAddresses(dest);
         resourcesManager.createOrUpdateUser(addressspace, cred);
-
-        getClientUtils().assertCanConnect(addressspace, cred, Collections.singletonList(dest), resourcesManager);
-
-        isolatedResourcesManager.replaceAddressSpace(addressspace);
 
         getClientUtils().assertCanConnect(addressspace, cred, Collections.singletonList(dest), resourcesManager);
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fix ApiServerTest.testReplaceAddressSpace that started failing in ocp4, the issues is that it does a nonsense address space replacing without modifiying it

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [x] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
