### PR TITLE
fix flaky test CustomResourceDefinitionAddressSpacesTest.testCliOutput

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/api/CustomResourceDefinitionAddressSpacesTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/api/CustomResourceDefinitionAddressSpacesTest.java
@@ -356,8 +356,8 @@ class CustomResourceDefinitionAddressSpacesTest extends TestBase implements ITes
             KubeCMDClient.deleteAddressSpace(namespace, brokered.getMetadata().getName());
             KubeCMDClient.deleteAddressSpace(namespace, standard.getMetadata().getName());
 
-            TestUtils.waitForNamespaceDeleted(kubernetes, brokered.getMetadata().getName());
-            TestUtils.waitForNamespaceDeleted(kubernetes, standard.getMetadata().getName());
+            AddressSpaceUtils.waitForAddressSpaceDeleted(brokered);
+            AddressSpaceUtils.waitForAddressSpaceDeleted(standard);
             TestUtils.waitUntilCondition(() -> {
                 ExecutionResultData allAddresses = KubeCMDClient.getAddressSpace(namespace, Optional.empty());
                 return allAddresses.getStdOut() + allAddresses.getStdErr();


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

CustomResourceDefinitionAddressSpacesTest.testCliOutput is failing in our CI , this PR changes a nonsense wait for deleted namespace to a wait for address space delete which will give us better information about the reason why test fails in case it keeps failing

### Checklist

- [ ] Update/write design documentation in `./documentation/design`
- [x] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
