### PR TITLE
Add delegate cache to handle caching of global objects

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -16,6 +16,7 @@ import (
 	enmassescheme "github.com/enmasseproject/enmasse/pkg/client/clientset/versioned/scheme"
 	"k8s.io/client-go/kubernetes/scheme"
 
+	"github.com/enmasseproject/enmasse/pkg/cache"
 	"github.com/enmasseproject/enmasse/pkg/controller"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -42,7 +43,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	mgr, err := manager.New(cfg, manager.Options{Namespace: namespace})
+	mgr, err := manager.New(cfg, manager.Options{
+		Namespace: namespace,
+		NewCache:  cache.NewDelegateCacheBuilder(namespace),
+	})
 	if err != nil {
 		log.Error(err, "Failed to create manager")
 		os.Exit(1)

--- a/pkg/cache/delegate_cache.go
+++ b/pkg/cache/delegate_cache.go
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2019, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package cache
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	rlog "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var log = rlog.Log.WithName("delegate_cache")
+
+// DelegateCacheBuilder - Builder function to create a new delegate cache.  This cache allows
+// mapping GVK to be served by a global cache while falling back to a default namespaced cache
+// for other types.
+func NewDelegateCacheBuilder(defaultNamespace string, globalGvks ...schema.GroupVersionKind) cache.NewCacheFunc {
+	return func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
+		opts.Namespace = defaultNamespace
+		defaultCache, err := cache.New(config, opts)
+		if err != nil {
+			return nil, err
+		}
+
+		opts.Namespace = ""
+		globalCache, err := cache.New(config, opts)
+		if err != nil {
+			return nil, err
+		}
+
+		globalGvkMap := make(map[schema.GroupVersionKind]bool)
+		for _, gvk := range globalGvks {
+			globalGvkMap[gvk] = true
+		}
+		return &delegateCache{
+			defaultNamespace: defaultNamespace,
+			defaultCache:     defaultCache,
+			globalCache:      globalCache,
+			globalGvkMap:     globalGvkMap,
+			Scheme:           opts.Scheme}, nil
+	}
+}
+
+type delegateCache struct {
+	defaultNamespace string
+	defaultCache     cache.Cache
+	globalCache      cache.Cache
+	globalGvkMap     map[schema.GroupVersionKind]bool
+	Scheme           *runtime.Scheme
+}
+
+var _ cache.Cache = &delegateCache{}
+
+// Methods for delegateCache to conform to the Informers interface
+func (c *delegateCache) GetInformer(obj runtime.Object) (cache.Informer, error) {
+	gvk, err := apiutil.GVKForObject(obj, c.Scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	if c.globalGvkMap[gvk] {
+		return c.globalCache.GetInformer(obj)
+	} else {
+		return c.defaultCache.GetInformer(obj)
+	}
+}
+
+func (c *delegateCache) GetInformerForKind(gvk schema.GroupVersionKind) (cache.Informer, error) {
+	if c.globalGvkMap[gvk] {
+		return c.globalCache.GetInformerForKind(gvk)
+	} else {
+		return c.defaultCache.GetInformerForKind(gvk)
+	}
+
+}
+
+func (c *delegateCache) Start(stopCh <-chan struct{}) error {
+	startFn := func(cacheType string, cache cache.Cache) {
+		err := cache.Start(stopCh)
+		if err != nil {
+			log.Error(err, "delegate cache failed to start cache", "cacheType", cacheType)
+		}
+	}
+
+	go startFn("namespaced", c.defaultCache)
+	go startFn("global", c.globalCache)
+
+	<-stopCh
+	return nil
+}
+
+func (c *delegateCache) WaitForCacheSync(stop <-chan struct{}) bool {
+	synced := true
+	if s := c.defaultCache.WaitForCacheSync(stop); !s {
+		synced = s
+	}
+
+	if s := c.globalCache.WaitForCacheSync(stop); !s {
+		synced = s
+	}
+	return synced
+}
+
+func (c *delegateCache) IndexField(obj runtime.Object, field string, extractValue client.IndexerFunc) error {
+	gvk, err := apiutil.GVKForObject(obj, c.Scheme)
+	if err != nil {
+		return err
+	}
+	if c.globalGvkMap[gvk] {
+		if err := c.globalCache.IndexField(obj, field, extractValue); err != nil {
+			return err
+		}
+	} else {
+		if err := c.defaultCache.IndexField(obj, field, extractValue); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *delegateCache) Get(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+	gvk, err := apiutil.GVKForObject(obj, c.Scheme)
+	if err != nil {
+		return err
+	}
+
+	if c.globalGvkMap[gvk] {
+		return c.globalCache.Get(ctx, key, obj)
+	} else {
+		return c.defaultCache.Get(ctx, key, obj)
+	}
+}
+
+func (c *delegateCache) List(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+	gvk, err := apiutil.GVKForObject(list, c.Scheme)
+	if err != nil {
+		return err
+	}
+
+	if c.globalGvkMap[gvk] {
+		return c.globalCache.List(ctx, list, opts...)
+	} else {
+		return c.defaultCache.List(ctx, list, opts...)
+	}
+}

--- a/pkg/cache/delegate_cache_test.go
+++ b/pkg/cache/delegate_cache_test.go
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package cache
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	userv1beta1 "github.com/enmasseproject/enmasse/pkg/apis/user/v1beta1"
+	userv1beta1informers "github.com/enmasseproject/enmasse/pkg/client/informers/externalversions/user/v1beta1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"k8s.io/client-go/kubernetes/scheme"
+	toolscache "k8s.io/client-go/tools/cache"
+
+	fake "sigs.k8s.io/controller-runtime/pkg/cache/informertest"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+func getGvk(t *testing.T, s *runtime.Scheme, obj runtime.Object) schema.GroupVersionKind {
+	gvk, err := apiutil.GVKForObject(obj, s)
+	if err != nil {
+		t.Fatal("error creating GVK", err)
+	}
+	return gvk
+}
+
+func TestDelegation(t *testing.T) {
+	s := scheme.Scheme
+	user := &userv1beta1.MessagingUser{}
+	s.AddKnownTypes(userv1beta1.SchemeGroupVersion, user)
+	userGvk := getGvk(t, s, user)
+
+	localCache := fake.FakeInformers{InformersByGVK: make(map[schema.GroupVersionKind]toolscache.SharedIndexInformer)}
+	globalCache := fake.FakeInformers{InformersByGVK: make(map[schema.GroupVersionKind]toolscache.SharedIndexInformer)}
+
+	// Set up mocks so that global cache returns something else
+	globalCache.InformersByGVK[userGvk] = userv1beta1informers.NewMessagingUserInformer(nil, "", time.Second*1, nil)
+
+	cache := delegateCache{
+		defaultNamespace: "test",
+		defaultCache:     &localCache,
+		globalCache:      &globalCache,
+		globalGvkMap:     make(map[schema.GroupVersionKind]bool),
+		Scheme:           s,
+	}
+
+	localInformer, err := cache.GetInformer(user)
+	if err != nil {
+		t.Fatal("Error getting informer", err)
+	}
+
+	if reflect.TypeOf(localInformer).String() != "*controllertest.FakeInformer" {
+		t.Error("Local informer is not the right type:", reflect.TypeOf(localInformer).String())
+	}
+
+	// Register MessagingUser in the global GVK map
+	cache.globalGvkMap[userGvk] = true
+
+	globalInformer, err := cache.GetInformer(user)
+	if reflect.TypeOf(globalInformer).String() != "*cache.sharedIndexInformer" {
+		t.Error("Global informer is not the right type:", reflect.TypeOf(globalInformer).String())
+	}
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/cache/informertest/fake_cache.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/cache/informertest/fake_cache.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package informertest
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
+	toolscache "k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllertest"
+)
+
+var _ cache.Cache = &FakeInformers{}
+
+// FakeInformers is a fake implementation of Informers
+type FakeInformers struct {
+	InformersByGVK map[schema.GroupVersionKind]toolscache.SharedIndexInformer
+	Scheme         *runtime.Scheme
+	Error          error
+	Synced         *bool
+}
+
+// GetInformerForKind implements Informers
+func (c *FakeInformers) GetInformerForKind(gvk schema.GroupVersionKind) (cache.Informer, error) {
+	if c.Scheme == nil {
+		c.Scheme = scheme.Scheme
+	}
+	obj, err := c.Scheme.New(gvk)
+	if err != nil {
+		return nil, err
+	}
+	return c.informerFor(gvk, obj)
+}
+
+// FakeInformerForKind implements Informers
+func (c *FakeInformers) FakeInformerForKind(gvk schema.GroupVersionKind) (*controllertest.FakeInformer, error) {
+	if c.Scheme == nil {
+		c.Scheme = scheme.Scheme
+	}
+	obj, err := c.Scheme.New(gvk)
+	if err != nil {
+		return nil, err
+	}
+	i, err := c.informerFor(gvk, obj)
+	if err != nil {
+		return nil, err
+	}
+	return i.(*controllertest.FakeInformer), nil
+}
+
+// GetInformer implements Informers
+func (c *FakeInformers) GetInformer(obj runtime.Object) (cache.Informer, error) {
+	if c.Scheme == nil {
+		c.Scheme = scheme.Scheme
+	}
+	gvks, _, err := c.Scheme.ObjectKinds(obj)
+	if err != nil {
+		return nil, err
+	}
+	gvk := gvks[0]
+	return c.informerFor(gvk, obj)
+}
+
+// WaitForCacheSync implements Informers
+func (c *FakeInformers) WaitForCacheSync(stop <-chan struct{}) bool {
+	if c.Synced == nil {
+		return true
+	}
+	return *c.Synced
+}
+
+// FakeInformerFor implements Informers
+func (c *FakeInformers) FakeInformerFor(obj runtime.Object) (*controllertest.FakeInformer, error) {
+	if c.Scheme == nil {
+		c.Scheme = scheme.Scheme
+	}
+	gvks, _, err := c.Scheme.ObjectKinds(obj)
+	if err != nil {
+		return nil, err
+	}
+	gvk := gvks[0]
+	i, err := c.informerFor(gvk, obj)
+	if err != nil {
+		return nil, err
+	}
+	return i.(*controllertest.FakeInformer), nil
+}
+
+func (c *FakeInformers) informerFor(gvk schema.GroupVersionKind, _ runtime.Object) (toolscache.SharedIndexInformer, error) {
+	if c.Error != nil {
+		return nil, c.Error
+	}
+	if c.InformersByGVK == nil {
+		c.InformersByGVK = map[schema.GroupVersionKind]toolscache.SharedIndexInformer{}
+	}
+	informer, ok := c.InformersByGVK[gvk]
+	if ok {
+		return informer, nil
+	}
+
+	c.InformersByGVK[gvk] = &controllertest.FakeInformer{}
+	return c.InformersByGVK[gvk], nil
+}
+
+// Start implements Informers
+func (c *FakeInformers) Start(stopCh <-chan struct{}) error {
+	return c.Error
+}
+
+// IndexField implements Cache
+func (c *FakeInformers) IndexField(obj runtime.Object, field string, extractValue client.IndexerFunc) error {
+	return nil
+}
+
+// Get implements Cache
+func (c *FakeInformers) Get(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+	return nil
+}
+
+// List implements Cache
+func (c *FakeInformers) List(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+	return nil
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/controller/controllertest/doc.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/controller/controllertest/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package controllertest contains fake informers for testing controllers
+// When in doubt, it's almost always better to test against a real API server
+// using envtest.Environment.
+package controllertest

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/controller/controllertest/testing.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/controller/controllertest/testing.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllertest
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/util/workqueue"
+)
+
+var _ runtime.Object = &ErrorType{}
+
+// ErrorType implements runtime.Object but isn't registered in any scheme and should cause errors in tests as a result.
+type ErrorType struct{}
+
+// GetObjectKind implements runtime.Object
+func (ErrorType) GetObjectKind() schema.ObjectKind { return nil }
+
+// DeepCopyObject implements runtime.Object
+func (ErrorType) DeepCopyObject() runtime.Object { return nil }
+
+var _ workqueue.RateLimitingInterface = Queue{}
+
+// Queue implements a RateLimiting queue as a non-ratelimited queue for testing.
+// This helps testing by having functions that use a RateLimiting queue synchronously add items to the queue.
+type Queue struct {
+	workqueue.Interface
+}
+
+// AddAfter implements RateLimitingInterface.
+func (q Queue) AddAfter(item interface{}, duration time.Duration) {
+	q.Add(item)
+}
+
+// AddRateLimited implements RateLimitingInterface.  TODO(community): Implement this.
+func (q Queue) AddRateLimited(item interface{}) {
+	q.Add(item)
+}
+
+// Forget implements RateLimitingInterface.  TODO(community): Implement this.
+func (q Queue) Forget(item interface{}) {}
+
+// NumRequeues implements RateLimitingInterface.  TODO(community): Implement this.
+func (q Queue) NumRequeues(item interface{}) int {
+	return 0
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/controller/controllertest/util.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/controller/controllertest/util.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllertest
+
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+var _ cache.SharedIndexInformer = &FakeInformer{}
+
+// FakeInformer provides fake Informer functionality for testing
+type FakeInformer struct {
+	// Synced is returned by the HasSynced functions to implement the Informer interface
+	Synced bool
+
+	// RunCount is incremented each time RunInformersAndControllers is called
+	RunCount int
+
+	handlers []cache.ResourceEventHandler
+}
+
+// AddIndexers does nothing.  TODO(community): Implement this.
+func (f *FakeInformer) AddIndexers(indexers cache.Indexers) error {
+	return nil
+}
+
+// GetIndexer does nothing.  TODO(community): Implement this.
+func (f *FakeInformer) GetIndexer() cache.Indexer {
+	return nil
+}
+
+// Informer returns the fake Informer.
+func (f *FakeInformer) Informer() cache.SharedIndexInformer {
+	return f
+}
+
+// HasSynced implements the Informer interface.  Returns f.Synced
+func (f *FakeInformer) HasSynced() bool {
+	return f.Synced
+}
+
+// AddEventHandler implements the Informer interface.  Adds an EventHandler to the fake Informers.
+func (f *FakeInformer) AddEventHandler(handler cache.ResourceEventHandler) {
+	f.handlers = append(f.handlers, handler)
+}
+
+// Run implements the Informer interface.  Increments f.RunCount
+func (f *FakeInformer) Run(<-chan struct{}) {
+	f.RunCount++
+}
+
+// Add fakes an Add event for obj
+func (f *FakeInformer) Add(obj metav1.Object) {
+	for _, h := range f.handlers {
+		h.OnAdd(obj)
+	}
+}
+
+// Update fakes an Update event for obj
+func (f *FakeInformer) Update(oldObj, newObj metav1.Object) {
+	for _, h := range f.handlers {
+		h.OnUpdate(oldObj, newObj)
+	}
+}
+
+// Delete fakes an Delete event for obj
+func (f *FakeInformer) Delete(obj metav1.Object) {
+	for _, h := range f.handlers {
+		h.OnDelete(obj)
+	}
+}
+
+// AddEventHandlerWithResyncPeriod does nothing.  TODO(community): Implement this.
+func (f *FakeInformer) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) {
+
+}
+
+// GetStore does nothing.  TODO(community): Implement this.
+func (f *FakeInformer) GetStore() cache.Store {
+	return nil
+}
+
+// GetController does nothing.  TODO(community): Implement this.
+func (f *FakeInformer) GetController() cache.Controller {
+	return nil
+}
+
+// LastSyncResourceVersion does nothing.  TODO(community): Implement this.
+func (f *FakeInformer) LastSyncResourceVersion() string {
+	return ""
+}


### PR DESCRIPTION
This allows for using both namespaced and global watches based on object
type.

### Type of change

- Enhancement / new feature

### Description

An implementation of controller-runtime Cache interface that delegates lookups and watches to either a local namespaced cache, or a global cache, depending on the type. The type mapping is registered at manager creation time.

The intention is to use this to allow the enmasse-operator deployment to watch both local and global objects.

### Checklist

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
