### PR TITLE
add OLM tests that create address space in different namespace

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/Environment.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/Environment.java
@@ -62,7 +62,8 @@ public class Environment {
     private final Duration kubernetesApiReadTimeout = Optional.ofNullable(System.getenv().get(K8S_API_READ_TIMEOUT)).map(i -> Duration.ofSeconds(Long.parseLong(i))).orElse(Duration.ofSeconds(60));
     private final Duration kubernetesApiWriteTimeout = Optional.ofNullable(System.getenv().get(K8S_API_WRITE_TIMEOUT)).map(i -> Duration.ofSeconds(Long.parseLong(i))).orElse(Duration.ofSeconds(60));
     private final EnmasseInstallType installType = Optional.ofNullable(System.getenv().get(INSTALL_TYPE)).map(EnmasseInstallType::valueOf).orElse(EnmasseInstallType.BUNDLE);
-    private final OLMInstallationType olmInstallType = Optional.ofNullable(System.getenv().get(OLM_INSTALL_TYPE)).map(OLMInstallationType::valueOf).orElse(OLMInstallationType.SPECIFIC);
+    private final OLMInstallationType olmInstallType = Optional.ofNullable(System.getenv().get(OLM_INSTALL_TYPE)).map(s->s.isEmpty() ? OLMInstallationType.SPECIFIC.name() : s)
+            .map(OLMInstallationType::valueOf).orElse(OLMInstallationType.SPECIFIC);
     protected String templatesPath = System.getenv().getOrDefault(TEMPLATES_PATH,
             Paths.get(System.getProperty("user.dir"), "..", "templates", "build", "enmasse-latest").toString());
     protected UserCredentials managementCredentials = new UserCredentials(null, null);

--- a/systemtests/src/test/java/io/enmasse/systemtest/olm/OLMDefaultTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/olm/OLMDefaultTest.java
@@ -23,9 +23,19 @@ public class OLMDefaultTest extends OLMTestBase{
         return kubernetes.getOlmNamespace();
     }
 
+    @Override
+    protected String getDifferentAddressSpaceNamespace() {
+        return "systemtests-default-olm";
+    }
+
     @Test
-    void testExampleResources() throws Exception {
-        doTestCreateExampleResources();
+    void testExampleResourcesSameNamespaceAsOperator() throws Exception {
+        doTestExampleResourcesSameNamespaceAsOperator();
+    }
+
+    @Test
+    void testExampleResourcesDifferentNamespaceThanOperator() throws Exception {
+        doTestExampleResourcesDifferentNamespaceThanOperator();
     }
 
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/olm/OLMSpecificTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/olm/OLMSpecificTest.java
@@ -23,9 +23,19 @@ public class OLMSpecificTest extends OLMTestBase{
         return kubernetes.getInfraNamespace();
     }
 
+    @Override
+    protected String getDifferentAddressSpaceNamespace() {
+        return "systemtests-specific-olm";
+    }
+
     @Test
-    void testExampleResources() throws Exception {
-        doTestCreateExampleResources();
+    void testExampleResourcesSameNamespaceAsOperator() throws Exception {
+        doTestExampleResourcesSameNamespaceAsOperator();
+    }
+
+    @Test
+    void testExampleResourcesDifferentNamespaceThanOperator() throws Exception {
+        doTestExampleResourcesDifferentNamespaceThanOperator();
     }
 
 }


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->
- Enhancement / new feature

### Description

This PR adds some refactor to OLM tests and adds new tests to create address space in different namespace than the one the operator is installed

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [x] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
