### PR TITLE
Apply proper pull policy on agent image

### DIFF
--- a/address-space-controller/src/main/resources/templates/standard-space-infra.yaml
+++ b/address-space-controller/src/main/resources/templates/standard-space-infra.yaml
@@ -361,7 +361,7 @@ objects:
                 key: cookie-secret
                 optional: true
           image: ${AGENT_IMAGE}
-          imagePullPolicy: ${env.IMAGE_PULL_POLICY}
+          imagePullPolicy: ${IMAGE_PULL_POLICY}
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Currently the image pull policy for agent image is ignored and "Always" is used.

