### PR TITLE
Allow addressspace spec changes

### DIFF
--- a/address-space-controller/src/main/java/io/enmasse/controller/AppliedConfig.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/AppliedConfig.java
@@ -36,6 +36,9 @@ public final class AppliedConfig {
         if (metadata.getMetadata().getAnnotations() == null) {
             metadata.getMetadata().setAnnotations(new HashMap<>());
         }
+        // Remove old annotation no longer used
+        metadata.getMetadata().getAnnotations().remove(AnnotationKeys.APPLIED_PLAN);
+
         metadata.getMetadata().getAnnotations().put(AnnotationKeys.APPLIED_CONFIGURATION, mapper.writeValueAsString(config));
     }
 

--- a/address-space-controller/src/main/java/io/enmasse/controller/AppliedConfig.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/AppliedConfig.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2018, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.enmasse.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.enmasse.address.model.AddressSpace;
+import io.enmasse.address.model.AddressSpaceSpec;
+import io.enmasse.admin.model.v1.InfraConfig;
+import io.enmasse.config.AnnotationKeys;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+public final class AppliedConfig {
+    private static final ObjectMapper mapper = new ObjectMapper();
+    private AppliedConfig() {
+    }
+
+    public static AddressSpaceSpec parseCurrentAppliedConfig(String json) throws IOException {
+        if (json == null) {
+            return null;
+        }
+        return mapper.readValue(json, AddressSpaceSpec.class);
+    }
+
+    public static AddressSpaceSpec parseCurrentAppliedConfig(final HasMetadata resource) throws IOException {
+        return parseCurrentAppliedConfig(resource.getMetadata().getAnnotations().get(AnnotationKeys.APPLIED_INFRA_CONFIG));
+    }
+
+    public static void setCurrentAppliedConfig(final HasMetadata metadata, AddressSpaceSpec config) throws JsonProcessingException {
+        if (metadata.getMetadata().getAnnotations() == null) {
+            metadata.getMetadata().setAnnotations(new HashMap<>());
+        }
+        metadata.getMetadata().getAnnotations().put(AnnotationKeys.APPLIED_CONFIGURATION, mapper.writeValueAsString(config));
+    }
+
+
+}

--- a/address-space-controller/src/main/java/io/enmasse/controller/AppliedConfig.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/AppliedConfig.java
@@ -29,7 +29,7 @@ public final class AppliedConfig {
     }
 
     public static AddressSpaceSpec parseCurrentAppliedConfig(final HasMetadata resource) throws IOException {
-        return parseCurrentAppliedConfig(resource.getMetadata().getAnnotations().get(AnnotationKeys.APPLIED_INFRA_CONFIG));
+        return parseCurrentAppliedConfig(resource.getMetadata().getAnnotations().get(AnnotationKeys.APPLIED_CONFIGURATION));
     }
 
     public static void setCurrentAppliedConfig(final HasMetadata metadata, AddressSpaceSpec config) throws JsonProcessingException {

--- a/address-space-controller/src/main/java/io/enmasse/controller/CreateController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/CreateController.java
@@ -101,7 +101,8 @@ public class CreateController implements Controller {
     public AddressSpace reconcileActive(AddressSpace addressSpace) throws Exception {
         Schema schema = schemaProvider.getSchema();
         AddressSpaceResolver addressSpaceResolver = new AddressSpaceResolver(schema);
-        if (!addressSpaceResolver.validate(addressSpace)) {
+        AddressSpaceSpec appliedConfig = kubernetes.getAppliedConfig(addressSpace);
+        if (!addressSpaceResolver.validate(addressSpace, appliedConfig)) {
             return addressSpace;
         }
 
@@ -133,13 +134,13 @@ public class CreateController implements Controller {
         AddressSpaceType addressSpaceType = addressSpaceResolver.getType(addressSpace.getSpec().getType());
         AddressSpacePlan addressSpacePlan = addressSpaceResolver.getPlan(addressSpaceType, addressSpace.getSpec().getPlan());
 
-        AddressSpaceSpec appliedConfig = kubernetes.getAppliedConfig(addressSpace);
         InfraConfig desiredInfraConfig = getInfraConfig(addressSpace);
         InfraConfig currentInfraConfig = kubernetes.getAppliedInfraConfig(addressSpace);
 
         // Apply changes to ensure controller logic works as expected
         InfraConfigs.setCurrentInfraConfig(addressSpace, currentInfraConfig);
         AppliedConfig.setCurrentAppliedConfig(addressSpace, appliedConfig);
+
 
         if (currentInfraConfig == null && !kubernetes.existsAddressSpace(addressSpace)) {
             KubernetesList resourceList = new KubernetesListBuilder()

--- a/address-space-controller/src/main/java/io/enmasse/controller/CreateController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/CreateController.java
@@ -133,27 +133,27 @@ public class CreateController implements Controller {
         AddressSpaceType addressSpaceType = addressSpaceResolver.getType(addressSpace.getSpec().getType());
         AddressSpacePlan addressSpacePlan = addressSpaceResolver.getPlan(addressSpaceType, addressSpace.getSpec().getPlan());
 
-        String appliedPlan = kubernetes.getAppliedPlan(addressSpace);
+        AddressSpaceSpec appliedConfig = kubernetes.getAppliedConfig(addressSpace);
         InfraConfig desiredInfraConfig = getInfraConfig(addressSpace);
         InfraConfig currentInfraConfig = kubernetes.getAppliedInfraConfig(addressSpace);
 
         // Apply changes to ensure controller logic works as expected
-        addressSpace.putAnnotation(AnnotationKeys.APPLIED_PLAN, appliedPlan);
         InfraConfigs.setCurrentInfraConfig(addressSpace, currentInfraConfig);
+        AppliedConfig.setCurrentAppliedConfig(addressSpace, appliedConfig);
 
         if (currentInfraConfig == null && !kubernetes.existsAddressSpace(addressSpace)) {
             KubernetesList resourceList = new KubernetesListBuilder()
                     .addAllToItems(infraResourceFactory.createInfraResources(addressSpace, desiredInfraConfig))
                     .build();
             addAppliedInfraConfigAnnotation(resourceList, desiredInfraConfig);
-            addAppliedPlanAnnotation(resourceList, addressSpace.getSpec().getPlan());
+            addAppliedConfigAnnotation(resourceList, addressSpace.getSpec());
 
             log.info("Creating address space {}", addressSpace);
 
             kubernetes.create(resourceList);
             eventLogger.log(AddressSpaceCreated, "Created address space", Normal, ControllerKind.AddressSpace, addressSpace.getMetadata().getName());
             InfraConfigs.setCurrentInfraConfig(addressSpace, desiredInfraConfig);
-            addressSpace.putAnnotation(AnnotationKeys.APPLIED_PLAN, addressSpace.getSpec().getPlan());
+            AppliedConfig.setCurrentAppliedConfig(addressSpace, addressSpace.getSpec());
             addressSpace.getStatus().setPhase(Phase.Configuring);
         } else if (currentInfraConfig == null || !currentInfraConfig.equals(desiredInfraConfig)) {
 
@@ -166,18 +166,18 @@ public class CreateController implements Controller {
                         .addAllToItems(infraResourceFactory.createInfraResources(addressSpace, desiredInfraConfig))
                         .build();
                 addAppliedInfraConfigAnnotation(resourceList, desiredInfraConfig);
-                addAppliedPlanAnnotation(resourceList, addressSpace.getSpec().getPlan());
+                addAppliedConfigAnnotation(resourceList, addressSpace.getSpec());
 
                 log.info("Upgrading address space {}", addressSpace);
 
                 kubernetes.apply(resourceList,desiredInfraConfig.getUpdatePersistentVolumeClaim());
                 eventLogger.log(AddressSpaceUpgraded, "Upgraded address space", Normal, ControllerKind.AddressSpace, addressSpace.getMetadata().getName());
                 InfraConfigs.setCurrentInfraConfig(addressSpace, desiredInfraConfig);
-                addressSpace.putAnnotation(AnnotationKeys.APPLIED_PLAN, addressSpace.getSpec().getPlan());
+                AppliedConfig.setCurrentAppliedConfig(addressSpace, addressSpace.getSpec());
             } else {
                 log.info("Version of desired config ({}) does not match controller version ({}), skipping upgrade", desiredInfraConfig.getVersion(), version);
             }
-        } else if (!addressSpace.getSpec().getPlan().equals(appliedPlan)) {
+        } else if (!addressSpace.getSpec().equals(appliedConfig)) {
             addressSpace.getStatus().setPhase(Phase.Configuring);
             if (checkExceedsQuota(addressSpaceType, addressSpacePlan, addressSpace)) {
                 return addressSpace;
@@ -187,23 +187,22 @@ public class CreateController implements Controller {
                     .addAllToItems(infraResourceFactory.createInfraResources(addressSpace, desiredInfraConfig))
                     .build();
             addAppliedInfraConfigAnnotation(resourceList, desiredInfraConfig);
-            addAppliedPlanAnnotation(resourceList, addressSpace.getSpec().getPlan());
+            addAppliedConfigAnnotation(resourceList, addressSpace.getSpec());
 
-            log.info("Updating address space plan {}", addressSpace);
+            log.info("Updating address space config {}", addressSpace);
 
             kubernetes.apply(resourceList, desiredInfraConfig.getUpdatePersistentVolumeClaim());
-            eventLogger.log(AddressSpaceChanged, "Changed address space plan", Normal, ControllerKind.AddressSpace, addressSpace.getMetadata().getName());
+            eventLogger.log(AddressSpaceChanged, "Changed applied config", Normal, ControllerKind.AddressSpace, addressSpace.getMetadata().getName());
             InfraConfigs.setCurrentInfraConfig(addressSpace, desiredInfraConfig);
-            addressSpace.putAnnotation(AnnotationKeys.APPLIED_PLAN, addressSpace.getSpec().getPlan());
+            AppliedConfig.setCurrentAppliedConfig(addressSpace, addressSpace.getSpec());
         }
-
         return addressSpace;
     }
 
-    private void addAppliedPlanAnnotation(KubernetesList resourceList, String plan) {
+    private void addAppliedConfigAnnotation(KubernetesList resourceList, AddressSpaceSpec spec) throws JsonProcessingException {
         for (HasMetadata resource : resourceList.getItems()) {
             if (resource instanceof Service) {
-                Kubernetes.addObjectAnnotation(resource, AnnotationKeys.APPLIED_PLAN, plan);
+                AppliedConfig.setCurrentAppliedConfig(resource, spec);
             }
         }
     }

--- a/address-space-controller/src/main/java/io/enmasse/controller/StatusController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/StatusController.java
@@ -19,6 +19,7 @@ import org.slf4j.LoggerFactory;
 
 import static io.enmasse.controller.InfraConfigs.parseCurrentInfraConfig;
 
+import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -39,7 +40,7 @@ public class StatusController implements Controller {
     }
 
     @Override
-    public AddressSpace reconcileActive(AddressSpace addressSpace) {
+    public AddressSpace reconcileActive(AddressSpace addressSpace) throws IOException {
         if (addressSpace.getStatus().isReady()) {
             checkComponentsReady(addressSpace);
             checkAuthServiceReady(addressSpace);
@@ -47,7 +48,8 @@ public class StatusController implements Controller {
         }
 
         if (addressSpace.getStatus().isReady()) {
-            if (addressSpace.getSpec().getPlan().equals(addressSpace.getAnnotation(AnnotationKeys.APPLIED_PLAN))) {
+            AddressSpaceSpec appliedSpec = AppliedConfig.parseCurrentAppliedConfig(addressSpace);
+            if (addressSpace.getSpec().equals(appliedSpec)) {
                 addressSpace.getStatus().setPhase(Phase.Active);
             }
         } else {

--- a/address-space-controller/src/main/java/io/enmasse/controller/common/Kubernetes.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/common/Kubernetes.java
@@ -5,6 +5,7 @@
 package io.enmasse.controller.common;
 
 import io.enmasse.address.model.AddressSpace;
+import io.enmasse.address.model.AddressSpaceSpec;
 import io.enmasse.admin.model.v1.InfraConfig;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.HasMetadata;
@@ -36,15 +37,6 @@ public interface Kubernetes {
 
     boolean existsAddressSpace(AddressSpace addressSpace);
 
-    static void addObjectAnnotation(HasMetadata item, String annotationKey, String annotationValue) {
-        Map<String, String> annotations = item.getMetadata().getAnnotations();
-        if (annotations == null) {
-            annotations = new LinkedHashMap<>();
-        }
-        annotations.put(annotationKey, annotationValue);
-        item.getMetadata().setAnnotations(annotations);
-    }
-
-    String getAppliedPlan(AddressSpace addressSpace);
     InfraConfig getAppliedInfraConfig(AddressSpace addressSpace) throws IOException;
+    AddressSpaceSpec getAppliedConfig(AddressSpace addressSpace) throws IOException;
 }

--- a/address-space-controller/src/main/java/io/enmasse/controller/common/KubernetesHelper.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/common/KubernetesHelper.java
@@ -6,10 +6,12 @@
 package io.enmasse.controller.common;
 
 import io.enmasse.address.model.AddressSpace;
+import io.enmasse.address.model.AddressSpaceSpec;
 import io.enmasse.address.model.KubeUtil;
 import io.enmasse.admin.model.v1.InfraConfig;
 import io.enmasse.config.AnnotationKeys;
 import io.enmasse.config.LabelKeys;
+import io.enmasse.controller.AppliedConfig;
 import io.enmasse.controller.InfraConfigs;
 import io.enmasse.k8s.util.Templates;
 import io.fabric8.kubernetes.api.model.*;
@@ -184,9 +186,9 @@ public class KubernetesHelper implements Kubernetes {
     }
 
     @Override
-    public String getAppliedPlan(AddressSpace addressSpace) {
-        if (addressSpace.getAnnotation(AnnotationKeys.APPLIED_PLAN) != null) {
-            return addressSpace.getAnnotation(AnnotationKeys.APPLIED_PLAN);
+    public AddressSpaceSpec getAppliedConfig(AddressSpace addressSpace) throws IOException {
+        if (addressSpace.getAnnotation(AnnotationKeys.APPLIED_CONFIGURATION) != null) {
+            return AppliedConfig.parseCurrentAppliedConfig(addressSpace.getAnnotation(AnnotationKeys.APPLIED_CONFIGURATION));
         }
         Service messaging = client.services().inNamespace(namespace).withName(KubeUtil.getAddressSpaceServiceName("messaging", addressSpace)).get();
         if (messaging == null) {
@@ -195,7 +197,7 @@ public class KubernetesHelper implements Kubernetes {
         if (messaging.getMetadata().getAnnotations() == null) {
             return null;
         }
-        return messaging.getMetadata().getAnnotations().get(AnnotationKeys.APPLIED_PLAN);
+        return AppliedConfig.parseCurrentAppliedConfig(messaging.getMetadata().getAnnotations().get(AnnotationKeys.APPLIED_CONFIGURATION));
     }
 
     @Override

--- a/address-space-controller/src/test/java/io/enmasse/controller/CreateControllerTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/CreateControllerTest.java
@@ -16,6 +16,8 @@ import static org.mockito.Mockito.when;
 import java.util.Arrays;
 import java.util.UUID;
 
+import io.enmasse.address.model.AddressSpaceSpec;
+import io.enmasse.address.model.AddressSpaceSpecBuilder;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -94,7 +96,6 @@ public class CreateControllerTest {
                 .withName("myspace")
                 .withNamespace("mynamespace")
                 .withUid(UUID.randomUUID().toString())
-                .addToAnnotations(AnnotationKeys.APPLIED_PLAN, "plan1")
                 .addToAnnotations(AnnotationKeys.APPLIED_INFRA_CONFIG,
                         mapper.writeValueAsString(testSchema.getSchema().findAddressSpaceType("type1").get().getInfraConfigs().get(0)))
                 .endMetadata()
@@ -107,6 +108,9 @@ public class CreateControllerTest {
                 .build();
 
 
+        AppliedConfig.setCurrentAppliedConfig(addressSpace, new AddressSpaceSpecBuilder(addressSpace.getSpec())
+                .withPlan("plan1")
+                .build());
         TestAddressSpaceApi addressSpaceApi = new TestAddressSpaceApi();
         addressSpaceApi.createAddressSpace(addressSpace);
 

--- a/api-model/src/main/java/io/enmasse/address/model/AddressSpaceResolver.java
+++ b/api-model/src/main/java/io/enmasse/address/model/AddressSpaceResolver.java
@@ -29,7 +29,14 @@ public class AddressSpaceResolver {
         return addressSpaceType.findAddressSpacePlan(plan);
     }
 
-    public boolean validate(AddressSpace addressSpace) {
+    public boolean validate(AddressSpace addressSpace, AddressSpaceSpec appliedConfig) {
+        if (appliedConfig != null && !appliedConfig.getType().equals(addressSpace.getSpec().getType())) {
+            // Don't set status false, as long as applied type is not taking effect
+            addressSpace.getStatus().appendMessage("Cannot change type of address space "
+                    + addressSpace.getMetadata().getName() + " from " + appliedConfig.getType()
+                    + " to " + addressSpace.getSpec().getType());
+            return false;
+        }
         if (addressSpace.getSpec().getAuthenticationService() != null && !schema.findAuthenticationService(addressSpace.getSpec().getAuthenticationService().getName()).isPresent()) {
             addressSpace.getStatus().setReady(false);
             addressSpace.getStatus().appendMessage("Unknown authentication service '" + addressSpace.getSpec().getAuthenticationService().getName() + "'");

--- a/api-model/src/main/java/io/enmasse/config/AnnotationKeys.java
+++ b/api-model/src/main/java/io/enmasse/config/AnnotationKeys.java
@@ -29,7 +29,8 @@ public interface AnnotationKeys {
     String MQTT_TEMPLATE_NAME = "enmasse.io/mqtt-template-name";
     String APPLIED_INFRA_CONFIG = "enmasse.io/applied-infra-config";
     String OPENSHIFT_SERVING_CERT_SECRET_NAME = "service.alpha.openshift.io/serving-cert-secret-name";
-    String APPLIED_PLAN = "enmasse.io/applied-plan";
     String GENERATION = "enmasse.io/generation";
     String VERSION = "enmasse.io/version";
+    String APPLIED_CONFIGURATION = "enmasse.io/applied-configuration";
+    String APPLIED_PLAN = "enmasse.io/applied-plan";
 }


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Enhancement / new feature
- Refactoring


### Description

Retrigger processing of templates whenever address space spec changes, not only when plan changes. This will cover cases such as changing the authentication service, or any other change to spec that requires reprocessing of templates.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
