### PR TITLE
Add resync period for agent watches

### DIFF
--- a/address-space-controller/src/main/resources/templates/brokered-space-infra.yaml
+++ b/address-space-controller/src/main/resources/templates/brokered-space-infra.yaml
@@ -315,6 +315,8 @@ objects:
             value: /opt/agent/messaging-cert/tls.crt
           - name: HEALTH_PORT
             value: '8088'
+          - name: RESYNC_INTERVAL
+            value: ${CONTROLLER_RESYNC_INTERVAL}
           - name: AUTHENTICATION_SERVICE_HOST
             value: ${AUTHENTICATION_SERVICE_HOST}
           - name: AUTHENTICATION_SERVICE_PORT
@@ -503,3 +505,6 @@ parameters:
   name: CONSOLE_SSO_COOKIE_SECRET_SECRET_NAME
 - description:
   name: CONSOLE_LINK
+- description: Interval (in seconds) to use between controller resync
+  name: CONTROLLER_RESYNC_INTERVAL
+  value: '600'

--- a/address-space-controller/src/main/resources/templates/standard-space-infra.yaml
+++ b/address-space-controller/src/main/resources/templates/standard-space-infra.yaml
@@ -320,6 +320,8 @@ objects:
             value: ${ADDRESS_SPACE_PLAN}
           - name: CERT_DIR
             value: /etc/enmasse-certs
+          - name: RESYNC_INTERVAL
+            value: ${CONTROLLER_RESYNC_INTERVAL}
           - name: AUTHENTICATION_SERVICE_HOST
             value: ${AUTHENTICATION_SERVICE_HOST}
           - name: AUTHENTICATION_SERVICE_PORT

--- a/agent/lib/kubernetes.js
+++ b/agent/lib/kubernetes.js
@@ -57,6 +57,7 @@ function get_options(options, path) {
     return {
         hostname: options.host || process.env.KUBERNETES_SERVICE_HOST,
         port: options.port || process.env.KUBERNETES_SERVICE_PORT,
+        resyncInterval: options.resyncInterval || process.env.RESYNC_INTERVAL,
         rejectUnauthorized: false,
         path: options.path || path,
         headers: {
@@ -238,7 +239,14 @@ Watcher.prototype.watch = function () {
             }
         });
     });
-    request.on('error', function(e) { log.error('error on watch: %s', e); });
+    request.on('error', function(e) {
+        log.error('error on watch: %s', e);
+    });
+    if (opts.resyncInterval !== undefined) {
+        request.setTimeout(opts.resyncInterval * 1000, function () {
+            request.abort();
+        });
+    }
 };
 
 function matcher(object) {

--- a/agent/lib/kubernetes.js
+++ b/agent/lib/kubernetes.js
@@ -232,7 +232,7 @@ Watcher.prototype.watch = function () {
         response.on('data', watch_handler(self));
         response.on('end', function () {
             if (!self.closed) {
-                log.debug('response ended; reconnecting...');
+                log.debug('response %s ended; reconnecting...', opts.path);
                 self.list();
             } else {
                 self.emit('closed');
@@ -240,10 +240,11 @@ Watcher.prototype.watch = function () {
         });
     });
     request.on('error', function(e) {
-        log.error('error on watch: %s', e);
+        log.error('error on watch %s: %s', opts.path, e);
     });
     if (opts.resyncInterval !== undefined) {
         request.setTimeout(opts.resyncInterval * 1000, function () {
+            log.info('response %s timeout', opts.path);
             request.abort();
         });
     }


### PR DESCRIPTION

### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

This adds periodic resync intervals to agent watches similar to what
exists for other controller processes.

On watch error, abort current request and reconnect.

Issue #3542


### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
