### PR TITLE
Delete network policies created for address space

### DIFF
--- a/address-space-controller/src/main/java/io/enmasse/controller/common/KubernetesHelper.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/common/KubernetesHelper.java
@@ -122,6 +122,7 @@ public class KubernetesHelper implements Kubernetes {
         client.apps().statefulSets().withLabel(LabelKeys.INFRA_UUID, infraUuid).withPropagationPolicy("Background").delete();
         client.secrets().withLabel(LabelKeys.INFRA_UUID, infraUuid).withPropagationPolicy("Background").delete();
         client.configMaps().withLabel(LabelKeys.INFRA_UUID, infraUuid).withPropagationPolicy("Background").delete();
+        client.network().networkPolicies().withLabel(LabelKeys.INFRA_UUID, infraUuid).withPropagationPolicy("Background").delete();
 
         // Work around fabric8 issue when deleting a deployment.  Internally there is a race between Fabric8's
         // scaling of the deployment to zero and the deletion of the replicaset.  If the replicaset is deleted first

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/policy/NetworkPolicyTestStandard.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/policy/NetworkPolicyTestStandard.java
@@ -18,6 +18,7 @@ import io.enmasse.admin.model.v1.StandardInfraConfigBuilder;
 import io.enmasse.admin.model.v1.StandardInfraConfigSpecAdminBuilder;
 import io.enmasse.admin.model.v1.StandardInfraConfigSpecBrokerBuilder;
 import io.enmasse.admin.model.v1.StandardInfraConfigSpecRouterBuilder;
+import io.enmasse.config.AnnotationKeys;
 import io.enmasse.systemtest.UserCredentials;
 import io.enmasse.systemtest.bases.TestBase;
 import io.enmasse.systemtest.bases.isolated.ITestIsolatedStandard;
@@ -107,6 +108,7 @@ class NetworkPolicyTestStandard extends TestBase implements ITestIsolatedStandar
         assertFalse(blockedClientSender.run(), "Sender was successful, expected return code -1");
         assertFalse(blockedClientReceiver.run(), "Receiver was successful, expected return code -1");
 
+        deleteAddressSpace(addressSpace);
     }
 
     @Test
@@ -148,6 +150,12 @@ class NetworkPolicyTestStandard extends TestBase implements ITestIsolatedStandar
         assertFalse(blockedClientSender.run(), "Sender was successful, expected return code -1");
         assertFalse(blockedClientReceiver.run(), "Receiver was successful, expected return code -1");
 
+        deleteAddressSpace(addressSpace);
+    }
+
+    private void deleteAddressSpace(AddressSpace addressSpace) throws Exception {
+        isolatedResourcesManager.deleteAddressSpace(addressSpace);
+        assertTrue(Kubernetes.getInstance().getClient().network().networkPolicies().withLabel(addressSpace.getAnnotation(AnnotationKeys.INFRA_UUID)).list().getItems().isEmpty());
     }
 
     private StandardInfraConfig prepareConfig(NetworkPolicyPeer networkPolicyPeer) {


### PR DESCRIPTION

### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix


### Description

Delete networkpolicies created for an address space. Add checks to systemtests to verify that networkpolicy is gone.

Fixes #3547

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
