### PR TITLE
Add API reader, cleanup logs, cleanup.

### DIFF
--- a/pkg/controller/iotconfig/iotconfig_controller.go
+++ b/pkg/controller/iotconfig/iotconfig_controller.go
@@ -172,6 +172,7 @@ func (r *ReconcileIoTConfig) Reconcile(request reconcile.Request) (reconcile.Res
 	})
 
 	if rc.Error() != nil || rc.NeedRequeue() {
+		log.Info("Re-queue after processing finalizers")
 		return rc.Result()
 	}
 

--- a/pkg/controller/iotproject/iotproject_controller.go
+++ b/pkg/controller/iotproject/iotproject_controller.go
@@ -41,7 +41,11 @@ func Add(mgr manager.Manager) error {
 }
 
 func newReconciler(mgr manager.Manager) *ReconcileIoTProject {
-	return &ReconcileIoTProject{client: mgr.GetClient(), scheme: mgr.GetScheme()}
+	return &ReconcileIoTProject{
+		client: mgr.GetClient(),
+		reader: mgr.GetAPIReader(),
+		scheme: mgr.GetScheme(),
+	}
 }
 
 func add(mgr manager.Manager, r *ReconcileIoTProject) error {
@@ -96,6 +100,7 @@ type ReconcileIoTProject struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
 	client client.Client
+	reader client.Reader
 	scheme *runtime.Scheme
 }
 
@@ -178,10 +183,11 @@ func (r *ReconcileIoTProject) Reconcile(request reconcile.Request) (reconcile.Re
 	rc := &recon.ReconcileContext{}
 
 	rc.Process(func() (result reconcile.Result, e error) {
-		return finalizer.ProcessFinalizers(ctx, r.client, project, finalizers)
+		return finalizer.ProcessFinalizers(ctx, r.client, r.reader, project, finalizers)
 	})
 
 	if rc.Error() != nil || rc.NeedRequeue() {
+		log.Info("Re-queue after processing finalizers")
 		// processing finalizers required to requeue already, or failed
 		return rc.Result()
 	}
@@ -245,6 +251,10 @@ func (r *ReconcileIoTProject) Reconcile(request reconcile.Request) (reconcile.Re
 			return r.updateProjectStatus(ctx, project, err)
 		})
 
+	}
+
+	if rc.NeedRequeue() {
+		log.Info("Re-queue scheduled")
 	}
 
 	return rc.Result()

--- a/pkg/controller/iotproject/managed.go
+++ b/pkg/controller/iotproject/managed.go
@@ -205,8 +205,6 @@ func (r *ReconcileIoTProject) ensureAdapterCredentials(ctx context.Context, proj
 		project.Status.Managed = &iotv1alpha1.ManagedStatus{}
 	}
 
-	//
-
 	changed := false
 
 	// eval address space
@@ -236,6 +234,7 @@ func (r *ReconcileIoTProject) ensureAdapterCredentials(ctx context.Context, proj
 			// clear out address space, will re-set in the next iteration
 
 			project.Status.Managed.AddressSpace = ""
+			log.Info("Re-queue: Address space changed")
 			changed = true
 
 		}
@@ -277,6 +276,7 @@ func (r *ReconcileIoTProject) ensureAdapterCredentials(ctx context.Context, proj
 
 		// re-queue right now to ensure the password is stored
 
+		log.Info("Re-queue: adapter password changed")
 		changed = true
 
 	}
@@ -300,8 +300,7 @@ func (r *ReconcileIoTProject) reconcileAddressSpace(ctx context.Context, project
 
 	var retryDelay time.Duration = 0
 
-	_, err := controllerutil.CreateOrUpdate(ctx, r.client, addressSpace, func() error {
-		log.V(2).Info("Reconcile address space", "AddressSpace", addressSpace)
+	rc, err := controllerutil.CreateOrUpdate(ctx, r.client, addressSpace, func() error {
 
 		managedStatus.remainingReady[resourceTypeAddressSpace] = addressSpace.Status.IsReady
 
@@ -309,10 +308,15 @@ func (r *ReconcileIoTProject) reconcileAddressSpace(ctx context.Context, project
 		if !addressSpace.Status.IsReady {
 			// delay for 30 seconds
 			retryDelay = 30 * time.Second
+			log.Info("Re-queue: Address space not ready")
 		}
 
 		return r.reconcileManagedAddressSpace(project, strategy, addressSpace)
 	})
+
+	if rc != controllerutil.OperationResultNone {
+		log.V(2).Info("Created/updated address space", "op", rc, "AddressSpace", addressSpace)
+	}
 
 	if err == nil {
 		managedStatus.remainingCreated[resourceTypeAddressSpace] = true
@@ -369,8 +373,6 @@ func (r *ReconcileIoTProject) createOrUpdateAddress(ctx context.Context, project
 	addressName := util.AddressName(project, addressBaseName)
 	addressMetaName := util.EncodeAddressSpaceAsMetaName(strategy.AddressSpace.Name, addressName)
 
-	log.Info("Creating/updating address", "basename", addressBaseName, "name", addressName, "metaname", addressMetaName)
-
 	stateKey := "Address|" + addressName
 	managedStatus.remainingCreated[stateKey] = false
 
@@ -381,11 +383,15 @@ func (r *ReconcileIoTProject) createOrUpdateAddress(ctx context.Context, project
 		},
 	}
 
-	_, err := controllerutil.CreateOrUpdate(ctx, r.client, address, func() error {
+	rc, err := controllerutil.CreateOrUpdate(ctx, r.client, address, func() error {
 		managedStatus.remainingReady[stateKey] = address.Status.IsReady
 
 		return r.reconcileAddress(project, strategy, addressName, plan, typeName, address)
 	})
+
+	if rc != controllerutil.OperationResultNone {
+		log.Info("Created/updated address", "op", rc, "basename", addressBaseName, "name", addressName, "metaname", addressMetaName)
+	}
 
 	if err == nil {
 		managedStatus.remainingCreated[stateKey] = true

--- a/pkg/util/finalizer/finalizer.go
+++ b/pkg/util/finalizer/finalizer.go
@@ -9,6 +9,8 @@ import (
 	"context"
 	"fmt"
 
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -16,9 +18,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+var log = logf.Log.WithName("controller_iotproject")
+
 type DeconstructorContext struct {
 	Context context.Context
 	Client  client.Client
+	Reader  client.Reader
 	Object  runtime.Object
 }
 
@@ -75,7 +80,7 @@ func removeFinalizer(name string, list []string) []string {
 // If the deletion timestamp is non-nil, it will iterate over the finalizers, and call the destructor for the first
 // finalizer it still finds in the list (in any order). If the deconstructor returns as "finished", then will remove
 // the finalizer from the list, update the object, and request to be re-queued.
-func ProcessFinalizers(ctx context.Context, client client.Client, obj runtime.Object, finalizers []Finalizer) (reconcile.Result, error) {
+func ProcessFinalizers(ctx context.Context, client client.Client, reader client.Reader, obj runtime.Object, finalizers []Finalizer) (reconcile.Result, error) {
 
 	object, ok := obj.(v1.Object)
 	if !ok {
@@ -102,6 +107,7 @@ func ProcessFinalizers(ctx context.Context, client client.Client, obj runtime.Ob
 		if changed {
 			// the list of finalizers has changed, update and return
 			object.SetFinalizers(current)
+			log.Info("Re-queue: added finalizer")
 			return reconcile.Result{Requeue: true}, client.Update(ctx, obj)
 		}
 
@@ -125,6 +131,7 @@ func ProcessFinalizers(ctx context.Context, client client.Client, obj runtime.Ob
 					result, err = f.Deconstruct(DeconstructorContext{
 						Context: ctx,
 						Client:  client,
+						Reader:  reader,
 						Object:  obj,
 					})
 				}
@@ -143,6 +150,7 @@ func ProcessFinalizers(ctx context.Context, client client.Client, obj runtime.Ob
 					c := current
 					object.SetFinalizers(removeFinalizer(f.Name, c))
 					// persist, and re-schedule for the next finalizer
+					log.Info("Re-queue: removed finalizer")
 					return reconcile.Result{Requeue: true}, client.Update(ctx, obj)
 
 				} else {

--- a/pkg/util/finalizer/finalizer_test.go
+++ b/pkg/util/finalizer/finalizer_test.go
@@ -59,9 +59,9 @@ func TestAdd(t *testing.T) {
 
 	objs := []runtime.Object{project}
 
-	client := fake.NewFakeClient(objs...)
+	client := fake.NewFakeClientWithScheme(scheme.Scheme, objs...)
 
-	result, err := ProcessFinalizers(context.TODO(), client, project, []Finalizer{
+	result, err := ProcessFinalizers(context.TODO(), client, client, project, []Finalizer{
 		{Name: "foo"},
 	})
 
@@ -95,11 +95,11 @@ func TestRemove1(t *testing.T) {
 
 	objs := []runtime.Object{project}
 
-	client := fake.NewFakeClient(objs...)
+	client := fake.NewFakeClientWithScheme(scheme.Scheme, objs...)
 
 	i := 0
 
-	result, err := ProcessFinalizers(context.TODO(), client, project, []Finalizer{
+	result, err := ProcessFinalizers(context.TODO(), client, client, project, []Finalizer{
 		{
 			Name: "foo", Deconstruct: func(ctx DeconstructorContext) (result reconcile.Result, e error) {
 				i++
@@ -124,7 +124,7 @@ func TestRemove1(t *testing.T) {
 		t.Fatal("Must have one element")
 	}
 
-	result, err = ProcessFinalizers(context.TODO(), client, project, []Finalizer{
+	result, err = ProcessFinalizers(context.TODO(), client, client, project, []Finalizer{
 		{
 			Name: "foo", Deconstruct: func(ctx DeconstructorContext) (result reconcile.Result, e error) {
 				i++
@@ -149,7 +149,7 @@ func TestRemove1(t *testing.T) {
 		t.Fatal("Must have no element")
 	}
 
-	result, err = ProcessFinalizers(context.TODO(), client, project, []Finalizer{
+	result, err = ProcessFinalizers(context.TODO(), client, client, project, []Finalizer{
 		{
 			Name: "foo", Deconstruct: func(ctx DeconstructorContext) (result reconcile.Result, e error) {
 				i++
@@ -188,7 +188,7 @@ type FinalizerTestStep struct {
 func RunFinalizerSteps(t *testing.T, project *v1alpha1.IoTProject, finalizers []string, steps []FinalizerTestStep) {
 	objs := []runtime.Object{project}
 
-	client := fake.NewFakeClient(objs...)
+	client := fake.NewFakeClientWithScheme(scheme.Scheme, objs...)
 
 	i := 0
 
@@ -210,7 +210,7 @@ func RunFinalizerSteps(t *testing.T, project *v1alpha1.IoTProject, finalizers []
 				})
 			}
 
-			result, err := ProcessFinalizers(context.TODO(), client, project, mockFinalizers)
+			result, err := ProcessFinalizers(context.TODO(), client, client, project, mockFinalizers)
 
 			if (err != nil) != (s.Error != nil) {
 				t.Errorf("Error state mismatch - expected: %v, found: %v", s.Error, err)


### PR DESCRIPTION
### Type of change

Pulling out more changes in preparation to #3557.

Aside from some cleanups, the adds the API reader, so that, later on, the finalizer can use this API reader, to read Jobs on a single namespace only, without creating a system wide informer on the "any" namespace for jobs.

<!--

_Select the type of your PR_

-->

- Refactoring

### Description

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
