### PR TITLE
Change order of destroying resources

### DIFF
--- a/cmd/iot-proxy-configurator/configurator.go
+++ b/cmd/iot-proxy-configurator/configurator.go
@@ -197,6 +197,8 @@ func (c *Configurator) syncHandler(key string) error {
 		return nil
 	}
 
+	log := log.WithValues("namespace", namespace, "name", name)
+
 	// read requested state
 	project, err := c.projectLister.IoTProjects(namespace).Get(name)
 	if err != nil {
@@ -218,6 +220,8 @@ func (c *Configurator) syncHandler(key string) error {
 			})
 
 		}
+
+		log.Error(err, "Failed to read IoTProject")
 
 		return err
 	}

--- a/cmd/iot-proxy-configurator/configurator.go
+++ b/cmd/iot-proxy-configurator/configurator.go
@@ -236,7 +236,10 @@ func (c *Configurator) syncHandler(key string) error {
 
 	}
 
+	log.Info("Change on IoTProject: " + project.Namespace + "." + project.Name)
+
 	if project.Status.Phase != v1alpha1.ProjectPhaseReady || project.Status.DownstreamEndpoint == nil {
+		log.Info("Project is not ready yet", "Phase", project.Status.Phase, "DownstreamEndpoint", project.Status.DownstreamEndpoint)
 		// project is not ready yet
 		return nil
 	}
@@ -247,6 +250,7 @@ func (c *Configurator) syncHandler(key string) error {
 	// something went wrong syncing the project
 	// we will re-queue this by returning the error state
 	if err != nil {
+		log.Error(err, "Failed to sync IoTProject with QDR")
 		return err
 	}
 

--- a/systemtests/src/main/java/io/enmasse/systemtest/listener/JunitExecutionListener.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/listener/JunitExecutionListener.java
@@ -30,63 +30,86 @@ public class JunitExecutionListener implements TestExecutionListener {
 
     @Override
     public void testPlanExecutionFinished(TestPlan testPlan) {
-        Environment env = Environment.getInstance();
+
+        final Environment env = Environment.getInstance();
+
         if (!env.skipCleanup()) {
-            Kubernetes kube = Kubernetes.getInstance();
-            GlobalLogCollector logCollector = new GlobalLogCollector(kube, env.testLogDir());
-            try {
-                kube.getAddressSpaceClient().inAnyNamespace().list().getItems().forEach((addrSpace) -> {
-                    LOGGER.info("address space '{}' will be removed", addrSpace);
-                    try {
-                        AddressSpaceUtils.deleteAddressSpaceAndWait(addrSpace, logCollector);
-                        IsolatedResourcesManager.getInstance().tearDown(TestInfo.getInstance().getActualTest());
-                    } catch (Exception e) {
-                        LOGGER.warn("Cleanup failed or no clean is needed");
-                    }
-                });
-            } catch (Exception e) {
-                LOGGER.warn("Cleanup failed or no clean is needed");
-            }
-            if (IoTUtils.isIoTInstalled(kube)) {
-                try {
-                    kube.getNonNamespacedIoTProjectClient().list().getItems().forEach(project -> {
-                        LOGGER.info("iot project '{}' will be removed", project.getMetadata().getName());
-                        try {
-                            IoTUtils.deleteIoTProjectAndWait(kube, project);
-                        } catch (Exception e) {
-                            e.printStackTrace();
-                        }
-                    });
-                    var iotConfigClient = kube.getIoTConfigClient();
-                    iotConfigClient.list().getItems().forEach(config -> {
-                        LOGGER.info("iot config '{}' will be removed", config.getMetadata().getName());
-                        try {
-                            IoTUtils.deleteIoTConfigAndWait(kube, config);
-                        } catch (Exception e) {
-                            e.printStackTrace();
-                        }
-                    });
-                    LOGGER.info("Infinispan server will be removed");
-                    SystemtestsKubernetesApps.deleteInfinispanServer();
-                    if (!SystemtestsKubernetesApps.INFINISPAN_PROJECT.equals(kube.getInfraNamespace())) {
-                        kube.deleteNamespace(SystemtestsKubernetesApps.INFINISPAN_PROJECT);
-                    }
-                } catch (Exception e) {
-                    LOGGER.warn("Cleanup failed or no clean is needed");
-                }
-            }
+            // clean up resources
+            performCleanup();
         } else {
             LOGGER.warn("Remove address spaces when test run finished - SKIPPED!");
         }
+
         TimeMeasuringSystem.printAndSaveResults();
-        if (!(Environment.getInstance().skipCleanup() || Environment.getInstance().skipUninstall())) {
+
+        if (!(env.skipCleanup() || env.skipUninstall())) {
+            // clean up infrastructure after resources
+            performInfraCleanup();
+        }
+
+    }
+
+    private void performCleanup() {
+        final Environment env = Environment.getInstance();
+        final Kubernetes kube = Kubernetes.getInstance();
+        final GlobalLogCollector logCollector = new GlobalLogCollector(kube, env.testLogDir());
+
+        if (IoTUtils.isIoTInstalled(kube)) {
             try {
-                OperatorManager.getInstance().removeIoTOperator();
-                OperatorManager.getInstance().deleteEnmasseOlm();
-                OperatorManager.getInstance().deleteEnmasseBundle();
+                kube.getNonNamespacedIoTProjectClient().list().getItems().forEach(project -> {
+                    LOGGER.info("iot project '{}' will be removed", project.getMetadata().getName());
+                    try {
+                        IoTUtils.deleteIoTProjectAndWait(kube, project);
+                    } catch (Exception e) {
+                        LOGGER.warn("Failed to delete IoT projects: {}", project, e);
+                    }
+                });
+                kube.getIoTConfigClient().list().getItems().forEach(config -> {
+                    LOGGER.info("iot config '{}' will be removed", config.getMetadata().getName());
+                    try {
+                        IoTUtils.deleteIoTConfigAndWait(kube, config);
+                    } catch (Exception e) {
+                        LOGGER.warn("Failed to delete IoT config: {}", config, e);
+                    }
+                });
+                LOGGER.info("Infinispan server will be removed");
+                SystemtestsKubernetesApps.deleteInfinispanServer();
+                if (!SystemtestsKubernetesApps.INFINISPAN_PROJECT.equals(kube.getInfraNamespace())) {
+                    kube.deleteNamespace(SystemtestsKubernetesApps.INFINISPAN_PROJECT);
+                }
             } catch (Exception e) {
-                e.printStackTrace();
+                LOGGER.warn("Cleanup failed or no clean is needed");
             }
         }
+
+        /*
+         * Clean up address spaces after IoT projects, as the iot operator immediately re-created missing
+         * address spaces.
+         */
+        try {
+            kube.getAddressSpaceClient().inAnyNamespace().list().getItems().forEach((addrSpace) -> {
+                LOGGER.info("address space '{}' will be removed", addrSpace);
+                try {
+                    AddressSpaceUtils.deleteAddressSpaceAndWait(addrSpace, logCollector);
+                    IsolatedResourcesManager.getInstance().tearDown(TestInfo.getInstance().getActualTest());
+                } catch (Exception e) {
+                    LOGGER.warn("Cleanup failed or no clean is needed");
+                }
+            });
+        } catch (Exception e) {
+            LOGGER.warn("Cleanup failed or no clean is needed");
+        }
+
     }
+
+    private void performInfraCleanup() {
+        try {
+            OperatorManager.getInstance().removeIoTOperator();
+            OperatorManager.getInstance().deleteEnmasseOlm();
+            OperatorManager.getInstance().deleteEnmasseBundle();
+        } catch (Exception e) {
+            LOGGER.error("Failed", e);
+        }
+    }
+
 }

--- a/systemtests/src/main/java/io/enmasse/systemtest/manager/ResourceManager.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/manager/ResourceManager.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.slf4j.Logger;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -396,6 +397,9 @@ public abstract class ResourceManager {
     //================================================================================================
 
     public User createOrUpdateUser(AddressSpace addressSpace, UserCredentials credentials) {
+        Objects.requireNonNull(addressSpace);
+        Objects.requireNonNull(credentials);
+
         User user = new UserBuilder()
                 .withNewMetadata()
                 .withName(addressSpace.getMetadata().getName() + "." + credentials.getUsername())
@@ -452,11 +456,16 @@ public abstract class ResourceManager {
     }
 
     public void removeUser(AddressSpace addressSpace, User user) {
+        Objects.requireNonNull(addressSpace);
+        Objects.requireNonNull(user);
+
         LOGGER.info("User {} in address space {} will be removed", user.getMetadata().getName(), addressSpace.getMetadata().getName());
         kubernetes.getUserClient(addressSpace.getMetadata().getNamespace()).withName(user.getMetadata().getName()).cascading(true).delete();
     }
 
     public void removeUser(AddressSpace addressSpace, String userName) {
+        Objects.requireNonNull(addressSpace);
+
         LOGGER.info("User {} in address space {} will be removed", userName, addressSpace.getMetadata().getName());
         kubernetes.getUserClient(addressSpace.getMetadata().getNamespace()).withName(String.format("%s.%s", addressSpace.getMetadata().getName(), userName)).cascading(true).delete();
     }

--- a/systemtests/src/main/java/io/enmasse/systemtest/utils/IoTUtils.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/utils/IoTUtils.java
@@ -144,13 +144,15 @@ public class IoTUtils {
                 Thread.sleep(10000);
             }
         }
+
+        final String jsonStatus = project.getStatus() != null ? project.getStatus().toString() : "Project doesn't have status";
         if (!isReady) {
-            String jsonStatus = project.getStatus() != null ? project.getStatus().toString() : "Project doesn't have status";
             throw new IllegalStateException("IoTProject " + project.getMetadata().getName() + " is not in Ready state within timeout: " + jsonStatus);
         }
 
         // refresh
         project = iotProjectClient.withName(project.getMetadata().getName()).get();
+        log.info("IoTProject is ready - phase: {} -> {}", project.getStatus().getPhase(), jsonStatus);
 
         if (project.getSpec().getDownstreamStrategy() != null
                 && project.getSpec().getDownstreamStrategy().getManagedStrategy() != null

--- a/systemtests/src/main/java/io/enmasse/systemtest/utils/IoTUtils.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/utils/IoTUtils.java
@@ -151,7 +151,6 @@ public class IoTUtils {
         }
 
         // refresh
-        project = iotProjectClient.withName(project.getMetadata().getName()).get();
         log.info("IoTProject is ready - phase: {} -> {}", project.getStatus().getPhase(), jsonStatus);
 
         if (project.getSpec().getDownstreamStrategy() != null

--- a/systemtests/src/test/java/io/enmasse/systemtest/iot/shared/http/HttpAdapterTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/iot/shared/http/HttpAdapterTest.java
@@ -100,7 +100,10 @@ class HttpAdapterTest extends TestBase implements ITestIoTShared {
         if (adapterClient != null) {
             adapterClient.close();
         }
-        resourcesManager.removeUser(getSharedAddressSpace(), businessApplicationUsername);
+        var addressSpace = getSharedAddressSpace();
+        if(addressSpace != null) {
+            resourcesManager.removeUser(addressSpace, businessApplicationUsername);
+        }
     }
 
     @AfterEach


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

The order in which the system tests destroy resources. IoT projects first, then address spaces. Otherwise the IoT operator will automatically re-created the resources.

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
