### PR TITLE
Use displayname for storing artifacts

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/listener/JunitCallbackListener.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/listener/JunitCallbackListener.java
@@ -198,7 +198,7 @@ public class JunitCallbackListener implements TestExecutionExceptionHandler, Lif
             throw throwable;
         }
 
-        Method testMethod = extensionContext.getTestMethod().orElse(null);
+        String testMethod = extensionContext.getDisplayName();
         Class<?> testClass = extensionContext.getRequiredTestClass();
         try {
             Kubernetes kube = Kubernetes.getInstance();
@@ -246,13 +246,13 @@ public class JunitCallbackListener implements TestExecutionExceptionHandler, Lif
         throw throwable;
     }
 
-    public static Path getPath(Method testMethod, Class<?> testClass) {
+    public static Path getPath(String testMethod, Class<?> testClass) {
         Path path = env.testLogDir().resolve(
                 Paths.get(
                         "failed_test_logs",
                         testClass.getName()));
         if (testMethod != null) {
-            path = path.resolve(testMethod.getName());
+            path = path.resolve(testMethod);
         }
         return path;
     }

--- a/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/ExternalClientsExtension.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/ExternalClientsExtension.java
@@ -35,7 +35,7 @@ public class ExternalClientsExtension implements BeforeTestExecutionCallback, Af
     @Override
     public void afterTestExecution(ExtensionContext extensionContext) throws Exception {
         if (extensionContext.getExecutionException().isPresent()) {
-            Path path = JunitCallbackListener.getPath(extensionContext.getTestMethod().get(), extensionContext.getTestClass().get());
+            Path path = JunitCallbackListener.getPath(extensionContext.getDisplayName(), extensionContext.getTestClass().get());
             SystemtestsKubernetesApps.collectMessagingClientAppLogs(path);
         }
         if (!isFullClass) {

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/clients/ClientTestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/clients/ClientTestBase.java
@@ -62,7 +62,7 @@ public abstract class ClientTestBase extends TestBase implements ITestBaseShared
                 Paths.get(
                         clientFolder,
                         info.getTestClass().get().getName(),
-                        info.getTestMethod().get().getName()));
+                        info.getDisplayName()));
 
         arguments.put(ClientArgument.USERNAME, defaultCredentials.getUsername());
         arguments.put(ClientArgument.PASSWORD, defaultCredentials.getPassword());


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Refactoring

### Description

<!--

_Please describe your pull request_

-->

Since we started using parametrized tests, we need to store artifacts in handlers with DisplayName of test to store every parametrized test iteration

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
