### PR TITLE
Default route annotation

### DIFF
--- a/address-space-controller/src/main/java/io/enmasse/controller/EndpointController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/EndpointController.java
@@ -188,7 +188,7 @@ public class EndpointController implements Controller {
                 .editOrNewMetadata()
                 .withName(routeName)
                 .withNamespace(namespace)
-                .addToAnnotations(exposeSpec.getAnnotations() != null ? exposeSpec.getAnnotations() : Collections.emptyMap())
+                .addToAnnotations(exposeSpec.getAnnotations() != null ? exposeSpec.getAnnotations() : Collections.singletonMap("haproxy.router.openshift.io/balance", "leastconn"))
                 .addToAnnotations(AnnotationKeys.ADDRESS_SPACE, addressSpace.getMetadata().getName())
                 .addToAnnotations(AnnotationKeys.SERVICE_NAME, serviceName)
                 .addToLabels(LabelKeys.INFRA_TYPE, addressSpace.getSpec().getType())


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Enhancement / new feature

### Description

Balance by least number of connections by default
    
Using this policy as a default is more appropriate for messaging application that typically have long-living connections.

Fixes #3484 

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
