### PR TITLE
Refactor "ApplyContainer" to support Init, Deployment and Job

### DIFF
--- a/pkg/controller/address_space_controller/controller.go
+++ b/pkg/controller/address_space_controller/controller.go
@@ -147,7 +147,7 @@ func (r *ReconcileAddressSpaceController) ensureDeployment(ctx context.Context, 
 
 func ApplyDeployment(deployment *appsv1.Deployment) error {
 	install.ApplyDeploymentDefaults(deployment, "address-space-controller", deployment.Name)
-	err := install.ApplyContainerWithError(deployment, "address-space-controller", func(container *corev1.Container) error {
+	err := install.ApplyDeploymentContainerWithError(deployment, "address-space-controller", func(container *corev1.Container) error {
 		install.ApplyContainerImage(container, "address-space-controller", nil)
 		install.ApplyHttpProbe(container.LivenessProbe, 30, "/healthz", 8080)
 		install.ApplyHttpProbe(container.ReadinessProbe, 30, "/healthz", 8080)

--- a/pkg/controller/authenticationservice/none.go
+++ b/pkg/controller/authenticationservice/none.go
@@ -42,7 +42,7 @@ func applyNoneAuthServiceDefaults(ctx context.Context, client client.Client, sch
 
 func applyNoneAuthServiceDeployment(authservice *adminv1beta1.AuthenticationService, deployment *appsv1.Deployment) error {
 	install.ApplyDeploymentDefaults(deployment, "none-authservice", authservice.Name)
-	if err := install.ApplyContainerWithError(deployment, "none-authservice", func(container *corev1.Container) error {
+	if err := install.ApplyDeploymentContainerWithError(deployment, "none-authservice", func(container *corev1.Container) error {
 		if err := install.ApplyContainerImage(container, "none-authservice", authservice.Spec.None.Image); err != nil {
 			return err
 		}

--- a/pkg/controller/authenticationservice/standard.go
+++ b/pkg/controller/authenticationservice/standard.go
@@ -117,7 +117,7 @@ func applyStandardAuthServiceDeployment(authservice *adminv1beta1.Authentication
 		return err
 	}
 
-	if err := install.ApplyContainerWithError(deployment, "keycloak", func(container *corev1.Container) error {
+	if err := install.ApplyDeploymentContainerWithError(deployment, "keycloak", func(container *corev1.Container) error {
 		if err := install.ApplyContainerImage(container, "keycloak", authservice.Spec.Standard.Image); err != nil {
 			return err
 		}

--- a/pkg/controller/consoleservice/consoleservice_controller.go
+++ b/pkg/controller/consoleservice/consoleservice_controller.go
@@ -613,7 +613,7 @@ func applyDeployment(consoleservice *v1beta1.ConsoleService, deployment *appsv1.
 	}
 
 	if util.IsOpenshift() {
-		if err := install.ApplyContainerWithError(deployment, "console-proxy", func(container *corev1.Container) error {
+		if err := install.ApplyDeploymentContainerWithError(deployment, "console-proxy", func(container *corev1.Container) error {
 			if err := install.ApplyContainerImage(container, "console-proxy-openshift", nil); err != nil {
 				return err
 			}
@@ -625,7 +625,7 @@ func applyDeployment(consoleservice *v1beta1.ConsoleService, deployment *appsv1.
 			return err
 		}
 
-		if err := install.ApplyContainerWithError(deployment, "console-httpd", func(container *corev1.Container) error {
+		if err := install.ApplyDeploymentContainerWithError(deployment, "console-httpd", func(container *corev1.Container) error {
 			if err := install.ApplyContainerImage(container, "console-httpd", nil); err != nil {
 				return err
 			}
@@ -660,7 +660,7 @@ func applyDeployment(consoleservice *v1beta1.ConsoleService, deployment *appsv1.
 			return err
 		}
 	} else {
-		if err := install.ApplyContainerWithError(deployment, "console-proxy", func(container *corev1.Container) error {
+		if err := install.ApplyDeploymentContainerWithError(deployment, "console-proxy", func(container *corev1.Container) error {
 			if err := install.ApplyContainerImage(container, "console-proxy-kubernetes", nil); err != nil {
 				return err
 			}

--- a/pkg/controller/iotconfig/adapter.go
+++ b/pkg/controller/iotconfig/adapter.go
@@ -89,7 +89,7 @@ func findAdapter(name string) adapter {
 
 func (r *ReconcileIoTConfig) addQpidProxySetup(config *iotv1alpha1.IoTConfig, deployment *appsv1.Deployment, containers iotv1alpha1.CommonAdapterContainers) error {
 
-	err := install.ApplyContainerWithError(deployment, "qdr-cfg", func(container *corev1.Container) error {
+	err := install.ApplyDeploymentContainerWithError(deployment, "qdr-cfg", func(container *corev1.Container) error {
 
 		if err := install.SetContainerImage(container, "iot-proxy-configurator", config); err != nil {
 			return err
@@ -124,7 +124,7 @@ func (r *ReconcileIoTConfig) addQpidProxySetup(config *iotv1alpha1.IoTConfig, de
 		return err
 	}
 
-	err = install.ApplyContainerWithError(deployment, "qdr-proxy", func(container *corev1.Container) error {
+	err = install.ApplyDeploymentContainerWithError(deployment, "qdr-proxy", func(container *corev1.Container) error {
 
 		if err := install.SetContainerImage(container, "router", config); err != nil {
 			return err

--- a/pkg/controller/iotconfig/auth_service.go
+++ b/pkg/controller/iotconfig/auth_service.go
@@ -61,7 +61,7 @@ func (r *ReconcileIoTConfig) reconcileAuthServiceDeployment(config *iotv1alpha1.
 	service := config.Spec.ServicesConfig.Authentication
 	applyDefaultDeploymentConfig(deployment, service.ServiceConfig, configCtx)
 
-	err := install.ApplyContainerWithError(deployment, "auth-service", func(container *corev1.Container) error {
+	err := install.ApplyDeploymentContainerWithError(deployment, "auth-service", func(container *corev1.Container) error {
 
 		if err := install.SetContainerImage(container, "iot-auth-service", config); err != nil {
 			return err

--- a/pkg/controller/iotconfig/file_device_registry.go
+++ b/pkg/controller/iotconfig/file_device_registry.go
@@ -83,7 +83,7 @@ func (r *ReconcileIoTConfig) reconcileFileDeviceRegistryDeployment(config *iotv1
 	// this is necessary to detach the volume first
 	deployment.Spec.Strategy.Type = appsv1.RecreateDeploymentStrategyType
 
-	err := install.ApplyContainerWithError(deployment, "device-registry", func(container *corev1.Container) error {
+	err := install.ApplyDeploymentContainerWithError(deployment, "device-registry", func(container *corev1.Container) error {
 
 		if err := install.SetContainerImage(container, "iot-device-registry-file", config); err != nil {
 			return err

--- a/pkg/controller/iotconfig/http_adapter.go
+++ b/pkg/controller/iotconfig/http_adapter.go
@@ -85,7 +85,7 @@ func (r *ReconcileIoTConfig) reconcileHttpAdapterDeployment(config *iotv1alpha1.
 	applyDefaultAdapterDeploymentSpec(deployment)
 
 	install.DropContainer(deployment, "http-adapter")
-	err := install.ApplyContainerWithError(deployment, "adapter", func(container *corev1.Container) error {
+	err := install.ApplyDeploymentContainerWithError(deployment, "adapter", func(container *corev1.Container) error {
 
 		if err := install.SetContainerImage(container, "iot-http-adapter", config); err != nil {
 			return err

--- a/pkg/controller/iotconfig/infinispan_device_registry.go
+++ b/pkg/controller/iotconfig/infinispan_device_registry.go
@@ -75,7 +75,7 @@ func (r *ReconcileIoTConfig) reconcileInfinispanDeviceRegistryDeployment(config 
 	service := config.Spec.ServicesConfig.DeviceRegistry
 	applyDefaultDeploymentConfig(deployment, service.ServiceConfig, nil)
 
-	err := install.ApplyContainerWithError(deployment, "device-registry", func(container *corev1.Container) error {
+	err := install.ApplyDeploymentContainerWithError(deployment, "device-registry", func(container *corev1.Container) error {
 
 		if err := install.SetContainerImage(container, "iot-device-registry-infinispan", config); err != nil {
 			return err

--- a/pkg/controller/iotconfig/lorawan_adapter.go
+++ b/pkg/controller/iotconfig/lorawan_adapter.go
@@ -84,7 +84,7 @@ func (r *ReconcileIoTConfig) reconcileLoraWanAdapterDeployment(config *iotv1alph
 	applyDefaultAdapterDeploymentSpec(deployment)
 
 	install.DropContainer(deployment, "lorawan-adapter")
-	err := install.ApplyContainerWithError(deployment, "adapter", func(container *corev1.Container) error {
+	err := install.ApplyDeploymentContainerWithError(deployment, "adapter", func(container *corev1.Container) error {
 
 		if err := install.SetContainerImage(container, "iot-lorawan-adapter", config); err != nil {
 			return err

--- a/pkg/controller/iotconfig/mqtt_adapter.go
+++ b/pkg/controller/iotconfig/mqtt_adapter.go
@@ -86,7 +86,7 @@ func (r *ReconcileIoTConfig) reconcileMqttAdapterDeployment(config *iotv1alpha1.
 	applyDefaultAdapterDeploymentSpec(deployment)
 
 	install.DropContainer(deployment, "mqtt-adapter")
-	err := install.ApplyContainerWithError(deployment, "adapter", func(container *corev1.Container) error {
+	err := install.ApplyDeploymentContainerWithError(deployment, "adapter", func(container *corev1.Container) error {
 
 		if err := install.SetContainerImage(container, "iot-mqtt-adapter", config); err != nil {
 			return err

--- a/pkg/controller/iotconfig/project_operator.go
+++ b/pkg/controller/iotconfig/project_operator.go
@@ -27,7 +27,7 @@ func (r *ReconcileIoTConfig) reconcileProjectOperator(config *iotv1alpha1.IoTCon
 
 	deployment.Spec.Template.Spec.ServiceAccountName = "iot-operator"
 
-	err := install.ApplyContainerWithError(deployment, "operator", func(container *corev1.Container) error {
+	err := install.ApplyDeploymentContainerWithError(deployment, "operator", func(container *corev1.Container) error {
 		if err := install.SetContainerImage(container, "controller-manager", config); err != nil {
 			return err
 		}

--- a/pkg/controller/iotconfig/sigfox_adapter.go
+++ b/pkg/controller/iotconfig/sigfox_adapter.go
@@ -85,7 +85,7 @@ func (r *ReconcileIoTConfig) reconcileSigfoxAdapterDeployment(config *iotv1alpha
 	applyDefaultAdapterDeploymentSpec(deployment)
 
 	install.DropContainer(deployment, "sigfox-adapter")
-	err := install.ApplyContainerWithError(deployment, "adapter", func(container *corev1.Container) error {
+	err := install.ApplyDeploymentContainerWithError(deployment, "adapter", func(container *corev1.Container) error {
 
 		if err := install.SetContainerImage(container, "iot-sigfox-adapter", config); err != nil {
 			return err

--- a/pkg/controller/iotconfig/tenant_service.go
+++ b/pkg/controller/iotconfig/tenant_service.go
@@ -53,7 +53,7 @@ func (r *ReconcileIoTConfig) reconcileTenantServiceDeployment(config *iotv1alpha
 	deployment.Spec.Template.Spec.ServiceAccountName = "iot-tenant-service"
 	applyDefaultDeploymentConfig(deployment, service.ServiceConfig, nil)
 
-	err := install.ApplyContainerWithError(deployment, "tenant-service", func(container *corev1.Container) error {
+	err := install.ApplyDeploymentContainerWithError(deployment, "tenant-service", func(container *corev1.Container) error {
 
 		if err := install.SetContainerImage(container, "iot-tenant-service", config); err != nil {
 			return err

--- a/pkg/util/install/utils.go
+++ b/pkg/util/install/utils.go
@@ -16,6 +16,7 @@ import (
 	"github.com/enmasseproject/enmasse/pkg/util/images"
 
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -111,15 +112,16 @@ func DropContainer(deployment *appsv1.Deployment, name string) {
 	}
 }
 
-func ApplyContainerWithError(deployment *appsv1.Deployment, name string, mutator func(*corev1.Container) error) error {
+func ApplyContainerWithError(containers []corev1.Container, name string, mutator func(*corev1.Container) error) ([]corev1.Container, error) {
 
-	if deployment.Spec.Template.Spec.Containers == nil {
-		deployment.Spec.Template.Spec.Containers = make([]corev1.Container, 0)
+	if containers == nil {
+		containers = make([]corev1.Container, 0)
 	}
 
-	for i, c := range deployment.Spec.Template.Spec.Containers {
+	for i, c := range containers {
 		if c.Name == name {
-			return mutator(&deployment.Spec.Template.Spec.Containers[i])
+			err := mutator(&containers[i])
+			return containers, err
 		}
 	}
 
@@ -129,31 +131,37 @@ func ApplyContainerWithError(deployment *appsv1.Deployment, name string, mutator
 
 	err := mutator(c)
 	if err == nil {
-		deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers, *c)
+		containers = append(containers, *c)
+	}
+
+	return containers, err
+}
+
+func ApplyDeploymentContainerWithError(deployment *appsv1.Deployment, name string, mutator func(*corev1.Container) error) error {
+	containers, err := ApplyContainerWithError(deployment.Spec.Template.Spec.Containers, name, mutator)
+
+	if err == nil {
+		deployment.Spec.Template.Spec.Containers = containers
 	}
 
 	return err
 }
 
 func ApplyInitContainerWithError(deployment *appsv1.Deployment, name string, mutator func(*corev1.Container) error) error {
+	containers, err := ApplyContainerWithError(deployment.Spec.Template.Spec.InitContainers, name, mutator)
 
-	if deployment.Spec.Template.Spec.InitContainers == nil {
-		deployment.Spec.Template.Spec.InitContainers = make([]corev1.Container, 0)
-	}
-
-	for i, c := range deployment.Spec.Template.Spec.InitContainers {
-		if c.Name == name {
-			return mutator(&deployment.Spec.Template.Spec.InitContainers[i])
-		}
-	}
-
-	c := &corev1.Container{
-		Name: name,
-	}
-
-	err := mutator(c)
 	if err == nil {
-		deployment.Spec.Template.Spec.InitContainers = append(deployment.Spec.Template.Spec.InitContainers, *c)
+		deployment.Spec.Template.Spec.InitContainers = containers
+	}
+
+	return err
+}
+
+func ApplyJobContainerWithError(job *batchv1.Job, name string, mutator func(*corev1.Container) error) error {
+	containers, err := ApplyContainerWithError(job.Spec.Template.Spec.Containers, name, mutator)
+
+	if err == nil {
+		job.Spec.Template.Spec.Containers = containers
 	}
 
 	return err

--- a/pkg/util/install/utils_test.go
+++ b/pkg/util/install/utils_test.go
@@ -46,7 +46,7 @@ func TestApplyDeploymentDefaults(t *testing.T) {
 func TestAddContainer(t *testing.T) {
 	d := appv1.Deployment{}
 
-	_ = ApplyContainerWithError(&d, "foo", func(container *corev1.Container) error {
+	_ = ApplyDeploymentContainerWithError(&d, "foo", func(container *corev1.Container) error {
 		container.Image = "bar"
 		return nil
 	})
@@ -68,11 +68,11 @@ func TestAddContainer(t *testing.T) {
 func TestReplaceContainer(t *testing.T) {
 	d := appv1.Deployment{}
 
-	_ = ApplyContainerWithError(&d, "foo", func(container *corev1.Container) error {
+	_ = ApplyDeploymentContainerWithError(&d, "foo", func(container *corev1.Container) error {
 		container.Image = "bar"
 		return nil
 	})
-	_ = ApplyContainerWithError(&d, "foo", func(container *corev1.Container) error {
+	_ = ApplyDeploymentContainerWithError(&d, "foo", func(container *corev1.Container) error {
 		container.Image = "baz"
 		return nil
 	})
@@ -94,15 +94,15 @@ func TestReplaceContainer(t *testing.T) {
 func TestTwoContainers(t *testing.T) {
 	d := appv1.Deployment{}
 
-	_ = ApplyContainerWithError(&d, "foo", func(container *corev1.Container) error {
+	_ = ApplyDeploymentContainerWithError(&d, "foo", func(container *corev1.Container) error {
 		container.Image = "bar"
 		return nil
 	})
-	_ = ApplyContainerWithError(&d, "foo2", func(container *corev1.Container) error {
+	_ = ApplyDeploymentContainerWithError(&d, "foo2", func(container *corev1.Container) error {
 		container.Image = "baz"
 		return nil
 	})
-	_ = ApplyContainerWithError(&d, "foo", func(container *corev1.Container) error {
+	_ = ApplyDeploymentContainerWithError(&d, "foo", func(container *corev1.Container) error {
 		container.Image = "baz2"
 		return nil
 	})


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Refactoring

### Description

Pull out changes from #3556. This change pulls "ApplyContainer" and "ApplyInitContainer" into a single function. And then re-uses that function to implement the feature for "Init", "Job" and "Deployment" containers.

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
