### PR TITLE
Fix chrome untrusted cert wss

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
@@ -495,7 +495,9 @@ public class TestUtils {
 
     public static RemoteWebDriver getChromeDriver() throws Exception {
         Endpoint endpoint = SystemtestsKubernetesApps.getChromeSeleniumAppEndpoint(Kubernetes.getInstance());
-        return getRemoteDriver(endpoint.getHost(), endpoint.getPort(), new ChromeOptions());
+        ChromeOptions options = new ChromeOptions();
+        options.setAcceptInsecureCerts(true);
+        return getRemoteDriver(endpoint.getHost(), endpoint.getPort(), options);
     }
 
     private static RemoteWebDriver getRemoteDriver(String host, int port, Capabilities options) throws Exception {


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

<!--

_Please describe your pull request_

-->

New version of chrome in selenium does not communicate on wss when cert is untrusted, so this setting allow to communicate with self signed certs

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
