### PR TITLE
Re-add Address Space Controller probes

### DIFF
--- a/pkg/controller/address_space_controller/controller.go
+++ b/pkg/controller/address_space_controller/controller.go
@@ -149,8 +149,8 @@ func ApplyDeployment(deployment *appsv1.Deployment) error {
 	install.ApplyDeploymentDefaults(deployment, "address-space-controller", deployment.Name)
 	err := install.ApplyDeploymentContainerWithError(deployment, "address-space-controller", func(container *corev1.Container) error {
 		install.ApplyContainerImage(container, "address-space-controller", nil)
-		install.ApplyHttpProbe(container.LivenessProbe, 30, "/healthz", 8080)
-		install.ApplyHttpProbe(container.ReadinessProbe, 30, "/healthz", 8080)
+		container.LivenessProbe = install.ApplyHttpProbe(container.LivenessProbe, 30, "/healthz", 8080)
+		container.ReadinessProbe = install.ApplyHttpProbe(container.ReadinessProbe, 30, "/healthz", 8080)
 		container.Ports = []corev1.ContainerPort{
 			{Name: "http", ContainerPort: 8080, Protocol: corev1.ProtocolTCP},
 		}


### PR DESCRIPTION
### Type of change

- Bugfix

### Description


On master the address-space-controller was missing its readiness/liveness probes.

### Checklist


- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
