### PR TITLE
Enabled tenant metrics

### DIFF
--- a/address-space-controller/src/main/resources/templates/brokered-space-infra.yaml
+++ b/address-space-controller/src/main/resources/templates/brokered-space-infra.yaml
@@ -193,6 +193,7 @@ objects:
   kind: Service
   metadata:
     labels:
+      monitoring-key: enmasse-tenants
       app: enmasse
       infraType: brokered
       infraUuid: ${INFRA_UUID}

--- a/address-space-controller/src/main/resources/templates/standard-space-infra.yaml
+++ b/address-space-controller/src/main/resources/templates/standard-space-infra.yaml
@@ -428,6 +428,7 @@ objects:
     annotations:
       addressSpace: ${ADDRESS_SPACE}
     labels:
+      monitoring-key: enmasse-tenants
       app: enmasse
       infraType: standard
       infraUuid: ${INFRA_UUID}

--- a/documentation/assemblies/assembly-monitoring.adoc
+++ b/documentation/assemblies/assembly-monitoring.adoc
@@ -1,6 +1,6 @@
 // This assembly is included in the following assemblies:
 //
-// assembly-service-admin-guide.adoc
+// assembly-monitoring.adoc
 
 :parent-context: {context}
 [id='monitoring-{context}']
@@ -18,6 +18,8 @@ include::../modules/proc-deploy-monitoring-using-bundle.adoc[leveloffset=+1]
 include::../modules/proc-deploy-monitoring-using-ansible.adoc[leveloffset=+1]
 
 include::../modules/proc-configure-alerts.adoc[leveloffset=+1]
+
+include::../modules/proc-enable-tenant-metrics.adoc[leveloffset=+1]
 
 :context: {parent-context}
 

--- a/documentation/modules/proc-enable-tenant-metrics.adoc
+++ b/documentation/modules/proc-enable-tenant-metrics.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// assembly-monitoring-kube.adoc
+// assembly-monitoring-oc.adoc
+
+[id='enable-tenant-metrics-{context}']
+= Enabling Tenant Metrics
+
+Metrics from brokers and routers can be exposed to tenants without exposing system-admin metrics. To expose tenant metrics create a service monitor in any non-`{ProductNamespace}` namespace, ideally the namespace of the concerned address space(s).
+
+.Prerequisites
+
+* The `servicemonitor` Custom Resource Definition provided by the Prometheus Operator must be installed.
+* The tenant must have their own monitoring stack installed.
+
+.Procedure
+
+* Creata a `servicemonitor` resource with a the selector configured to match labels of `monitoring-key: enmasse-tenants` and the `{ProductNamespace}` as the namespace selector. An example service monitor is shown below:
+
++
+[options="nowrap",subs="+quotes,attributes"]
+----
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: enmasse-tenants
+  labels:
+    app: enmasse
+spec:
+  selector:
+    matchLabels:
+      monitoring-key: enmasse-tenants
+  endpoints:
+  - port: health
+  namespaceSelector:
+    matchNames:
+      - enmasse-infra
+----
+
+* Ensure the tenant's monitoring stack has read permissions for service monitors in the service monitor's namespace but not in the `{ProductNamespace}` as this would expose service-admin metrics too.

--- a/standard-controller/src/main/resources/templates/queue-persisted.yaml
+++ b/standard-controller/src/main/resources/templates/queue-persisted.yaml
@@ -12,6 +12,7 @@ objects:
       addressSpace: ${ADDRESS_SPACE}
       cluster_id: ${CLUSTER_ID}
     labels:
+      monitoring-key: enmasse-tenants
       app: enmasse
       infraType: standard
       infraUuid: ${INFRA_UUID}

--- a/standard-controller/src/main/resources/templates/topic-persisted.yaml
+++ b/standard-controller/src/main/resources/templates/topic-persisted.yaml
@@ -12,6 +12,7 @@ objects:
       addressSpace: ${ADDRESS_SPACE}
       cluster_id: ${CLUSTER_ID}
     labels:
+      monitoring-key: enmasse-tenants
       app: enmasse
       infraType: standard
       infraUuid: ${INFRA_UUID}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Added a label to tenant specific metrics, allowing them to be scrape independently of system-admin metrics and provided sample service monitor to scrape only tenant metrics in docs.

### Checklist

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
