### PR TITLE
Refactor upgrade tests preparation to simplify code

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/info/TestInfo.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/info/TestInfo.java
@@ -204,15 +204,6 @@ public class TestInfo {
                 .orElseThrow();
     }
 
-    //TODO remove this method and move the logic associated with this to beforeAll callback
-    public boolean isNextTestUpgrade() {
-        int currentClassIndex = getCurrentClassIndex();
-        if (currentClassIndex + 1 < testClasses.size()) {
-            return getTags(testClasses.get(currentClassIndex + 1)).stream().anyMatch(TestTag.UPGRADE::equals);
-        }
-        return false;
-    }
-
     private List<String> getTags(TestIdentifier test) {
         return test.getTags().stream().map(org.junit.platform.engine.TestTag::getName).collect(Collectors.toList());
     }
@@ -234,17 +225,6 @@ public class TestInfo {
                     .findFirst()
                     .get();
             return tests.indexOf(test);
-        }
-        return 0;
-    }
-
-    private int getCurrentClassIndex() {
-        if (currentTestClass != null && testClasses.size() > 0) {
-            TestIdentifier test = testClasses.stream()
-                    .filter(testClass -> isSameClass(testClass, currentTestClass))
-                    .findFirst()
-                    .get();
-            return testClasses.indexOf(test);
         }
         return 0;
     }

--- a/systemtests/src/main/java/io/enmasse/systemtest/listener/JunitCallbackListener.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/listener/JunitCallbackListener.java
@@ -54,6 +54,9 @@ public class JunitCallbackListener implements TestExecutionExceptionHandler, Lif
         try { //TODO remove it after upgrade to surefire plugin 3.0.0-M5
             handleCallBackError(context, () -> {
                 if (testInfo.isUpgradeTest()) {
+                    if (operatorManager.isEnmasseBundleDeployed()) {
+                        operatorManager.deleteEnmasseBundle();
+                    }
                     LOGGER.info("Enmasse is not installed because next test is {}", context.getDisplayName());
                 } else if (testInfo.isOLMTest()) {
                     LOGGER.info("Test is OLM");
@@ -95,9 +98,6 @@ public class JunitCallbackListener implements TestExecutionExceptionHandler, Lif
             } else if (env.installType() == EnmasseInstallType.BUNDLE) {
                 if (testInfo.isEndOfIotTests() && operatorManager.isIoTOperatorDeployed()) {
                     operatorManager.removeIoTOperator();
-                }
-                if (operatorManager.isEnmasseBundleDeployed() && testInfo.isNextTestUpgrade()) {
-                    operatorManager.deleteEnmasseBundle();
                 }
                 if (operatorManager.isEnmasseOlmDeployed()) {
                     operatorManager.deleteEnmasseOlm();


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Refactoring

### Description

This PR moves the preparation for UpgradeTest from the afterAll callback to the beforeAll callback, this is being done to get rid of the method `isNextTestUpgrade` in `TestInfo` class. IMO we should avoid the kind of logic that were in methods like `isNextTestUpgrade`

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
