### PR TITLE
Order CRD cleanup by iot,tenant-api and the rest

### DIFF
--- a/documentation/modules/proc-uninstalling.adoc
+++ b/documentation/modules/proc-uninstalling.adoc
@@ -24,6 +24,8 @@ ifeval::["{cmdcli}" == "oc"]
 +
 [options="nowrap",subs="attributes"]
 ----
+{cmdcli} delete crd -l app=enmasse,enmasse-component=iot
+{cmdcli} delete crd -l app=enmasse,enmasse-component=tenant-api
 {cmdcli} delete crd -l app=enmasse
 {cmdcli} delete clusterrolebindings -l app=enmasse
 {cmdcli} delete clusterroles -l app=enmasse

--- a/systemtests/src/main/java/io/enmasse/systemtest/operator/OperatorManager.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/operator/OperatorManager.java
@@ -249,6 +249,8 @@ public class OperatorManager {
     }
 
     public boolean clean() throws Exception {
+        KubeCMDClient.runOnCluster("delete", "-v", "6", "crd", "-l", "app=enmasse,enmasse-component=iot");
+        KubeCMDClient.runOnCluster("delete", "-v", "6", "crd", "-l", "app=enmasse,enmasse-component=tenant-api");
         KubeCMDClient.runOnCluster("delete", "-v", "6", "crd", "-l", "app=enmasse");
         KubeCMDClient.runOnCluster("delete", "clusterrolebindings", "-l", "app=enmasse");
         KubeCMDClient.runOnCluster("delete", "clusterroles", "-l", "app=enmasse");

--- a/templates/crds/addresses.crd.yaml
+++ b/templates/crds/addresses.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   name: addresses.enmasse.io
   labels:
     app: enmasse
+    enmasse-component: tenant-api
 spec:
   group: enmasse.io
   version: v1beta1

--- a/templates/crds/addressspaces.crd.yaml
+++ b/templates/crds/addressspaces.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   name: addressspaces.enmasse.io
   labels:
     app: enmasse
+    enmasse-component: tenant-api
 spec:
   group: enmasse.io
   version: v1beta1

--- a/templates/crds/messagingusers.crd.yaml
+++ b/templates/crds/messagingusers.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   name: messagingusers.user.enmasse.io
   labels:
     app: enmasse
+    enmasse-component: tenant-api
 spec:
   group: user.enmasse.io
   version: v1beta1


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix


### Description

Order the CRD deletion so that the iot is cleanup before addresses/addressspaces/users, and addresses/addressspaces/users are cleaned up before the infrastructure.

This ensures that finalizers will be run correctly.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
