### PR TITLE
Configure router pod anti-affinity preference default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 *  #3621: Add status section for plans and authentication services #3621
 *  Qpid Dispatch Router upgraded to 1.10.0
+*  #3657 Configure router pod anti-affinity by default
 
 ## 0.30.2
 *  #2714: Allow setting security context of pods using persistent volumes

--- a/address-space-controller/src/main/resources/templates/standard-space-infra.yaml
+++ b/address-space-controller/src/main/resources/templates/standard-space-infra.yaml
@@ -65,6 +65,18 @@ objects:
     name: qdrouterd-${INFRA_UUID}
   spec:
     affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: enmasse
+                  capability: router
+                  name: qdrouterd
+                  infraType: standard
+                  infraUuid: ${INFRA_UUID}
+              topologyKey: kubernetes.io/hostname
       nodeAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 1


### PR DESCRIPTION
Fixes #3646

### Type of change

<!--

_Select the type of your PR_

-->

- Enhancement / new feature

### Description

Define commonly desired default policy for router anti-affinity.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
