### PR TITLE
[IoT] Prevent tenant cleaner to update caches schema

### DIFF
--- a/iot/iot-device-registry-infinispan/src/main/java/io/enmasse/iot/registry/infinispan/health/AbstractCacheHealthCheck.java
+++ b/iot/iot-device-registry-infinispan/src/main/java/io/enmasse/iot/registry/infinispan/health/AbstractCacheHealthCheck.java
@@ -7,11 +7,15 @@ package io.enmasse.iot.registry.infinispan.health;
 
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.ServerStatistics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.vertx.core.Vertx;
 import io.vertx.ext.healthchecks.Status;
 
 public abstract class AbstractCacheHealthCheck extends AbstractSyncHealthCheck {
+
+    private static final Logger log = LoggerFactory.getLogger(AbstractCacheHealthCheck.class);
 
     private final RemoteCache<?, ?> cache;
 
@@ -26,16 +30,16 @@ public abstract class AbstractCacheHealthCheck extends AbstractSyncHealthCheck {
      */
     @Override
     protected Status checkLivenessSync() {
-
         try {
             final ServerStatistics result = this.cache.serverStatistics();
             if (result == null) {
+                log.info("Cache health liveness failed: No server info");
                 return KO("No server info", null);
             }
         } catch (final Exception e) {
+            log.info("Cache health liveness failed: {}", e);
             return KO("Failed to ping server", e);
         }
-
         return Status.OK();
     }
 }

--- a/iot/iot-device-registry-infinispan/src/main/java/io/enmasse/iot/registry/infinispan/health/AbstractSyncHealthCheck.java
+++ b/iot/iot-device-registry-infinispan/src/main/java/io/enmasse/iot/registry/infinispan/health/AbstractSyncHealthCheck.java
@@ -9,6 +9,8 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 
 import org.eclipse.hono.service.HealthCheckProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
@@ -16,6 +18,8 @@ import io.vertx.ext.healthchecks.HealthCheckHandler;
 import io.vertx.ext.healthchecks.Status;
 
 public abstract class AbstractSyncHealthCheck implements HealthCheckProvider {
+
+    private static final Logger log = LoggerFactory.getLogger(AbstractSyncHealthCheck.class);
 
     private final Vertx vertx;
     private final String name;
@@ -49,6 +53,8 @@ public abstract class AbstractSyncHealthCheck implements HealthCheckProvider {
             }
             info.put("exception", sw.toString());
         }
+
+        log.debug("Check KO: {}", info);
 
         return Status.KO(info);
 

--- a/iot/iot-infinispan-base/src/main/java/io/enmasse/iot/infinispan/cache/DeviceManagementCacheProvider.java
+++ b/iot/iot-infinispan-base/src/main/java/io/enmasse/iot/infinispan/cache/DeviceManagementCacheProvider.java
@@ -163,6 +163,7 @@ public class DeviceManagementCacheProvider extends AbstractCacheProvider {
             throw new IllegalStateException("Schema has illegal content");
         }
         if (!schema.equals(this.schema)) {
+            log.info("Schema doesn't match expected content: {} vs {}", this.schema, schema);
             throw new IllegalStateException("Schema doesn't match expected content");
         }
     }

--- a/iot/iot-service-base/src/main/java/io/enmasse/iot/service/base/AbstractProjectBasedService.java
+++ b/iot/iot-service-base/src/main/java/io/enmasse/iot/service/base/AbstractProjectBasedService.java
@@ -109,8 +109,8 @@ public abstract class AbstractProjectBasedService extends AbstractKubernetesBase
 
     protected void stopWatcher() {
         if (this.factory != null) {
-            this.factory = null;
             this.factory.stopAllRegisteredInformers();
+            this.factory = null;
         }
     }
 

--- a/iot/iot-tenant-cleaner/src/main/java/io/enmasse/iot/tools/cleanup/InfinispanTenantCleaner.java
+++ b/iot/iot-tenant-cleaner/src/main/java/io/enmasse/iot/tools/cleanup/InfinispanTenantCleaner.java
@@ -58,6 +58,8 @@ public class InfinispanTenantCleaner implements AutoCloseable {
 
         final LinkedList<Closer> cleanup = new LinkedList<>();
 
+        config.getInfinispan().setUploadSchema(false);
+
         try (
                 var mgmtProvider = new DeviceManagementCacheProvider(config.getInfinispan());
                 var deviceconProvider = new DeviceConnectionCacheProvider(config.getInfinispan());) {


### PR DESCRIPTION
### Type of change


- Bugfix

### Description

Cache schema check is not consistent when the schema is updated multiple times. The schema is the same, just with the reordered elements. The quick fix is to prevent tenant cleaner job to update the schema (as I think it shouldn't do anyways). But we might want to revisit how we do this check in the future anyways.


### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
