### PR TITLE
Fix logs folder name

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/bases/ITestSeparator.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/bases/ITestSeparator.java
@@ -8,6 +8,8 @@ import io.enmasse.systemtest.logs.CustomLogger;
 import io.enmasse.systemtest.resolvers.ExtensionContextParameterResolver;
 import io.enmasse.systemtest.time.SystemtestsOperation;
 import io.enmasse.systemtest.time.TimeMeasuringSystem;
+import io.enmasse.systemtest.utils.TestUtils;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
@@ -42,7 +44,7 @@ public interface ITestSeparator {
         TimeMeasuringSystem.setTestName(testInfo.getTestClass().get().getName(), testInfo.getTestMethod().get().getName());
         TimeMeasuringSystem.startOperation(SystemtestsOperation.TEST_EXECUTION);
         log.info(String.join("", Collections.nCopies(100, separatorChar)));
-        log.info(String.format("%s.%s-STARTED", testInfo.getTestClass().get().getName(), testInfo.getDisplayName()));
+        log.info(String.format("%s.%s-STARTED", testInfo.getTestClass().get().getName(), TestUtils.getTestName(testInfo)));
     }
 
     @AfterEach
@@ -57,7 +59,7 @@ public interface ITestSeparator {
             }
         }
         TimeMeasuringSystem.stopOperation(SystemtestsOperation.TEST_EXECUTION);
-        log.info(String.format("%s.%s-FINISHED", testInfo.getTestClass().get().getName(), testInfo.getDisplayName()));
+        log.info(String.format("%s.%s-FINISHED", testInfo.getTestClass().get().getName(), TestUtils.getTestName(testInfo)));
         log.info(String.join("", Collections.nCopies(100, separatorChar)));
     }
 }

--- a/systemtests/src/main/java/io/enmasse/systemtest/info/TestInfo.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/info/TestInfo.java
@@ -180,9 +180,9 @@ public class TestInfo {
     }
 
     public boolean isEndOfIotTests() {
-        int currentTestIndex = getCurrentTestIndex();
-        if (currentTestIndex + 1 < tests.size()) {
-            return getTags(tests.get(currentTestIndex + 1)).stream().noneMatch(TestTag.IOT_TAGS::contains);
+        int currentClassIndex = getCurrentClassIndex();
+        if (currentClassIndex + 1 < testClasses.size()) {
+            return getTags(testClasses.get(currentClassIndex + 1)).stream().noneMatch(TestTag.IOT_TAGS::contains);
         }
         return true;
     }
@@ -225,6 +225,17 @@ public class TestInfo {
                     .findFirst()
                     .get();
             return tests.indexOf(test);
+        }
+        return 0;
+    }
+
+    private int getCurrentClassIndex() {
+        if (currentTestClass != null && testClasses.size() > 0) {
+            TestIdentifier test = testClasses.stream()
+                    .filter(testClass -> isSameClass(testClass, currentTestClass))
+                    .findFirst()
+                    .get();
+            return testClasses.indexOf(test);
         }
         return 0;
     }

--- a/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
@@ -11,7 +11,6 @@ import io.enmasse.address.model.AddressSpace;
 import io.enmasse.address.model.BrokerState;
 import io.enmasse.address.model.BrokerStatus;
 import io.enmasse.config.AnnotationKeys;
-import io.enmasse.config.LabelKeys;
 import io.enmasse.systemtest.Endpoint;
 import io.enmasse.systemtest.logs.CustomLogger;
 import io.enmasse.systemtest.logs.GlobalLogCollector;
@@ -25,8 +24,11 @@ import io.enmasse.systemtest.time.WaitPhase;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
-import io.vertx.core.VertxException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.function.ThrowingSupplier;
+import org.junit.platform.commons.support.AnnotationSupport;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.FirefoxOptions;
@@ -34,6 +36,7 @@ import org.openqa.selenium.remote.RemoteWebDriver;
 import org.opentest4j.AssertionFailedError;
 import org.slf4j.Logger;
 
+import java.lang.reflect.Method;
 import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.URL;
@@ -772,4 +775,28 @@ public class TestUtils {
     public static interface ThrowingCallable {
         void call() throws Exception;
     }
+
+    public static String getTestName(TestInfo testInfo) {
+        return getTestName(testInfo.getDisplayName(), testInfo.getTestMethod());
+    }
+
+    public static String getTestName(ExtensionContext extensionContext) {
+        return getTestName(extensionContext.getDisplayName(), extensionContext.getTestMethod());
+    }
+
+    public static String getTestName(String displayName, Optional<Method> testMethod) {
+        String testName;
+        if (testMethod.isPresent()) {
+            Optional<DisplayName> annotation = AnnotationSupport.findAnnotation(testMethod.get(), DisplayName.class);
+            if (annotation.isPresent()) {
+                testName = displayName;
+            } else {
+                testName = testMethod.get().getName();
+            }
+        } else {
+            testName = displayName;
+        }
+        return testName;
+    }
+
 }


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

This PR fixes the test name that were printed and used as logs folder because it had whitespaces. Also adds a fix for the method TestInfo.isEndOfIotTests because I saw errors produced because an exception there in our CI

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [X] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
