### PR TITLE
Fix: searchbar auto-populate issue

### DIFF
--- a/console/console-init/ui/src/Components/AddressSpaceList/AddressSpaceListFilter.tsx
+++ b/console/console-init/ui/src/Components/AddressSpaceList/AddressSpaceListFilter.tsx
@@ -38,10 +38,10 @@ import { useApolloClient } from "@apollo/react-hooks";
 interface IAddressSpaceListFilterProps {
   filterValue?: string;
   setFilterValue: (value: string) => void;
-  filterNames: string[];
-  setFilterNames: (value: Array<string>) => void;
-  filterNamespaces: string[];
-  setFilterNamespaces: (value: Array<string>) => void;
+  filterNames: any[];
+  setFilterNames: (value: Array<any>) => void;
+  filterNamespaces: any[];
+  setFilterNamespaces: (value: Array<any>) => void;
   filterType?: string | null;
   setFilterType: (value: string | null) => void;
   totalAddressSpaces: number;
@@ -78,6 +78,8 @@ export const AddressSpaceListFilter: React.FunctionComponent<IAddressSpaceListFi
   const [nameSelected, setNameSelected] = React.useState<string>();
   const [namespaceSelected, setNamespaceSelected] = React.useState<string>();
   const [nameOptions, setNameOptions] = React.useState<Array<string>>();
+  const [nameInput, setNameInput] = React.useState<string>("");
+  const [nameSpaceInput, setNameSpaceInput] = React.useState<string>("");
   const [namespaceOptions, setNamespaceOptions] = React.useState<
     Array<string>
   >();
@@ -98,15 +100,20 @@ export const AddressSpaceListFilter: React.FunctionComponent<IAddressSpaceListFi
     if (filterValue) {
       if (filterValue === "Name") {
         if (nameSelected && nameSelected.trim() !== "" && filterNames)
-          if (filterNames.indexOf(nameSelected) < 0) {
-            setFilterNames([...filterNames, nameSelected]);
-          }
+          if (filterNames.map(filter => filter.value).indexOf(nameSelected) < 0)
+            setFilterNames([...filterNames, { value: nameSelected.trim(), isExact: true }]);
+          if (!nameSelected && nameInput && nameInput.trim() !== "")
+            if (filterNames.map(filter => filter.value).indexOf(nameInput.trim()) < 0)
+              setFilterNames([...filterNames, { value: nameInput.trim(), isExact: false }]);
         setNameSelected(undefined);
       } else if (filterValue === "Namespace") {
         if (namespaceSelected && namespaceSelected.trim() !== "" && filterNames)
-          if (filterNamespaces.indexOf(namespaceSelected) < 0) {
-            setFilterNamespaces([...filterNamespaces, namespaceSelected]);
+          if (filterNamespaces.map(filter => filter.value).indexOf(namespaceSelected) < 0) {
+            setFilterNamespaces([...filterNamespaces, { value: namespaceSelected.trim(), isExact: true }]);
           }
+          if (!namespaceSelected && nameSpaceInput && nameSpaceInput.trim() !== "")
+            if (filterNamespaces.map(filter => filter.value).indexOf(nameSpaceInput.trim()) < 0)
+              setFilterNamespaces([...filterNamespaces, { value: nameSpaceInput.trim(), isExact: false }]);
         setNamespaceSelected(undefined);
       }
     }
@@ -120,14 +127,14 @@ export const AddressSpaceListFilter: React.FunctionComponent<IAddressSpaceListFi
     switch (type) {
       case "Name":
         if (filterNames && id) {
-          index = filterNames.indexOf(id.toString());
+          index = filterNames.map(filter => filter.value).indexOf(id.toString());
           if (index >= 0) filterNames.splice(index, 1);
           setFilterNames([...filterNames]);
         }
         break;
-      case "NamespaAddressSpaceListKebabce":
+      case "Namespace":
         if (filterNamespaces && id) {
-          index = filterNamespaces.indexOf(id.toString());
+          index = filterNamespaces.map(filter => filter.value).indexOf(id.toString());
           if (index >= 0) filterNamespaces.splice(index, 1);
           setFilterNamespaces([...filterNamespaces]);
         }
@@ -188,6 +195,7 @@ export const AddressSpaceListFilter: React.FunctionComponent<IAddressSpaceListFi
   };
 
   const onNameSelectFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setNameInput(e.target.value);
     onChangeNameData(e.target.value);
     const options: React.ReactElement[] = nameOptions
       ? nameOptions.map((option, index) => (
@@ -235,6 +243,7 @@ export const AddressSpaceListFilter: React.FunctionComponent<IAddressSpaceListFi
   const onNamespaceSelectFilterChange = (
     e: React.ChangeEvent<HTMLInputElement>
   ) => {
+    setNameSpaceInput(e.target.value);
     onChangeNamespaceData(e.target.value);
     const options: React.ReactElement[] = namespaceOptions
       ? namespaceOptions.map((option, index) => (
@@ -302,7 +311,7 @@ export const AddressSpaceListFilter: React.FunctionComponent<IAddressSpaceListFi
           <>
             <DataToolbarItem>
               <DataToolbarFilter
-                chips={filterNames}
+                chips={filterNames.map(filter => filter.value)}
                 deleteChip={onDelete}
                 categoryName="Name"
               >
@@ -318,6 +327,7 @@ export const AddressSpaceListFilter: React.FunctionComponent<IAddressSpaceListFi
                         setNameSelected(undefined);
                         setIsSelectNameExpanded(false);
                       }}
+                      maxHeight="200px"
                       selections={nameSelected}
                       onFilter={onNameSelectFilterChange}
                       isExpanded={isSelectNameExpanded}
@@ -346,7 +356,7 @@ export const AddressSpaceListFilter: React.FunctionComponent<IAddressSpaceListFi
             </DataToolbarItem>
             <DataToolbarItem>
               <DataToolbarFilter
-                chips={filterNamespaces}
+                chips={filterNamespaces.map(filter => filter.value)}
                 deleteChip={onDelete}
                 categoryName="Namespace"
               >
@@ -362,6 +372,7 @@ export const AddressSpaceListFilter: React.FunctionComponent<IAddressSpaceListFi
                         setNamespaceSelected(undefined);
                         setIsSelectNamespaceExpanded(false);
                       }}
+                      maxHeight="200px"
                       selections={namespaceSelected}
                       onFilter={onNamespaceSelectFilterChange}
                       isExpanded={isSelectNamespaceExpanded}

--- a/console/console-init/ui/src/Pages/AddressDetail/AddressLinksFilter.tsx
+++ b/console/console-init/ui/src/Pages/AddressDetail/AddressLinksFilter.tsx
@@ -44,10 +44,10 @@ import {
 interface IAddressLinksFilterProps {
   filterValue: string;
   setFilterValue: (value: string) => void;
-  filterNames: string[];
-  setFilterNames: (value: Array<string>) => void;
-  filterContainers: string[];
-  setFilterContainers: (value: Array<string>) => void;
+  filterNames: any[];
+  setFilterNames: (value: Array<any>) => void;
+  filterContainers: any[];
+  setFilterContainers: (value: Array<any>) => void;
   filterRole?: string;
   setFilterRole: (role: string | undefined) => void;
   totalLinks: number;
@@ -92,6 +92,8 @@ export const AddressLinksFilter: React.FunctionComponent<IAddressLinksFilterProp
   const [containerOptions, setContainerOptions] = React.useState<
     Array<string>
   >();
+  const [nameInput, setNameInput] = React.useState<string>("");
+  const [containerInput, setContainerInput] = React.useState<string>("");
   const filterMenuItems = [
     { key: "filterName", value: "Name" },
     { key: "filterContainers", value: "Container" },
@@ -112,16 +114,22 @@ export const AddressLinksFilter: React.FunctionComponent<IAddressLinksFilterProp
   const onAddInput = (event: any) => {
     if (filterValue && filterValue === "Name") {
       if (nameSelected && nameSelected.trim() !== "")
-        if (filterNames.indexOf(nameSelected.trim()) < 0) {
-          setFilterNames([...filterNames, nameSelected.trim()]);
+        if (filterNames.map(filter => filter.value).indexOf(nameSelected.trim()) < 0) {
+          setFilterNames([...filterNames, { value: nameSelected.trim(), isExact: true }]);
           setNameSelected(undefined);
         }
+      if(!nameSelected && nameInput && nameInput.trim() !== "")
+        if (filterNames.map(filter => filter.value).indexOf(nameInput.trim()) < 0)
+          setFilterNames([...filterNames, { value: nameInput.trim(), isExact: false }]);
     } else if (filterValue && filterValue === "Container") {
       if (containerSelected && containerSelected.trim() !== "")
-        if (filterContainers.indexOf(containerSelected.trim()) < 0) {
-          setFilterContainers([...filterContainers, containerSelected.trim()]);
+        if (filterContainers.map(filter => filter.value).indexOf(containerSelected.trim()) < 0) {
+          setFilterContainers([...filterContainers, { value: containerSelected.trim(), isExact: true }]);
           setContainerSelected(undefined);
         }
+      if (!containerSelected && containerInput && containerInput.trim() !== "")
+        if (filterContainers.map(filter => filter.value).indexOf(containerInput.trim()) < 0)
+          setFilterContainers([...filterContainers, { value: containerInput.trim(), isExact: false }]);
     }
   };
 
@@ -175,6 +183,7 @@ export const AddressLinksFilter: React.FunctionComponent<IAddressLinksFilterProp
     }
   };
   const onNameSelectFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setNameInput(e.target.value);
     const data = onChangeNameData(e.target.value);
     const options: React.ReactElement[] = nameOptions
       ? nameOptions.map((option, index) => (
@@ -223,6 +232,7 @@ export const AddressLinksFilter: React.FunctionComponent<IAddressLinksFilterProp
   const onContainerSelectFilterChange = (
     e: React.ChangeEvent<HTMLInputElement>
   ) => {
+    setContainerInput(e.target.value);
     const data = onChangeContainerData(e.target.value);
     const options: React.ReactElement[] = containerOptions
       ? containerOptions.map((option, index) => (
@@ -252,14 +262,14 @@ export const AddressLinksFilter: React.FunctionComponent<IAddressLinksFilterProp
     switch (type) {
       case "Name":
         if (filterNames && id) {
-          let index = filterNames.indexOf(id.toString());
+          let index = filterNames.map(filter => filter.value).indexOf(id.toString());
           if (index >= 0) filterNames.splice(index, 1);
           setFilterNames([...filterNames]);
         }
         break;
       case "Container":
         if (filterContainers && id) {
-          let index = filterContainers.indexOf(id.toString());
+          let index = filterContainers.map(filter => filter.value).indexOf(id.toString());
           if (index >= 0) filterContainers.splice(index, 1);
           setFilterContainers([...filterContainers]);
         }
@@ -318,7 +328,7 @@ export const AddressLinksFilter: React.FunctionComponent<IAddressLinksFilterProp
         <>
           <DataToolbarItem>
             <DataToolbarFilter
-              chips={filterNames}
+              chips={filterNames.map(filter => filter.value)}
               deleteChip={onDelete}
               categoryName="Name"
             >
@@ -334,6 +344,7 @@ export const AddressLinksFilter: React.FunctionComponent<IAddressLinksFilterProp
                       setNameSelected(undefined);
                       setIsSelectNameExpanded(false);
                     }}
+                    maxHeight="200px"
                     selections={nameSelected}
                     onFilter={onNameSelectFilterChange}
                     isExpanded={isSelectNameExpanded}
@@ -366,7 +377,7 @@ export const AddressLinksFilter: React.FunctionComponent<IAddressLinksFilterProp
           </DataToolbarItem>
           <DataToolbarItem>
             <DataToolbarFilter
-              chips={filterContainers}
+              chips={filterContainers.map(filter => filter.value)}
               deleteChip={onDelete}
               categoryName="Container"
             >
@@ -382,6 +393,7 @@ export const AddressLinksFilter: React.FunctionComponent<IAddressLinksFilterProp
                       setContainerSelected(undefined);
                       setIsSelectContainerExpanded(false);
                     }}
+                    maxHeight="200px"
                     selections={containerSelected}
                     onFilter={onContainerSelectFilterChange}
                     isExpanded={isSelectContainerExpanded}

--- a/console/console-init/ui/src/Pages/AddressDetail/AddressLinksWithFilterAndPaginationPage.tsx
+++ b/console/console-init/ui/src/Pages/AddressDetail/AddressLinksWithFilterAndPaginationPage.tsx
@@ -37,9 +37,9 @@ export const AddressLinksWithFilterAndPagination: React.FunctionComponent<IAddre
   const perPage = parseInt(searchParams.get("perPage") || "", 10) || 10;
   const [addresLinksTotal, setAddressLinksTotal] = React.useState<number>(0);
   const [filterValue, setFilterValue] = React.useState<string>("Name");
-  const [filterNames, setFilterNames] = React.useState<Array<string>>([]);
+  const [filterNames, setFilterNames] = React.useState<Array<any>>([]);
   const [sortDropDownValue, setSortDropdownValue] = React.useState<ISortBy>();
-  const [filterContainers, setFilterContainers] = React.useState<Array<string>>(
+  const [filterContainers, setFilterContainers] = React.useState<Array<any>>(
     []
   );
   const [filterRole, setFilterRole] = React.useState<string>();

--- a/console/console-init/ui/src/Pages/AddressSpaceDetail/AddressList/AddressListFilter.tsx
+++ b/console/console-init/ui/src/Pages/AddressSpaceDetail/AddressList/AddressListFilter.tsx
@@ -38,8 +38,8 @@ import { RETURN_ALL_ADDRESS_NAMES_OF_ADDRESS_SPACES_FOR_TYPEAHEAD_SEARCH } from 
 interface IAddressListFilterProps {
   filterValue: string | null;
   setFilterValue: (value: string | null) => void;
-  filterNames: string[];
-  setFilterNames: (value: Array<string>) => void;
+  filterNames: any[];
+  setFilterNames: (value: Array<any>) => void;
   typeValue: string | null;
   setTypeValue: (value: string | null) => void;
   statusValue: string | null;
@@ -74,6 +74,7 @@ export const AddressListFilter: React.FunctionComponent<IAddressListFilterProps>
   >(false);
   const [nameSelected, setNameSelected] = React.useState<string>();
   const [nameOptions, setNameOptions] = React.useState<Array<string>>();
+  const [nameInput, setNameInput] = React.useState<string>("");
   const filterMenuItems = [
     { key: "filterName", value: "Name" },
     { key: "filterType", value: "Type" },
@@ -97,11 +98,18 @@ export const AddressListFilter: React.FunctionComponent<IAddressListFilterProps>
   const onClickSearchIcon = (event: any) => {
     if (filterValue && filterValue === "Name") {
       if (nameSelected && nameSelected.trim() !== "")
-        if (filterNames.indexOf(nameSelected.trim()) < 0) {
-          setFilterNames([...filterNames, nameSelected.trim()]);
+        if (
+          filterNames.map(filter => filter.value).indexOf(nameSelected.trim()) < 0
+        ) {
+          setFilterNames([...filterNames, { value: nameSelected.trim(), isExact: true }]);
           setNameSelected(undefined);
         }
     }
+    if (!nameSelected && nameInput && nameInput.trim() !== "")
+      if (
+        filterNames.map(filter => filter.value).indexOf(nameInput.trim()) < 0
+      )
+        setFilterNames([...filterNames, { value: nameInput.trim(), isExact: false }]);
   };
 
   const onFilterSelect = (event: any) => {
@@ -156,6 +164,7 @@ export const AddressListFilter: React.FunctionComponent<IAddressListFilterProps>
   };
 
   const onNameSelectFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setNameInput(e.target.value);
     onChangeNameData(e.target.value);
     const options: React.ReactElement[] = nameOptions
       ? nameOptions.map((option, index) => (
@@ -178,7 +187,7 @@ export const AddressListFilter: React.FunctionComponent<IAddressListFilterProps>
       case "Name":
         let index;
         if (filterNames && id) {
-          index = filterNames.indexOf(id.toString());
+          index = filterNames.map(filter => filter.value).indexOf(id.toString());
           if (index >= 0) filterNames.splice(index, 1);
           setFilterNames([...filterNames]);
         }
@@ -237,7 +246,7 @@ export const AddressListFilter: React.FunctionComponent<IAddressListFilterProps>
           <>
             <DataToolbarItem>
               <DataToolbarFilter
-                chips={filterNames}
+                chips={filterNames.map(filter => filter.value)}
                 deleteChip={onDelete}
                 categoryName="Name"
               >
@@ -253,6 +262,7 @@ export const AddressListFilter: React.FunctionComponent<IAddressListFilterProps>
                         setNameSelected(undefined);
                         setIsSelectNameExpanded(false);
                       }}
+                      maxHeight="200px"
                       selections={nameSelected}
                       onFilter={onNameSelectFilterChange}
                       isExpanded={isSelectNameExpanded}

--- a/console/console-init/ui/src/Pages/AddressSpaceDetail/AddressList/AddressListFilterPage.tsx
+++ b/console/console-init/ui/src/Pages/AddressSpaceDetail/AddressList/AddressListFilterPage.tsx
@@ -25,8 +25,8 @@ import { ISortBy } from "@patternfly/react-table";
 interface AddressListFilterProps {
   filterValue: string | null;
   setFilterValue: (value: string | null) => void;
-  filterNames: string[];
-  setFilterNames: (value: Array<string>) => void;
+  filterNames: any[];
+  setFilterNames: (value: Array<any>) => void;
   typeValue: string | null;
   setTypeValue: (value: string | null) => void;
   statusValue: string | null;

--- a/console/console-init/ui/src/Pages/AddressSpaceDetail/AddressList/AddressListPage.tsx
+++ b/console/console-init/ui/src/Pages/AddressSpaceDetail/AddressList/AddressListPage.tsx
@@ -26,7 +26,7 @@ export interface IAddressListPageProps {
   name?: string;
   namespace?: string;
   addressSpaceType?: string;
-  filterNames?: string[];
+  filterNames?: any[];
   typeValue?: string | null;
   statusValue?: string | null;
   page: number;

--- a/console/console-init/ui/src/Pages/AddressSpaceDetail/AddressList/AddressesListWithFilterAndPaginationPage.tsx
+++ b/console/console-init/ui/src/Pages/AddressSpaceDetail/AddressList/AddressesListWithFilterAndPaginationPage.tsx
@@ -50,7 +50,7 @@ export default function AddressesList() {
   useA11yRouteChange();
   const { name, namespace, type } = useParams();
   const [filterValue, setFilterValue] = React.useState<string | null>("Name");
-  const [filterNames, setFilterNames] = React.useState<string[]>([]);
+  const [filterNames, setFilterNames] = React.useState<any[]>([]);
   const [typeValue, setTypeValue] = React.useState<string | null>(null);
   const [statusValue, setStatusValue] = React.useState<string | null>(null);
   const [totalAddresses, setTotalAddress] = React.useState<number>(0);

--- a/console/console-init/ui/src/Pages/AddressSpaceDetail/ConnectionList/ConnectionListFilter.tsx
+++ b/console/console-init/ui/src/Pages/AddressSpaceDetail/ConnectionList/ConnectionListFilter.tsx
@@ -37,10 +37,10 @@ import { IConnectionListNameSearchResponse } from "src/Types/ResponseTypes";
 interface IConnectionListFilterProps {
   filterValue?: string | null;
   setFilterValue: (value: string) => void;
-  hostnames?: Array<string>;
-  setHostnames: (value: Array<string>) => void;
-  containerIds?: Array<string>;
-  setContainerIds: (value: Array<string>) => void;
+  hostnames: Array<any>;
+  setHostnames: (value: Array<any>) => void;
+  containerIds: Array<any>;
+  setContainerIds: (value: Array<any>) => void;
   sortValue?: ISortBy;
   setSortValue: (value: ISortBy) => void;
   totalConnections: number;
@@ -77,6 +77,8 @@ export const ConnectionListFilter: React.FunctionComponent<IConnectionListFilter
   ] = React.useState<boolean>(false);
   const [hostnameSelected, setHostnameSelected] = React.useState<string>();
   const [containerSelected, setContainerSelected] = React.useState<string>();
+  const [hostNameInput, setHostNameInput] = React.useState<string>("");
+  const [containerInput, setContainerInput] = React.useState<string>("");
   const [hostnameOptions, setHostnameOptions] = React.useState<Array<string>>();
   const [containerOptions, setContainerOptions] = React.useState<
     Array<string>
@@ -105,16 +107,31 @@ export const ConnectionListFilter: React.FunctionComponent<IConnectionListFilter
           containerSelected.trim() !== "" &&
           containerIds
         ) {
-          if (containerIds.indexOf(containerSelected.trim()) < 0) {
-            setContainerIds([...containerIds, containerSelected.trim()]);
+          if (containerIds.map(filter => filter.value).indexOf(containerSelected.trim()) < 0) {
+            setContainerIds([...containerIds, { value: containerSelected.trim(), isExact: true }]);
           }
+          setContainerSelected(undefined);
+        }
+        if (
+          !containerSelected &&
+          containerInput &&
+          containerInput.trim() !== "" &&
+          containerIds
+        ) {
+          if (containerIds.map(filter => filter.value).indexOf(containerInput.trim()) < 0)
+            setContainerIds([...containerIds, { value: containerInput.trim(), isExact: false }]);
           setContainerSelected(undefined);
         }
       } else if (filterValue === "Hostname") {
         if (hostnameSelected && hostnameSelected.trim() !== "" && hostnames) {
-          if (hostnames.indexOf(hostnameSelected) < 0) {
-            setHostnames([...hostnames, hostnameSelected]);
+          if (hostnames.map(filter => filter.value).indexOf(hostnameSelected) < 0) {
+            setHostnames([...hostnames, { value: hostnameSelected.trim(), isExact: true }]);
           }
+          setHostnameSelected(undefined);
+        }
+        if (!hostnameSelected && hostNameInput.trim() !== "" && hostnames) {
+          if (hostnames.map(filter => filter.value).indexOf(hostNameInput) < 0)
+            setHostnames([...hostnames, { value: hostNameInput.trim(), isExact: false }]);
           setHostnameSelected(undefined);
         }
       }
@@ -166,6 +183,7 @@ export const ConnectionListFilter: React.FunctionComponent<IConnectionListFilter
   const onHostnameSelectFilterChange = (
     e: React.ChangeEvent<HTMLInputElement>
   ) => {
+    setHostNameInput(e.target.value);
     onChangeHostnameData(e.target.value);
     const options: React.ReactElement[] = hostnameOptions
       ? hostnameOptions.map((option, index) => (
@@ -212,6 +230,7 @@ export const ConnectionListFilter: React.FunctionComponent<IConnectionListFilter
   const onContainerSelectFilterChange = (
     e: React.ChangeEvent<HTMLInputElement>
   ) => {
+    setContainerInput(e.target.value);
     onChangeContainerData(e.target.value);
     const options: React.ReactElement[] = containerOptions
       ? containerOptions.map((option, index) => (
@@ -246,7 +265,7 @@ export const ConnectionListFilter: React.FunctionComponent<IConnectionListFilter
     switch (type) {
       case "Hostname":
         if (hostnames && id) {
-          index = hostnames.indexOf(id.toString());
+          index = hostnames.map(filter => filter.value).indexOf(id.toString());
           if (index >= 0) hostnames.splice(index, 1);
           setHostnames([...hostnames]);
         }
@@ -254,7 +273,7 @@ export const ConnectionListFilter: React.FunctionComponent<IConnectionListFilter
       case "Container":
         if (containerIds && id) {
           const containers = containerIds;
-          index = containerIds.indexOf(id.toString());
+          index = containerIds.map(filter => filter.value).indexOf(id.toString());
           if (index >= 0) containers.splice(index, 1);
           setContainerIds([...containers]);
         }
@@ -309,7 +328,7 @@ export const ConnectionListFilter: React.FunctionComponent<IConnectionListFilter
         </DataToolbarFilter>
         <DataToolbarItem>
           <DataToolbarFilter
-            chips={hostnames}
+            chips={hostnames.map(filter => filter.value)}
             deleteChip={onDelete}
             categoryName="Hostname"
           >
@@ -325,6 +344,7 @@ export const ConnectionListFilter: React.FunctionComponent<IConnectionListFilter
                     setHostnameSelected(undefined);
                     setIsSelectHostnameExpanded(false);
                   }}
+                  maxHeight="200px"
                   selections={hostnameSelected}
                   onFilter={onHostnameSelectFilterChange}
                   isExpanded={isSelectHostnameExpanded}
@@ -353,7 +373,7 @@ export const ConnectionListFilter: React.FunctionComponent<IConnectionListFilter
         </DataToolbarItem>
         <DataToolbarItem>
           <DataToolbarFilter
-            chips={containerIds}
+            chips={containerIds.map(filter => filter.value)}
             deleteChip={onDelete}
             categoryName="Container"
           >
@@ -369,6 +389,7 @@ export const ConnectionListFilter: React.FunctionComponent<IConnectionListFilter
                     setContainerSelected(undefined);
                     setIsSelectContainerExpanded(false);
                   }}
+                  maxHeight="200px"
                   selections={containerSelected}
                   onFilter={onContainerSelectFilterChange}
                   isExpanded={isSelectContainerExpanded}

--- a/console/console-init/ui/src/Pages/AddressSpaceDetail/ConnectionList/ConnectionListWithFilterAndPaginationPage.tsx
+++ b/console/console-init/ui/src/Pages/AddressSpaceDetail/ConnectionList/ConnectionListWithFilterAndPaginationPage.tsx
@@ -24,8 +24,8 @@ const ConnectionListFunction = () => {
   useA11yRouteChange();
   const { name, namespace } = useParams();
   const [filterValue, setFilterValue] = React.useState<string>("Hostname");
-  const [hostnames, setHostnames] = React.useState<Array<string>>([]);
-  const [containerIds, setContainerIds] = React.useState<Array<string>>([]);
+  const [hostnames, setHostnames] = React.useState<Array<any>>([]);
+  const [containerIds, setContainerIds] = React.useState<Array<any>>([]);
   const [totalConnections, setTotalConnections] = React.useState<number>(0);
   const location = useLocation();
   const history = useHistory();

--- a/console/console-init/ui/src/Pages/AddressSpaceList/AddressSpaceListFilterPage.tsx
+++ b/console/console-init/ui/src/Pages/AddressSpaceList/AddressSpaceListFilterPage.tsx
@@ -21,10 +21,10 @@ import useWindowDimensions from "src/Components/Common/WindowDimension";
 interface IAddressSpaceListFilterPageProps {
   filterValue?: string;
   setFilterValue: (value: string) => void;
-  filterNames: string[];
-  setFilterNames: (value: Array<string>) => void;
-  filterNamespaces: string[];
-  setFilterNamespaces: (value: Array<string>) => void;
+  filterNames: any[];
+  setFilterNames: (value: Array<any>) => void;
+  filterNamespaces: any[];
+  setFilterNamespaces: (value: Array<any>) => void;
   filterType?: string | null;
   setFilterType: (value: string | null) => void;
   totalAddressSpaces: number;

--- a/console/console-init/ui/src/Pages/ConnectionDetail/ConnectionLinksFilter.tsx
+++ b/console/console-init/ui/src/Pages/ConnectionDetail/ConnectionLinksFilter.tsx
@@ -43,9 +43,9 @@ import {
 interface IConnectionLinksFilterProps {
   filterValue: string;
   setFilterValue: (value: string) => void;
-  filterNames: string[];
+  filterNames: any[];
   setFilterNames: (value: Array<string>) => void;
-  filterAddresses: string[];
+  filterAddresses: any[];
   setFilterAddresses: (value: Array<string>) => void;
   filterRole?: string;
   setFilterRole: (role: string | undefined) => void;
@@ -85,6 +85,8 @@ export const ConnectionLinksFilter: React.FunctionComponent<IConnectionLinksFilt
   >(false);
   const [nameSelected, setNameSelected] = React.useState<string>();
   const [addressSelected, setAddressSelected] = React.useState<string>();
+  const [nameInput, setNameInput] = React.useState<string>("");
+  const [addressInput, setAddressInput] = React.useState<string>("");
   const [nameOptions, setNameOptions] = React.useState<Array<string>>();
   const [addressOptions, setAddressOptions] = React.useState<Array<string>>();
 
@@ -113,16 +115,22 @@ export const ConnectionLinksFilter: React.FunctionComponent<IConnectionLinksFilt
   const onClickSearchIcon = (event: any) => {
     if (filterValue && filterValue === "Name") {
       if (nameSelected && nameSelected.trim() !== "")
-        if (filterNames.indexOf(nameSelected.trim()) < 0) {
-          setFilterNames([...filterNames, nameSelected.trim()]);
+        if (filterNames.map(filter => filter.value).indexOf(nameSelected.trim()) < 0) {
+          setFilterNames([...filterNames, { value: nameSelected.trim(), isExact: true }]);
           setNameSelected(undefined);
         }
+      if (!nameSelected && nameInput && nameInput.trim() !== "")
+        if (filterNames.map(filter => filter.value).indexOf(nameInput.trim()) < 0)
+          setFilterNames([...filterNames, { value: nameInput.trim(), isExact: false }]);
     } else if (filterValue && filterValue === "Address") {
       if (addressSelected && addressSelected.trim() !== "")
-        if (filterAddresses.indexOf(addressSelected.trim()) < 0) {
-          setFilterAddresses([...filterAddresses, addressSelected.trim()]);
+        if (filterAddresses.map(filter => filter.value).indexOf(addressSelected.trim()) < 0) {
+          setFilterAddresses([...filterAddresses, { value: addressSelected.trim(), isExact: true }]);
           setAddressSelected(undefined);
         }
+      if (!addressSelected && addressInput && addressInput.trim() !== "")
+        if (filterAddresses.map(filter => filter.value).indexOf(addressInput.trim()) < 0)
+          setFilterAddresses([...filterAddresses, { value: addressInput.trim(), isExact: false }]);
     }
   };
 
@@ -180,6 +188,7 @@ export const ConnectionLinksFilter: React.FunctionComponent<IConnectionLinksFilt
   };
 
   const onNameSelectFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setNameInput(e.target.value);
     onChangeNameData(e.target.value);
     const options: React.ReactElement[] = nameOptions
       ? nameOptions.map((option, index) => (
@@ -227,6 +236,7 @@ export const ConnectionLinksFilter: React.FunctionComponent<IConnectionLinksFilt
   const onAddressSelectFilterChange = (
     e: React.ChangeEvent<HTMLInputElement>
   ) => {
+    setAddressInput(e.target.value);
     onChangeAddressData(e.target.value);
     const options: React.ReactElement[] = addressOptions
       ? addressOptions.map((option, index) => (
@@ -256,14 +266,14 @@ export const ConnectionLinksFilter: React.FunctionComponent<IConnectionLinksFilt
     switch (type) {
       case "Name":
         if (filterNames && id) {
-          let index = filterNames.indexOf(id.toString());
+          let index = filterNames.map(filter => filter.value).indexOf(id.toString());
           if (index >= 0) filterNames.splice(index, 1);
           setFilterNames([...filterNames]);
         }
         break;
       case "Address":
         if (filterAddresses && id) {
-          let index = filterAddresses.indexOf(id.toString());
+          let index = filterAddresses.map(filter => filter.value).indexOf(id.toString());
           if (index >= 0) filterAddresses.splice(index, 1);
           setFilterAddresses([...filterAddresses]);
         }
@@ -321,7 +331,7 @@ export const ConnectionLinksFilter: React.FunctionComponent<IConnectionLinksFilt
         <>
           <DataToolbarItem>
             <DataToolbarFilter
-              chips={filterNames}
+              chips={filterNames.map(filter => filter.value)}
               deleteChip={onDelete}
               categoryName="Name"
             >
@@ -337,6 +347,7 @@ export const ConnectionLinksFilter: React.FunctionComponent<IConnectionLinksFilt
                       setNameSelected(undefined);
                       setIsSelectNameExpanded(false);
                     }}
+                    maxHeight="200px"
                     selections={nameSelected}
                     onFilter={onNameSelectFilterChange}
                     isExpanded={isSelectNameExpanded}
@@ -365,7 +376,7 @@ export const ConnectionLinksFilter: React.FunctionComponent<IConnectionLinksFilt
           </DataToolbarItem>
           <DataToolbarItem>
             <DataToolbarFilter
-              chips={filterAddresses}
+              chips={filterAddresses.map(filter => filter.value)}
               deleteChip={onDelete}
               categoryName="Address"
             >
@@ -381,6 +392,7 @@ export const ConnectionLinksFilter: React.FunctionComponent<IConnectionLinksFilt
                       setAddressSelected(undefined);
                       setIsSelectAddressExpanded(false);
                     }}
+                    maxHeight="200px"
                     selections={addressSelected}
                     onFilter={onAddressSelectFilterChange}
                     isExpanded={isSelectAddressExpanded}

--- a/console/console-init/ui/src/Pages/ConnectionDetail/ConnectionsLinksListPage.tsx
+++ b/console/console-init/ui/src/Pages/ConnectionDetail/ConnectionsLinksListPage.tsx
@@ -19,8 +19,8 @@ interface IConnectionLinksListPageProps {
   page: number;
   perPage: number;
   setTotalLinks: (value: number) => void;
-  filterNames: string[];
-  filterAddresses: string[];
+  filterNames: any[];
+  filterAddresses: any[];
   filterRole?: string;
   sortValue?: ISortBy;
   setSortValue: (value: ISortBy) => void;
@@ -65,7 +65,6 @@ export const ConnectionLinksListPage: React.FunctionComponent<IConnectionLinksLi
     connections: { Total: 0, Connections: [] }
   };
   const connection = connections.Connections[0];
-  console.log(connection.Links.Links);
   let linkRows: ILink[] = [];
   if (connection && connection.Links.Total > 0) {
     setTotalLinks(connection.Links.Total);

--- a/console/console-init/ui/src/Queries/Queries.tsx
+++ b/console/console-init/ui/src/Queries/Queries.tsx
@@ -25,23 +25,30 @@ export const DELETE_ADDRESS = gql`
 export const RETURN_ALL_ADDRESS_SPACES = (
   page: number,
   perPage: number,
-  filter_Names?: string[],
-  filter_NameSpace?: string[],
+  filter_Names?: any[],
+  filter_NameSpace?: any[],
   filter_Type?: string | null,
   sortBy?: ISortBy
 ) => {
   let filter = "";
   if (filter_Names && filter_Names.length > 0) {
     if (filter_Names.length > 1) {
-      filter += "(";
-      filter += "`$.ObjectMeta.Name` ='" + filter_Names[0].trim() + "' ";
-      let i;
-      for (i = 1; i < filter_Names.length; i++) {
-        filter += "OR `$.ObjectMeta.Name` ='" + filter_Names[i].trim() + "' ";
+      if(filter_Names[0].isExact)
+        filter += "(`$.ObjectMeta.Name` = '" + filter_Names[0].value.trim() + "'";
+      else
+        filter += "(`$.ObjectMeta.Name` LIKE '" + filter_Names[0].value.trim() + "%'";
+      for (let i = 1; i < filter_Names.length; i++) {
+        if(filter_Names[i].isExact)
+          filter += "OR `$.ObjectMeta.Name` = '" + filter_Names[i].value.trim() + "'";
+        else
+          filter += "OR `$.ObjectMeta.Name` LIKE '" + filter_Names[i].value.trim() + "%'";
       }
       filter += ")";
     } else {
-      filter += "`$.ObjectMeta.Name` ='" + filter_Names[0].trim() + "' ";
+        if(filter_Names[0].isExact)
+          filter += "`$.ObjectMeta.Name` = '" + filter_Names[0].value.trim() + "'";
+        else
+          filter += "`$.ObjectMeta.Name` LIKE '" + filter_Names[0].value.trim() + "%'";
     }
   }
   if (
@@ -53,19 +60,29 @@ export const RETURN_ALL_ADDRESS_SPACES = (
     filter += " AND ";
   }
   if (filter_NameSpace && filter_NameSpace.length > 0) {
-    if (filter_NameSpace.length > 0) {
-      filter += "(";
-      filter +=
-        "`$.ObjectMeta.Namespace` ='" + filter_NameSpace[0].trim() + "' ";
-      let i;
-      for (i = 1; i < filter_NameSpace.length; i++) {
+    if (filter_NameSpace.length > 1) {
+      if (filter_NameSpace[0].isExact)
         filter +=
-          "OR `$.ObjectMeta.Namespace` ='" + filter_NameSpace[i].trim() + "' ";
+          "(`$.ObjectMeta.Namespace` = '" + filter_NameSpace[0].value.trim() + "'";
+      else
+        filter +=
+          "(`$.ObjectMeta.Namespace` LIKE '" + filter_NameSpace[0].value.trim() + "%'";
+      for (let i = 1; i < filter_NameSpace.length; i++) {
+        if (filter_NameSpace[i].isExact)
+          filter +=
+            "OR `$.ObjectMeta.Namespace` = '" + filter_NameSpace[i].value.trim() + "'";
+        else
+        filter +=
+          "OR `$.ObjectMeta.Namespace` LIKE '" + filter_NameSpace[i].value.trim() + "%'";
       }
       filter += ")";
     } else {
-      filter +=
-        "`$.ObjectMeta.Namespace` ='" + filter_NameSpace[0].trim() + "' ";
+      if (filter_NameSpace[0].isExact)
+        filter +=
+          "`$.ObjectMeta.Namespace` = '" + filter_NameSpace[0].value.trim() + "'";
+      else
+        filter +=
+          "`$.ObjectMeta.Namespace` LIKE '" + filter_NameSpace[0].value.trim() + "%'";
     }
   }
   if (
@@ -127,7 +144,7 @@ export const RETURN_ALL_ADDRESS_FOR_ADDRESS_SPACE = (
   perPage: number,
   name?: string,
   namespace?: string,
-  filterNames?: string[],
+  filterNames?: any[],
   typeValue?: string | null,
   statusValue?: string | null,
   sortBy?: ISortBy
@@ -143,17 +160,27 @@ export const RETURN_ALL_ADDRESS_FOR_ADDRESS_SPACE = (
     filterString += " AND ";
   }
   if (filterNames && filterNames.length > 0) {
-    if (filterNames.length > 0) {
-      filterString += "(";
-      filterString += "`$.ObjectMeta.Name` ='" + filterNames[0].trim() + "' ";
-      let i;
-      for (i = 1; i < filterNames.length; i++) {
-        filterString +=
-          "OR `$.ObjectMeta.Name` ='" + filterNames[i].trim() + "' ";
+    if (filterNames.length > 1) {
+      if(filterNames[0].isExact)
+        filterString += "(`$.ObjectMeta.Name` = '" + filterNames[0].value.trim() + "'";
+      else
+        filterString += "(`$.ObjectMeta.Name` LIKE '" + filterNames[0].value.trim() + "%' ";
+      for (let i = 1; i < filterNames.length; i++) {
+        if(filterNames[i].isExact){
+          filterString +=
+            "OR `$.ObjectMeta.Name` = '" + filterNames[i].value.trim() + "'";
+        }
+        else{
+          filterString +=
+            "OR `$.ObjectMeta.Name` LIKE '" + filterNames[i].value.trim() + "%' ";
+        }   
       }
       filterString += ")";
     } else {
-      filterString += "`$.ObjectMeta.Name` ='" + filterNames[0].trim() + "' ";
+        if(filterNames[0].isExact)
+          filterString += "`$.ObjectMeta.Name` = '" + filterNames[0].value.trim() + "'";
+        else
+          filterString += "`$.ObjectMeta.Name` LIKE '" + filterNames[0].value.trim() + "%' ";
     }
   }
   if (filterNames && filterNames.length > 0 && (typeValue || statusValue)) {
@@ -369,8 +396,8 @@ export const RETURN_ADDRESS_DETAIL = (
 export const RETURN_ADDRESS_LINKS = (
   page: number,
   perPage: number,
-  filterNames: string[],
-  filterContainers: string[],
+  filterNames: any[],
+  filterContainers: any[],
   addressSpace?: string,
   namespace?: string,
   addressName?: string,
@@ -413,16 +440,24 @@ export const RETURN_ADDRESS_LINKS = (
   let filterForLink = "";
   if (filterNames && filterNames.length > 0) {
     if (filterNames.length > 1) {
-      filterForLink += "(";
-      filterForLink += "`$.ObjectMeta.Name` ='" + filterNames[0].trim() + "' ";
-      let i;
-      for (i = 1; i < filterNames.length; i++) {
-        filterForLink +=
-          "OR `$.ObjectMeta.Name` ='" + filterNames[i].trim() + "' ";
+      if(filterNames[0].isExact)
+        filterForLink += "(`$.ObjectMeta.Name` = '" + filterNames[0].value.trim() + "'";
+      else
+        filterForLink += "(`$.ObjectMeta.Name` LIKE '" + filterNames[0].value.trim() + "%' ";
+      for (let i = 1; i < filterNames.length; i++) {
+        if(filterNames[i].isExact)
+          filterForLink +=
+            "OR `$.ObjectMeta.Name` = '" + filterNames[i].value.trim() + "'";
+        else
+          filterForLink +=
+            "OR `$.ObjectMeta.Name` LIKE '" + filterNames[i].value.trim() + "%' ";
       }
       filterForLink += ")";
     } else {
-      filterForLink += "`$.ObjectMeta.Name` ='" + filterNames[0].trim() + "' ";
+        if(filterNames[0].isExact)
+          filterForLink += "(`$.ObjectMeta.Name` = '" + filterNames[0].value.trim() + "')";
+        else
+          filterForLink += "(`$.ObjectMeta.Name` LIKE '" + filterNames[0].value.trim() + "%')";
     }
     if (
       (filterContainers && filterContainers.length > 0) ||
@@ -433,24 +468,40 @@ export const RETURN_ADDRESS_LINKS = (
   }
   if (filterContainers && filterContainers.length > 0) {
     if (filterContainers.length > 1) {
-      filterForLink += "(";
-      filterForLink +=
-        "`$.Spec.Connection.Spec.ContainerId` ='" +
-        filterContainers[0].trim() +
-        "' ";
-      let i;
-      for (i = 1; i < filterContainers.length; i++) {
+      if(filterContainers[0].isExact)
         filterForLink +=
-          "OR `$.Spec.Connection.Spec.ContainerId` ='" +
-          filterContainers[i].trim() +
-          "' ";
+          "(`$.Spec.Connection.Spec.ContainerId` = '" +
+          filterContainers[0].value.trim() +
+          "'";
+      else
+        filterForLink +=
+          "(`$.Spec.Connection.Spec.ContainerId` LIKE '" +
+          filterContainers[0].value.trim() +
+          "%'";
+      for (let i = 1; i < filterContainers.length; i++) {
+        if(filterContainers[i].isExact)
+          filterForLink +=
+            "OR `$.Spec.Connection.Spec.ContainerId` = '" +
+            filterContainers[i].value.trim() +
+            "'";
+        else
+          filterForLink +=
+            "OR `$.Spec.Connection.Spec.ContainerId` LIKE '" +
+            filterContainers[i].value.trim() +
+            "%";
       }
       filterForLink += ")";
     } else {
-      filterForLink +=
-        "`$.Spec.Connection.Spec.ContainerId` ='" +
-        filterContainers[0].trim() +
-        "' ";
+      if(filterContainers[0].isExact)
+        filterForLink +=
+          "(`$.Spec.Connection.Spec.ContainerId` = '" +
+          filterContainers[0].value.trim() +
+          "')";
+      else
+        filterForLink +=
+          "(`$.Spec.Connection.Spec.ContainerId` LIKE '" +
+          filterContainers[0].value.trim() +
+          "%')";
     }
     if (filterRole && filterRole.trim() != "") {
       filterForLink += " AND ";
@@ -586,8 +637,8 @@ export const ADDRESS_SPACE_COMMAND_REVIEW_DETAIL = gql`
 export const RETURN_ALL_CONECTION_LIST = (
   page: number,
   perPage: number,
-  hostnames: string[],
-  containers: string[],
+  hostnames: any[],
+  containers: any[],
   name?: string,
   namespace?: string,
   sortBy?: ISortBy
@@ -606,38 +657,48 @@ export const RETURN_ALL_CONECTION_LIST = (
   ) {
     filter += " AND ";
   }
-  if (hostnames) {
-    if (hostnames.length > 0) {
-      if (hostnames.length > 1) {
-        filter += "(";
-        filter += "`$.Spec.Hostname` ='" + hostnames[0].trim() + "' ";
-        let i;
-        for (i = 1; i < hostnames.length; i++) {
-          filter += "OR `$.Spec.Hostname` ='" + hostnames[i].trim() + "' ";
-        }
-        filter += ")";
-      } else {
-        filter += "`$.Spec.Hostname` ='" + hostnames[0].trim() + "' ";
+  if (hostnames && hostnames.length > 0) {
+    if (hostnames.length > 1) {
+      if (hostnames[0].isExact)
+        filter += "(`$.Spec.Hostname` = '" + hostnames[0].value.trim() + "'";
+      else
+        filter += "(`$.Spec.Hostname` LIKE '" + hostnames[0].value.trim() + "%' ";
+      for (let i = 1; i < hostnames.length; i++) {
+        if (hostnames[i].isExact)
+          filter += "OR `$.Spec.Hostname` = '" + hostnames[i].value.trim() + "'";
+        else
+          filter += "OR `$.Spec.Hostname` LIKE '" + hostnames[i].value.trim() + "%' ";
       }
+      filter += ")";
+    } else {
+        if (hostnames[0].isExact)
+          filter += "(`$.Spec.Hostname` = '" + hostnames[0].value.trim() + "')";
+        else
+          filter += "(`$.Spec.Hostname` LIKE '" + hostnames[0].value.trim() + "%')";
     }
   }
 
-  if (containers) {
-    if (containers.length > 0) {
-      if (hostnames && hostnames.length > 0) {
-        filter += " AND ";
+  if (containers && containers.length > 0) {
+    if (hostnames && hostnames.length > 0) {
+      filter += " AND ";
+    }
+    if (containers.length > 1) {
+      if (containers[0].isExact)
+        filter += "(`$.Spec.ContainerId` = '" + containers[0].value.trim() + "'";
+      else
+        filter += "(`$.Spec.ContainerId` LIKE '" + containers[0].value.trim() + "%' ";
+      for (let i = 1; i < containers.length; i++) {
+        if (containers[i].isExact)
+          filter += "OR `$.Spec.ContainerId` = '" + containers[i].value.trim() + "'";
+        else
+          filter += "OR `$.Spec.ContainerId` LIKE '" + containers[i].value.trim() + "%' ";
       }
-      if (containers.length > 1) {
-        filter += "(";
-        filter += "`$.Spec.ContainerId` ='" + containers[0].trim() + "' ";
-        let i;
-        for (i = 1; i < containers.length; i++) {
-          filter += "OR `$.Spec.ContainerId` ='" + containers[i].trim() + "' ";
-        }
-        filter += ")";
-      } else {
-        filter += "`$.Spec.ContainerId` ='" + containers[0].trim() + "' ";
-      }
+      filter += ")";
+    } else {
+        if (containers[0].isExact)
+          filter += "(`$.Spec.ContainerId` = '" + containers[0].value.trim() + "')";
+        else
+          filter += "(`$.Spec.ContainerId` LIKE '" + containers[0].value.trim() + "%')";
     }
   }
 
@@ -797,8 +858,8 @@ export const RETURN_ADDRESS_SPACE_PLANS = gql`
 export const RETURN_CONNECTION_LINKS = (
   page: number,
   perPage: number,
-  filterNames: string[],
-  filterAddresses: string[],
+  filterNames: any[],
+  filterAddresses: any[],
   addressSpaceName?: string,
   addressSpaceNameSpcae?: string,
   connectionName?: string,
@@ -857,16 +918,24 @@ export const RETURN_CONNECTION_LINKS = (
   let filterForLink = "";
   if (filterNames && filterNames.length > 0) {
     if (filterNames.length > 1) {
-      filterForLink += "(";
-      filterForLink += "`$.ObjectMeta.Name` ='" + filterNames[0].trim() + "' ";
-      let i;
-      for (i = 1; i < filterNames.length; i++) {
-        filterForLink +=
-          "OR `$.ObjectMeta.Name` ='" + filterNames[i].trim() + "' ";
+      if (filterNames[0].isExact)
+        filterForLink += "(`$.ObjectMeta.Name` = '" + filterNames[0].value.trim() + "'";
+      else
+        filterForLink += "(`$.ObjectMeta.Name` LIKE '" + filterNames[0].value.trim() + "%' ";
+      for (let i = 1; i < filterNames.length; i++) {
+        if (filterNames[i].isExact)
+          filterForLink +=
+            "OR `$.ObjectMeta.Name` = '" + filterNames[i].value.trim() + "'";
+        else
+          filterForLink +=
+            "OR `$.ObjectMeta.Name` LIKE '" + filterNames[i].value.trim() + "%' ";
       }
       filterForLink += ")";
     } else {
-      filterForLink += "`$.ObjectMeta.Name` ='" + filterNames[0].trim() + "' ";
+        if (filterNames[0].isExact)
+          filterForLink += "`$.ObjectMeta.Name` = '" + filterNames[0].value.trim() + "'";
+        else
+          filterForLink += "`$.ObjectMeta.Name` LIKE '" + filterNames[0].value.trim() + "%' ";
     }
     if (
       (filterAddresses && filterAddresses.length > 0) ||
@@ -877,15 +946,24 @@ export const RETURN_CONNECTION_LINKS = (
   }
   if (filterAddresses && filterAddresses.length > 0) {
     if (filterAddresses.length > 1) {
-      filterForLink += "(";
-      filterForLink += "`$.Spec.Address` ='" + filterAddresses[0].trim() + "' ";
-      let i;
-      for (i = 1; i < filterAddresses.length; i++) {
-        filterForLink +=
-          "OR `$.Spec.Address` ='" + filterAddresses[i].trim() + "' ";
+      if (filterAddresses[0].isExact)
+        filterForLink += "(`$.Spec.Address` = '" + filterAddresses[0].value.trim() + "'";
+      else
+        filterForLink += "(`$.Spec.Address` LIKE '" + filterAddresses[0].value.trim() + "%' ";
+      for (let i = 1; i < filterAddresses.length; i++) {
+        if (filterAddresses[i].isExact)
+          filterForLink +=
+            "OR `$.Spec.Address` = '" + filterAddresses[i].value.trim() + "'";
+        else
+          filterForLink +=
+            "OR `$.Spec.Address` LIKE '" + filterAddresses[i].value.trim() + "%' ";
       }
+      filterForLink += ")";
     } else {
-      filterForLink += "`$.Spec.Address` ='" + filterAddresses[0].trim() + "' ";
+        if (filterAddresses[0].isExact)
+          filterForLink += "`$.Spec.Address` = '" + filterAddresses[0].value.trim() + "'";
+        else
+          filterForLink += "`$.Spec.Address` LIKE '" + filterAddresses[0].value.trim() + "%' ";
     }
     if (filterRole && filterRole.trim() != "") {
       filterForLink += " AND ";
@@ -989,7 +1067,7 @@ export const RETURN_ALL_NAMES_OF_ADDRESS_LINK_FOR_TYPEAHEAD_SEARCH = (
     ) {
       Total
       Addresses {
-        Links(filter:"\`$.ObjectMeta.Name\` LIKE '${name}%'" first:100,offset:0)  {
+        Links(filter:"\`$.ObjectMeta.Name\` LIKE '${name}%'" first:10,offset:0)  {
           Total
           Links{
             ObjectMeta {
@@ -1016,7 +1094,7 @@ export const RETURN_ALL_CONTAINER_IDS_OF_ADDRESS_LINKS_FOR_TYPEAHEAD_SEARCH = (
     ) {
       Total
       Addresses {
-        Links(filter:"\`$.Spec.Connection.Spec.ContainerId\` LIKE '${container}%'" first:100,offset:0)  {
+        Links(filter:"\`$.Spec.Connection.Spec.ContainerId\` LIKE '${container}%'" first:10 ,offset:0)  {
           Total
           Links{
             Spec{
@@ -1055,7 +1133,7 @@ export const RETURN_ALL_CONNECTION_LINKS_FOR_NAME_SEARCH = (
     ) {
       Total
       Connections {
-        Links(first:100 offset:0 filter:"\`$.ObjectMeta.Name\` LIKE '${name}%'") {
+        Links(first:10 offset:0 filter:"\`$.ObjectMeta.Name\` LIKE '${name}%'") {
           Total
           Links {
             ObjectMeta {
@@ -1090,7 +1168,7 @@ export const RETURN_ALL_CONNECTION_LINKS_FOR_ADDRESS_SEARCH = (
     ) {
       Total
       Connections {
-        Links(first:100 offset:0
+        Links(first:10 offset:0
               filter:"\`$.Spec.Address\` LIKE '${address}%'") {
           Links {
             Spec {
@@ -1152,7 +1230,7 @@ export const RETURN_ALL_ADDRESS_NAMES_OF_ADDRESS_SPACES_FOR_TYPEAHEAD_SEARCH = (
   }
   const ALL_ADDRESS_FOR_ADDRESS_SPACE = gql`
   query all_addresses_for_addressspace_view {
-    addresses( first:100 offset:0
+    addresses( first:10 offset:0
       filter:"${filterString}"
     ) {
       Total
@@ -1193,7 +1271,7 @@ export const RETURN_ALL_CONNECTIONS_HOSTNAME_AND_CONTAINERID_OF_ADDRESS_SPACES_F
   const ALL_CONECTION_LIST = gql(
     `query all_connections_for_addressspace_view {
       connections(
-        filter: "${filter}" first:100 offset:0
+        filter: "${filter}" first:10 offset:0
       ) {
       Total
       Connections {


### PR DESCRIPTION
The filters now use 'LIKE' instead of '='. The filters have been modified in all of the 5 lists.

ToDos : 
* In some cases redundant elements are encountered in the dropdowns.
