### PR TITLE
[iot] remove hashed passwords details in device registry management API

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/iot/isolated/registry/H2DeviceRegistryTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/iot/isolated/registry/H2DeviceRegistryTest.java
@@ -71,7 +71,6 @@ class H2DeviceRegistryTest extends DeviceRegistryTest {
     }
 
     @Test
-    @Disabled("Fixed in hono/pull/1565")
     void testDeviceCredentialsDoesNotContainsPasswordDetails() throws Exception {
         super.doTestDeviceCredentialsDoesNotContainsPasswordDetails();
     }

--- a/systemtests/src/test/java/io/enmasse/systemtest/iot/isolated/registry/InfinispanDeviceRegistryTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/iot/isolated/registry/InfinispanDeviceRegistryTest.java
@@ -64,7 +64,6 @@ class InfinispanDeviceRegistryTest extends DeviceRegistryTest {
     }
 
     @Test
-    @Disabled("Fixed in hono/pull/1565")
     void testDeviceCredentialsDoesNotContainsPasswordDetails() throws Exception {
         super.doTestDeviceCredentialsDoesNotContainsPasswordDetails();
     }

--- a/systemtests/src/test/java/io/enmasse/systemtest/iot/isolated/registry/PostgresTableDeviceRegistryTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/iot/isolated/registry/PostgresTableDeviceRegistryTest.java
@@ -57,7 +57,6 @@ class PostgresTableDeviceRegistryTest extends DeviceRegistryTest {
     }
 
     @Test
-    @Disabled("Fixed in hono/pull/1711")
     void testDeviceCredentialsDoesNotContainsPasswordDetails() throws Exception {
         super.doTestDeviceCredentialsDoesNotContainsPasswordDetails();
     }

--- a/systemtests/src/test/java/io/enmasse/systemtest/iot/isolated/registry/PostgresTableDeviceRegistryTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/iot/isolated/registry/PostgresTableDeviceRegistryTest.java
@@ -57,7 +57,7 @@ class PostgresTableDeviceRegistryTest extends DeviceRegistryTest {
     }
 
     @Test
-    @Disabled("Fixed in hono/pull/1565")
+    @Disabled("Fixed in hono/pull/1711")
     void testDeviceCredentialsDoesNotContainsPasswordDetails() throws Exception {
         super.doTestDeviceCredentialsDoesNotContainsPasswordDetails();
     }

--- a/systemtests/src/test/java/io/enmasse/systemtest/iot/isolated/registry/PostgresTableSplitDeviceRegistryTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/iot/isolated/registry/PostgresTableSplitDeviceRegistryTest.java
@@ -58,7 +58,6 @@ class PostgresTableSplitDeviceRegistryTest extends DeviceRegistryTest {
     }
 
     @Test
-    @Disabled("Fixed in hono/pull/1565")
     void testDeviceCredentialsDoesNotContainsPasswordDetails() throws Exception {
         super.doTestDeviceCredentialsDoesNotContainsPasswordDetails();
     }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The device registry should not hand out passwords details through the management API.

### Checklist

- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Update CHANGELOG.md
