### PR TITLE
Added metrics to address space controller

### DIFF
--- a/address-space-controller/src/test/java/io/enmasse/controller/MetricsReporterTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/MetricsReporterTest.java
@@ -6,6 +6,7 @@ package io.enmasse.controller;
 
 import io.enmasse.address.model.AddressSpace;
 import io.enmasse.address.model.AddressSpaceBuilder;
+import io.enmasse.address.model.Phase;
 import io.enmasse.metrics.api.Metric;
 import io.enmasse.metrics.api.MetricSnapshot;
 import io.enmasse.metrics.api.Metrics;
@@ -30,7 +31,7 @@ public class MetricsReporterTest {
                 createAddressSpace("s3", false)));
 
         List<Metric> metricList = metrics.getMetrics();
-        assertEquals(7, metricList.size());
+        assertEquals(12, metricList.size());
         MetricSnapshot numReady = createSnapshot("address_space_status_ready", metricList);
         assertNotNull(numReady);
         assertEquals(3, numReady.getValues().size());
@@ -43,6 +44,9 @@ public class MetricsReporterTest {
         assertNotNull(total);
         assertEquals(3, total.getValues().iterator().next().getValue());
 
+        MetricSnapshot numActive = createSnapshot("address_spaces_active_total", metricList);
+        assertNotNull(numActive);
+        assertEquals(Long.valueOf(2), numActive.getValues().iterator().next().getValue());
     }
 
     private MetricSnapshot createSnapshot(String name, List<Metric> metricList) {
@@ -55,6 +59,7 @@ public class MetricsReporterTest {
     }
 
     private AddressSpace createAddressSpace(String name, boolean isReady) {
+        Phase phase = isReady ? Phase.Active : Phase.Configuring;
         return new AddressSpaceBuilder()
                 .editOrNewMetadata()
                 .withName(name)
@@ -65,6 +70,7 @@ public class MetricsReporterTest {
                 .endSpec()
                 .editOrNewStatus()
                 .withReady(isReady)
+                .withPhase(phase)
                 .endStatus()
                 .build();
 

--- a/pkg/controller/address_space_controller/controller.go
+++ b/pkg/controller/address_space_controller/controller.go
@@ -237,6 +237,7 @@ func (r *ReconcileAddressSpaceController) ensureService(ctx context.Context, req
 
 func applyService(service *corev1.Service) error {
 	install.ApplyServiceDefaults(service, service.Name, service.Name)
+	install.CreateCustomLabel(service, "monitoring-key", "enmasse-tenants")
 	service.Spec.Ports = []corev1.ServicePort{
 		{
 			Port:       8080,

--- a/pkg/util/install/utils.go
+++ b/pkg/util/install/utils.go
@@ -35,6 +35,11 @@ func CreateDefaultLabels(labels map[string]string, component string, name string
 	return labels
 }
 
+// Apply a custom label
+func CreateCustomLabel(service *corev1.Service, key string, value string) {
+	service.ObjectMeta.Labels[key] = value
+}
+
 // Apply standard set of labels
 func ApplyDefaultLabels(meta *v1.ObjectMeta, component string, name string) {
 	meta.Labels = CreateDefaultLabels(meta.Labels, component, name)


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Added metrics for address space phases and allowed them to be scraped by
tenant service monitors

### Checklist

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
