### PR TITLE
Pod distruption budget

### DIFF
--- a/address-space-controller/src/main/java/io/enmasse/controller/RouterConfigController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/RouterConfigController.java
@@ -62,7 +62,7 @@ public class RouterConfigController implements Controller {
             String name = String.format("enmasse.%s.%s", addressSpace.getMetadata().getNamespace(), addressSpace.getMetadata().getName());
             try {
                 boolean changed = false;
-                PodDisruptionBudget podDisruptionBudget = client.policy().podDisruptionBudget().withName(name).get();
+                PodDisruptionBudget podDisruptionBudget = client.inNamespace(namespace).policy().podDisruptionBudget().withName(name).get();
                 if (podDisruptionBudget == null) {
                     podDisruptionBudget = new PodDisruptionBudgetBuilder()
                             .editOrNewMetadata()
@@ -86,7 +86,7 @@ public class RouterConfigController implements Controller {
                 }
 
                 if (changed) {
-                    client.policy().podDisruptionBudget().createOrReplace(podDisruptionBudget);
+                    client.inNamespace(namespace).policy().podDisruptionBudget().createOrReplace(podDisruptionBudget);
                 }
             } catch (KubernetesClientException e) {
                 log.warn("Error creating pod distruption budget", e);

--- a/address-space-controller/src/main/java/io/enmasse/controller/RouterConfigController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/RouterConfigController.java
@@ -15,6 +15,9 @@ import io.enmasse.controller.router.config.Address;
 import io.enmasse.controller.router.config.*;
 import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
+import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudget;
+import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudgetBuilder;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,12 +47,51 @@ public class RouterConfigController implements Controller {
             RouterSet routerSet = RouterSet.create(namespace, addressSpace, client);
             reconcileRouterSetSecrets(addressSpace, routerSet);
             reconcileRouterConfig(addressSpace, routerSet, (StandardInfraConfig) infraConfig);
+            reconcileRouterPodDistruptionBudget(addressSpace, routerSet, (StandardInfraConfig) infraConfig);
             if (routerSet.isModified()) {
                 addressSpace.getStatus().setPhase(Phase.Configuring);
             }
             routerSet.apply(client);
         }
         return addressSpace;
+    }
+
+    private void reconcileRouterPodDistruptionBudget(AddressSpace addressSpace, RouterSet routerSet, StandardInfraConfig infraConfig) {
+        if (infraConfig.getSpec() != null && infraConfig.getSpec().getRouter() != null && infraConfig.getSpec().getRouter().getMinAvailable() != null) {
+            int minAvailable = infraConfig.getSpec().getRouter().getMinAvailable();
+            String name = String.format("enmasse.%s.%s", addressSpace.getMetadata().getNamespace(), addressSpace.getMetadata().getName());
+            try {
+                boolean changed = false;
+                PodDisruptionBudget podDisruptionBudget = client.policy().podDisruptionBudget().withName(name).get();
+                if (podDisruptionBudget == null) {
+                    podDisruptionBudget = new PodDisruptionBudgetBuilder()
+                            .editOrNewMetadata()
+                            .withName(name)
+                            .addToLabels("app", "enmasse")
+                            .endMetadata()
+                            .editOrNewSpec()
+                            .endSpec()
+                            .build();
+                    changed = true;
+                }
+
+                if (podDisruptionBudget.getSpec().getMinAvailable().getIntVal() != minAvailable) {
+                    podDisruptionBudget.getSpec().setMinAvailable(new IntOrString(minAvailable));
+                    changed = true;
+                }
+
+                if (!podDisruptionBudget.getSpec().getSelector().equals(routerSet.getStatefulSet().getSpec().getSelector())) {
+                    podDisruptionBudget.getSpec().setSelector(routerSet.getStatefulSet().getSpec().getSelector());
+                    changed = true;
+                }
+
+                if (changed) {
+                    client.policy().podDisruptionBudget().createOrReplace(podDisruptionBudget);
+                }
+            } catch (KubernetesClientException e) {
+                log.warn("Error creating pod distruption budget", e);
+            }
+        }
     }
 
     private static String routerConfigName(String infraUuid) {

--- a/api-model/src/main/java/io/enmasse/admin/model/v1/StandardInfraConfigSpecRouter.java
+++ b/api-model/src/main/java/io/enmasse/admin/model/v1/StandardInfraConfigSpecRouter.java
@@ -22,11 +22,12 @@ import io.sundr.builder.annotations.Inline;
         refs = {@BuildableReference(AbstractWithAdditionalProperties.class)},
         inline = @Inline(type = Doneable.class, prefix = "Doneable", value = "done")
 )
-@JsonPropertyOrder({"minReplicas", "resources", "linkCapacity", "handshakeTimeout", "idleTimeout", "workerThreads", "policy", "podTemplate"})
+@JsonPropertyOrder({"minAvailable", "minReplicas", "resources", "linkCapacity", "handshakeTimeout", "idleTimeout", "workerThreads", "policy", "podTemplate"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class StandardInfraConfigSpecRouter extends AbstractWithAdditionalProperties {
     private StandardInfraConfigSpecRouterResources resources;
     private Integer minReplicas;
+    private Integer minAvailable;
     private Integer linkCapacity;
     private Integer handshakeTimeout;
     private Integer idleTimeout;
@@ -48,6 +49,10 @@ public class StandardInfraConfigSpecRouter extends AbstractWithAdditionalPropert
 
     public Integer getLinkCapacity() {
         return linkCapacity;
+    }
+
+    public Integer getMinAvailable() {
+        return minAvailable;
     }
 
     public void setMinReplicas(Integer minReplicas) {
@@ -105,6 +110,7 @@ public class StandardInfraConfigSpecRouter extends AbstractWithAdditionalPropert
         StandardInfraConfigSpecRouter that = (StandardInfraConfigSpecRouter) o;
         return Objects.equals(resources, that.resources) &&
                 Objects.equals(minReplicas, that.minReplicas) &&
+                Objects.equals(minAvailable, that.minAvailable) &&
                 Objects.equals(handshakeTimeout, that.handshakeTimeout) &&
                 Objects.equals(idleTimeout, that.idleTimeout) &&
                 Objects.equals(linkCapacity, that.linkCapacity) &&
@@ -115,7 +121,7 @@ public class StandardInfraConfigSpecRouter extends AbstractWithAdditionalPropert
 
     @Override
     public int hashCode() {
-        return Objects.hash(resources, linkCapacity, minReplicas, handshakeTimeout, idleTimeout, workerThreads, policy, podTemplate);
+        return Objects.hash(resources, linkCapacity, minAvailable, minReplicas, handshakeTimeout, idleTimeout, workerThreads, policy, podTemplate);
     }
 
     @Override
@@ -123,6 +129,7 @@ public class StandardInfraConfigSpecRouter extends AbstractWithAdditionalPropert
         return "StandardInfraConfigSpecRouter{" +
                 "resources=" + resources +
                 ", minReplicas=" + minReplicas +
+                ", minAvailable=" + minAvailable +
                 ", linkCapacity=" + linkCapacity +
                 ", handshakeTimeout=" + handshakeTimeout +
                 ", idleTimeout=" + idleTimeout +
@@ -130,5 +137,9 @@ public class StandardInfraConfigSpecRouter extends AbstractWithAdditionalPropert
                 ", policy=" + policy +
                 ", podTemplate=" + podTemplate +
                 '}';
+    }
+
+    public void setMinAvailable(Integer minAvailable) {
+        this.minAvailable = minAvailable;
     }
 }

--- a/api-model/src/main/java/io/enmasse/admin/model/v1/StandardInfraConfigSpecRouter.java
+++ b/api-model/src/main/java/io/enmasse/admin/model/v1/StandardInfraConfigSpecRouter.java
@@ -22,12 +22,13 @@ import io.sundr.builder.annotations.Inline;
         refs = {@BuildableReference(AbstractWithAdditionalProperties.class)},
         inline = @Inline(type = Doneable.class, prefix = "Doneable", value = "done")
 )
-@JsonPropertyOrder({"minAvailable", "minReplicas", "resources", "linkCapacity", "handshakeTimeout", "idleTimeout", "workerThreads", "policy", "podTemplate"})
+@JsonPropertyOrder({"minAvailable", "maxUnavailable", "minReplicas", "resources", "linkCapacity", "handshakeTimeout", "idleTimeout", "workerThreads", "policy", "podTemplate"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class StandardInfraConfigSpecRouter extends AbstractWithAdditionalProperties {
     private StandardInfraConfigSpecRouterResources resources;
     private Integer minReplicas;
     private Integer minAvailable;
+    private Integer maxUnavailable;
     private Integer linkCapacity;
     private Integer handshakeTimeout;
     private Integer idleTimeout;
@@ -53,6 +54,18 @@ public class StandardInfraConfigSpecRouter extends AbstractWithAdditionalPropert
 
     public Integer getMinAvailable() {
         return minAvailable;
+    }
+
+    public void setMinAvailable(Integer minAvailable) {
+        this.minAvailable = minAvailable;
+    }
+
+    public Integer getMaxUnavailable() {
+        return maxUnavailable;
+    }
+
+    public void setMaxUnavailable(Integer maxUnavailable) {
+        this.maxUnavailable = maxUnavailable;
     }
 
     public void setMinReplicas(Integer minReplicas) {
@@ -111,6 +124,7 @@ public class StandardInfraConfigSpecRouter extends AbstractWithAdditionalPropert
         return Objects.equals(resources, that.resources) &&
                 Objects.equals(minReplicas, that.minReplicas) &&
                 Objects.equals(minAvailable, that.minAvailable) &&
+                Objects.equals(maxUnavailable, that.maxUnavailable) &&
                 Objects.equals(handshakeTimeout, that.handshakeTimeout) &&
                 Objects.equals(idleTimeout, that.idleTimeout) &&
                 Objects.equals(linkCapacity, that.linkCapacity) &&
@@ -121,7 +135,7 @@ public class StandardInfraConfigSpecRouter extends AbstractWithAdditionalPropert
 
     @Override
     public int hashCode() {
-        return Objects.hash(resources, linkCapacity, minAvailable, minReplicas, handshakeTimeout, idleTimeout, workerThreads, policy, podTemplate);
+        return Objects.hash(resources, linkCapacity, minAvailable, maxUnavailable, minReplicas, handshakeTimeout, idleTimeout, workerThreads, policy, podTemplate);
     }
 
     @Override
@@ -130,6 +144,7 @@ public class StandardInfraConfigSpecRouter extends AbstractWithAdditionalPropert
                 "resources=" + resources +
                 ", minReplicas=" + minReplicas +
                 ", minAvailable=" + minAvailable +
+                ", maxUnavailable=" + maxUnavailable +
                 ", linkCapacity=" + linkCapacity +
                 ", handshakeTimeout=" + handshakeTimeout +
                 ", idleTimeout=" + idleTimeout +
@@ -137,9 +152,5 @@ public class StandardInfraConfigSpecRouter extends AbstractWithAdditionalPropert
                 ", policy=" + policy +
                 ", podTemplate=" + podTemplate +
                 '}';
-    }
-
-    public void setMinAvailable(Integer minAvailable) {
-        this.minAvailable = minAvailable;
     }
 }

--- a/documentation/src/main/resources/swagger.json
+++ b/documentation/src/main/resources/swagger.json
@@ -485,6 +485,9 @@
                 "minReplicas": {
                     "type": "integer"
                 },
+                "minAvailable": {
+                    "type": "integer"
+                },
                 "podTemplate": {
                     "$ref": "#/definitions/io.enmasse.admin.v1beta1.InfraConfigPodSpec"
                 },

--- a/olm-manifest/src/main/resources/latest/enmasse.clusterserviceversion.yaml
+++ b/olm-manifest/src/main/resources/latest/enmasse.clusterserviceversion.yaml
@@ -490,6 +490,9 @@ spec:
         - apiGroups: [ "apps", "extensions" ]
           resources: [ "statefulsets", "deployments", "replicasets" ]
           verbs: [ "create", "update", "patch", "get", "list", "delete" ]
+        - apiGroups: [ "policy" ]
+          resources: [ "poddisruptionbudgets" ]
+          verbs: [ "create", "update", "get", "patch", "list", "watch", "delete" ]
       - serviceAccountName: address-space-admin
         rules:
         - apiGroups: [ "admin.enmasse.io" ]
@@ -538,9 +541,6 @@ spec:
         - apiGroups: [ "user.enmasse.io" ]
           resources: [ "messagingusers" ]
           verbs: [ "create", "update", "patch", "get", "list", "watch", "delete" ]
-        - apiGroups: [ "policy" ]
-          resources: [ "poddistruptionbudgets" ]
-          verbs: [ "create", "update", "get", "patch", "delete" ]
       - serviceAccountName: address-space-admin
         rules:
         - apiGroups: [ "enmasse.io" ]

--- a/olm-manifest/src/main/resources/latest/enmasse.clusterserviceversion.yaml
+++ b/olm-manifest/src/main/resources/latest/enmasse.clusterserviceversion.yaml
@@ -538,6 +538,9 @@ spec:
         - apiGroups: [ "user.enmasse.io" ]
           resources: [ "messagingusers" ]
           verbs: [ "create", "update", "patch", "get", "list", "watch", "delete" ]
+        - apiGroups: [ "policy" ]
+          resources: [ "poddistruptionbudgets" ]
+          verbs: [ "create", "update", "get", "patch", "delete" ]
       - serviceAccountName: address-space-admin
         rules:
         - apiGroups: [ "enmasse.io" ]

--- a/templates/address-space-controller/020-ClusterRole-address-space-controller.yaml
+++ b/templates/address-space-controller/020-ClusterRole-address-space-controller.yaml
@@ -11,6 +11,3 @@ rules:
   - apiGroups: [ "user.enmasse.io" ]
     resources: [ "messagingusers" ]
     verbs: [ "create", "update", "patch", "get", "list", "watch", "delete" ]
-  - apiGroups: [ "policy" ]
-    resources: [ "poddistruptionbudgets" ]
-    verbs: [ "create", "update", "get", "patch", "delete" ]

--- a/templates/address-space-controller/020-ClusterRole-address-space-controller.yaml
+++ b/templates/address-space-controller/020-ClusterRole-address-space-controller.yaml
@@ -11,3 +11,6 @@ rules:
   - apiGroups: [ "user.enmasse.io" ]
     resources: [ "messagingusers" ]
     verbs: [ "create", "update", "patch", "get", "list", "watch", "delete" ]
+  - apiGroups: [ "policy" ]
+    resources: [ "poddistruptionbudgets" ]
+    verbs: [ "create", "update", "get", "patch", "delete" ]

--- a/templates/address-space-controller/020-Role-address-space-controller.yaml
+++ b/templates/address-space-controller/020-Role-address-space-controller.yaml
@@ -29,3 +29,6 @@ rules:
   - apiGroups: [ "apps", "extensions" ]
     resources: [ "statefulsets", "deployments", "replicasets" ]
     verbs: [ "create", "update", "patch", "get", "list", "delete" ]
+  - apiGroups: [ "policy" ]
+    resources: [ "poddisruptionbudgets" ]
+    verbs: [ "create", "update", "get", "patch", "list", "watch", "delete" ]

--- a/templates/crds/standardinfraconfigs.crd.yaml
+++ b/templates/crds/standardinfraconfigs.crd.yaml
@@ -150,6 +150,8 @@ spec:
                   type: integer
                 minAvailable:
                   type: integer
+                maxUnavailable:
+                  type: integer
                 linkCapacity:
                   type: integer
                 idleTimeout:

--- a/templates/crds/standardinfraconfigs.crd.yaml
+++ b/templates/crds/standardinfraconfigs.crd.yaml
@@ -148,6 +148,8 @@ spec:
                       type: string
                 minReplicas:
                   type: integer
+                minAvailable:
+                  type: integer
                 linkCapacity:
                   type: integer
                 idleTimeout:


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Enhancement / new feature

### Description

Allow specifying minAvailable for the router pods created for an address space. This will create a pod disruption budget to ensure minAvailable routers are always running.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
