### PR TITLE
Disruption budget broker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@
    * Some of the resource validation that was taking place in the api-server has been replaced with a resource status check and error message.
    * The address space schema resource has been changed to a cluster-wide CRD. Users will not be able to read/list it without addition permissions.
 
-*  #3621: Add status section for plans and authentication services #3621
+*  #3621: Add status section for plans and authentication services
 *  Qpid Dispatch Router upgraded to 1.10.0
 *  #3657 Configure router pod anti-affinity by default
+
+* #3673: Add support for pod disruption budgets
 
 ## 0.30.2
 *  #2714: Allow setting security context of pods using persistent volumes

--- a/address-space-controller/src/main/java/io/enmasse/controller/AddressSpaceController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/AddressSpaceController.java
@@ -128,6 +128,7 @@ public class AddressSpaceController {
         controllerChain.addController(new RealmFinalizerController(keycloakRealmApi, authenticationServiceRegistry));
         controllerChain.addController(new CreateController(kubernetes, schemaProvider, infraResourceFactory, eventLogger, authController.getDefaultCertProvider(), options.getVersion(), addressSpaceApi, authenticationServiceResolver));
         controllerChain.addController(new RouterConfigController(controllerClient, controllerClient.getNamespace(), authenticationServiceResolver));
+        controllerChain.addController(new PodDistruptionBudgetController(controllerClient, controllerClient.getNamespace()));
         controllerChain.addController(new RealmController(keycloakRealmApi, authenticationServiceRegistry));
         controllerChain.addController(new NetworkPolicyController(controllerClient));
         controllerChain.addController(new StatusController(kubernetes, schemaProvider, infraResourceFactory, authenticationServiceRegistry, keycloakRealmApi,

--- a/address-space-controller/src/main/java/io/enmasse/controller/PodDistruptionBudgetController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/PodDistruptionBudgetController.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.controller;
+
+import io.enmasse.address.model.AddressSpace;
+import io.enmasse.admin.model.v1.InfraConfig;
+import io.enmasse.admin.model.v1.StandardInfraConfig;
+import io.enmasse.config.AnnotationKeys;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudget;
+import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudgetBuilder;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PodDistruptionBudgetController implements Controller {
+    private static final Logger log = LoggerFactory.getLogger(PodDistruptionBudgetController.class);
+
+    private final NamespacedKubernetesClient client;
+    private final String namespace;
+
+    public PodDistruptionBudgetController(NamespacedKubernetesClient client, String namespace) {
+        this.client = client;
+        this.namespace = namespace;
+    }
+
+    public AddressSpace reconcileActive(AddressSpace addressSpace) throws Exception {
+        InfraConfig infraConfig = InfraConfigs.parseCurrentInfraConfig(addressSpace);
+
+        if (infraConfig instanceof StandardInfraConfig) {
+            RouterSet routerSet = RouterSet.create(namespace, addressSpace, client);
+            reconcileRouterPodDisruptionBudget(addressSpace, routerSet, (StandardInfraConfig) infraConfig);
+            reconcileBrokerPodDisruptionBudget(addressSpace, (StandardInfraConfig) infraConfig);
+        }
+        return addressSpace;
+    }
+
+    private static boolean needsUpdate(IntOrString existing, Integer updated) {
+        return updated != null && (existing == null || !updated.equals(existing.getIntVal()));
+    }
+
+
+    private void reconcileRouterPodDisruptionBudget(AddressSpace addressSpace, RouterSet routerSet, StandardInfraConfig infraConfig) {
+        if (infraConfig.getSpec() != null && infraConfig.getSpec().getRouter() != null && (infraConfig.getSpec().getRouter().getMinAvailable() != null || infraConfig.getSpec().getRouter().getMaxUnavailable() != null)) {
+            String name = String.format("enmasse.%s.%s.qdrouterd", addressSpace.getMetadata().getNamespace(), addressSpace.getMetadata().getName());
+            try {
+                boolean changed = false;
+                PodDisruptionBudget podDisruptionBudget = client.inNamespace(namespace).policy().podDisruptionBudget().withName(name).get();
+                if (podDisruptionBudget == null) {
+                    podDisruptionBudget = new PodDisruptionBudgetBuilder()
+                            .editOrNewMetadata()
+                            .withName(name)
+                            .addToLabels("app", "enmasse")
+                            .endMetadata()
+                            .editOrNewSpec()
+                            .endSpec()
+                            .build();
+                    changed = true;
+                }
+
+                Integer minAvailable = infraConfig.getSpec().getRouter().getMinAvailable();
+                if (needsUpdate(podDisruptionBudget.getSpec().getMinAvailable(), minAvailable)) {
+                    podDisruptionBudget.getSpec().setMinAvailable(new IntOrString(minAvailable));
+                    changed = true;
+                }
+
+                Integer maxUnavailable = infraConfig.getSpec().getRouter().getMaxUnavailable();
+                if (needsUpdate(podDisruptionBudget.getSpec().getMaxUnavailable(), maxUnavailable)) {
+                    podDisruptionBudget.getSpec().setMaxUnavailable(new IntOrString(maxUnavailable));
+                    changed = true;
+                }
+
+                if (!routerSet.getStatefulSet().getSpec().getSelector().equals(podDisruptionBudget.getSpec().getSelector())) {
+                    podDisruptionBudget.getSpec().setSelector(routerSet.getStatefulSet().getSpec().getSelector());
+                    changed = true;
+                }
+
+                if (changed) {
+                    client.inNamespace(namespace).policy().podDisruptionBudget().createOrReplace(podDisruptionBudget);
+                }
+            } catch (KubernetesClientException e) {
+                log.warn("Error creating pod distruption budget for router", e);
+            }
+        }
+    }
+
+    private void reconcileBrokerPodDisruptionBudget(AddressSpace addressSpace, StandardInfraConfig infraConfig) {
+        if (infraConfig.getSpec() != null && infraConfig.getSpec().getBroker() != null &&
+                (infraConfig.getSpec().getBroker().getMinAvailable() != null || infraConfig.getSpec().getBroker().getMaxUnavailable() != null)) {
+
+            String name = String.format("enmasse.%s.%s.broker", addressSpace.getMetadata().getNamespace(), addressSpace.getMetadata().getName());
+            String infraUuid = addressSpace.getAnnotation(AnnotationKeys.INFRA_UUID);
+            try {
+                boolean changed = false;
+                PodDisruptionBudget podDisruptionBudget = client.inNamespace(namespace).policy().podDisruptionBudget().withName(name).get();
+                if (podDisruptionBudget == null) {
+                    podDisruptionBudget = new PodDisruptionBudgetBuilder()
+                            .editOrNewMetadata()
+                            .withName(name)
+                            .addToLabels("app", "enmasse")
+                            .endMetadata()
+                            .editOrNewSpec()
+                            .withNewSelector()
+                            .addToMatchLabels("app", "enmasse")
+                            .addToMatchLabels("role", "broker")
+                            .addToMatchLabels("infraType", "standard")
+                            .addToMatchLabels("infraUuid", infraUuid)
+                            .endSelector()
+                            .endSpec()
+                            .build();
+                    changed = true;
+                }
+
+                Integer minAvailable = infraConfig.getSpec().getRouter().getMinAvailable();
+                if (needsUpdate(podDisruptionBudget.getSpec().getMinAvailable(), minAvailable)) {
+                    podDisruptionBudget.getSpec().setMinAvailable(new IntOrString(minAvailable));
+                    changed = true;
+                }
+
+                Integer maxUnavailable = infraConfig.getSpec().getRouter().getMaxUnavailable();
+                if (needsUpdate(podDisruptionBudget.getSpec().getMaxUnavailable(), maxUnavailable)) {
+                    podDisruptionBudget.getSpec().setMaxUnavailable(new IntOrString(maxUnavailable));
+                    changed = true;
+                }
+
+                if (changed) {
+                    client.inNamespace(namespace).policy().podDisruptionBudget().createOrReplace(podDisruptionBudget);
+                }
+            } catch (KubernetesClientException e) {
+                log.warn("Error creating pod distruption budget for broker", e);
+            }
+        }
+    }
+}

--- a/address-space-controller/src/main/java/io/enmasse/controller/RouterConfigController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/RouterConfigController.java
@@ -4,7 +4,18 @@
  */
 package io.enmasse.controller;
 
-import io.enmasse.address.model.*;
+import io.enmasse.address.model.AddressSpace;
+import io.enmasse.address.model.AddressSpaceSpecConnector;
+import io.enmasse.address.model.AddressSpaceSpecConnectorAddressRule;
+import io.enmasse.address.model.AddressSpaceSpecConnectorCredentials;
+import io.enmasse.address.model.AddressSpaceSpecConnectorEndpoint;
+import io.enmasse.address.model.AddressSpaceSpecConnectorTls;
+import io.enmasse.address.model.AddressSpaceStatusConnector;
+import io.enmasse.address.model.AddressSpaceStatusConnectorBuilder;
+import io.enmasse.address.model.AuthenticationServiceSettings;
+import io.enmasse.address.model.KubeUtil;
+import io.enmasse.address.model.Phase;
+import io.enmasse.address.model.StringOrSecretSelector;
 import io.enmasse.admin.model.v1.InfraConfig;
 import io.enmasse.admin.model.v1.RouterPolicySpec;
 import io.enmasse.admin.model.v1.StandardInfraConfig;
@@ -12,18 +23,43 @@ import io.enmasse.admin.model.v1.StandardInfraConfigSpecRouter;
 import io.enmasse.config.AnnotationKeys;
 import io.enmasse.config.LabelKeys;
 import io.enmasse.controller.router.config.Address;
-import io.enmasse.controller.router.config.*;
-import io.fabric8.kubernetes.api.model.*;
+import io.enmasse.controller.router.config.AuthServicePlugin;
+import io.enmasse.controller.router.config.AutoLink;
+import io.enmasse.controller.router.config.Connector;
+import io.enmasse.controller.router.config.Distribution;
+import io.enmasse.controller.router.config.LinkDirection;
+import io.enmasse.controller.router.config.LinkRoute;
+import io.enmasse.controller.router.config.Listener;
+import io.enmasse.controller.router.config.Policy;
+import io.enmasse.controller.router.config.Role;
+import io.enmasse.controller.router.config.Router;
+import io.enmasse.controller.router.config.RouterConfig;
+import io.enmasse.controller.router.config.SslProfile;
+import io.enmasse.controller.router.config.VhostPolicy;
+import io.enmasse.controller.router.config.VhostPolicyGroup;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
-import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudget;
-import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudgetBuilder;
-import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class RouterConfigController implements Controller {
@@ -47,61 +83,12 @@ public class RouterConfigController implements Controller {
             RouterSet routerSet = RouterSet.create(namespace, addressSpace, client);
             reconcileRouterSetSecrets(addressSpace, routerSet);
             reconcileRouterConfig(addressSpace, routerSet, (StandardInfraConfig) infraConfig);
-            reconcileRouterPodDistruptionBudget(addressSpace, routerSet, (StandardInfraConfig) infraConfig);
             if (routerSet.isModified()) {
                 addressSpace.getStatus().setPhase(Phase.Configuring);
             }
             routerSet.apply(client);
         }
         return addressSpace;
-    }
-
-    private static boolean needsUpdate(IntOrString existing, Integer updated) {
-        return updated != null && (existing == null || !updated.equals(existing.getIntVal()));
-    }
-
-    private void reconcileRouterPodDistruptionBudget(AddressSpace addressSpace, RouterSet routerSet, StandardInfraConfig infraConfig) {
-        if (infraConfig.getSpec() != null && infraConfig.getSpec().getRouter() != null && (infraConfig.getSpec().getRouter().getMinAvailable() != null || infraConfig.getSpec().getRouter().getMaxUnavailable() != null)) {
-            String name = String.format("enmasse.%s.%s", addressSpace.getMetadata().getNamespace(), addressSpace.getMetadata().getName());
-            try {
-                boolean changed = false;
-                PodDisruptionBudget podDisruptionBudget = client.inNamespace(namespace).policy().podDisruptionBudget().withName(name).get();
-                if (podDisruptionBudget == null) {
-                    podDisruptionBudget = new PodDisruptionBudgetBuilder()
-                            .editOrNewMetadata()
-                            .withName(name)
-                            .addToLabels("app", "enmasse")
-                            .endMetadata()
-                            .editOrNewSpec()
-                            .endSpec()
-                            .build();
-                    changed = true;
-                }
-
-                Integer minAvailable = infraConfig.getSpec().getRouter().getMinAvailable();
-                if (needsUpdate(podDisruptionBudget.getSpec().getMinAvailable(), minAvailable)) {
-                    podDisruptionBudget.getSpec().setMinAvailable(new IntOrString(minAvailable));
-                    changed = true;
-                }
-
-                Integer maxUnavailable = infraConfig.getSpec().getRouter().getMaxUnavailable();
-                if (needsUpdate(podDisruptionBudget.getSpec().getMaxUnavailable(), maxUnavailable)) {
-                    podDisruptionBudget.getSpec().setMaxUnavailable(new IntOrString(maxUnavailable));
-                    changed = true;
-                }
-
-                if (!routerSet.getStatefulSet().getSpec().getSelector().equals(podDisruptionBudget.getSpec().getSelector())) {
-                    podDisruptionBudget.getSpec().setSelector(routerSet.getStatefulSet().getSpec().getSelector());
-                    changed = true;
-                }
-
-                if (changed) {
-                    client.inNamespace(namespace).policy().podDisruptionBudget().createOrReplace(podDisruptionBudget);
-                }
-            } catch (KubernetesClientException e) {
-                log.warn("Error creating pod distruption budget", e);
-            }
-        }
     }
 
     private static String routerConfigName(String infraUuid) {

--- a/api-model/src/main/java/io/enmasse/admin/model/v1/StandardInfraConfigSpecBroker.java
+++ b/api-model/src/main/java/io/enmasse/admin/model/v1/StandardInfraConfigSpecBroker.java
@@ -22,7 +22,7 @@ import io.sundr.builder.annotations.Inline;
         refs = {@BuildableReference(AbstractHasMetadataWithAdditionalProperties.class)},
         inline = @Inline(type = Doneable.class, prefix = "Doneable", value = "done")
 )
-@JsonPropertyOrder({"resources", "addressFullPolicy", "globalMaxSize", "storageClassName", "updatePersistentVolumeClaim", "podTemplate", "connectorIdleTimeout", "connectorWorkerThreads"})
+@JsonPropertyOrder({"resources", "addressFullPolicy", "globalMaxSize", "storageClassName", "updatePersistentVolumeClaim", "podTemplate", "connectorIdleTimeout", "connectorWorkerThreads", "minAvailable", "maxUnavailable"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class StandardInfraConfigSpecBroker extends AbstractWithAdditionalProperties {
     private StandardInfraConfigSpecBrokerResources resources;
@@ -33,6 +33,8 @@ public class StandardInfraConfigSpecBroker extends AbstractWithAdditionalPropert
     private PodTemplateSpec podTemplate;
     private Integer connectorIdleTimeout;
     private Integer connectorWorkerThreads;
+    private Integer minAvailable;
+    private Integer maxUnavailable;
 
     public void setResources(StandardInfraConfigSpecBrokerResources resources) {
         this.resources = resources;
@@ -107,6 +109,22 @@ public class StandardInfraConfigSpecBroker extends AbstractWithAdditionalPropert
         this.connectorWorkerThreads = connectorWorkerThreads;
     }
 
+    public Integer getMinAvailable() {
+        return minAvailable;
+    }
+
+    public void setMinAvailable(Integer minAvailable) {
+        this.minAvailable = minAvailable;
+    }
+
+    public Integer getMaxUnavailable() {
+        return maxUnavailable;
+    }
+
+    public void setMaxUnavailable(Integer maxUnavailable) {
+        this.maxUnavailable = maxUnavailable;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -119,12 +137,14 @@ public class StandardInfraConfigSpecBroker extends AbstractWithAdditionalPropert
                 Objects.equals(updatePersistentVolumeClaim, that.updatePersistentVolumeClaim) &&
                 Objects.equals(podTemplate, that.podTemplate) &&
                 Objects.equals(connectorIdleTimeout, that.connectorIdleTimeout) &&
-                Objects.equals(connectorWorkerThreads, that.connectorWorkerThreads);
+                Objects.equals(connectorWorkerThreads, that.connectorWorkerThreads) &&
+                Objects.equals(minAvailable, that.minAvailable) &&
+                Objects.equals(maxUnavailable, that.maxUnavailable);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(resources, addressFullPolicy, globalMaxSize, storageClassName, updatePersistentVolumeClaim, podTemplate, connectorIdleTimeout, connectorWorkerThreads);
+        return Objects.hash(resources, addressFullPolicy, globalMaxSize, storageClassName, updatePersistentVolumeClaim, podTemplate, connectorIdleTimeout, connectorWorkerThreads, minAvailable, maxUnavailable);
     }
 
     @Override
@@ -138,6 +158,9 @@ public class StandardInfraConfigSpecBroker extends AbstractWithAdditionalPropert
                 ", podTemplate=" + podTemplate +
                 ", connectorIdleTimeout=" + connectorIdleTimeout +
                 ", connectorWorkerThreads=" + connectorWorkerThreads +
+                ", minAvailable=" + minAvailable +
+                ", maxUnavailable=" + maxUnavailable +
                 '}';
     }
+
 }

--- a/standard-controller/src/main/resources/templates/queue-persisted.yaml
+++ b/standard-controller/src/main/resources/templates/queue-persisted.yaml
@@ -45,6 +45,17 @@ objects:
     name: ${NAME}
   spec:
     affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: enmasse
+                  role: broker
+                  infraType: standard
+                  infraUuid: ${INFRA_UUID}
+              topologyKey: kubernetes.io/hostname
       nodeAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 1

--- a/templates/crds/standardinfraconfigs.crd.yaml
+++ b/templates/crds/standardinfraconfigs.crd.yaml
@@ -74,6 +74,10 @@ spec:
             broker:
               type: object
               properties:
+                minAvailable:
+                  type: integer
+                maxUnavailable:
+                  type: integer
                 podTemplate:
                   type: object
                   properties:


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Enhancement / new feature

### Description

Allow creating poddisruptionbudgets for brokers, and prefer to schedule brokers on separate hosts. This is mainly useful in combination with partitioned queues in order to get HA during node upgrades.

Fixes #3637 

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
