### PR TITLE
Let the tenant cleaner upload, but not override the protobuf schema

### DIFF
--- a/iot/iot-infinispan-base/src/main/java/io/enmasse/iot/infinispan/cache/AbstractCacheProvider.java
+++ b/iot/iot-infinispan-base/src/main/java/io/enmasse/iot/infinispan/cache/AbstractCacheProvider.java
@@ -16,6 +16,7 @@ import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.client.hotrod.configuration.ServerConfigurationBuilder;
 import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.query.remote.client.ProtobufMetadataManagerConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,6 +81,25 @@ public abstract class AbstractCacheProvider implements AutoCloseable {
     @Override
     public void close() throws Exception {
         stop();
+    }
+
+    protected void uploadSchema(final String fileName, final String schema) {
+
+        if (!this.properties.isUploadSchema()) {
+            return;
+        }
+
+        var cache = this.remoteCacheManager
+                .getCache(ProtobufMetadataManagerConstants.PROTOBUF_METADATA_CACHE_NAME);
+
+        if (this.properties.isOverrideSchema()) {
+            log.info("Uploading (put) schema - name: {}, schema: {}", fileName, schema);
+            cache.put(fileName, schema);
+        } else {
+            log.info("Uploading (putIfAbsent) schema - name: {}, schema: {}", fileName, schema);
+            cache.putIfAbsent(fileName, schema);
+        }
+
     }
 
     /**

--- a/iot/iot-infinispan-base/src/main/java/io/enmasse/iot/infinispan/cache/DeviceConnectionCacheProvider.java
+++ b/iot/iot-infinispan-base/src/main/java/io/enmasse/iot/infinispan/cache/DeviceConnectionCacheProvider.java
@@ -14,9 +14,6 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Index;
 import org.infinispan.protostream.SerializationContext;
 import org.infinispan.protostream.annotations.ProtoSchemaBuilder;
-import org.infinispan.query.remote.client.ProtobufMetadataManagerConstants;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -25,8 +22,6 @@ import io.enmasse.iot.infinispan.devcon.DeviceConnectionKey;
 
 @Component
 public class DeviceConnectionCacheProvider extends AbstractCacheProvider {
-
-    private static final Logger log = LoggerFactory.getLogger(DeviceConnectionCacheProvider.class);
 
     private static final String GENERATED_PROTOBUF_FILE_NAME = "deviceConnection.proto";
 
@@ -47,20 +42,11 @@ public class DeviceConnectionCacheProvider extends AbstractCacheProvider {
     }
 
     private void uploadSchema() throws Exception {
-
-        if (this.properties.isUploadSchema()) {
-
-            final String generatedSchema = createSchema();
-            log.info("Generated protobuf schema - {}", generatedSchema);
-
-            this.remoteCacheManager
-                    .getCache(ProtobufMetadataManagerConstants.PROTOBUF_METADATA_CACHE_NAME)
-                    .put(GENERATED_PROTOBUF_FILE_NAME, generatedSchema);
-        }
-
+        final String generatedSchema = generateSchema();
+        uploadSchema(GENERATED_PROTOBUF_FILE_NAME, generatedSchema);
     }
 
-    private String createSchema() throws Exception {
+    private String generateSchema() throws Exception {
         final SerializationContext serCtx = ProtoStreamMarshaller.getSerializationContext(this.remoteCacheManager);
 
         return new ProtoSchemaBuilder()

--- a/iot/iot-infinispan-base/src/main/java/io/enmasse/iot/infinispan/cache/DeviceManagementCacheProvider.java
+++ b/iot/iot-infinispan-base/src/main/java/io/enmasse/iot/infinispan/cache/DeviceManagementCacheProvider.java
@@ -156,7 +156,9 @@ public class DeviceManagementCacheProvider extends AbstractCacheProvider {
         }
         if (!schema.equals(this.schema)) {
             log.info("Schema doesn't match expected content: {} vs {}", this.schema, schema);
-            throw new IllegalStateException("Schema doesn't match expected content");
+            if ( this.properties.isFailOnSchemaMismatch()) {
+                throw new IllegalStateException("Schema doesn't match expected content");
+            }
         }
     }
 

--- a/iot/iot-infinispan-base/src/main/java/io/enmasse/iot/infinispan/cache/DeviceManagementCacheProvider.java
+++ b/iot/iot-infinispan-base/src/main/java/io/enmasse/iot/infinispan/cache/DeviceManagementCacheProvider.java
@@ -54,15 +54,7 @@ public class DeviceManagementCacheProvider extends AbstractCacheProvider {
     }
 
     private void uploadSchema() throws Exception {
-
-        if (this.properties.isUploadSchema()) {
-            log.info("Generated protobuf schema - {}", this.schema);
-
-            this.remoteCacheManager
-                    .getCache(ProtobufMetadataManagerConstants.PROTOBUF_METADATA_CACHE_NAME)
-                    .put(GENERATED_PROTOBUF_FILE_NAME, this.schema);
-        }
-
+        uploadSchema(GENERATED_PROTOBUF_FILE_NAME, this.schema);
     }
 
     private String generateSchema() throws IOException {

--- a/iot/iot-infinispan-base/src/main/java/io/enmasse/iot/infinispan/config/InfinispanProperties.java
+++ b/iot/iot-infinispan-base/src/main/java/io/enmasse/iot/infinispan/config/InfinispanProperties.java
@@ -11,6 +11,7 @@ public class InfinispanProperties {
 
     private static final boolean DEFAULT_TRY_CREATE = false;
     public static final boolean DEFAULT_UPLOAD_SCHEMA = true;
+    public static final boolean DEFAULT_OVERRIDE_SCHEMA = true;
 
     private static final String DEFAULT_HOST = "localhost";
     private static final int DEFAULT_PORT = 11222;
@@ -26,7 +27,20 @@ public class InfinispanProperties {
     private int port = DEFAULT_PORT;
 
     private boolean useTls = DEFAULT_USE_TLS;
+
+    /**
+     * If {@code true}, then schema should be uploaded to the registry.
+     */
     private boolean uploadSchema = DEFAULT_UPLOAD_SCHEMA;
+
+    /**
+     * If {@code true}, then schema should be overwritten when uploading to the registry.
+     * <br>
+     * <strong>Note:</strong> If the field {@link #uploadSchema} is set to {@code false}, then
+     * this field has no effect.
+     */
+    private boolean overrideSchema = DEFAULT_OVERRIDE_SCHEMA;
+
     private String trustStorePath;
 
     private String username;
@@ -52,6 +66,14 @@ public class InfinispanProperties {
 
     public boolean isUploadSchema() {
         return uploadSchema;
+    }
+
+    public void setOverrideSchema(boolean overrideSchema) {
+        this.overrideSchema = overrideSchema;
+    }
+
+    public boolean isOverrideSchema() {
+        return overrideSchema;
     }
 
     public void setHost(String host) {

--- a/iot/iot-infinispan-base/src/main/java/io/enmasse/iot/infinispan/config/InfinispanProperties.java
+++ b/iot/iot-infinispan-base/src/main/java/io/enmasse/iot/infinispan/config/InfinispanProperties.java
@@ -11,7 +11,8 @@ public class InfinispanProperties {
 
     private static final boolean DEFAULT_TRY_CREATE = false;
     public static final boolean DEFAULT_UPLOAD_SCHEMA = true;
-    public static final boolean DEFAULT_OVERRIDE_SCHEMA = true;
+    private static final boolean DEFAULT_OVERRIDE_SCHEMA = true;
+    private static final boolean DEFAULT_FAIL_ON_SCHEMA_MISMATCH = false;
 
     private static final String DEFAULT_HOST = "localhost";
     private static final int DEFAULT_PORT = 11222;
@@ -20,6 +21,7 @@ public class InfinispanProperties {
     private static final String DEFAULT_ADAPTER_CREDENTIALS_CACHE_NAME = "adapterCredentials";
     private static final String DEFAULT_DEVICE_STATES_CACHE_NAME = "deviceStates";
     private static final String DEFAULT_DEVICES_CACHE_NAME = "devices";
+
 
     private boolean tryCreate = DEFAULT_TRY_CREATE;
 
@@ -40,6 +42,8 @@ public class InfinispanProperties {
      * this field has no effect.
      */
     private boolean overrideSchema = DEFAULT_OVERRIDE_SCHEMA;
+
+    private boolean failOnSchemaMismatch = DEFAULT_FAIL_ON_SCHEMA_MISMATCH;
 
     private String trustStorePath;
 
@@ -74,6 +78,14 @@ public class InfinispanProperties {
 
     public boolean isOverrideSchema() {
         return overrideSchema;
+    }
+
+    public void setFailOnSchemaMismatch(boolean failOnSchemaMismatch) {
+        this.failOnSchemaMismatch = failOnSchemaMismatch;
+    }
+
+    public boolean isFailOnSchemaMismatch() {
+        return failOnSchemaMismatch;
     }
 
     public void setHost(String host) {

--- a/iot/iot-tenant-cleaner/src/main/java/io/enmasse/iot/tools/cleanup/InfinispanTenantCleaner.java
+++ b/iot/iot-tenant-cleaner/src/main/java/io/enmasse/iot/tools/cleanup/InfinispanTenantCleaner.java
@@ -41,6 +41,7 @@ public class InfinispanTenantCleaner implements AutoCloseable {
 
     public InfinispanTenantCleaner(final CleanerConfig config) {
         this.config = config;
+        this.config.getInfinispan().setOverrideSchema(false);
     }
 
     @Override
@@ -58,11 +59,9 @@ public class InfinispanTenantCleaner implements AutoCloseable {
 
         final LinkedList<Closer> cleanup = new LinkedList<>();
 
-        config.getInfinispan().setUploadSchema(false);
-
         try (
-                var mgmtProvider = new DeviceManagementCacheProvider(config.getInfinispan());
-                var deviceconProvider = new DeviceConnectionCacheProvider(config.getInfinispan());) {
+                var mgmtProvider = new DeviceManagementCacheProvider(this.config.getInfinispan());
+                var deviceconProvider = new DeviceConnectionCacheProvider(this.config.getInfinispan());) {
 
             mgmtProvider.start();
             final var devicesCache = mgmtProvider.getOrCreateDeviceManagementCache();

--- a/systemtests/src/main/java/io/enmasse/systemtest/iot/MessageSendTester.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/iot/MessageSendTester.java
@@ -409,7 +409,7 @@ public class MessageSendTester {
 
             var json = new JsonObject(Buffer.buffer(((Data) body).getValue().getArray()));
             var testId = json.getString("test-id");
-            var timestamp = json.getInteger("timestamp");
+            var timestamp = json.getLong("timestamp");
             if (!this.testId.equals(testId) || timestamp == null) {
                 handleInvalidMessage(message);
                 return;
@@ -421,7 +421,7 @@ public class MessageSendTester {
         private void handleInvalidMessage(final Message message) {
         }
 
-        private void handleValidMessage(final Message message, int timestamp, final JsonObject payload) {
+        private void handleValidMessage(final Message message, long timestamp, final JsonObject payload) {
             var diff = System.currentTimeMillis() - timestamp;
             sendTime += diff;
             log.debug("Received message took {} ms", diff);

--- a/systemtests/src/main/java/io/enmasse/systemtest/iot/MessageSendTester.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/iot/MessageSendTester.java
@@ -5,15 +5,7 @@
 
 package io.enmasse.systemtest.iot;
 
-import io.enmasse.systemtest.amqp.AmqpClient;
-import io.enmasse.systemtest.logs.CustomLogger;
-import io.enmasse.systemtest.time.TimeoutBudget;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.json.JsonObject;
-import org.apache.qpid.proton.amqp.messaging.Data;
-import org.apache.qpid.proton.message.Message;
-import org.opentest4j.AssertionFailedError;
-import org.slf4j.Logger;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.time.Duration;
 import java.util.LinkedList;
@@ -23,7 +15,16 @@ import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import org.apache.qpid.proton.amqp.messaging.Data;
+import org.apache.qpid.proton.message.Message;
+import org.opentest4j.AssertionFailedError;
+import org.slf4j.Logger;
+
+import io.enmasse.systemtest.amqp.AmqpClient;
+import io.enmasse.systemtest.logs.CustomLogger;
+import io.enmasse.systemtest.time.TimeoutBudget;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
 
 /**
  * Run a message send test.
@@ -379,10 +380,14 @@ public class MessageSendTester {
 
             final int missing = MessageSendTester.this.amount - this.receivedMessages.size();
             if (missing > MessageSendTester.this.acceptableMessageLoss) {
-                fail(String.format("Unacceptable loss of messages - expected: %s, received: %s, acceptedLoss: %s, actualLoss: %s",
+                var msg = String.format("Unacceptable loss of messages - expected: %s, received: %s, acceptedLoss: %s, actualLoss: %s",
                         MessageSendTester.this.amount, this.receivedMessages.size(),
-                        MessageSendTester.this.acceptableMessageLoss, missing));
+                        MessageSendTester.this.acceptableMessageLoss, missing);
+                log.info("Test failed: {}", msg);
+                fail(msg);
             }
+
+            log.info("Result is ok");
         }
 
         private void startConsumer() {


### PR DESCRIPTION
This change tries to fix the issue when the tenant cleaner tries to
clean up a tenant from an infinispan cluster, which never got
the protobuf schema uploaded by the device registry.

In change 4824dbb7ae73eda147fccf9cb0b19553ed8f6699 the tenant cleaner
was changes to never upload the protobuf schema. But this may cause
the problem, that when an IoTProject is being created and deleted
without the device registry properly uploading the schema, then the
tenant cleaner will fail.

While in production the argument could be, that the device registry
should be brought up online, before starting to clean up IoTProjects,
in testing this might be an issue, especially when the test environment
gets broken by that situation.

So with this change, when the device registry is configured to upload
the schema, it will overwrite it (as before). While the tenant cleaner
will only set the schema if it does not exists.

### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
