### PR TITLE
Feat: implement authentication service dropdown

### DIFF
--- a/console/console-init/ui/src/Pages/CreateAddressSpace/ReviewAddressSpace.tsx
+++ b/console/console-init/ui/src/Pages/CreateAddressSpace/ReviewAddressSpace.tsx
@@ -75,7 +75,7 @@ export const ReviewAddressSpace: React.FunctionComponent<IAddressSpaceReview> = 
       </Title>
       <Title size="xl" style={{ marginBottom: 32 }}>
         {" "}
-        Review the information below and Click Finish to create the new address.
+        Review the information below and Click Finish to create the new address space.
         Use the Back button to make changes.
       </Title>
       <Grid>
@@ -89,50 +89,50 @@ export const ReviewAddressSpace: React.FunctionComponent<IAddressSpaceReview> = 
           <Grid>
             {name && (
               <>
-                <GridItem span={4} style={{ marginBottom: 16, marginRight: 5 }}>
+                <GridItem span={5} style={{ marginBottom: 16, marginRight: 5 }}>
                   Instance name
                 </GridItem>
-                <GridItem id="preview-addr-name" span={8}>
+                <GridItem id="preview-addr-name" span={7}>
                   {name}
                 </GridItem>
               </>
             )}
             {namespace && (
               <>
-                <GridItem span={4} style={{ marginBottom: 16, marginRight: 5 }}>
+                <GridItem span={5} style={{ marginBottom: 16, marginRight: 5 }}>
                   Namespace
                 </GridItem>
-                <GridItem id="preview-addr-name" span={8}>
+                <GridItem id="preview-addr-name" span={7}>
                   {namespace}
                 </GridItem>
               </>
             )}
             {type && type.trim() !== "" && (
               <>
-                <GridItem span={4} style={{ marginBottom: 16, marginRight: 5 }}>
+                <GridItem span={5} style={{ marginBottom: 16, marginRight: 5 }}>
                   Type
                 </GridItem>
-                <GridItem id="preview-addr-type" span={8}>
+                <GridItem id="preview-addr-type" span={7}>
                   {type}
                 </GridItem>
               </>
             )}
             {plan && plan.trim() !== "" && (
               <>
-                <GridItem span={4} style={{ marginBottom: 16, marginRight: 5 }}>
+                <GridItem span={5} style={{ marginBottom: 16, marginRight: 5 }}>
                   Plan
                 </GridItem>
-                <GridItem id="preview-addr-plan" span={8}>
+                <GridItem id="preview-addr-plan" span={7}>
                   {plan}
                 </GridItem>
               </>
             )}
             {authenticationService && authenticationService.trim() !== "" && (
               <>
-                <GridItem span={4} style={{ marginBottom: 16, marginRight: 5 }}>
+                <GridItem span={5} style={{ marginBottom: 16, marginRight: 5 }}>
                   Authentication Service
                 </GridItem>
-                <GridItem id="preview-addr-plan" span={8}>
+                <GridItem id="preview-addr-plan" span={7}>
                   {authenticationService}
                 </GridItem>
               </>

--- a/console/console-init/ui/src/Queries/Queries.tsx
+++ b/console/console-init/ui/src/Queries/Queries.tsx
@@ -1207,3 +1207,16 @@ export const RETURN_ALL_CONNECTIONS_HOSTNAME_AND_CONTAINERID_OF_ADDRESS_SPACES_F
   );
   return ALL_CONECTION_LIST;
 };
+
+export const RETURN_AUTHENTICATION_SERVICES = gql
+  `query addressspace_schema {
+    addressSpaceSchema_v2  {
+      ObjectMeta {
+        Name
+      }
+      Spec {
+        AuthenticationServices
+      }
+    }
+  }
+`;


### PR DESCRIPTION
* The authentication services dropdown is now getting populated through data returned by backend.
* The grid had to be adjusted to display address space preview properly.
* The as_create mutation was failing due to defect in PF dropdown which has been fixed.

