### PR TITLE
Safer cleanup in case GOPATH points to the wrong place

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ $(GOPRJ):
 	ln -s $(TOPDIR) $(GOPRJ)
 
 clean_go:
-	@rm -Rf $(GOPATH)
+	@rm -Rf $(GOPRJ)
 
 clean_java:
 	mvn -B -q clean $(MAVEN_ARGS)


### PR DESCRIPTION
Does it make sense? I don't fully understand how a clean could go wrong, but I am wondering if using some uncommon make version could cause it.