### PR TITLE
fix - ENTMQMAAS-1609, add orderBy clause for name and address

### DIFF
--- a/console/console-init/ui/src/Queries/Queries.tsx
+++ b/console/console-init/ui/src/Queries/Queries.tsx
@@ -826,10 +826,10 @@ export const RETURN_CONNECTION_LINKS = (
         orderByString = "";
         break;
       case 1:
-        orderByString = "";
+        orderByString = "`$.ObjectMeta.Name` ";
         break;
       case 2:
-        orderByString = "";
+        orderByString = "`$.Spec.Address` ";
         break;
       case 3:
         orderByString = "`$.Metrics[?(@.Name=='enmasse_deliveries')].Value` ";


### PR DESCRIPTION
### Description
address column ordering on the connection detail page not working