### PR TITLE
use correct method to delete iotproject in DeviceRegistryTest

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/iot/isolated/registry/DeviceRegistryTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/iot/isolated/registry/DeviceRegistryTest.java
@@ -288,7 +288,7 @@ abstract class DeviceRegistryTest extends TestBase implements ITestIoTIsolated {
             IoTUtils.checkCredentials(authId, newPassword, false, httpAdapterEndpoint, amqpClient, iotProject);
 
             // Now delete the tenant
-            IoTUtils.deleteIoTProjectAndWait(kubernetes, iotProject);
+            isolatedIoTManager.deleteIoTProject(iotProject);
 
             // second check, the credentials and device should be deleted
 


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

Fix test in DeviceRegistryTest which uses incorrect method to delete an IoTProject, this could be the cause of some issues

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
