### PR TITLE
Fix: remove extra filter icons

### DIFF
--- a/console/console-init/ui/src/Components/AddressSpaceList/AddressSpaceListFilter.tsx
+++ b/console/console-init/ui/src/Components/AddressSpaceList/AddressSpaceListFilter.tsx
@@ -414,11 +414,9 @@ export const AddressSpaceListFilter: React.FunctionComponent<IAddressSpaceListFi
                       isOpen={typeFilterIsExpanded}
                       toggle={
                         <DropdownToggle onToggle={setTypeFilterIsExpanded}>
-                          <FilterIcon />
-                          &nbsp;
                           {filterType && filterType.trim() !== ""
                             ? filterType
-                            : "Type"}
+                            : "Select Type"}
                         </DropdownToggle>
                       }
                       dropdownItems={typeFilterMenuItems.map(option => (

--- a/console/console-init/ui/src/Pages/AddressDetail/AddressLinksFilter.tsx
+++ b/console/console-init/ui/src/Pages/AddressDetail/AddressLinksFilter.tsx
@@ -439,8 +439,7 @@ export const AddressLinksFilter: React.FunctionComponent<IAddressLinksFilterProp
                   isOpen={roleIsExpanded}
                   toggle={
                     <DropdownToggle onToggle={setRoleIsExpanded}>
-                      <FilterIcon />
-                      &nbsp;{filterRole || "Select Role"}
+                      {filterRole || "Select Role"}
                     </DropdownToggle>
                   }
                   dropdownItems={roleMenuItems.map(option => (

--- a/console/console-init/ui/src/Pages/AddressSpaceDetail/AddressList/AddressListFilter.tsx
+++ b/console/console-init/ui/src/Pages/AddressSpaceDetail/AddressList/AddressListFilter.tsx
@@ -307,8 +307,7 @@ export const AddressListFilter: React.FunctionComponent<IAddressListFilterProps>
                     isOpen={typeIsExpanded}
                     toggle={
                       <DropdownToggle onToggle={setTypeIsExpanded}>
-                        <FilterIcon />
-                        &nbsp;{typeValue || "Select Type"}
+                        {typeValue || "Select Type"}
                       </DropdownToggle>
                     }
                     dropdownItems={typeMenuItems.map(option => (
@@ -340,7 +339,6 @@ export const AddressListFilter: React.FunctionComponent<IAddressListFilterProps>
                     isOpen={statusIsExpanded}
                     toggle={
                       <DropdownToggle onToggle={setStatusIsExpanded}>
-                        <FilterIcon />
                         &nbsp;{statusValue || "Select Status"}
                       </DropdownToggle>
                     }

--- a/console/console-init/ui/src/Pages/ConnectionDetail/ConnectionLinksFilter.tsx
+++ b/console/console-init/ui/src/Pages/ConnectionDetail/ConnectionLinksFilter.tsx
@@ -433,8 +433,7 @@ export const ConnectionLinksFilter: React.FunctionComponent<IConnectionLinksFilt
                   isOpen={roleIsExpanded}
                   toggle={
                     <DropdownToggle onToggle={setRoleIsExpanded}>
-                      <FilterIcon />
-                      &nbsp;{filterRole || "Select Role"}
+                      {filterRole || "Select Role"}
                     </DropdownToggle>
                   }
                   dropdownItems={roleMenuItems.map(option => (


### PR DESCRIPTION
The filters were showing  an extra unnecessary filter icon for certain drop down items.
