### PR TITLE
Start from empty object when extracting spec

### DIFF
--- a/agent/lib/internal_address_source.js
+++ b/agent/lib/internal_address_source.js
@@ -26,16 +26,9 @@ function extract_spec(def) {
     if (def.spec === undefined) {
         console.error('no spec found on %j', def);
     }
-    var o = myutils.merge(def.spec, {status:def.status});
+    var o = myutils.merge({}, def.spec, {status:def.status});
     o.name = def.metadata ? def.metadata.name : def.address;
-    if (def.metadata && def.metadata.annotations && def.metadata.annotations['enmasse.io/broker-id']) {
-        var broker_id = def.metadata.annotations['enmasse.io/broker-id'];
-        var cluster_id = def.metadata.annotations['cluster_id'];
-        if (cluster_id === undefined) {
-            cluster_id = broker_id;
-        }
-        o.allocated_to = [{clusterId: cluster_id, containerId: broker_id, state: 'Active'}];
-    }
+
     if (def.status && def.status.brokerStatuses) {
         o.allocated_to = def.status.brokerStatuses;
     }

--- a/agent/test/internal_address_source.js
+++ b/agent/test/internal_address_source.js
@@ -59,8 +59,8 @@ describe('configmap backed address source', function() {
         });
     });
     it('indicates allocation to broker', function(done) {
-        address_server.add_address_definition({address:'foo', type:'queue'}, undefined, '1234', {'enmasse.io/broker-id':'broker-1'});
-        address_server.add_address_definition({address:'bar', type:'topic'}, undefined, '1234', {'enmasse.io/broker-id':'broker-2'});
+        address_server.add_address_definition({address:'foo', type:'queue'}, undefined, '1234', undefined, {brokerStatuses:[{containerId: 'broker-1'}]});
+        address_server.add_address_definition({address:'bar', type:'topic'}, undefined, '1234', undefined, {brokerStatuses:[{containerId: 'broker-2'}]});
         address_server.add_address_definition({address:'baz', type:'anycast'}, undefined, '1234');
         var source = new AddressSource({port:address_server.port, host:'localhost', token:'foo', namespace:'default', INFRA_UUID: '1234'});
         source.start();

--- a/agent/test/ragent.js
+++ b/agent/test/ragent.js
@@ -1098,8 +1098,8 @@ describe('broker configuration', function() {
         var broker_a = new MockBroker('broker_a-0');
         var broker_b = new MockBroker('broker_b-0');
         Promise.all([connect_broker(broker_a), connect_broker(broker_b)]).then(function () {
-            address_source.add_address_definition({address:'a', type:'queue'}, undefined, '1234', {'cluster_id': 'broker_a', 'enmasse.io/broker-id':'broker_a-0'});
-            address_source.add_address_definition({address:'b', type:'queue'}, undefined, '1234', {'cluster_id': 'broker_b', 'enmasse.io/broker-id':'broker_b-0'});
+            address_source.add_address_definition({address:'a', type:'queue'}, undefined, '1234', undefined, {brokerStatuses:[{clusterId: 'broker_a', containerId:'broker_a-0', state: 'Active'}]});
+            address_source.add_address_definition({address:'b', type:'queue'}, undefined, '1234', undefined, {brokerStatuses:[{clusterId: 'broker_b', containerId:'broker_b-0', state: 'Active'}]});
             ragent.wait_for_stable(2, 1, 2).then(function () {
                 verify_addresses([{address:'a', type:'queue', allocated_to:[broker_state('broker_a')]}, {address:'b', type:'queue', allocated_to:[broker_state('broker_b')]}], router);
                 //verify queues on respective brokers:
@@ -1115,9 +1115,9 @@ describe('broker configuration', function() {
         var broker_a = new MockBroker('broker_a-0');
         var broker_b = new MockBroker('broker_b-0');
         Promise.all([connect_broker(broker_a), connect_broker(broker_b)]).then(function () {
-            address_source.add_address_definition({address:'a', type:'queue'}, 'address-config-a', '1234', {'cluster_id': 'broker_a', 'enmasse.io/broker-id':'broker_a-0'});
-            address_source.add_address_definition({address:'b', type:'queue'}, 'address-config-b', '1234', {'cluster_id': 'broker_b', 'enmasse.io/broker-id':'broker_b-0'});
-            address_source.add_address_definition({address:'c', type:'queue'}, 'address-config-c', '1234', {'cluster_id': 'broker_a', 'enmasse.io/broker-id':'broker_a-0'});
+            address_source.add_address_definition({address:'a', type:'queue'}, 'address-config-a', '1234', undefined, {brokerStatuses:[{clusterId: 'broker_a', containerId:'broker_a-0', state: 'Active'}]});
+            address_source.add_address_definition({address:'b', type:'queue'}, 'address-config-b', '1234', undefined, {brokerStatuses:[{clusterId: 'broker_b', containerId:'broker_b-0', state: 'Active'}]});
+            address_source.add_address_definition({address:'c', type:'queue'}, 'address-config-c', '1234', undefined, {brokerStatuses:[{clusterId: 'broker_a', containerId:'broker_a-0', state: 'Active'}]});
             ragent.wait_for_stable(3, 1, 2).then(function () {
                 verify_addresses([{address:'a', type:'queue', allocated_to:[broker_state('broker_a')]}, {address:'b', type:'queue', allocated_to:[broker_state('broker_b')]}, {address:'c', type:'queue', allocated_to:[broker_state('broker_a')]}], router);
                 //verify queues on respective brokers:
@@ -1140,10 +1140,10 @@ describe('broker configuration', function() {
         var broker_a = new MockBroker('broker_a-0');
         var broker_b = new MockBroker('broker_b-0');
         Promise.all([connect_broker(broker_a), connect_broker(broker_b)]).then(function () {
-            address_source.add_address_definition({address:'a', type:'topic'}, undefined, '1234', {'enmasse.io/broker-id':'broker_a-0'});
-            address_source.add_address_definition({address:'b', type:'topic'}, undefined, '1234', {'enmasse.io/broker-id':'broker_b-0'});
-            address_source.add_address_definition({address:'sub-a', type:'subscription', topic:'a'}, undefined, '1234', {'enmasse.io/broker-id':'broker_a-0'});
-            address_source.add_address_definition({address:'sub-b', type:'subscription', topic:'b'}, undefined, '1234', {'enmasse.io/broker-id':'broker_b-0'});
+            address_source.add_address_definition({address:'a', type:'topic'}, undefined, '1234', undefined, {brokerStatuses:[{containerId:'broker_a-0', state: 'Active'}]});
+            address_source.add_address_definition({address:'b', type:'topic'}, undefined, '1234', undefined, {brokerStatuses:[{containerId:'broker_b-0', state: 'Active'}]});
+            address_source.add_address_definition({address:'sub-a', type:'subscription', topic:'a'}, undefined, '1234', undefined, {brokerStatuses:[{containerId:'broker_a-0', state: 'Active'}]});
+            address_source.add_address_definition({address:'sub-b', type:'subscription', topic:'b'}, undefined, '1234', undefined, {brokerStatuses:[{containerId:'broker_b-0', state: 'Active'}]});
             ragent.wait_for_stable(4, 1, 2).then(function () {
                 verify_addresses([{address:'a', type:'topic', allocated_to:[broker_state('broker_a')]}, {address:'b', type:'topic', allocated_to:[broker_state('broker_b')]},
                                   {address:'sub-a', type:'subscription', topic:'a', allocated_to:[broker_state('broker_a')]},
@@ -1161,10 +1161,10 @@ describe('broker configuration', function() {
         var broker_a = new MockBroker('broker_a-0');
         var broker_b = new MockBroker('broker_b-0');
         Promise.all([connect_broker(broker_a), connect_broker(broker_b)]).then(function () {
-            address_source.add_address_definition({address:'sub-a', type:'subscription', topic:'topic-a'}, undefined, '1234', {'enmasse.io/broker-id':'broker_a-0'});
-            address_source.add_address_definition({address:'sub-b', type:'subscription', topic:'topic-b'}, undefined, '1234', {'enmasse.io/broker-id':'broker_b-0'});
-            address_source.add_address_definition({address:'topic-a', type:'topic'}, undefined, '1234', {'enmasse.io/broker-id':'broker_a-0'});
-            address_source.add_address_definition({address:'topic-b', type:'topic'}, undefined, '1234', {'enmasse.io/broker-id':'broker_b-0'});
+            address_source.add_address_definition({address:'sub-a', type:'subscription', topic:'topic-a'}, undefined, '1234', undefined, {brokerStatuses:[{containerId:'broker_a-0', state: 'Active'}]});
+            address_source.add_address_definition({address:'sub-b', type:'subscription', topic:'topic-b'}, undefined, '1234', undefined, {brokerStatuses:[{containerId:'broker_b-0', state: 'Active'}]});
+            address_source.add_address_definition({address:'topic-a', type:'topic'}, undefined, '1234', undefined, {brokerStatuses:[{containerId:'broker_a-0', state: 'Active'}]});
+            address_source.add_address_definition({address:'topic-b', type:'topic'}, undefined, '1234', undefined, {brokerStatuses:[{containerId:'broker_b-0', state: 'Active'}]});
             ragent.wait_for_stable(4, 1, 2).then(function () {
                 verify_addresses([{address:'topic-a', type:'topic', allocated_to:[broker_state('broker_a')]}, {address:'topic-b', type:'topic', allocated_to:[broker_state('broker_b')]},
                                   {address:'sub-a', type:'subscription', topic:'topic-a', allocated_to:[broker_state('broker_a')]},
@@ -1205,7 +1205,7 @@ describe('broker configuration', function() {
             desired.forEach(function (a, i) {
                 var allocated_to = i % 2 ? 'broker_a' : 'broker_b';
                 a.allocated_to = [broker_state(allocated_to)];
-                address_source.add_address_definition(a, undefined, '1234', {'cluster_id': allocated_to, 'enmasse.io/broker-id': allocated_to + "-0"});
+                address_source.add_address_definition(a, undefined, '1234', undefined, {brokerStatuses:[{clusterId: allocated_to, containerId: allocated_to + "-0", state: 'Active'}]});
             });
             ragent.wait_for_stable(2000, 1, 2).then(function () {
                 verify_addresses(desired, router);


### PR DESCRIPTION
### Type of change

- Bugfix


### Description

This prevents the original object from being modified and cause issues
for other address comparisons happening when addresses are updated. This
happened when objects were created from Go-based code where status field
was initialized.

Remove check for unused annotation.

### Checklist

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
