### PR TITLE
Fix: show partitions instead of shards for addresses

### DIFF
--- a/console/console-init/ui/src/Components/AddressDetail/AddressDetailHeader.tsx
+++ b/console/console-init/ui/src/Components/AddressDetail/AddressDetailHeader.tsx
@@ -24,7 +24,7 @@ export interface IAddressDetailHeaderProps {
   type: string;
   name: string;
   plan: string;
-  shards: number;
+  partitions: number;
   onEdit: (name: string) => void;
   onDelete: (name: string) => void;
 }
@@ -60,7 +60,7 @@ export const AddressDetailHeader: React.FunctionComponent<IAddressDetailHeaderPr
   type,
   name,
   plan,
-  shards,
+  partitions,
   onEdit,
   onDelete
 }) => {
@@ -113,9 +113,15 @@ export const AddressDetailHeader: React.FunctionComponent<IAddressDetailHeaderPr
             >
               <b>{plan}</b>
             </FlexItem>
-            <FlexItem id="adheader-shards">
-              Stored in <b>{shards}</b> Shard
-            </FlexItem>
+            { 
+              type === "queue"
+                &&
+              (
+                <FlexItem id="adheader-partitions">
+                  Stored in <b>{partitions}</b> Partitions
+                </FlexItem>
+              )
+            }
           </Flex>
         </SplitItem>
         <SplitItem isFilled></SplitItem>

--- a/console/console-init/ui/src/Components/AddressSpace/Address/AddressList.tsx
+++ b/console/console-init/ui/src/Components/AddressSpace/Address/AddressList.tsx
@@ -31,7 +31,7 @@ export interface IAddress {
   storedMessages: number;
   senders: number;
   receivers: number;
-  shards: number;
+  partitions: number;
   isReady: boolean;
   errorMessages?: string[];
   status?: string;
@@ -95,7 +95,7 @@ export const AddressList: React.FunctionComponent<IAddressListProps> = ({
           row.storedMessages,
           row.senders,
           row.receivers,
-          row.shards
+          row.type == "queue" ? row.partitions : ""
         ],
         originalData: row
       };
@@ -152,7 +152,7 @@ export const AddressList: React.FunctionComponent<IAddressListProps> = ({
     { title: "Stored Messages", transforms: [sortable] },
     "Senders",
     "Receivers",
-    "Shards"
+    "Partitions"
   ];
 
   const onSelect = (

--- a/console/console-init/ui/src/Pages/AddressDetail/AddressDetailPage.tsx
+++ b/console/console-init/ui/src/Pages/AddressDetail/AddressDetailPage.tsx
@@ -142,7 +142,7 @@ export default function AddressDetailPage() {
           type={addressDetail.Spec.Plan.Spec.AddressType}
           name={addressDetail.Spec.Address}
           plan={addressDetail.Spec.Plan.Spec.DisplayName}
-          shards={getFilteredValue(
+          partitions={getFilteredValue(
             addressDetail.Metrics,
             "enmasse_messages_stored"
           )}

--- a/console/console-init/ui/src/Pages/AddressSpaceDetail/AddressList/AddressListPage.tsx
+++ b/console/console-init/ui/src/Pages/AddressSpaceDetail/AddressList/AddressListPage.tsx
@@ -103,7 +103,7 @@ export const AddressListPage: React.FunctionComponent<IAddressListPageProps> = (
     ),
     senders: getFilteredValue(address.Metrics, "enmasse_senders"),
     receivers: getFilteredValue(address.Metrics, "enmasse_receivers"),
-    shards: address.Status.PlanStatus.Partitions,
+    partitions: address.Status.PlanStatus.Partitions,
     isReady: address.Status.IsReady,
     status: address.Status.Phase,
     errorMessages: address.Status.Messages

--- a/console/console-init/ui/src/Tests/AddressDetialHeader.test.tsx
+++ b/console/console-init/ui/src/Tests/AddressDetialHeader.test.tsx
@@ -14,9 +14,9 @@ describe("Address Detail Header", () => {
   test("it renders address space headers at top", () => {
     const props: IAddressDetailHeaderProps = {
       name: "newqueue",
-      type: "Queue",
+      type: "queue",
       plan: "Small",
-      shards: 2,
+      partitions: 2,
       onDelete: () => {},
       onEdit: () => {}
     };
@@ -25,6 +25,6 @@ describe("Address Detail Header", () => {
 
     getByText(props.name);
     getByText(props.plan);
-    getByText(String(props.shards));
+    getByText(String(props.partitions));
   });
 });

--- a/console/console-init/ui/src/Tests/AddressList.test.tsx
+++ b/console/console-init/ui/src/Tests/AddressList.test.tsx
@@ -18,7 +18,7 @@ describe("Address List", () => {
       {
         name: "leo_b",
         namespace: "leo_b",
-        type: "Queue",
+        type: "queue",
         planLabel: "small",
         planValue: "",
         messagesIn: 8,
@@ -26,14 +26,14 @@ describe("Address List", () => {
         storedMessages: 10,
         senders: 11,
         receivers: 12,
-        shards: 13,
+        partitions: 13,
         status: "running",
         isReady: true
       },
       {
         name: "newqueue",
         namespace: "newqueue",
-        type: "Random",
+        type: "queue",
         planLabel: "large",
         planValue: "",
         messagesIn: 2,
@@ -41,7 +41,7 @@ describe("Address List", () => {
         storedMessages: 4,
         senders: 5,
         receivers: 6,
-        shards: 7,
+        partitions: 7,
         status: "creating",
         isReady: true
       }
@@ -68,7 +68,7 @@ describe("Address List", () => {
     getByText(addresses[0].storedMessages.toString());
     getByText(addresses[0].senders.toString());
     getByText(addresses[0].receivers.toString());
-    getByText(addresses[0].shards.toString());
+    getByText(addresses[0].partitions.toString());
 
     //Testing elements of second row
     getByText(addresses[1].name);
@@ -79,7 +79,7 @@ describe("Address List", () => {
     getByText(addresses[1].storedMessages.toString());
     getByText(addresses[1].senders.toString());
     getByText(addresses[1].receivers.toString());
-    getByText(addresses[1].shards.toString());
+    getByText(addresses[1].partitions.toString());
   });
 });
 

--- a/console/console-init/ui/src/stories/AddressDetailHeader.stories.tsx
+++ b/console/console-init/ui/src/stories/AddressDetailHeader.stories.tsx
@@ -20,7 +20,7 @@ export const AddressDetailHead = () => (
       type={text("Type", "Queue")}
       name={text("Name", "newqueue")}
       plan={text("Plan", "Small")}
-      shards={number("shard", 1)}
+      partitions={number("partition", 1)}
       onEdit={action("onEdit Clicked")}
       onDelete={action("onDelete Clicked")}
     />

--- a/console/console-init/ui/src/stories/AddressList.stories.tsx
+++ b/console/console-init/ui/src/stories/AddressList.stories.tsx
@@ -30,7 +30,7 @@ const rows: IAddress[] = [
     storedMessages: 123,
     senders: 123,
     receivers: 123,
-    shards: 123,
+    partitions: 123,
     isReady: true,
     status: "running"
   },
@@ -45,7 +45,7 @@ const rows: IAddress[] = [
     storedMessages: 123,
     senders: 123,
     receivers: 123,
-    shards: 123,
+    partitions: 123,
     isReady: true,
     status: "creating"
   },
@@ -60,7 +60,7 @@ const rows: IAddress[] = [
     storedMessages: 123,
     senders: 123,
     receivers: 123,
-    shards: 123,
+    partitions: 123,
     isReady: true,
     status: "deleting"
   }


### PR DESCRIPTION
Shards has been replaced with Partitions for addresses. The partitions is being shown only for addresses of type queue.

#### AddressListTable

![Screenshot from 2020-01-21 22-59-28](https://user-images.githubusercontent.com/23582438/72828134-12713900-3ca2-11ea-80c0-6b55b7a583b5.png)

#### AddressDetailHeader for queues

![Screenshot from 2020-01-21 23-00-21](https://user-images.githubusercontent.com/23582438/72828198-316fcb00-3ca2-11ea-94b7-bbe9b6f14652.png)

#### AddressDetailHeader for subscriptions

![Screenshot from 2020-01-21 23-00-47](https://user-images.githubusercontent.com/23582438/72828238-4187aa80-3ca2-11ea-92dd-ad4ae945bc18.png)
