### PR TITLE
Fix - connection detail page to use connecion's hostname rather than id

### DIFF
--- a/console/console-init/ui/src/Pages/ConnectionDetail/ConnectionDetailPage.tsx
+++ b/console/console-init/ui/src/Pages/ConnectionDetail/ConnectionDetailPage.tsx
@@ -85,8 +85,8 @@ export default function ConnectionDetailPage() {
   );
 
   const connectionDetail: IConnectionHeaderDetailProps = {
-    hostname: connection.ObjectMeta.Name,
-    containerId: connection.ObjectMeta.Namespace,
+    hostname: connection.Spec.Hostname,
+    containerId: connection.Spec.ContainerId,
     version: getProductFilteredValue(connection.Spec.Properties, "version"),
     protocol: connection.Spec.Protocol.toUpperCase(),
     encrypted: connection.Spec.Encrypted || false,


### PR DESCRIPTION
### Description 
Fix - On the connection detail page, use the connection's hostname as a title rather than the uuid.