### PR TITLE
Fix -  Use address on the address list page rather than name

### DIFF
--- a/console/console-init/ui/src/Components/AddressSpace/Address/AddressList.tsx
+++ b/console/console-init/ui/src/Components/AddressSpace/Address/AddressList.tsx
@@ -22,6 +22,7 @@ import useWindowDimensions from "src/Components/Common/WindowDimension";
 
 export interface IAddress {
   name: string;
+  displayName:string;
   namespace: string;
   type: string;
   planLabel: string;
@@ -72,7 +73,7 @@ export const AddressList: React.FunctionComponent<IAddressListProps> = ({
     if (row.isReady) {
       const tableRow: IRowData = {
         cells: [
-          { title: <Link to={`addresses/${row.name}`}>{row.name}</Link> },
+          { title: <Link to={`addresses/${row.name}`}>{row.displayName}</Link> },
           { title: <TypePlan type={row.type} plan={row.planLabel} /> },
           {
             title: (
@@ -103,7 +104,7 @@ export const AddressList: React.FunctionComponent<IAddressListProps> = ({
     } else {
       const tableRow: IRowData = {
         cells: [
-          { title: <Link to={`addresses/${row.name}`}>{row.name}</Link> },
+          { title: <Link to={`addresses/${row.name}`}>{row.displayName}</Link> },
           { title: <TypePlan type={row.type} plan={row.planLabel} /> },
           {
             title: row.errorMessages ? (

--- a/console/console-init/ui/src/Pages/AddressDetail/AddressDetailPage.tsx
+++ b/console/console-init/ui/src/Pages/AddressDetail/AddressDetailPage.tsx
@@ -68,6 +68,7 @@ export default function AddressDetailPage() {
     RETURN_ADDRESS_DETAIL(name, namespace, addressname),
     { pollInterval: 20000 }
   );
+  console.log(data)
 
   const addressSpaces = useQuery<IAddressSpacePlanResponse>(
     CURRENT_ADDRESS_SPACE_PLAN(name, namespace)
@@ -120,7 +121,7 @@ export default function AddressDetailPage() {
     if (addressDetail && type) {
       await client.mutate({
         mutation: EDIT_ADDRESS,
-        variables: {
+        variables: {  
           a: {
             Name: addressDetail.ObjectMeta.Name,
             Namespace: addressDetail.ObjectMeta.Namespace.toString()

--- a/console/console-init/ui/src/Pages/AddressSpaceDetail/AddressList/AddressListFilter.tsx
+++ b/console/console-init/ui/src/Pages/AddressSpaceDetail/AddressList/AddressListFilter.tsx
@@ -155,7 +155,7 @@ export const AddressListFilter: React.FunctionComponent<IAddressListFilterProps>
       } else {
         const obtainedList = response.data.addresses.Addresses.map(
           (address: any) => {
-            return address.ObjectMeta.Name;
+            return address.Spec.Address;
           }
         );
         setNameOptions(obtainedList);

--- a/console/console-init/ui/src/Pages/AddressSpaceDetail/AddressList/AddressListPage.tsx
+++ b/console/console-init/ui/src/Pages/AddressSpaceDetail/AddressList/AddressListPage.tsx
@@ -88,9 +88,11 @@ export const AddressListPage: React.FunctionComponent<IAddressListPageProps> = (
   const { addresses } = data || {
     addresses: { Total: 0, Addresses: [] }
   };
+  console.log(data);
   setTotalAddress(addresses.Total);
   const addressesList: IAddress[] = addresses.Addresses.map(address => ({
-    name: address.Spec.Address,
+    name: address.ObjectMeta.Name,
+    displayName:address.Spec.Address,
     namespace: address.ObjectMeta.Namespace,
     type: address.Spec.Type,
     planLabel: address.Spec.Plan.Spec.DisplayName,
@@ -218,7 +220,7 @@ export const AddressListPage: React.FunctionComponent<IAddressListPageProps> = (
       )}
       {addressBeingDeleted && (
         <DeletePrompt
-          detail={`Are you sure you want to delete ${addressBeingDeleted.name} ?`}
+          detail={`Are you sure you want to delete ${addressBeingDeleted.displayName} ?`}
           name={addressBeingDeleted.name}
           header="Delete this Address  ?"
           handleCancelDelete={handleCancelDelete}

--- a/console/console-init/ui/src/Pages/AddressSpaceDetail/AddressList/AddressListPage.tsx
+++ b/console/console-init/ui/src/Pages/AddressSpaceDetail/AddressList/AddressListPage.tsx
@@ -90,7 +90,7 @@ export const AddressListPage: React.FunctionComponent<IAddressListPageProps> = (
   };
   setTotalAddress(addresses.Total);
   const addressesList: IAddress[] = addresses.Addresses.map(address => ({
-    name: address.ObjectMeta.Name,
+    name: address.Spec.Address,
     namespace: address.ObjectMeta.Namespace,
     type: address.Spec.Type,
     planLabel: address.Spec.Plan.Spec.DisplayName,

--- a/console/console-init/ui/src/Queries/Queries.tsx
+++ b/console/console-init/ui/src/Queries/Queries.tsx
@@ -162,25 +162,25 @@ export const RETURN_ALL_ADDRESS_FOR_ADDRESS_SPACE = (
   if (filterNames && filterNames.length > 0) {
     if (filterNames.length > 1) {
       if(filterNames[0].isExact)
-        filterString += "(`$.ObjectMeta.Name` = '" + filterNames[0].value.trim() + "'";
+        filterString += "(`$.Spec.Address` = '" + filterNames[0].value.trim() + "'";
       else
-        filterString += "(`$.ObjectMeta.Name` LIKE '" + filterNames[0].value.trim() + "%' ";
+        filterString += "(`$.Spec.Address` LIKE '" + filterNames[0].value.trim() + "%' ";
       for (let i = 1; i < filterNames.length; i++) {
         if(filterNames[i].isExact){
           filterString +=
-            "OR `$.ObjectMeta.Name` = '" + filterNames[i].value.trim() + "'";
+            "OR `$.Spec.Address` = '" + filterNames[i].value.trim() + "'";
         }
         else{
           filterString +=
-            "OR `$.ObjectMeta.Name` LIKE '" + filterNames[i].value.trim() + "%' ";
+            "OR `$.Spec.Address` LIKE '" + filterNames[i].value.trim() + "%' ";
         }   
       }
       filterString += ")";
     } else {
         if(filterNames[0].isExact)
-          filterString += "`$.ObjectMeta.Name` = '" + filterNames[0].value.trim() + "'";
+          filterString += "`$.Spec.Address` = '" + filterNames[0].value.trim() + "'";
         else
-          filterString += "`$.ObjectMeta.Name` LIKE '" + filterNames[0].value.trim() + "%' ";
+          filterString += "`$.Spec.Address` LIKE '" + filterNames[0].value.trim() + "%' ";
     }
   }
   if (filterNames && filterNames.length > 0 && (typeValue || statusValue)) {
@@ -1226,7 +1226,7 @@ export const RETURN_ALL_ADDRESS_NAMES_OF_ADDRESS_SPACES_FOR_TYPEAHEAD_SEARCH = (
   }
   if (name && name.trim() != "") {
     filterString += " AND ";
-    filterString += "`$.ObjectMeta.Name` LIKE '" + name.trim() + "%' ";
+    filterString += "`$.Spec.Address` LIKE '" + name.trim() + "%' ";
   }
   const ALL_ADDRESS_FOR_ADDRESS_SPACE = gql`
   query all_addresses_for_addressspace_view {
@@ -1235,8 +1235,8 @@ export const RETURN_ALL_ADDRESS_NAMES_OF_ADDRESS_SPACES_FOR_TYPEAHEAD_SEARCH = (
     ) {
       Total
       Addresses {
-        ObjectMeta {
-          Name
+        Spec{
+          Address
         }
       }
     }

--- a/console/console-init/ui/src/Tests/AddressList.test.tsx
+++ b/console/console-init/ui/src/Tests/AddressList.test.tsx
@@ -17,6 +17,7 @@ describe("Address List", () => {
     const addresses: IAddress[] = [
       {
         name: "leo_b",
+        displayName:"leo_b",
         namespace: "leo_b",
         type: "Queue",
         planLabel: "small",
@@ -32,6 +33,7 @@ describe("Address List", () => {
       },
       {
         name: "newqueue",
+        displayName:"newqueue",
         namespace: "newqueue",
         type: "Random",
         planLabel: "large",

--- a/console/console-init/ui/src/Types/ResponseTypes.tsx
+++ b/console/console-init/ui/src/Types/ResponseTypes.tsx
@@ -288,8 +288,8 @@ export interface IAddressListNameSearchResponse {
   addresses: {
     Total: number;
     Addresses: Array<{
-      ObjectMeta: {
-        Name: string;
+      Spec: {
+        Address: string;
       };
     }>;
   };

--- a/console/console-init/ui/src/stories/AddressList.stories.tsx
+++ b/console/console-init/ui/src/stories/AddressList.stories.tsx
@@ -20,7 +20,8 @@ export default {
 
 const rows: IAddress[] = [
   {
-    name: "foo",
+    name: "foo.juu",
+    displayName:"juu",
     namespace: "foo",
     type: "Queue",
     planLabel: "small",
@@ -35,7 +36,8 @@ const rows: IAddress[] = [
     status: "running"
   },
   {
-    name: "foo",
+    name: "foo.hui",
+    displayName:"hui",
     namespace: "foo",
     type: "Queue",
     planLabel: "small",
@@ -50,7 +52,8 @@ const rows: IAddress[] = [
     status: "creating"
   },
   {
-    name: "foo",
+    name: "foo.ganymede",
+    displayName:"ganymede",
     namespace: "foo",
     type: "Queue",
     planLabel: "small",


### PR DESCRIPTION
### Description 
Fix - On the address list page, replace the name column with an address column (address.Spec.Address). The name filter should be changed into a filter on address name. In the address creation dialogue collect the address rather than the name.