### PR TITLE
Fix: hide stored messages for anycast/multicast address types

### DIFF
--- a/console/console-init/ui/src/Components/AddressSpace/Address/AddressList.tsx
+++ b/console/console-init/ui/src/Components/AddressSpace/Address/AddressList.tsx
@@ -92,7 +92,7 @@ export const AddressList: React.FunctionComponent<IAddressListProps> = ({
               />
             )
           },
-          row.storedMessages,
+          row.type === "multicast" || row.type === "anycast"? "" : row.storedMessages,
           row.senders,
           row.receivers,
           row.shards


### PR DESCRIPTION
On the address list page, the stored message value has been hidden for rows corresponding to anycast and mulicast addressTypes.