### PR TITLE
Fix: Change Name /Namespace label of AddressSpaceList

### DIFF
--- a/console/console-init/ui/src/Components/AddressSpaceList/AddressSpaceList.tsx
+++ b/console/console-init/ui/src/Components/AddressSpaceList/AddressSpaceList.tsx
@@ -113,7 +113,18 @@ export const AddressSpaceList: React.FunctionComponent<IAddressListProps> = ({
 
   useEffect(() => setTableRows(rows.map(toTableCells)), [rows]);
   const tableColumns = [
-    { title: "Name/Name Space", transforms: [sortable] },
+    { 
+      title: (
+        <span style={{ display: "inline-flex"}}>
+          <div>
+            Name
+            <br />
+            <small>Namespace</small>
+          </div>
+        </span>
+      ),
+      transforms: [sortable]
+    },
     "Type",
     "Status",
     "Time created"


### PR DESCRIPTION
The name/namespace label of AddressSpaceList has been substituted with a line break separation.

#### Current appearance : 

![Screenshot from 2020-01-22 19-04-50](https://user-images.githubusercontent.com/23582438/72902274-2fb11080-3d51-11ea-8f09-87e6c3e13442.png)
