### PR TITLE
Limit objects that the user may see by filtering using cached SelfSubjectAccessReviews

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ replace (
 require (
 	github.com/99designs/gqlgen v0.10.1
 	github.com/Nerzal/gocloak/v3 v3.7.0
+	github.com/alexedwards/scs/v2 v2.2.0
 	github.com/fortytw2/leaktest v1.3.0 // indirect
 	github.com/go-logr/logr v0.1.0
 	github.com/google/go-cmp v0.3.2-0.20191216211814-5a6f75716e12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 h1:Hs82Z41s6SdL1CELW+XaDYmOH4hkBN4/N9og/AsOv7E=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alexedwards/scs/v2 v2.2.0 h1:C0iQ8WHgzEe0zck4whkzvCXnLMP/rw2AM6BdQYNa4/c=
+github.com/alexedwards/scs/v2 v2.2.0/go.mod h1:ToaROZxyKukJKT/xLcVQAChi5k6+Pn1Gvmdl7h3RRj8=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=

--- a/pkg/consolegraphql/accesscontroller/access_controller.go
+++ b/pkg/consolegraphql/accesscontroller/access_controller.go
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ *
+ */
+
+package accesscontroller
+
+import (
+	"github.com/enmasseproject/enmasse/pkg/consolegraphql/cache"
+	authv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/kubernetes"
+)
+
+type AccessController interface {
+	CanRead(obj interface{}) (bool, error)
+	ViewFilter() cache.ObjectFilter
+}
+
+type AccessControlledResource interface {
+	GetControllingResourceAttributes() *authv1.ResourceAttributes
+}
+
+type allowAll struct {
+}
+
+func NewAllowAllAccessController() AccessController {
+	return &allowAll{}
+}
+
+func (a *allowAll) CanRead(obj interface{}) (bool, error) {
+	return true, nil
+}
+
+func (a *allowAll) ViewFilter() cache.ObjectFilter {
+	return func(obj interface{}) (bool, bool, error) {
+		return true, true, nil
+	}
+}
+
+type kubernetesRbac struct {
+	clientSet         kubernetes.Interface
+	cachedPermissions map[authv1.ResourceAttributes]bool
+}
+
+func NewKubernetesRBACAccessController(clientSet kubernetes.Interface) AccessController {
+	return &kubernetesRbac{
+		clientSet: clientSet,
+		cachedPermissions: make(map[authv1.ResourceAttributes]bool, 0),
+	}
+}
+
+func (k *kubernetesRbac) CanRead(obj interface{}) (bool, error) {
+	switch o := obj.(type) {
+	case AccessControlledResource:
+		attributes := o.GetControllingResourceAttributes()
+		if attributes == nil {
+			return false, nil
+		}
+
+		resourceAttributes := attributes.DeepCopy()
+		resourceAttributes.Verb = "get"
+		return k.makeAccessDecision(resourceAttributes)
+	case *corev1.Namespace:
+		gvk := o.TypeMeta.GroupVersionKind()
+		plural, _ := meta.UnsafeGuessKindToResource(gvk)
+
+		attributes := &authv1.ResourceAttributes{
+			Verb:      "get",
+			Resource:  plural.Resource, // Resource is Kind
+			Version:   gvk.Version,
+			Namespace: o.Name,
+		}
+		return k.makeAccessDecision(attributes)
+	default:
+		return true, nil
+	}
+}
+
+func (a *kubernetesRbac) ViewFilter() cache.ObjectFilter {
+	return FilterAdapter(a)
+}
+
+func  (k *kubernetesRbac) makeAccessDecision(resourceAttributes *authv1.ResourceAttributes) (bool, error) {
+	if decision, present := k.cachedPermissions[*resourceAttributes]; present {
+		// TODO: Implement expiry
+		// TODO: use of map - thread safety concerns? check me.
+		return decision, nil
+	}
+
+	ssar := &authv1.SelfSubjectAccessReview{
+		Spec: authv1.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: resourceAttributes,
+		},
+	}
+
+	resp, err := k.clientSet.AuthorizationV1().SelfSubjectAccessReviews().Create(ssar)
+	if err != nil {
+		return false, err
+	} else {
+		k.cachedPermissions[*resourceAttributes] = resp.Status.Allowed
+		return resp.Status.Allowed, nil
+	}
+}
+
+
+func FilterAdapter(controller AccessController) cache.ObjectFilter {
+	return func(obj interface{}) (bool, bool, error) {
+		readable, err := controller.CanRead(obj)
+		return readable, true, err
+	}
+}
+
+

--- a/pkg/consolegraphql/accesscontroller/access_controller_test.go
+++ b/pkg/consolegraphql/accesscontroller/access_controller_test.go
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ *
+ */
+
+package accesscontroller
+
+import (
+	"github.com/enmasseproject/enmasse/pkg/apis/enmasse/v1beta1"
+	"github.com/enmasseproject/enmasse/pkg/consolegraphql"
+	"github.com/stretchr/testify/assert"
+	authv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	clientTesting "k8s.io/client-go/testing"
+	"testing"
+)
+
+type acTestResource struct {
+	clientset kubernetes.Interface
+}
+
+func newAcTestResource(*testing.T) *acTestResource {
+	return &acTestResource{
+		clientset: &fake.Clientset{},
+	}
+}
+
+func TestReadAddressAllowed(t *testing.T) {
+	tr := newAcTestResource(t)
+
+	accessController := NewKubernetesRBACAccessController(tr.clientset)
+	address := createAddress("foons", "foo")
+
+	configureReactor(tr.clientset, ssarResponseYielding(true))
+	read, err := accessController.CanRead(address)
+	assert.NoError(t, err)
+	assert.True(t, read)
+}
+
+func TestAllowedAccessRequestsCached(t *testing.T) {
+	tr := newAcTestResource(t)
+
+	accessController := NewKubernetesRBACAccessController(tr.clientset)
+	address1 := createAddress("foons", "foo1")
+	address2 := createAddress("foons", "foo2")
+
+	ssars := 0
+	configureReactor(tr.clientset, ssarResponseYielding(true, func() {ssars++}))
+
+	read, err := accessController.CanRead(address1)
+	assert.NoError(t, err)
+	assert.True(t, read)
+	assert.Equal(t, 1, ssars)
+
+	read, err = accessController.CanRead(address2)
+	assert.NoError(t, err)
+	assert.True(t, read)
+	assert.Equal(t, 1, ssars)
+
+	read, err = accessController.CanRead(address1)
+	assert.NoError(t, err)
+	assert.True(t, read)
+	assert.Equal(t, 1, ssars)
+
+}
+
+func TestReadAddressesDifferentNamespacePermissions(t *testing.T) {
+	tr := newAcTestResource(t)
+
+	accessController := NewKubernetesRBACAccessController(tr.clientset)
+	addr1 := createAddress("secretns", "myaddr")
+	addr2 := createAddress("publicns", "myaddr")
+
+	configureReactor(tr.clientset, ssarResponseDenyMatching(
+		&authv1.ResourceAttributes{
+			Namespace:   addr1.Namespace,
+			Group:       "enmasse.io",
+			Version:     "v1beta1",
+			Resource:    "addresses",
+		}))
+
+	addr1Readable, err := accessController.CanRead(addr1)
+	assert.NoError(t, err)
+	assert.False(t, addr1Readable)
+
+	addr2Readable, err := accessController.CanRead(addr2)
+	assert.NoError(t, err)
+	assert.True(t, addr2Readable)
+
+}
+
+
+func TestReadNamespaceAllowed(t *testing.T) {
+	tr := newAcTestResource(t)
+
+	accessController := NewKubernetesRBACAccessController(tr.clientset)
+	namespace := createNamespace("foons")
+
+	configureReactor(tr.clientset, ssarResponseYielding(true))
+	read, err := accessController.CanRead(namespace)
+	assert.NoError(t, err)
+	assert.True(t, read)
+}
+
+func TestReadNamespaceDenied(t *testing.T) {
+	tr := newAcTestResource(t)
+
+	accessController := NewKubernetesRBACAccessController(tr.clientset)
+	namespace := createNamespace("foons")
+
+	configureReactor(tr.clientset, ssarResponseDenyMatching(
+		&authv1.ResourceAttributes{
+			Namespace:   namespace.Name,
+			Version:     "v1",
+			Resource:    "namespaces",
+		}))
+
+	read, err := accessController.CanRead(namespace)
+	assert.NoError(t, err)
+	assert.False(t, read)
+}
+
+
+/* {"namespace":"foo","verb":"get","resource":"namespaces"} */
+
+func createAddress(namespace, name string) *consolegraphql.AddressHolder {
+	address := &consolegraphql.AddressHolder{
+		Address: v1beta1.Address{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "enmasse.io/v1beta1",
+				Kind:       "Address",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name: name,
+			},
+		},
+	}
+	return address
+}
+
+func createNamespace(name string) *corev1.Namespace {
+	namespace := &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Namespace",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	return namespace
+}
+
+
+func configureReactor(clientset kubernetes.Interface, function func(action clientTesting.Action) (handled bool, ret runtime.Object, err error)) {
+	clientset.(*fake.Clientset).Fake.AddReactor("create", "selfsubjectaccessreviews", function)
+}
+
+func ssarResponseDenyMatching(denied... *authv1.ResourceAttributes) func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+	return func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+		// NB 'create' here refers to the sending of the SSAR itself rather than its object
+		create := action.(clientTesting.CreateAction)
+		review := create.GetObject().(*authv1.SelfSubjectAccessReview).Spec.ResourceAttributes
+
+
+		allowed := true
+		for _, deny := range denied {
+			if deny.Namespace == review.Namespace &&
+				deny.Name == review.Name &&
+				deny.Version == review.Version &&
+				deny.Resource == review.Resource &&
+				deny.Group == review.Group {
+				allowed = false
+				break
+			}
+		}
+
+		res := &authv1.SelfSubjectAccessReview{
+			Status: authv1.SubjectAccessReviewStatus{
+				Allowed: allowed,
+			},
+		}
+
+		return true, res, nil
+	}
+}
+
+func ssarResponseYielding(result bool, cbs... func()) func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+	return func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+
+		for _, cb := range cbs {
+			cb()
+		}
+
+		res := &authv1.SelfSubjectAccessReview{
+			Status: authv1.SubjectAccessReviewStatus{
+				Allowed: result,
+			},
+		}
+
+		return true, res, nil
+	}
+}

--- a/pkg/consolegraphql/resolvers/resolver_address.go
+++ b/pkg/consolegraphql/resolvers/resolver_address.go
@@ -77,6 +77,9 @@ func (r *Resolver) AddressSpec_enmasse_io_v1beta1() AddressSpec_enmasse_io_v1bet
 type addressSpecK8sResolver struct{ *Resolver }
 
 func (r *queryResolver) Addresses(ctx context.Context, first *int, offset *int, filter *string, orderBy *string) (*AddressQueryResultConsoleapiEnmasseIoV1beta1, error) {
+	requestState := server.GetRequestStateFromContext(ctx)
+	viewFilter := requestState.AccessController.ViewFilter()
+
 	fltrfunc, e := BuildFilter(filter)
 	if e != nil {
 		return nil, e
@@ -87,7 +90,7 @@ func (r *queryResolver) Addresses(ctx context.Context, first *int, offset *int, 
 		return nil, e
 	}
 
-	objects, e := r.Cache.Get(cache.PrimaryObjectIndex, "Address/", fltrfunc)
+	objects, e := r.Cache.Get(cache.PrimaryObjectIndex, "Address/", cache.And(viewFilter, fltrfunc))
 	if e != nil {
 		return nil, e
 	}

--- a/pkg/consolegraphql/resolvers/resolver_addressspace.go
+++ b/pkg/consolegraphql/resolvers/resolver_addressspace.go
@@ -26,6 +26,9 @@ func (r *Resolver) AddressSpaceSpec_enmasse_io_v1beta1() AddressSpaceSpec_enmass
 }
 
 func (r *queryResolver) AddressSpaces(ctx context.Context, first *int, offset *int, filter *string, orderBy *string) (*AddressSpaceQueryResultConsoleapiEnmasseIoV1beta1, error) {
+	requestState := server.GetRequestStateFromContext(ctx)
+	viewFilter := requestState.AccessController.ViewFilter()
+
 	fltrfunc, err := BuildFilter(filter)
 	if err != nil {
 		return nil, err
@@ -36,7 +39,7 @@ func (r *queryResolver) AddressSpaces(ctx context.Context, first *int, offset *i
 		return nil, err
 	}
 
-	objects, e := r.Cache.Get(cache.PrimaryObjectIndex, "AddressSpace/", fltrfunc)
+	objects, e := r.Cache.Get(cache.PrimaryObjectIndex, "AddressSpace/", cache.And(viewFilter, fltrfunc))
 	if e != nil {
 		return nil, e
 	}

--- a/pkg/consolegraphql/resolvers/resolver_addressspace.go
+++ b/pkg/consolegraphql/resolvers/resolver_addressspace.go
@@ -114,10 +114,7 @@ func (r *addressSpaceSpecK8sResolver) Type(ctx context.Context, obj *v1beta1.Add
 	return spaceType, nil
 }
 
-
-
 type addressSpaceK8sResolver struct{ *Resolver }
-
 
 func (r *addressSpaceK8sResolver) Connections(ctx context.Context, obj *consolegraphql.AddressSpaceHolder, first *int, offset *int, filter *string, orderBy *string) (*ConnectionQueryResultConsoleapiEnmasseIoV1beta1, error) {
 	if obj != nil {
@@ -160,6 +157,9 @@ func (r *addressSpaceK8sResolver) Connections(ctx context.Context, obj *consoleg
 
 func (r *addressSpaceK8sResolver) Addresses(ctx context.Context, obj *consolegraphql.AddressSpaceHolder, first *int, offset *int, filter *string, orderBy *string) (*AddressQueryResultConsoleapiEnmasseIoV1beta1, error) {
 	if obj != nil {
+		requestState := server.GetRequestStateFromContext(ctx)
+		viewFilter := requestState.AccessController.ViewFilter()
+
 		fltrfunc, e := BuildFilter(filter)
 		if e != nil {
 			return nil, e
@@ -171,7 +171,7 @@ func (r *addressSpaceK8sResolver) Addresses(ctx context.Context, obj *consolegra
 		}
 
 		key := fmt.Sprintf("Address/%s/%s/", obj.Namespace, obj.Name)
-		objects, e := r.Cache.Get(cache.PrimaryObjectIndex, key, fltrfunc)
+		objects, e := r.Cache.Get(cache.PrimaryObjectIndex, key, cache.And(viewFilter, fltrfunc))
 		if e != nil {
 			return nil, e
 		}

--- a/pkg/consolegraphql/resolvers/resolver_connection.go
+++ b/pkg/consolegraphql/resolvers/resolver_connection.go
@@ -11,6 +11,7 @@ import (
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/enmasseproject/enmasse/pkg/consolegraphql"
 	"github.com/enmasseproject/enmasse/pkg/consolegraphql/cache"
+	"github.com/enmasseproject/enmasse/pkg/consolegraphql/server"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -117,6 +118,9 @@ func (r *Resolver) LinkSpec_consoleapi_enmasse_io_v1beta1() LinkSpec_consoleapi_
 }
 
 func (r *queryResolver) Connections(ctx context.Context, first *int, offset *int, filter *string, orderBy *string) (*ConnectionQueryResultConsoleapiEnmasseIoV1beta1, error) {
+	requestState := server.GetRequestStateFromContext(ctx)
+	viewFilter := requestState.AccessController.ViewFilter()
+
 	fltrfunc, e := BuildFilter(filter)
 	if e != nil {
 		return nil, e
@@ -127,7 +131,7 @@ func (r *queryResolver) Connections(ctx context.Context, first *int, offset *int
 		return nil, e
 	}
 
-	objects, e := r.Cache.Get(cache.PrimaryObjectIndex, "Connection/", fltrfunc)
+	objects, e := r.Cache.Get(cache.PrimaryObjectIndex, "Connection/", cache.And(viewFilter, fltrfunc))
 	if e != nil {
 		return nil, e
 	}

--- a/pkg/consolegraphql/resolvers/resolver_namespace.go
+++ b/pkg/consolegraphql/resolvers/resolver_namespace.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/enmasseproject/enmasse/pkg/consolegraphql/cache"
+	"github.com/enmasseproject/enmasse/pkg/consolegraphql/server"
 	"k8s.io/api/core/v1"
 )
 
@@ -17,7 +18,10 @@ func (r *Resolver) NamespaceStatus_v1() NamespaceStatus_v1Resolver {
 }
 
 func (r *queryResolver) Namespaces(ctx context.Context) ([]*v1.Namespace, error) {
-	objects, e := r.Cache.Get(cache.PrimaryObjectIndex, "Namespace/", nil)
+	requestState := server.GetRequestStateFromContext(ctx)
+	viewFilter := requestState.AccessController.ViewFilter()
+
+	objects, e := r.Cache.Get(cache.PrimaryObjectIndex, "Namespace/", viewFilter)
 	if e != nil {
 		return nil, e
 	}

--- a/pkg/consolegraphql/resolvers/resolver_namespace_test.go
+++ b/pkg/consolegraphql/resolvers/resolver_namespace_test.go
@@ -7,46 +7,93 @@ package resolvers
 
 import (
 	"context"
+	"github.com/enmasseproject/enmasse/pkg/consolegraphql/accesscontroller"
 	"github.com/enmasseproject/enmasse/pkg/consolegraphql/cache"
+	"github.com/enmasseproject/enmasse/pkg/consolegraphql/server"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"strings"
 	"testing"
 )
 
-func newTestNamespaceResolver(t *testing.T) *Resolver {
+type testAccController struct {
+}
+
+func newTestAccessController() accesscontroller.AccessController {
+	return &testAccController{}
+}
+
+func (a *testAccController) CanRead(obj interface{}) (bool, error) {
+	return strings.HasPrefix(obj.(*v1.Namespace).Name, "public_"), nil
+}
+
+func (a *testAccController) ViewFilter() cache.ObjectFilter {
+	return accesscontroller.FilterAdapter(a)
+}
+
+func newTestNamespaceResolver(t *testing.T) (*Resolver, context.Context) {
 	objectCache, err := cache.CreateObjectCache()
 	assert.NoError(t, err, "failed to create object cache")
 
 	resolver := Resolver{}
 	resolver.Cache = objectCache
-	return &resolver
+
+	requestState := &server.RequestState{
+		AccessController: accesscontroller.NewAllowAllAccessController(),
+	}
+
+	ctx := server.ContextWithRequestState(requestState, context.TODO())
+	return &resolver, ctx
 }
 
 func TestQueryNamespace(t *testing.T) {
-	r := newTestNamespaceResolver(t)
+	r, ctx := newTestNamespaceResolver(t)
+	namespace := createNamespace("mynamespace")
+	err := r.Cache.Add(namespace)
+	assert.NoError(t, err)
+
+	objs, err := r.Query().Namespaces(ctx)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, len(objs), "Unexpected number of namespaces")
+	assert.Equal(t, namespace, objs[0], "Unexpected namespace")
+}
+
+func TestQueryNamespaceUserView(t *testing.T) {
+	r, _ := newTestNamespaceResolver(t)
+
+	requestState := &server.RequestState{
+		AccessController: newTestAccessController(),
+	}
+	ctx := server.ContextWithRequestState(requestState, context.TODO())
+
+	namespace1 := createNamespace("public_mynamespace")
+	namespace2 := createNamespace("private_mynamespace")
+	err := r.Cache.Add(namespace1, namespace2)
+	assert.NoError(t, err)
+
+	objs, err := r.Query().Namespaces(ctx)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, len(objs), "Unexpected number of namespaces")
+	assert.Equal(t, namespace1, objs[0], "Unexpected namespace")
+}
+
+func createNamespace(name string) *v1.Namespace {
 	namespace := &v1.Namespace{
 		TypeMeta: v12.TypeMeta{
 			Kind: "Namespace",
 		},
 		ObjectMeta: v12.ObjectMeta{
-			Name: "mynamespace",
+			Name: name,
 			UID:  types.UID(uuid.New().String()),
 		},
 		Status: v1.NamespaceStatus{
 			Phase: v1.NamespaceActive,
 		},
 	}
-	err := r.Cache.Add(namespace)
-	assert.NoError(t, err)
-
-	objs, err := r.Query().Namespaces(context.TODO())
-	assert.NoError(t, err)
-
-	expected := 1
-	actual := len(objs)
-	assert.Equal(t, expected, actual, "Unexpected number of namespaces")
-	assert.Equal(t, namespace, objs[0], "Unexpected namespace")
+	return namespace
 }

--- a/pkg/consolegraphql/resolvers/resolver_namespace_test.go
+++ b/pkg/consolegraphql/resolvers/resolver_namespace_test.go
@@ -34,6 +34,10 @@ func (a *testAccController) ViewFilter() cache.ObjectFilter {
 	return accesscontroller.FilterAdapter(a)
 }
 
+func (a *testAccController) GetState() (bool, interface{}) {
+	return false, nil
+}
+
 func newTestNamespaceResolver(t *testing.T) (*Resolver, context.Context) {
 	objectCache, err := cache.CreateObjectCache()
 	assert.NoError(t, err, "failed to create object cache")

--- a/pkg/consolegraphql/server/request_context.go
+++ b/pkg/consolegraphql/server/request_context.go
@@ -8,12 +8,14 @@ package server
 import (
 	"context"
 	"github.com/enmasseproject/enmasse/pkg/client/clientset/versioned/typed/enmasse/v1beta1"
+	"github.com/enmasseproject/enmasse/pkg/consolegraphql/accesscontroller"
 	userv1 "github.com/openshift/client-go/user/clientset/versioned/typed/user/v1"
 )
 
 type RequestState struct {
-	UserInterface userv1.UserInterface
+	UserInterface        userv1.UserInterface
 	EnmasseV1beta1Client v1beta1.EnmasseV1beta1Interface
+	AccessController     accesscontroller.AccessController
 }
 
 func ContextWithRequestState(requestState *RequestState, ctx context.Context) context.Context {

--- a/pkg/consolegraphql/server/tracer.go
+++ b/pkg/consolegraphql/server/tracer.go
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ *
+ */
+
+package server
+
+import (
+	"log"
+	"net/http"
+	"net/http/httputil"
+)
+
+type Tracer struct {
+	http.RoundTripper
+}
+
+
+// http://people.redhat.com/jrivera/openshift-docs_preview/openshift-origin/glusterfs-review/go_client/tracing_api_requests_and_responses.html
+// RoundTrip calls the nested RoundTripper while printing each request and
+// response/error to os.Stderr on either side of the nested call.  WARNING: this
+// may output sensitive information including bearer tokens.
+func (t *Tracer) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Dump the request to os.Stderr.
+	b, err := httputil.DumpRequestOut(req, true)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Printf("TRACE: -> %s\n", string(b))
+
+	// Call the nested RoundTripper.
+	resp, err := t.RoundTripper.RoundTrip(req)
+
+	// If an error was returned, dump it to os.Stderr.
+	if err != nil {
+		return resp, err
+	}
+
+	// Dump the response to os.Stderr.
+	b, err = httputil.DumpResponse(resp, req.URL.Query().Get("watch") != "true")
+	if err != nil {
+		return nil, err
+	}
+	log.Printf("TRACE: <- %s\n", string(b))
+
+	return resp, err
+}

--- a/vendor/github.com/alexedwards/scs/v2/.travis.yml
+++ b/vendor/github.com/alexedwards/scs/v2/.travis.yml
@@ -1,0 +1,7 @@
+language: go
+
+go:
+- 1.11.x
+- 1.12.x
+
+script: go test -race .

--- a/vendor/github.com/alexedwards/scs/v2/LICENSE
+++ b/vendor/github.com/alexedwards/scs/v2/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Alex Edwards
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/alexedwards/scs/v2/README.md
+++ b/vendor/github.com/alexedwards/scs/v2/README.md
@@ -1,0 +1,211 @@
+# SCS: HTTP Session Management for Go
+
+[![GoDoc](https://godoc.org/github.com/alexedwards/scs?status.png)](https://godoc.org/github.com/alexedwards/scs)
+[![Build status](https://travis-ci.org/alexedwards/stack.svg?branch=master)](https://travis-ci.org/alexedwards/scs)
+[![Go report card](https://goreportcard.com/badge/github.com/alexedwards/scs)](https://goreportcard.com/report/github.com/alexedwards/scs)
+[![Test coverage](http://gocover.io/_badge/github.com/alexedwards/scs)](https://gocover.io/github.com/alexedwards/scs)
+
+
+## Features
+
+* Automatic loading and saving of session data via middleware.
+* Choice of server-side session stores including PostgreSQL, MySQL, Redis, BadgerDB and BoltDB. Custom session stores are also supported.
+* Supports multiple sessions per request, 'flash' messages, session token regeneration, and idle and absolute session timeouts.
+* Easy to extend and customize. Communicate session tokens to/from clients in HTTP headers or request/response bodies.
+* Efficient design. Smaller, faster and uses less memory than [gorilla/sessions](https://github.com/gorilla/sessions).
+
+## Instructions
+
+* [Installation](#installation)
+* [Basic Use](#basic-use)
+* [Configuring Session Behavior](#configuring-session-behavior)
+* [Working with Session Data](#working-with-session-data)
+* [Loading and Saving Sessions](#loading-and-saving-sessions)
+* [Configuring the Session Store](#configuring-the-session-store)
+* [Using Custom Session Stores](#using-custom-session-stores)
+* [Preventing Session Fixation](#preventing-session-fixation)
+* [Multiple Sessions per Request](#multiple-sessions-per-request)
+* [Compatibility](#compatibility)
+
+### Installation
+
+This package requires Go 1.11 or newer.
+
+```
+$ go get github.com/alexedwards/scs/v2@latest
+```
+
+Note: If you're using the traditional `GOPATH` mechanism to manage dependencies, instead of modules, you'll need to `go get` and `import` `github.com/alexedwards/scs` without the `v2` suffix.
+
+
+### Basic Use
+
+SCS implements a session management pattern following the [OWASP security guidelines](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Session_Management_Cheat_Sheet.md). Session data is stored on the server, and a randomly-generated unique session token (or *session ID*) is communicated to and from the client in a session cookie.
+
+```go
+package main
+
+import (
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/alexedwards/scs/v2"
+)
+
+var sessionManager *scs.SessionManager
+
+func main() {
+	// Initialize a new session manager and configure the session lifetime.
+	sessionManager = scs.New()
+	sessionManager.Lifetime = 24 * time.Hour
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/put", putHandler)
+	mux.HandleFunc("/get", getHandler)
+
+	// Wrap your handlers with the LoadAndSave() middleware.
+	http.ListenAndServe(":4000", sessionManager.LoadAndSave(mux))
+}
+
+func putHandler(w http.ResponseWriter, r *http.Request) {
+	// Store a new key and value in the session data.
+	sessionManager.Put(r.Context(), "message", "Hello from a session!")
+}
+
+func getHandler(w http.ResponseWriter, r *http.Request) {
+	// Use the GetString helper to retrieve the string value associated with a
+	// key. The zero value is returned if the key does not exist.
+	msg := sessionManager.GetString(r.Context(), "message")
+	io.WriteString(w, msg)
+}
+```
+
+```
+$ curl -i --cookie-jar cj --cookie cj localhost:4000/put
+HTTP/1.1 200 OK
+Cache-Control: no-cache="Set-Cookie"
+Set-Cookie: session=lHqcPNiQp_5diPxumzOklsSdE-MJ7zyU6kjch1Ee0UM; Path=/; Expires=Sat, 27 Apr 2019 10:28:20 GMT; Max-Age=86400; HttpOnly; SameSite=Lax
+Vary: Cookie
+Date: Fri, 26 Apr 2019 10:28:19 GMT
+Content-Length: 0
+
+$ curl -i --cookie-jar cj --cookie cj localhost:4000/get
+HTTP/1.1 200 OK
+Date: Fri, 26 Apr 2019 10:28:24 GMT
+Content-Length: 21
+Content-Type: text/plain; charset=utf-8
+
+Hello from a session!
+```
+
+### Configuring Session Behavior
+
+Session behavior can be configured via the `SessionManager` fields.
+
+```go
+sessionManager = scs.New()
+sessionManager.Lifetime = 3 * time.Hour
+sessionManager.IdleTimeout = 20 * time.Minute
+sessionManager.Cookie.Name = "session_id"
+sessionManager.Cookie.Domain = "example.com"
+sessionManager.Cookie.HttpOnly = true
+sessionManager.Cookie.Path = "/example/"
+sessionManager.Cookie.Persist = true
+sessionManager.Cookie.SameSite = http.SameSiteStrictMode
+sessionManager.Cookie.Secure = true
+```
+
+Documentation for all available settings and their default values can be [found here](https://godoc.org/github.com/alexedwards/scs#SessionManager).
+
+### Working with Session Data
+
+Data can be set using the [`Put()`](https://godoc.org/github.com/alexedwards/scs#SessionManager.Put) method and retrieved with the [`Get()`](https://godoc.org/github.com/alexedwards/scs#SessionManager.Get) method. A variety of helper methods like [`GetString()`](https://godoc.org/github.com/alexedwards/scs#SessionManager.GetString), [`GetInt()`](https://godoc.org/github.com/alexedwards/scs#SessionManager.GetInt) and [`GetBytes()`](https://godoc.org/github.com/alexedwards/scs#SessionManager.GetBytes) are included for common data types. Please see [the documentation](https://godoc.org/github.com/alexedwards/scs#pkg-index) for a full list of helper methods.
+
+The [`Pop()`](https://godoc.org/github.com/alexedwards/scs#SessionManager.Pop) method (and accompanying helpers for common data types) act like a one-time `Get()`, retrieving the data and removing it from the session in one step. These are useful if you want to implement 'flash' message functionality in your application, where messages are displayed to the user once only.
+
+Some other useful functions are [`Exists()`](https://godoc.org/github.com/alexedwards/scs#SessionManager.Exists) (which returns a `bool` indicating whether or not a given key exists in the session data) and [`Keys()`](https://godoc.org/github.com/alexedwards/scs#SessionManager.Keys) (which returns a sorted slice of keys in the session data).
+
+Individual data items can be deleted from the session using the [`Remove()`](https://godoc.org/github.com/alexedwards/scs#SessionManager.Remove) method. Alternatively, all session data can de deleted by using the [`Destroy()`](https://godoc.org/github.com/alexedwards/scs#SessionManager.Destroy) method. After calling `Destroy()`, any further operations in the same request cycle will result in a new session being created --- with a new session token and a new lifetime.
+
+Behind the scenes SCS uses gob encoding to store session data, so if you want to store custom types in the session data they must be [registered](https://golang.org/pkg/encoding/gob/#Register) with the encoding/gob package first. Struct fields of custom types must also be exported so that they are visible to the encoding/gob package. Please [see here](https://gist.github.com/alexedwards/d6eca7136f98ec12ad606e774d3abad3) for a working example.
+
+### Loading and Saving Sessions
+
+Most applications will use the [`LoadAndSave()`](https://godoc.org/github.com/alexedwards/scs#SessionManager.LoadAndSave) middleware. This middleware takes care of loading and committing session data to the session store, and communicating the session token to/from the client in a cookie as necessary.
+
+If you want to communicate the session token to/from the client in a different way (for example in a different HTTP header) you are encouraged to create your own alternative middleware using the code in [`LoadAndSave()`](https://godoc.org/github.com/alexedwards/scs#SessionManager.LoadAndSave) as a template. An example is [given here](https://gist.github.com/alexedwards/cc6190195acfa466bf27f05aa5023f50).
+
+Or for more fine-grained control you can load and save sessions within your individual handlers (or from anywhere in your application). [See here](https://gist.github.com/alexedwards/0570e5a59677e278e13acb8ea53a3b30) for an example.
+
+### Configuring the Session Store
+
+By default SCS uses an in-memory store for session data. This is convenient (no setup!) and very fast, but all session data will be lost when your application is stopped or restarted. Therefore it's useful for applications where data loss is an acceptable trade off for fast performance, or for prototyping and testing purposes. In most production applications you will want to use a persistent session store like PostgreSQL or MySQL instead.
+
+The session stores currently included are shown in the table below. Please click the links for usage instructions and examples.
+
+| Package                                                                               |                                                                                  |
+|:------------------------------------------------------------------------------------- |----------------------------------------------------------------------------------|
+| [badgerstore](https://github.com/alexedwards/scs/tree/master/badgerstore)       		| BadgerDB based session store  		                                               |
+| [boltstore](https://github.com/alexedwards/scs/tree/master/boltstore)       			| BoltDB based session store  		                                               |
+| [memstore](https://github.com/alexedwards/scs/tree/master/memstore)       			| In-memory session store (default)                                                |
+| [mysqlstore](https://github.com/alexedwards/scs/tree/master/mysqlstore)   			| MySQL based session store                                                        |
+| [postgresstore](https://github.com/alexedwards/scs/tree/master/postgresstore)         | PostgreSQL based session store                                                   |
+| [redisstore](https://github.com/alexedwards/scs/tree/master/redisstore)       		| Redis based session store                                                        |
+
+Custom session stores are also supported. Please [see here](#using-custom-session-stores) for more information.
+
+### Using Custom Session Stores
+
+[`scs.Store`](https://godoc.org/github.com/alexedwards/scs#Store) defines the interface for custom session stores. Any object that implements this interface can be set as the store when configuring the session.
+
+```go
+type Store interface {
+	// Delete should remove the session token and corresponding data from the
+	// session store. If the token does not exist then Delete should be a no-op
+	// and return nil (not an error).
+	Delete(token string) (err error)
+
+	// Find should return the data for a session token from the store. If the
+	// session token is not found or is expired, the found return value should
+	// be false (and the err return value should be nil). Similarly, tampered
+	// or malformed tokens should result in a found return value of false and a
+	// nil err value. The err return value should be used for system errors only.
+	Find(token string) (b []byte, found bool, err error)
+
+	// Commit should add the session token and data to the store, with the given
+	// expiry time. If the session token already exists, then the data and
+	// expiry time should be overwritten.
+	Commit(token string, b []byte, expiry time.Time) (err error)
+}
+```
+
+### Preventing Session Fixation
+
+To help prevent session fixation attacks you should [renew the session token after any privilege level change](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Session_Management_Cheat_Sheet.md#renew-the-session-id-after-any-privilege-level-change). Commonly, this means that the session token must to be changed when a user logs in or out of your application. You can do this using the [`RenewToken()`](https://godoc.org/github.com/alexedwards/scs#SessionManager.RenewToken) method like so:
+
+```go
+func loginHandler(w http.ResponseWriter, r *http.Request) {
+	userID := 123
+
+	// First renew the session token...
+	err := sessionManager.RenewToken(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), 500)
+		return
+	}
+
+	// Then make the privilege-level change.
+	sessionManager.Put(r.Context(), "userID", userID)
+}
+```
+
+### Multiple Sessions per Request
+
+It is possible for an application to support multiple sessions per request, with different lifetime lengths and even different stores. Please [see here for an example](https://gist.github.com/alexedwards/22535f758356bfaf96038fffad154824).
+
+### Compatibility
+
+This package requires Go 1.11 or newer.
+
+It is not compatible with the [Echo](https://echo.labstack.com/) framework. Please consider using the [Echo session manager](https://echo.labstack.com/middleware/session) instead.

--- a/vendor/github.com/alexedwards/scs/v2/codec.go
+++ b/vendor/github.com/alexedwards/scs/v2/codec.go
@@ -1,0 +1,49 @@
+package scs
+
+import (
+	"bytes"
+	"encoding/gob"
+	"time"
+)
+
+// Codec is the interface for encoding/decoding session data to and from a byte
+// slice for use by the session store.
+type Codec interface {
+	Encode(deadline time.Time, values map[string]interface{}) ([]byte, error)
+	Decode([]byte) (deadline time.Time, values map[string]interface{}, err error)
+}
+
+type gobCodec struct{}
+
+func (gobCodec) Encode(deadline time.Time, values map[string]interface{}) ([]byte, error) {
+	aux := &struct {
+		Deadline time.Time
+		Values   map[string]interface{}
+	}{
+		Deadline: deadline,
+		Values:   values,
+	}
+
+	var b bytes.Buffer
+	err := gob.NewEncoder(&b).Encode(&aux)
+	if err != nil {
+		return nil, err
+	}
+
+	return b.Bytes(), nil
+}
+
+func (gobCodec) Decode(b []byte) (time.Time, map[string]interface{}, error) {
+	aux := &struct {
+		Deadline time.Time
+		Values   map[string]interface{}
+	}{}
+
+	r := bytes.NewReader(b)
+	err := gob.NewDecoder(r).Decode(&aux)
+	if err != nil {
+		return time.Time{}, nil, err
+	}
+
+	return aux.Deadline, aux.Values, nil
+}

--- a/vendor/github.com/alexedwards/scs/v2/data.go
+++ b/vendor/github.com/alexedwards/scs/v2/data.go
@@ -1,0 +1,494 @@
+package scs
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+)
+
+// Status represents the state of the session data during a request cycle.
+type Status int
+
+const (
+	// Unmodified indicates that the session data hasn't been changed in the
+	// current request cycle.
+	Unmodified Status = iota
+
+	// Modified indicates that the session data has been changed in the current
+	// request cycle.
+	Modified
+
+	// Destroyed indicates that the session data has been destroyed in the
+	// current request cycle.
+	Destroyed
+)
+
+type sessionData struct {
+	deadline time.Time
+	status   Status
+	token    string
+	values   map[string]interface{}
+	mu       sync.Mutex
+}
+
+func newSessionData(lifetime time.Duration) *sessionData {
+	return &sessionData{
+		deadline: time.Now().Add(lifetime).UTC(),
+		status:   Unmodified,
+		values:   make(map[string]interface{}),
+	}
+}
+
+// Load retrieves the session data for the given token from the session store,
+// and returns a new context.Context containing the session data. If no matching
+// token is found then this will create a new session.
+//
+// Most applications will use the LoadAndSave() middleware and will not need to
+// use this method.
+func (s *SessionManager) Load(ctx context.Context, token string) (context.Context, error) {
+	if _, ok := ctx.Value(s.contextKey).(*sessionData); ok {
+		return ctx, nil
+	}
+
+	if token == "" {
+		return s.addSessionDataToContext(ctx, newSessionData(s.Lifetime)), nil
+	}
+
+	b, found, err := s.Store.Find(token)
+	if err != nil {
+		return nil, err
+	} else if !found {
+		return s.addSessionDataToContext(ctx, newSessionData(s.Lifetime)), nil
+	}
+
+	sd := &sessionData{
+		status: Unmodified,
+		token:  token,
+	}
+	sd.deadline, sd.values, err = s.Codec.Decode(b)
+	if err != nil {
+		return nil, err
+	}
+	// Mark the session data as modified if an idle timeout is being used. This
+	// will force the session data to be re-committed to the session store with
+	// a new expiry time.
+	if s.IdleTimeout > 0 {
+		sd.status = Modified
+	}
+
+	return s.addSessionDataToContext(ctx, sd), nil
+}
+
+// Commit saves the session data to the session store and returns the session
+// token and expiry time.
+//
+// Most applications will use the LoadAndSave() middleware and will not need to
+// use this method.
+func (s *SessionManager) Commit(ctx context.Context) (string, time.Time, error) {
+	sd := s.getSessionDataFromContext(ctx)
+
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+
+	if sd.token == "" {
+		var err error
+		sd.token, err = generateToken()
+		if err != nil {
+			return "", time.Time{}, err
+		}
+	}
+
+	b, err := s.Codec.Encode(sd.deadline, sd.values)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+
+	expiry := sd.deadline
+	if s.IdleTimeout > 0 {
+		ie := time.Now().Add(s.IdleTimeout)
+		if ie.Before(expiry) {
+			expiry = ie
+		}
+	}
+
+	err = s.Store.Commit(sd.token, b, expiry)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+
+	return sd.token, expiry, nil
+}
+
+// Destroy deletes the session data from the session store and sets the session
+// status to Destroyed. Any further operations in the same request cycle will
+// result in a new session being created.
+func (s *SessionManager) Destroy(ctx context.Context) error {
+	sd := s.getSessionDataFromContext(ctx)
+
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+
+	err := s.Store.Delete(sd.token)
+	if err != nil {
+		return err
+	}
+
+	sd.status = Destroyed
+
+	// Reset everything else to defaults.
+	sd.token = ""
+	sd.deadline = time.Now().Add(s.Lifetime).UTC()
+	for key := range sd.values {
+		delete(sd.values, key)
+	}
+
+	return nil
+}
+
+// Put adds a key and corresponding value to the session data. Any existing
+// value for the key will be replaced. The session data status will be set to
+// Modified.
+func (s *SessionManager) Put(ctx context.Context, key string, val interface{}) {
+	sd := s.getSessionDataFromContext(ctx)
+
+	sd.mu.Lock()
+	sd.values[key] = val
+	sd.status = Modified
+	sd.mu.Unlock()
+}
+
+// Get returns the value for a given key from the session data. The return
+// value has the type interface{} so will usually need to be type asserted
+// before you can use it. For example:
+//
+//	foo, ok := session.Get(r, "foo").(string)
+//	if !ok {
+//		return errors.New("type assertion to string failed")
+//	}
+//
+// Also see the GetString(), GetInt(), GetBytes() and other helper methods which
+// wrap the type conversion for common types.
+func (s *SessionManager) Get(ctx context.Context, key string) interface{} {
+	sd := s.getSessionDataFromContext(ctx)
+
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+
+	return sd.values[key]
+}
+
+// Pop acts like a one-time Get. It returns the value for a given key from the
+// session data and deletes the key and value from the session data. The
+// session data status will be set to Modified. The return value has the type
+// interface{} so will usually need to be type asserted before you can use it.
+func (s *SessionManager) Pop(ctx context.Context, key string) interface{} {
+	sd := s.getSessionDataFromContext(ctx)
+
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+
+	val, exists := sd.values[key]
+	if !exists {
+		return nil
+	}
+	delete(sd.values, key)
+	sd.status = Modified
+
+	return val
+}
+
+// Remove deletes the given key and corresponding value from the session data.
+// The session data status will be set to Modified. If the key is not present
+// this operation is a no-op.
+func (s *SessionManager) Remove(ctx context.Context, key string) {
+	sd := s.getSessionDataFromContext(ctx)
+
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+
+	_, exists := sd.values[key]
+	if !exists {
+		return
+	}
+
+	delete(sd.values, key)
+	sd.status = Modified
+}
+
+// Clear removes all data for the current session. The session token and
+// lifetime are unaffected. If there is no data in the current session this is
+// a no-op.
+func (s *SessionManager) Clear(ctx context.Context) error {
+	sd := s.getSessionDataFromContext(ctx)
+
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+
+	if len(sd.values) == 0 {
+		return nil
+	}
+
+	for key := range sd.values {
+		delete(sd.values, key)
+	}
+	sd.status = Modified
+	return nil
+}
+
+// Exists returns true if the given key is present in the session data.
+func (s *SessionManager) Exists(ctx context.Context, key string) bool {
+	sd := s.getSessionDataFromContext(ctx)
+
+	sd.mu.Lock()
+	_, exists := sd.values[key]
+	sd.mu.Unlock()
+
+	return exists
+}
+
+// Keys returns a slice of all key names present in the session data, sorted
+// alphabetically. If the data contains no data then an empty slice will be
+// returned.
+func (s *SessionManager) Keys(ctx context.Context) []string {
+	sd := s.getSessionDataFromContext(ctx)
+
+	sd.mu.Lock()
+	keys := make([]string, len(sd.values))
+	i := 0
+	for key := range sd.values {
+		keys[i] = key
+		i++
+	}
+	sd.mu.Unlock()
+
+	sort.Strings(keys)
+	return keys
+}
+
+// RenewToken updates the session data to have a new session token while
+// retaining the current session data. The session lifetime is also reset and
+// the session data status will be set to Modified.
+//
+// The old session token and accompanying data are deleted from the session store.
+//
+// To mitigate the risk of session fixation attacks, it's important that you call
+// RenewToken before making any changes to privilege levels (e.g. login and
+// logout operations). See https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Session_Management_Cheat_Sheet.md#renew-the-session-id-after-any-privilege-level-change
+// for additional information.
+func (s *SessionManager) RenewToken(ctx context.Context) error {
+	sd := s.getSessionDataFromContext(ctx)
+
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+
+	err := s.Store.Delete(sd.token)
+	if err != nil {
+		return err
+	}
+
+	newToken, err := generateToken()
+	if err != nil {
+		return err
+	}
+
+	sd.token = newToken
+	sd.deadline = time.Now().Add(s.Lifetime).UTC()
+	sd.status = Modified
+
+	return nil
+}
+
+// Status returns the current status of the session data.
+func (s *SessionManager) Status(ctx context.Context) Status {
+	sd := s.getSessionDataFromContext(ctx)
+
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+
+	return sd.status
+}
+
+// GetString returns the string value for a given key from the session data.
+// The zero value for a string ("") is returned if the key does not exist or the
+// value could not be type asserted to a string.
+func (s *SessionManager) GetString(ctx context.Context, key string) string {
+	val := s.Get(ctx, key)
+	str, ok := val.(string)
+	if !ok {
+		return ""
+	}
+	return str
+}
+
+// GetBool returns the bool value for a given key from the session data. The
+// zero value for a bool (false) is returned if the key does not exist or the
+// value could not be type asserted to a bool.
+func (s *SessionManager) GetBool(ctx context.Context, key string) bool {
+	val := s.Get(ctx, key)
+	b, ok := val.(bool)
+	if !ok {
+		return false
+	}
+	return b
+}
+
+// GetInt returns the int value for a given key from the session data. The
+// zero value for an int (0) is returned if the key does not exist or the
+// value could not be type asserted to an int.
+func (s *SessionManager) GetInt(ctx context.Context, key string) int {
+	val := s.Get(ctx, key)
+	i, ok := val.(int)
+	if !ok {
+		return 0
+	}
+	return i
+}
+
+// GetFloat returns the float64 value for a given key from the session data. The
+// zero value for an float64 (0) is returned if the key does not exist or the
+// value could not be type asserted to a float64.
+func (s *SessionManager) GetFloat(ctx context.Context, key string) float64 {
+	val := s.Get(ctx, key)
+	f, ok := val.(float64)
+	if !ok {
+		return 0
+	}
+	return f
+}
+
+// GetBytes returns the byte slice ([]byte) value for a given key from the session
+// data. The zero value for a slice (nil) is returned if the key does not exist
+// or could not be type asserted to []byte.
+func (s *SessionManager) GetBytes(ctx context.Context, key string) []byte {
+	val := s.Get(ctx, key)
+	b, ok := val.([]byte)
+	if !ok {
+		return nil
+	}
+	return b
+}
+
+// GetTime returns the time.Time value for a given key from the session data. The
+// zero value for a time.Time object is returned if the key does not exist or the
+// value could not be type asserted to a time.Time. This can be tested with the
+// time.IsZero() method.
+func (s *SessionManager) GetTime(ctx context.Context, key string) time.Time {
+	val := s.Get(ctx, key)
+	t, ok := val.(time.Time)
+	if !ok {
+		return time.Time{}
+	}
+	return t
+}
+
+// PopString returns the string value for a given key and then deletes it from the
+// session data. The session data status will be set to Modified. The zero
+// value for a string ("") is returned if the key does not exist or the value
+// could not be type asserted to a string.
+func (s *SessionManager) PopString(ctx context.Context, key string) string {
+	val := s.Pop(ctx, key)
+	str, ok := val.(string)
+	if !ok {
+		return ""
+	}
+	return str
+}
+
+// PopBool returns the bool value for a given key and then deletes it from the
+// session data. The session data status will be set to Modified. The zero
+// value for a bool (false) is returned if the key does not exist or the value
+// could not be type asserted to a bool.
+func (s *SessionManager) PopBool(ctx context.Context, key string) bool {
+	val := s.Pop(ctx, key)
+	b, ok := val.(bool)
+	if !ok {
+		return false
+	}
+	return b
+}
+
+// PopInt returns the int value for a given key and then deletes it from the
+// session data. The session data status will be set to Modified. The zero
+// value for an int (0) is returned if the key does not exist or the value could
+// not be type asserted to an int.
+func (s *SessionManager) PopInt(ctx context.Context, key string) int {
+	val := s.Pop(ctx, key)
+	i, ok := val.(int)
+	if !ok {
+		return 0
+	}
+	return i
+}
+
+// PopFloat returns the float64 value for a given key and then deletes it from the
+// session data. The session data status will be set to Modified. The zero
+// value for an float64 (0) is returned if the key does not exist or the value
+// could not be type asserted to a float64.
+func (s *SessionManager) PopFloat(ctx context.Context, key string) float64 {
+	val := s.Pop(ctx, key)
+	f, ok := val.(float64)
+	if !ok {
+		return 0
+	}
+	return f
+}
+
+// PopBytes returns the byte slice ([]byte) value for a given key and then
+// deletes it from the from the session data. The session data status will be
+// set to Modified. The zero value for a slice (nil) is returned if the key does
+// not exist or could not be type asserted to []byte.
+func (s *SessionManager) PopBytes(ctx context.Context, key string) []byte {
+	val := s.Pop(ctx, key)
+	b, ok := val.([]byte)
+	if !ok {
+		return nil
+	}
+	return b
+}
+
+// PopTime returns the time.Time value for a given key and then deletes it from
+// the session data. The session data status will be set to Modified. The zero
+// value for a time.Time object is returned if the key does not exist or the
+// value could not be type asserted to a time.Time.
+func (s *SessionManager) PopTime(ctx context.Context, key string) time.Time {
+	val := s.Pop(ctx, key)
+	t, ok := val.(time.Time)
+	if !ok {
+		return time.Time{}
+	}
+	return t
+}
+
+func (s *SessionManager) addSessionDataToContext(ctx context.Context, sd *sessionData) context.Context {
+	return context.WithValue(ctx, s.contextKey, sd)
+}
+
+func (s *SessionManager) getSessionDataFromContext(ctx context.Context) *sessionData {
+	c, ok := ctx.Value(s.contextKey).(*sessionData)
+	if !ok {
+		panic("scs: no session data in context")
+	}
+	return c
+}
+
+func generateToken() (string, error) {
+	b := make([]byte, 32)
+	_, err := rand.Read(b)
+	if err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+type contextKey string
+
+var contextKeyID int
+
+func generateContextKey() contextKey {
+	contextKeyID = contextKeyID + 1
+	return contextKey(fmt.Sprintf("session.%d", contextKeyID))
+}

--- a/vendor/github.com/alexedwards/scs/v2/go.mod
+++ b/vendor/github.com/alexedwards/scs/v2/go.mod
@@ -1,0 +1,3 @@
+module github.com/alexedwards/scs/v2
+
+go 1.12

--- a/vendor/github.com/alexedwards/scs/v2/memstore/README.md
+++ b/vendor/github.com/alexedwards/scs/v2/memstore/README.md
@@ -1,0 +1,74 @@
+# memstore
+
+An in-memory session store for [SCS](https://github.com/alexedwards/scs).
+
+
+Because memstore uses in-memory storage only, all session data will be lost when your application is stopped or restarted. Therefore it should only be used in applications where data loss is an acceptable trade off for fast performance, or for prototyping and testing purposes.
+
+## Example
+
+```go
+package main
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/alexedwards/scs/v2"
+	"github.com/alexedwards/scs/v2/memstore"
+)
+
+var sessionManager *scs.SessionManager
+
+func main() {
+	// Initialize a new session manager and configure it to use memstore as
+	// the session store.
+	sessionManager = scs.New()
+	sessionManager.Store = memstore.New()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/put", putHandler)
+	mux.HandleFunc("/get", getHandler)
+
+	http.ListenAndServe(":4000", sessionManager.LoadAndSave(mux))
+}
+
+func putHandler(w http.ResponseWriter, r *http.Request) {
+	sessionManager.Put(r.Context(), "message", "Hello from a session!")
+}
+
+func getHandler(w http.ResponseWriter, r *http.Request) {
+	msg := sessionManager.GetString(r.Context(), "message")
+	io.WriteString(w, msg)
+}
+```
+
+## Expired Session Cleanup
+
+This package provides a background 'cleanup' goroutine to delete expired session data. This stops the database table from holding on to invalid sessions indefinitely and growing unnecessarily large. By default the cleanup runs once every minute. You can change this by using the `NewWithCleanupInterval()` function to initialize your session store. For example:
+
+```go
+// Run a cleanup every 30 seconds.
+memstore.NewWithCleanupInterval(db, 30*time.Second)
+
+// Disable the cleanup goroutine by setting the cleanup interval to zero.
+memstore.NewWithCleanupInterval(db, 0)
+```
+
+### Terminating the Cleanup Goroutine
+
+It's rare that the cleanup goroutine needs to be terminated --- it is generally intended to be long-lived and run for the lifetime of your application.
+
+However, there may be occasions when your use of a session store instance is transient. A common example would be using it in a short-lived test function. In this scenario, the cleanup goroutine (which will run forever) will prevent the session store instance from being garbage collected even after the test function has finished. You can prevent this by either disabling the cleanup goroutine altogether (as described above) or by stopping it using the `StopCleanup()` method. For example:
+
+```go
+func TestExample(t *testing.T) {
+	store := memstore.New()
+	defer store.StopCleanup()
+
+	sessionManager = scs.New()
+	sessionManager.Store = store
+
+	// Run test...
+}
+```

--- a/vendor/github.com/alexedwards/scs/v2/memstore/memstore.go
+++ b/vendor/github.com/alexedwards/scs/v2/memstore/memstore.go
@@ -1,0 +1,131 @@
+package memstore
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+var errTypeAssertionFailed = errors.New("type assertion failed: could not convert interface{} to []byte")
+
+type item struct {
+	object     interface{}
+	expiration int64
+}
+
+// MemStore represents the session store.
+type MemStore struct {
+	items       map[string]item
+	mu          sync.RWMutex
+	stopCleanup chan bool
+}
+
+// New returns a new MemStore instance, with a background cleanup goroutine that
+// runs every minute to remove expired session data.
+func New() *MemStore {
+	return NewWithCleanupInterval(time.Minute)
+}
+
+// NewWithCleanupInterval returns a new MemStore instance. The cleanupInterval
+// parameter controls how frequently expired session data is removed by the
+// background cleanup goroutine. Setting it to 0 prevents the cleanup goroutine
+// from running (i.e. expired sessions will not be removed).
+func NewWithCleanupInterval(cleanupInterval time.Duration) *MemStore {
+	m := &MemStore{
+		items: make(map[string]item),
+	}
+
+	if cleanupInterval > 0 {
+		go m.startCleanup(cleanupInterval)
+	}
+
+	return m
+}
+
+// Find returns the data for a given session token from the MemStore instance.
+// If the session token is not found or is expired, the returned exists flag will
+// be set to false.
+func (m *MemStore) Find(token string) ([]byte, bool, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	item, found := m.items[token]
+	if !found {
+		return nil, false, nil
+	}
+	if time.Now().UnixNano() > item.expiration {
+		return nil, false, nil
+	}
+
+	b, ok := item.object.([]byte)
+	if !ok {
+		return nil, true, errTypeAssertionFailed
+	}
+
+	return b, true, nil
+}
+
+// Commit adds a session token and data to the MemStore instance with the given
+// expiry time. If the session token already exists, then the data and expiry
+// time are updated.
+func (m *MemStore) Commit(token string, b []byte, expiry time.Time) error {
+	m.mu.Lock()
+	m.items[token] = item{
+		object:     b,
+		expiration: expiry.UnixNano(),
+	}
+	m.mu.Unlock()
+
+	return nil
+}
+
+// Delete removes a session token and corresponding data from the MemStore
+// instance.
+func (m *MemStore) Delete(token string) error {
+	m.mu.Lock()
+	delete(m.items, token)
+	m.mu.Unlock()
+
+	return nil
+}
+
+func (m *MemStore) startCleanup(interval time.Duration) {
+	m.stopCleanup = make(chan bool)
+	ticker := time.NewTicker(interval)
+	for {
+		select {
+		case <-ticker.C:
+			m.deleteExpired()
+		case <-m.stopCleanup:
+			ticker.Stop()
+			return
+		}
+	}
+}
+
+// StopCleanup terminates the background cleanup goroutine for the MemStore
+// instance. It's rare to terminate this; generally MemStore instances and
+// their cleanup goroutines are intended to be long-lived and run for the lifetime
+// of your application.
+//
+// There may be occasions though when your use of the MemStore is transient.
+// An example is creating a new MemStore instance in a test function. In this
+// scenario, the cleanup goroutine (which will run forever) will prevent the
+// MemStore object from being garbage collected even after the test function
+// has finished. You can prevent this by manually calling StopCleanup.
+func (m *MemStore) StopCleanup() {
+	if m.stopCleanup != nil {
+		m.stopCleanup <- true
+	}
+}
+
+func (m *MemStore) deleteExpired() {
+	now := time.Now().UnixNano()
+	m.mu.Lock()
+	for token, item := range m.items {
+		if now > item.expiration {
+			delete(m.items, token)
+		}
+	}
+	m.mu.Unlock()
+}

--- a/vendor/github.com/alexedwards/scs/v2/session.go
+++ b/vendor/github.com/alexedwards/scs/v2/session.go
@@ -1,0 +1,209 @@
+package scs
+
+import (
+	"bufio"
+	"bytes"
+	"log"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/alexedwards/scs/v2/memstore"
+)
+
+// Deprecated: Session is a backwards-compatible alias for SessionManager.
+type Session = SessionManager
+
+// SessionManager holds the configuration settings for your sessions.
+type SessionManager struct {
+	// IdleTimeout controls the maximum length of time a session can be inactive
+	// before it expires. For example, some applications may wish to set this so
+	// there is a timeout after 20 minutes of inactivity. By default IdleTimeout
+	// is not set and there is no inactivity timeout.
+	IdleTimeout time.Duration
+
+	// Lifetime controls the maximum length of time that a session is valid for
+	// before it expires. The lifetime is an 'absolute expiry' which is set when
+	// the session is first created and does not change. The default value is 24
+	// hours.
+	Lifetime time.Duration
+
+	// Store controls the session store where the session data is persisted.
+	Store Store
+
+	// Cookie contains the configuration settings for session cookies.
+	Cookie SessionCookie
+
+	// Codec controls the encoder/decoder used to transform session data to a
+	// byte slice for use by the session store. By default session data is
+	// encoded/decoded using encoding/gob.
+	Codec Codec
+
+	// contextKey is the key used to set and retrieve the session data from a
+	// context.Context. It's automatically generated to ensure uniqueness.
+	contextKey contextKey
+}
+
+// SessionCookie contains the configuration settings for session cookies.
+type SessionCookie struct {
+	// Name sets the name of the session cookie. It should not contain
+	// whitespace, commas, colons, semicolons, backslashes, the equals sign or
+	// control characters as per RFC6265. The default cookie name is "session".
+	// If your application uses two different sessions, you must make sure that
+	// the cookie name for each is unique.
+	Name string
+
+	// Domain sets the 'Domain' attribute on the session cookie. By default
+	// it will be set to the domain name that the cookie was issued from.
+	Domain string
+
+	// HttpOnly sets the 'HttpOnly' attribute on the session cookie. The
+	// default value is true.
+	HttpOnly bool
+
+	// Path sets the 'Path' attribute on the session cookie. The default value
+	// is "/". Passing the empty string "" will result in it being set to the
+	// path that the cookie was issued from.
+	Path string
+
+	// Persist sets whether the session cookie should be persistent or not
+	// (i.e. whether it should be retained after a user closes their browser).
+	// The default value is true, which means that the session cookie will not
+	// be destroyed when the user closes their browser and the appropriate
+	// 'Expires' and 'MaxAge' values will be added to the session cookie.
+	Persist bool
+
+	// SameSite controls the value of the 'SameSite' attribute on the session
+	// cookie. By default this is set to 'SameSite=Lax'. If you want no SameSite
+	// attribute or value in the session cookie then you should set this to 0.
+	SameSite http.SameSite
+
+	// Secure sets the 'Secure' attribute on the session cookie. The default
+	// value is false. It's recommended that you set this to true and serve all
+	// requests over HTTPS in production environments.
+	// See https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Session_Management_Cheat_Sheet.md#transport-layer-security.
+	Secure bool
+}
+
+// New returns a new session manager with the default options. It is safe for
+// concurrent use.
+func New() *SessionManager {
+	s := &SessionManager{
+		IdleTimeout: 0,
+		Lifetime:    24 * time.Hour,
+		Store:       memstore.New(),
+		Codec:       gobCodec{},
+		contextKey:  generateContextKey(),
+		Cookie: SessionCookie{
+			Name:     "session",
+			Domain:   "",
+			HttpOnly: true,
+			Path:     "/",
+			Persist:  true,
+			Secure:   false,
+			SameSite: http.SameSiteLaxMode,
+		},
+	}
+	return s
+}
+
+// Deprecated: NewSession is a backwards-compatible alias for New. Use the New
+// function instead.
+func NewSession() *SessionManager {
+	return New()
+}
+
+// LoadAndSave provides middleware which automatically loads and saves session
+// data for the current request, and communicates the session token to and from
+// the client in a cookie.
+func (s *SessionManager) LoadAndSave(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var token string
+		cookie, err := r.Cookie(s.Cookie.Name)
+		if err == nil {
+			token = cookie.Value
+		}
+
+		ctx, err := s.Load(r.Context(), token)
+		if err != nil {
+			log.Output(2, err.Error())
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
+
+		sr := r.WithContext(ctx)
+		bw := &bufferedResponseWriter{ResponseWriter: w}
+		next.ServeHTTP(bw, sr)
+
+		switch s.Status(ctx) {
+		case Modified:
+			token, expiry, err := s.Commit(ctx)
+			if err != nil {
+				log.Output(2, err.Error())
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				return
+			}
+			s.writeSessionCookie(w, token, expiry)
+		case Destroyed:
+			s.writeSessionCookie(w, "", time.Time{})
+		}
+
+		if bw.code != 0 {
+			w.WriteHeader(bw.code)
+		}
+		w.Write(bw.buf.Bytes())
+	})
+}
+
+func (s *SessionManager) writeSessionCookie(w http.ResponseWriter, token string, expiry time.Time) {
+	cookie := &http.Cookie{
+		Name:     s.Cookie.Name,
+		Value:    token,
+		Path:     s.Cookie.Path,
+		Domain:   s.Cookie.Domain,
+		Secure:   s.Cookie.Secure,
+		HttpOnly: s.Cookie.HttpOnly,
+		SameSite: s.Cookie.SameSite,
+	}
+
+	if expiry.IsZero() {
+		cookie.Expires = time.Unix(1, 0)
+		cookie.MaxAge = -1
+	} else if s.Cookie.Persist {
+		cookie.Expires = time.Unix(expiry.Unix()+1, 0)        // Round up to the nearest second.
+		cookie.MaxAge = int(time.Until(expiry).Seconds() + 1) // Round up to the nearest second.
+	}
+
+	w.Header().Add("Set-Cookie", cookie.String())
+	addHeaderIfMissing(w, "Cache-Control", `no-cache="Set-Cookie"`)
+	addHeaderIfMissing(w, "Vary", "Cookie")
+
+}
+
+func addHeaderIfMissing(w http.ResponseWriter, key, value string) {
+	for _, h := range w.Header()[key] {
+		if h == value {
+			return
+		}
+	}
+	w.Header().Add(key, value)
+}
+
+type bufferedResponseWriter struct {
+	http.ResponseWriter
+	buf  bytes.Buffer
+	code int
+}
+
+func (bw *bufferedResponseWriter) Write(b []byte) (int, error) {
+	return bw.buf.Write(b)
+}
+
+func (bw *bufferedResponseWriter) WriteHeader(code int) {
+	bw.code = code
+}
+
+func (bw *bufferedResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hj := bw.ResponseWriter.(http.Hijacker)
+	return hj.Hijack()
+}

--- a/vendor/github.com/alexedwards/scs/v2/store.go
+++ b/vendor/github.com/alexedwards/scs/v2/store.go
@@ -1,0 +1,25 @@
+package scs
+
+import (
+	"time"
+)
+
+// Store is the interface for session stores.
+type Store interface {
+	// Delete should remove the session token and corresponding data from the
+	// session store. If the token does not exist then Delete should be a no-op
+	// and return nil (not an error).
+	Delete(token string) (err error)
+
+	// Find should return the data for a session token from the store. If the
+	// session token is not found or is expired, the found return value should
+	// be false (and the err return value should be nil). Similarly, tampered
+	// or malformed tokens should result in a found return value of false and a
+	// nil err value. The err return value should be used for system errors only.
+	Find(token string) (b []byte, found bool, err error)
+
+	// Commit should add the session token and data to the store, with the given
+	// expiry time. If the session token already exists, then the data and
+	// expiry time should be overwritten.
+	Commit(token string, b []byte, expiry time.Time) (err error)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -43,6 +43,9 @@ github.com/PuerkitoBio/urlesc
 github.com/agnivade/levenshtein
 # github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
 github.com/alecthomas/units
+# github.com/alexedwards/scs/v2 v2.2.0
+github.com/alexedwards/scs/v2
+github.com/alexedwards/scs/v2/memstore
 # github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da
 github.com/armon/go-metrics
 # github.com/aws/aws-sdk-go v1.25.48
@@ -526,6 +529,7 @@ gopkg.in/inf.v0
 gopkg.in/yaml.v2
 # k8s.io/api v0.0.0 => k8s.io/api v0.0.0-20191004102349-159aefb8556b
 k8s.io/api/core/v1
+k8s.io/api/authorization/v1
 k8s.io/api/apps/v1
 k8s.io/api/batch/v1
 k8s.io/api/admission/v1beta1
@@ -534,7 +538,6 @@ k8s.io/api/apps/v1beta1
 k8s.io/api/apps/v1beta2
 k8s.io/api/authentication/v1
 k8s.io/api/authentication/v1beta1
-k8s.io/api/authorization/v1
 k8s.io/api/authorization/v1beta1
 k8s.io/api/autoscaling/v1
 k8s.io/api/autoscaling/v2beta1
@@ -576,6 +579,7 @@ k8s.io/apimachinery/pkg/runtime/serializer
 k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/pkg/types
 k8s.io/apimachinery/pkg/labels
+k8s.io/apimachinery/pkg/api/meta
 k8s.io/apimachinery/pkg/apis/meta/v1/unstructured
 k8s.io/apimachinery/pkg/selection
 k8s.io/apimachinery/pkg/util/errors
@@ -583,7 +587,6 @@ k8s.io/apimachinery/pkg/util/validation
 k8s.io/apimachinery/pkg/runtime/serializer/streaming
 k8s.io/apimachinery/pkg/util/net
 k8s.io/apimachinery/pkg/util/sets
-k8s.io/apimachinery/pkg/api/meta
 k8s.io/apimachinery/pkg/fields
 k8s.io/apimachinery/pkg/util/json
 k8s.io/apimachinery/pkg/util/validation/field
@@ -599,8 +602,8 @@ k8s.io/apimachinery/pkg/runtime/serializer/protobuf
 k8s.io/apimachinery/pkg/runtime/serializer/recognizer
 k8s.io/apimachinery/pkg/runtime/serializer/versioning
 k8s.io/apimachinery/pkg/util/strategicpatch
-k8s.io/apimachinery/pkg/util/yaml
 k8s.io/apimachinery/pkg/apis/meta/v1beta1
+k8s.io/apimachinery/pkg/util/yaml
 k8s.io/apimachinery/pkg/util/uuid
 k8s.io/apimachinery/third_party/forked/golang/reflect
 k8s.io/apimachinery/pkg/apis/meta/internalversion
@@ -608,11 +611,11 @@ k8s.io/apimachinery/pkg/util/framer
 k8s.io/apimachinery/pkg/util/mergepatch
 k8s.io/apimachinery/third_party/forked/golang/json
 # k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible => k8s.io/client-go v11.0.1-0.20191029005444-8e4128053008+incompatible
+k8s.io/client-go/kubernetes
 k8s.io/client-go/tools/clientcmd
 k8s.io/client-go/tools/clientcmd/api
 k8s.io/client-go/plugin/pkg/client/auth
 k8s.io/client-go/rest
-k8s.io/client-go/kubernetes
 k8s.io/client-go/kubernetes/scheme
 k8s.io/client-go/tools/cache
 k8s.io/client-go/util/workqueue
@@ -625,22 +628,6 @@ k8s.io/client-go/util/jsonpath
 k8s.io/client-go/kubernetes/typed/core/v1
 k8s.io/client-go/util/retry
 k8s.io/client-go/util/cert
-k8s.io/client-go/tools/auth
-k8s.io/client-go/tools/clientcmd/api/latest
-k8s.io/client-go/util/homedir
-k8s.io/client-go/dynamic
-k8s.io/client-go/plugin/pkg/client/auth/azure
-k8s.io/client-go/plugin/pkg/client/auth/gcp
-k8s.io/client-go/plugin/pkg/client/auth/oidc
-k8s.io/client-go/plugin/pkg/client/auth/openstack
-k8s.io/client-go/pkg/version
-k8s.io/client-go/plugin/pkg/client/auth/exec
-k8s.io/client-go/rest/watch
-k8s.io/client-go/tools/metrics
-k8s.io/client-go/transport
-k8s.io/client-go/tools/leaderelection
-k8s.io/client-go/tools/leaderelection/resourcelock
-k8s.io/client-go/tools/record
 k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1
 k8s.io/client-go/kubernetes/typed/apps/v1
 k8s.io/client-go/kubernetes/typed/apps/v1beta1
@@ -676,10 +663,26 @@ k8s.io/client-go/kubernetes/typed/settings/v1alpha1
 k8s.io/client-go/kubernetes/typed/storage/v1
 k8s.io/client-go/kubernetes/typed/storage/v1alpha1
 k8s.io/client-go/kubernetes/typed/storage/v1beta1
+k8s.io/client-go/tools/auth
+k8s.io/client-go/tools/clientcmd/api/latest
+k8s.io/client-go/util/homedir
+k8s.io/client-go/dynamic
+k8s.io/client-go/plugin/pkg/client/auth/azure
+k8s.io/client-go/plugin/pkg/client/auth/gcp
+k8s.io/client-go/plugin/pkg/client/auth/oidc
+k8s.io/client-go/plugin/pkg/client/auth/openstack
+k8s.io/client-go/pkg/version
+k8s.io/client-go/plugin/pkg/client/auth/exec
+k8s.io/client-go/rest/watch
+k8s.io/client-go/tools/metrics
+k8s.io/client-go/transport
+k8s.io/client-go/tools/leaderelection
+k8s.io/client-go/tools/leaderelection/resourcelock
+k8s.io/client-go/tools/record
 k8s.io/client-go/tools/pager
 k8s.io/client-go/restmapper
-k8s.io/client-go/tools/reference
 k8s.io/client-go/kubernetes/fake
+k8s.io/client-go/tools/reference
 k8s.io/client-go/kubernetes/typed/core/v1/fake
 k8s.io/client-go/util/keyutil
 k8s.io/client-go/tools/clientcmd/api/v1


### PR DESCRIPTION
Limits the namespace, address space, address objects visible to the logged on console user to those that the user has GET permission.   Connections are permissions by considering the permissions of the address space to which they belong.