### PR TITLE
Fix: handle validations of creation wizards

### DIFF
--- a/console/console-init/ui/src/Pages/CreateAddress/CreateAddressDefinition.tsx
+++ b/console/console-init/ui/src/Pages/CreateAddress/CreateAddressDefinition.tsx
@@ -112,6 +112,8 @@ export const AddressDefinitaion: React.FunctionComponent<IAddressDefinition> = (
             description: plan.Spec.ShortDescription
           };
         });
+        setPlan(" ");
+        setTopic(" ");
         setPlanOptions(planOptions);
       }
       if (type === "subscription") {

--- a/console/console-init/ui/src/Pages/CreateAddress/CreateAddressPage.tsx
+++ b/console/console-init/ui/src/Pages/CreateAddress/CreateAddressPage.tsx
@@ -49,7 +49,16 @@ export const CreateAddressPage: React.FunctionComponent<ICreateAddressProps> = (
   };
 
   const handleSave = async () => {
-    if (addressSpace && addressName && plan && namespace) {
+    if (
+      addressSpace &&
+      addressName.trim() !== "" &&
+      plan.trim() !== "" &&
+      addressType.trim() !== "" &&
+        (
+          (addressType === "subscription") === 
+            (topic.trim() !== "")
+        )
+    ) {
       const getVariables = () => {
         let variable:any = {
           ObjectMeta: {
@@ -105,6 +114,15 @@ export const CreateAddressPage: React.FunctionComponent<ICreateAddressProps> = (
           setTopicForSubscripitons={setTopicForSubscription}
         />
       ),
+      enableNext : (
+        addressName.trim() !== "" &&
+        plan.trim() !== "" &&
+        addressType.trim() !== "" &&
+        (
+          (addressType === "subscription") === 
+            (topic.trim() !== "")
+        )
+      ),
       backButton: "hide"
     },
     {
@@ -118,6 +136,15 @@ export const CreateAddressPage: React.FunctionComponent<ICreateAddressProps> = (
           namespace={namespace || ""}
           addressspace={addressSpace}
         />
+      ),
+      enableNext : (
+        addressName.trim() !== "" &&
+        plan.trim() !== "" &&
+        addressType.trim() !== "" &&
+        (
+          (addressType === "subscription") === 
+            (topic.trim() !== "")
+        )
       ),
       nextButtonText: "Finish"
     }

--- a/console/console-init/ui/src/Pages/CreateAddressSpace/CreateAddressSpaceConfiguration.tsx
+++ b/console/console-init/ui/src/Pages/CreateAddressSpace/CreateAddressSpaceConfiguration.tsx
@@ -178,12 +178,16 @@ export const AddressSpaceConfiguration: React.FunctionComponent<IAddressSpaceCon
   const handleBrokeredChange = () => {
     setIsBrokeredChecked(true);
     setIsStandardChecked(false);
+    setPlan(" ");
+    setAuthenticationService(" ");
     setType("brokered");
   };
 
   const handleStandardChange = () => {
     setIsStandardChecked(true);
     setIsBrokeredChecked(false);
+    setPlan(" ");
+    setAuthenticationService(" ");
     setType("standard");
   };
 
@@ -268,12 +272,13 @@ export const AddressSpaceConfiguration: React.FunctionComponent<IAddressSpaceCon
               <br />
               <Dropdown
                 id="cas-dropdown-plan"
-                position={DropdownPosition.left}
+                position={DropdownPosition.right}
                 onSelect={onPlanSelect}
                 isOpen={isPlanOpen}
                 style={{ display: "flex" }}
                 toggle={
                   <DropdownToggle
+                    isDisabled={type.trim() === ""}
                     style={{ flex: "1", position: "inherit" }}
                     onToggle={() => setIsPlanOpen(!isPlanOpen)}
                   >
@@ -309,6 +314,7 @@ export const AddressSpaceConfiguration: React.FunctionComponent<IAddressSpaceCon
                 style={{ display: "flex" }}
                 toggle={
                   <DropdownToggle
+                    isDisabled={type.trim() === ""}
                     style={{ flex: "1", position: "inherit" }}
                     onToggle={() =>
                       setIsAuthenticationServiceOpen(
@@ -328,8 +334,6 @@ export const AddressSpaceConfiguration: React.FunctionComponent<IAddressSpaceCon
                     component={"button"}
                   >
                     <b>{option.label}</b>
-                    <br />
-                    {option.description}
                   </DropdownItem>
                 ))}
               />

--- a/console/console-init/ui/src/Pages/CreateAddressSpace/CreateAddressSpacePage.tsx
+++ b/console/console-init/ui/src/Pages/CreateAddressSpace/CreateAddressSpacePage.tsx
@@ -28,6 +28,8 @@ export const CreateAddressSpace: React.FunctionComponent<ICreateAddressSpaceProp
   setOnCreationRefetch
 }) => {
   const [addressSpaceName, setAddressSpaceName] = React.useState("");
+  // State has been initialized to " " instead of null string 
+  // due to dropdown arrow positioning issues
   const [addressSpaceType, setAddressSpaceType] = React.useState(" ");
   const [addressSpacePlan, setAddressSpacePlan] = React.useState(" ");
   const [namespace, setNamespace] = React.useState(" ");
@@ -95,10 +97,18 @@ export const CreateAddressSpace: React.FunctionComponent<ICreateAddressSpaceProp
           setAuthenticationService={setAuthenticationService}
         />
       ),
+      enableNext : (
+        addressSpaceName.trim() !== "" &&
+        addressSpaceType.trim() !== "" &&
+        authenticationService.trim() !== "" &&
+        addressSpacePlan.trim() !== "" &&
+        namespace.trim() !== ""
+      ),
       backButton: "hide"
     },
     {
       name: "Review",
+      isDisabled : true,
       component: (
         <ReviewAddressSpace
           name={addressSpaceName}
@@ -107,6 +117,13 @@ export const CreateAddressSpace: React.FunctionComponent<ICreateAddressSpaceProp
           plan={addressSpacePlan}
           authenticationService={authenticationService}
         />
+      ),
+      enableNext : (
+        addressSpaceName.trim() !== "" &&
+        addressSpaceType.trim() !== "" &&
+        authenticationService.trim() !== "" &&
+        addressSpacePlan.trim() !== "" &&
+        namespace.trim() !== ""
       ),
       nextButtonText: "Finish"
     }

--- a/console/console-init/ui/src/Pages/CreateAddressSpace/ReviewAddressSpace.tsx
+++ b/console/console-init/ui/src/Pages/CreateAddressSpace/ReviewAddressSpace.tsx
@@ -87,7 +87,7 @@ export const ReviewAddressSpace: React.FunctionComponent<IAddressSpaceReview> = 
           }}
         >
           <Grid>
-            {name && (
+            {name && name.trim() !== "" && (
               <>
                 <GridItem span={5} style={{ marginBottom: 16, marginRight: 5 }}>
                   Instance name
@@ -97,7 +97,7 @@ export const ReviewAddressSpace: React.FunctionComponent<IAddressSpaceReview> = 
                 </GridItem>
               </>
             )}
-            {namespace && (
+            {namespace && namespace.trim() !== "" && (
               <>
                 <GridItem span={5} style={{ marginBottom: 16, marginRight: 5 }}>
                   Namespace


### PR DESCRIPTION
The AddressSpaceCreation and AddressCreation wizards now allow going to the next step only after all the required fields are available/provided.