### PR TITLE
Add systemtests for pdb and fix StandardInfraConfig CRD

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/Kubernetes.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/Kubernetes.java
@@ -71,6 +71,7 @@ import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.extensions.Ingress;
+import io.fabric8.kubernetes.api.model.policy.PodDisruptionBudget;
 import io.fabric8.kubernetes.api.model.storage.StorageClass;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -873,6 +874,14 @@ public abstract class Kubernetes {
 
     public CustomResourceDefinition getCRD(String name) {
         return client.customResourceDefinitions().withName(name).get();
+    }
+
+    public PodDisruptionBudget getPodDisruptionBudget(String namespace, String name) {
+        return client.policy().podDisruptionBudget().inNamespace(namespace).withName(name).get();
+    }
+
+    public void deletePodDisruptionBudget(String namespace, String name) {
+        client.policy().podDisruptionBudget().inNamespace(namespace).withName(name).delete();
     }
 
     public abstract void createExternalEndpoint(String name, String namespace, Service service, ServicePort targetPort);

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/infra/InfraTestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/infra/InfraTestBase.java
@@ -6,7 +6,6 @@ package io.enmasse.systemtest.bases.infra;
 
 import io.enmasse.address.model.AddressSpace;
 import io.enmasse.admin.model.v1.AddressPlan;
-import io.enmasse.admin.model.v1.InfraConfig;
 import io.enmasse.systemtest.bases.ITestBase;
 import io.enmasse.systemtest.bases.TestBase;
 import io.enmasse.systemtest.logs.CustomLogger;
@@ -37,7 +36,6 @@ public abstract class InfraTestBase extends TestBase implements ITestBase {
             "kubernetes.io/azure-file", "kubernetes.io/azure-disk", "kubernetes.io/glusterfs", "kubernetes.io/cinder",
             "kubernetes.io/portworx-volume", "kubernetes.io/rbd");
     private static Logger log = CustomLogger.getLogger();
-    protected InfraConfig testInfra;
     protected AddressPlan exampleAddressPlan;
     protected AddressSpace exampleAddressSpace;
 

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/infra/brokered/InfraTestBrokered.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/infra/brokered/InfraTestBrokered.java
@@ -39,7 +39,7 @@ class InfraTestBrokered extends InfraTestBase implements ITestIsolatedBrokered {
     void testCreateInfra() throws Exception {
         PodTemplateSpec brokerTemplateSpec = PlanUtils.createTemplateSpec(Collections.singletonMap("mycomponent", "broker"), "mybrokernode", "broker");
         PodTemplateSpec adminTemplateSpec = PlanUtils.createTemplateSpec(Collections.singletonMap("mycomponent", "admin"), "myadminnode", "admin");
-        testInfra = new BrokeredInfraConfigBuilder()
+        BrokeredInfraConfig testInfra = new BrokeredInfraConfigBuilder()
                 .withNewMetadata()
                 .withName("test-infra-3-brokered")
                 .endMetadata()
@@ -61,7 +61,7 @@ class InfraTestBrokered extends InfraTestBase implements ITestIsolatedBrokered {
                         .build())
                 .endSpec()
                 .build();
-        resourcesManager.createInfraConfig((BrokeredInfraConfig) testInfra);
+        resourcesManager.createInfraConfig(testInfra);
 
         exampleAddressPlan = PlanUtils.createAddressPlanObject("example-queue-plan-brokered", AddressType.QUEUE,
                 Collections.singletonList(new ResourceRequest("broker", 1.0)));
@@ -181,7 +181,7 @@ class InfraTestBrokered extends InfraTestBase implements ITestIsolatedBrokered {
 
     @Test
     void testReadInfra() throws Exception {
-        testInfra = new BrokeredInfraConfigBuilder()
+        BrokeredInfraConfig testInfra = new BrokeredInfraConfigBuilder()
                 .withNewMetadata()
                 .withName("test-infra-1-brokered")
                 .endMetadata()
@@ -201,17 +201,17 @@ class InfraTestBrokered extends InfraTestBase implements ITestIsolatedBrokered {
                         .build())
                 .endSpec()
                 .build();
-        resourcesManager.createInfraConfig((BrokeredInfraConfig) testInfra);
+        resourcesManager.createInfraConfig(testInfra);
 
         BrokeredInfraConfig actualInfra = resourcesManager.getBrokeredInfraConfig(testInfra.getMetadata().getName());
 
         assertEquals(testInfra.getMetadata().getName(), actualInfra.getMetadata().getName());
 
-        BrokeredInfraConfigSpecAdmin expectedAdmin = ((BrokeredInfraConfig) testInfra).getSpec().getAdmin();
+        BrokeredInfraConfigSpecAdmin expectedAdmin = testInfra.getSpec().getAdmin();
         BrokeredInfraConfigSpecAdmin actualAdmin = actualInfra.getSpec().getAdmin();
         assertEquals(expectedAdmin.getResources().getMemory(), actualAdmin.getResources().getMemory());
 
-        BrokeredInfraConfigSpecBroker expectedBroker = ((BrokeredInfraConfig) testInfra).getSpec().getBroker();
+        BrokeredInfraConfigSpecBroker expectedBroker = testInfra.getSpec().getBroker();
         BrokeredInfraConfigSpecBroker actualBroker = actualInfra.getSpec().getBroker();
         assertEquals(expectedBroker.getResources().getMemory(), actualBroker.getResources().getMemory());
         assertEquals(expectedBroker.getResources().getStorage(), actualBroker.getResources().getStorage());

--- a/templates/crds/standardinfraconfigs.crd.yaml
+++ b/templates/crds/standardinfraconfigs.crd.yaml
@@ -75,9 +75,13 @@ spec:
               type: object
               properties:
                 minAvailable:
-                  type: int-or-string
+                  anyOf:
+                  - type: integer
+                  - type: string
                 maxUnavailable:
-                  type: int-or-string
+                  anyOf:
+                  - type: integer
+                  - type: string
                 podTemplate:
                   type: object
                   properties:
@@ -153,9 +157,13 @@ spec:
                 minReplicas:
                   type: integer
                 minAvailable:
-                  type: int-or-string
+                  anyOf:
+                  - type: integer
+                  - type: string
                 maxUnavailable:
-                  type: int-or-string
+                  anyOf:
+                  - type: integer
+                  - type: string
                 linkCapacity:
                   type: integer
                 idleTimeout:


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix
- Systemtests

### Description

This PR adds new systemtests to verify the PodDisruptionBudget functionalities, also fixes the StandardInfraConfig CRD which I broke before :) 
Note atm the tests added are expected to fail because address-space-controller doesn't implement the delete of the pdb when a addressspace is deleted or when the infraconfig is updated.

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [X] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [X] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
