### PR TITLE
Fix: show proper title for ConnectionDetailPage

### DIFF
--- a/console/console-init/ui/src/Pages/ConnectionDetail/ConnectionDetailPage.tsx
+++ b/console/console-init/ui/src/Pages/ConnectionDetail/ConnectionDetailPage.tsx
@@ -15,7 +15,7 @@ import {
 } from "@patternfly/react-core";
 import { useQuery } from "@apollo/react-hooks";
 import { useParams } from "react-router";
-import { Loading, useA11yRouteChange, useBreadcrumb } from "use-patternfly";
+import { Loading, useA11yRouteChange, useBreadcrumb, useDocumentTitle } from "use-patternfly";
 import { getFilteredValue } from "src/Components/Common/ConnectionListFormatter";
 import { IConnectionDetailResponse } from "src/Types/ResponseTypes";
 import { Link } from "react-router-dom";
@@ -45,6 +45,7 @@ const getSplitValue = (value: string) => {
 
 export default function ConnectionDetailPage() {
   const { name, namespace, type, connectionname } = useParams();
+  useDocumentTitle("Connection Details");
   const breadcrumb = React.useMemo(
     () => (
       <Breadcrumb>


### PR DESCRIPTION
The connection detail page now shows the right title 'Connection Details' instead of 'Address Space Detail'.
