### PR TITLE
Replace images during image build time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,10 +50,10 @@ templates: imageenv
 	$(MAKE) -C templates
 
 deploy: build_go
-	$(IMAGE_ENV) mvn -Prelease deploy $(MAVEN_ARGS)
+	$(IMAGE_ENV) IMAGE_ENV="$(IMAGE_ENV)" mvn -Prelease deploy $(MAVEN_ARGS)
 
 build_java: build_go templates
-	$(IMAGE_ENV) mvn package -q $(MAVEN_ARGS)
+	$(IMAGE_ENV) IMAGE_ENV="$(IMAGE_ENV)" mvn package -q $(MAVEN_ARGS)
 
 build_go: $(GO_DIRS) test_go
 

--- a/Makefile.java.mk
+++ b/Makefile.java.mk
@@ -8,7 +8,7 @@ endif
 
 ifneq ($(FULL_BUILD),true)
 build:
-	cd $(TOPDIR); $(IMAGE_ENV) mvn -pl $(MVNPROJ) -am clean install $(MAVEN_ARGS)
+	cd $(TOPDIR); $(IMAGE_ENV) IMAGE_ENV="$(IMAGE_ENV)" mvn -pl $(MVNPROJ) -am clean install $(MAVEN_ARGS)
 
 test:
 ifeq ($(SKIP_TESTS),true)
@@ -18,7 +18,7 @@ else
 endif
 
 package_java:
-	$(IMAGE_ENV) mvn package -DskipTests $(MAVEN_ARGS)
+	$(IMAGE_ENV) IMAGE_ENV="$(IMAGE_ENV)" mvn package -DskipTests $(MAVEN_ARGS)
 
 package: package_java
 endif

--- a/olm-manifest/Dockerfile
+++ b/olm-manifest/Dockerfile
@@ -11,6 +11,9 @@ ARG maven_version
 ENV VERSION=${version} MAVEN_VERSION=${maven_version} COMMIT=${commit}
 
 ADD target/olm-manifest-${maven_version}-dist.tar.gz /
+USER root
+RUN /bin/replace-images.sh
+USER 1001
 
 RUN /usr/bin/initializer -m /manifests -o bundles.db
 ENTRYPOINT ["/usr/bin/registry-server"]

--- a/olm-manifest/src/assembly/unix-dist.xml
+++ b/olm-manifest/src/assembly/unix-dist.xml
@@ -40,6 +40,12 @@
     </fileSets>
     <files>
         <file>
+          <source>${project.basedir}/target/classes/sh/replace-images.sh</source>
+          <outputDirectory>/bin</outputDirectory>
+          <destName>replace-images.sh</destName>
+          <fileMode>0755</fileMode>
+        </file>
+        <file>
           <source>${project.basedir}/target/classes/latest/enmasse.package.yaml</source>
           <outputDirectory>/manifests</outputDirectory>
           <destName>${application.bundle.prefix}.package.yaml</destName>

--- a/olm-manifest/src/main/resources/latest/enmasse.clusterserviceversion.yaml
+++ b/olm-manifest/src/main/resources/latest/enmasse.clusterserviceversion.yaml
@@ -11,7 +11,7 @@ metadata:
     categories: "Streaming & Messaging"
     certified: "false"
     description: ${olm.csv.name.long} provides messaging as a managed service on ${olm.csv.platform}
-    containerImage: ${env.CONTROLLER_MANAGER_IMAGE}
+    containerImage: ${CONTROLLER_MANAGER_IMAGE}
     createdAt: 2019-02-19T00:00:00Z
     capabilities: Seamless Upgrades
     repository: ${olm.csv.repository}
@@ -442,59 +442,59 @@ spec:
 
   relatedImages:
     - name: address-space-controller
-      image: ${env.ADDRESS_SPACE_CONTROLLER_IMAGE}
+      image: ${ADDRESS_SPACE_CONTROLLER_IMAGE}
     - name: standard-controller
-      image: ${env.STANDARD_CONTROLLER_IMAGE}
+      image: ${STANDARD_CONTROLLER_IMAGE}
     - name: router
-      image: ${env.ROUTER_IMAGE}
+      image: ${ROUTER_IMAGE}
     - name: broker
-      image: ${env.BROKER_IMAGE}
+      image: ${BROKER_IMAGE}
     - name: broker-plugin
-      image: ${env.BROKER_PLUGIN_IMAGE}
+      image: ${BROKER_PLUGIN_IMAGE}
     - name: topic-forwarder
-      image: ${env.TOPIC_FORWARDER_IMAGE}
+      image: ${TOPIC_FORWARDER_IMAGE}
     - name: agent
-      image: ${env.AGENT_IMAGE}
+      image: ${AGENT_IMAGE}
     - name: none-authservice
-      image: ${env.NONE_AUTHSERVICE_IMAGE}
+      image: ${NONE_AUTHSERVICE_IMAGE}
     - name: keycloak
-      image: ${env.KEYCLOAK_IMAGE}
+      image: ${KEYCLOAK_IMAGE}
     - name: keycloak-plugin
-      image: ${env.KEYCLOAK_PLUGIN_IMAGE}
+      image: ${KEYCLOAK_PLUGIN_IMAGE}
     - name: mqtt-gateway
-      image: ${env.MQTT_GATEWAY_IMAGE}
+      image: ${MQTT_GATEWAY_IMAGE}
     - name: mqtt-lwt
-      image: ${env.MQTT_LWT_IMAGE}
+      image: ${MQTT_LWT_IMAGE}
     - name: console-init
-      image: ${env.CONSOLE_INIT_IMAGE}
+      image: ${CONSOLE_INIT_IMAGE}
     - name: console-proxy-openshift
-      image: ${env.CONSOLE_PROXY_OPENSHIFT_IMAGE}
+      image: ${CONSOLE_PROXY_OPENSHIFT_IMAGE}
     - name: console-proxy-kubernetes
-      image: ${env.CONSOLE_PROXY_KUBERNETES_IMAGE}
+      image: ${CONSOLE_PROXY_KUBERNETES_IMAGE}
     - name: console-httpd
-      image: ${env.CONSOLE_HTTPD_IMAGE}
+      image: ${CONSOLE_HTTPD_IMAGE}
     - name: controller-manager
-      image: ${env.CONTROLLER_MANAGER_IMAGE}
+      image: ${CONTROLLER_MANAGER_IMAGE}
     - name: iot-proxy-configurator
-      image: ${env.IOT_PROXY_CONFIGURATOR_IMAGE}
+      image: ${IOT_PROXY_CONFIGURATOR_IMAGE}
     - name: iot-auth-service
-      image: ${env.IOT_AUTH_SERVICE_IMAGE}
+      image: ${IOT_AUTH_SERVICE_IMAGE}
     - name: iot-device-registry-file
-      image: ${env.IOT_DEVICE_REGISTRY_FILE_IMAGE}
+      image: ${IOT_DEVICE_REGISTRY_FILE_IMAGE}
     - name: iot-device-registry-infinispan
-      image: ${env.IOT_DEVICE_REGISTRY_INFINISPAN_IMAGE}
+      image: ${IOT_DEVICE_REGISTRY_INFINISPAN_IMAGE}
     - name: iot-http-adapter
-      image: ${env.IOT_HTTP_ADAPTER_IMAGE}
+      image: ${IOT_HTTP_ADAPTER_IMAGE}
     - name: iot-mqtt-adapter
-      image: ${env.IOT_MQTT_ADAPTER_IMAGE}
+      image: ${IOT_MQTT_ADAPTER_IMAGE}
     - name: iot-lorawan-adapter
-      image: ${env.IOT_LORAWAN_ADAPTER_IMAGE}
+      image: ${IOT_LORAWAN_ADAPTER_IMAGE}
     - name: iot-sigfox-adapter
-      image: ${env.IOT_SIGFOX_ADAPTER_IMAGE}
+      image: ${IOT_SIGFOX_ADAPTER_IMAGE}
     - name: iot-tenant-service
-      image: ${env.IOT_TENANT_SERVICE_IMAGE}
+      image: ${IOT_TENANT_SERVICE_IMAGE}
     - name: iot-tenant-cleaner
-      image: ${env.IOT_TENANT_CLEANER_IMAGE}
+      image: ${IOT_TENANT_CLEANER_IMAGE}
   install:
     strategy: deployment
     spec:
@@ -662,7 +662,7 @@ spec:
               serviceAccountName: enmasse-operator
               containers:
               - name: controller
-                image: ${env.CONTROLLER_MANAGER_IMAGE}
+                image: ${CONTROLLER_MANAGER_IMAGE}
                 imagePullPolicy: ${env.IMAGE_PULL_POLICY}
                 env:
                 - name: POD_NAME
@@ -694,63 +694,61 @@ spec:
                 - name: CONTROLLER_ENABLE_MESSAGING_USER
                   value: "true"
                 - name: ADDRESS_SPACE_CONTROLLER_IMAGE
-                  value: ${env.ADDRESS_SPACE_CONTROLLER_IMAGE}
+                  value: ${ADDRESS_SPACE_CONTROLLER_IMAGE}
                 - name: CONTROLLER_MANAGER_IMAGE
-                  value: ${env.CONTROLLER_MANAGER_IMAGE}
+                  value: ${CONTROLLER_MANAGER_IMAGE}
                 - name: IOT_AUTH_SERVICE_IMAGE
-                  value: ${env.IOT_AUTH_SERVICE_IMAGE}
+                  value: ${IOT_AUTH_SERVICE_IMAGE}
                 - name: IOT_DEVICE_REGISTRY_FILE_IMAGE
-                  value: ${env.IOT_DEVICE_REGISTRY_FILE_IMAGE}
+                  value: ${IOT_DEVICE_REGISTRY_FILE_IMAGE}
                 - name: IOT_DEVICE_REGISTRY_INFINISPAN_IMAGE
-                  value: ${env.IOT_DEVICE_REGISTRY_INFINISPAN_IMAGE}
-                - name: IOT_GC_IMAGE
-                  value: ${env.IOT_GC_IMAGE}
+                  value: ${IOT_DEVICE_REGISTRY_INFINISPAN_IMAGE}
                 - name: IOT_HTTP_ADAPTER_IMAGE
-                  value: ${env.IOT_HTTP_ADAPTER_IMAGE}
+                  value: ${IOT_HTTP_ADAPTER_IMAGE}
                 - name: IOT_MQTT_ADAPTER_IMAGE
-                  value: ${env.IOT_MQTT_ADAPTER_IMAGE}
+                  value: ${IOT_MQTT_ADAPTER_IMAGE}
                 - name: IOT_LORAWAN_ADAPTER_IMAGE
-                  value: ${env.IOT_LORAWAN_ADAPTER_IMAGE}
+                  value: ${IOT_LORAWAN_ADAPTER_IMAGE}
                 - name: IOT_SIGFOX_ADAPTER_IMAGE
-                  value: ${env.IOT_SIGFOX_ADAPTER_IMAGE}
+                  value: ${IOT_SIGFOX_ADAPTER_IMAGE}
                 - name: IOT_TENANT_CLEANER_IMAGE
                   value: ${IOT_TENANT_CLEANER_IMAGE}
                 - name: IOT_TENANT_SERVICE_IMAGE
-                  value: ${env.IOT_TENANT_SERVICE_IMAGE}
+                  value: ${IOT_TENANT_SERVICE_IMAGE}
                 - name: IOT_PROXY_CONFIGURATOR_IMAGE
-                  value: ${env.IOT_PROXY_CONFIGURATOR_IMAGE}
+                  value: ${IOT_PROXY_CONFIGURATOR_IMAGE}
                 - name: ROUTER_IMAGE
-                  value: ${env.ROUTER_IMAGE}
+                  value: ${ROUTER_IMAGE}
                 - name: STANDARD_CONTROLLER_IMAGE
-                  value: ${env.STANDARD_CONTROLLER_IMAGE}
+                  value: ${STANDARD_CONTROLLER_IMAGE}
                 - name: AGENT_IMAGE
-                  value: ${env.AGENT_IMAGE}
+                  value: ${AGENT_IMAGE}
                 - name: BROKER_IMAGE
-                  value: ${env.BROKER_IMAGE}
+                  value: ${BROKER_IMAGE}
                 - name: BROKER_PLUGIN_IMAGE
-                  value: ${env.BROKER_PLUGIN_IMAGE}
+                  value: ${BROKER_PLUGIN_IMAGE}
                 - name: TOPIC_FORWARDER_IMAGE
-                  value: ${env.TOPIC_FORWARDER_IMAGE}
+                  value: ${TOPIC_FORWARDER_IMAGE}
                 - name: MQTT_GATEWAY_IMAGE
-                  value: ${env.MQTT_GATEWAY_IMAGE}
+                  value: ${MQTT_GATEWAY_IMAGE}
                 - name: MQTT_LWT_IMAGE
-                  value: ${env.MQTT_LWT_IMAGE}
+                  value: ${MQTT_LWT_IMAGE}
                 - name: NONE_AUTHSERVICE_IMAGE
-                  value: ${env.NONE_AUTHSERVICE_IMAGE}
+                  value: ${NONE_AUTHSERVICE_IMAGE}
                 - name: KEYCLOAK_IMAGE
-                  value: ${env.KEYCLOAK_IMAGE}
+                  value: ${KEYCLOAK_IMAGE}
                 - name: KEYCLOAK_PLUGIN_IMAGE
-                  value: ${env.KEYCLOAK_PLUGIN_IMAGE}
+                  value: ${KEYCLOAK_PLUGIN_IMAGE}
                 - name: CONTROLLER_ENABLE_CONSOLE_SERVICE
                   value: "true"
                 - name: CONSOLE_INIT_IMAGE
-                  value: "${env.CONSOLE_INIT_IMAGE}"
+                  value: "${CONSOLE_INIT_IMAGE}"
                 - name: CONSOLE_PROXY_OPENSHIFT_IMAGE
-                  value: "${env.CONSOLE_PROXY_OPENSHIFT_IMAGE}"
+                  value: "${CONSOLE_PROXY_OPENSHIFT_IMAGE}"
                 - name: CONSOLE_PROXY_KUBERNETES_IMAGE
-                  value: "${env.CONSOLE_PROXY_KUBERNETES_IMAGE}"
+                  value: "${CONSOLE_PROXY_KUBERNETES_IMAGE}"
                 - name: CONSOLE_HTTPD_IMAGE
-                  value: "${env.CONSOLE_HTTPD_IMAGE}"
+                  value: "${CONSOLE_HTTPD_IMAGE}"
                 - name: "FS_GROUP_FALLBACK_MAP"
                   value: "{\"standard-authservice\": 1000}"
   customresourcedefinitions:

--- a/olm-manifest/src/main/resources/sh/replace-images.sh
+++ b/olm-manifest/src/main/resources/sh/replace-images.sh
@@ -1,0 +1,43 @@
+#!/bin/bash -ex
+# Script that replaces image version in the operator CSV to work with Operator Hub tooling
+#
+# The list of components to derive are automatically added as part of the build process for the script.
+#
+# The script itself is invoked during the build of the container image where it will allow overriding the image urls via ${MY_IMAGE_PULL_URL}
+
+CSV_FILE=/manifests/${olm.version}/${application.bundle.prefix}.${olm.version}.clusterserviceversion.yaml
+export ${env.IMAGE_ENV}
+COMPONENTS=$(echo ${env.IMAGE_ENV} | sed -e 's/ /\n/g' | cut -f 1 -d '=')
+
+function replace_images() {
+    local -a component normalized key replacement replacement_key
+
+    for component in ${COMPONENTS}; do
+        echo "Inspecting component ${component}"
+        if [[ "${component}" == *_IMAGE ]]; then
+            replacement_key=${component}_PULL_URL
+
+            replacement=$(printenv ${replacement_key}) || found=0
+
+            if [[ -v "${replacement_key}" ]]; then
+                sed -e "s,\${${component}},${replacement},g" -i ${CSV_FILE}
+            else
+                value=$(printenv ${component})
+                sed -e "s,\${${component}},${value},g" -i ${CSV_FILE}
+                missing_vars+=("${replacement_key}")
+            fi
+        fi
+    done
+
+    [[ "${#missing_vars[@]}" -eq 0 ]] || {
+        echo "External variables not set (defaults used): ${missing_vars[*]}" >&2
+    }
+}
+
+main() {
+       replace_images
+}
+
+[[ "${BASH_SOURCE[0]}" == "$0" ]] && {
+    main
+}


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Refactoring

### Description

Replacing images during image build time instead of during source
build time allows for building the manifest image build in a separate
stage after the main images.


### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
