### PR TITLE
Fix-create address of type subscription to pass Spec.address as topic

### DIFF
--- a/console/console-init/ui/src/Pages/CreateAddress/CreateAddressDefinition.tsx
+++ b/console/console-init/ui/src/Pages/CreateAddress/CreateAddressDefinition.tsx
@@ -132,8 +132,8 @@ export const AddressDefinitaion: React.FunctionComponent<IAddressDefinition> = (
           const topics = topics_addresses.data.addresses.Addresses.map(
             address => {
               return {
-                value: address.ObjectMeta.Name,
-                label: address.Spec.Address
+                value: address.Spec.Address,
+                label: address.ObjectMeta.Name
               };
             }
           );


### PR DESCRIPTION
Pass address in Spec.topic for creating address of type subscription instead of ObjectMeta.Name