### PR TITLE
Fix code generation locally

### DIFF
--- a/hack/run-codegen.sh
+++ b/hack/run-codegen.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2018, EnMasse authors.
+# License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPTPATH="$(cd "$(dirname "$0")" && pwd -P)"
+
+"$SCRIPTPATH/generate-groups.sh" "all" \
+    github.com/enmasseproject/enmasse/pkg/client \
+    github.com/enmasseproject/enmasse/pkg/apis \
+    "admin:v1beta1 admin:v1beta2 enmasse:v1beta1 user:v1beta1 iot:v1alpha1" \
+    --go-header-file "${SCRIPTPATH}/header.txt" \
+    "$@"

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -11,9 +11,20 @@ set -o pipefail
 
 SCRIPTPATH="$(cd "$(dirname "$0")" && pwd -P)"
 
-"$SCRIPTPATH/generate-groups.sh" "all" \
-    github.com/enmasseproject/enmasse/pkg/client \
-    github.com/enmasseproject/enmasse/pkg/apis \
-    "admin:v1beta1 admin:v1beta2 enmasse:v1beta1 user:v1beta1 iot:v1alpha1" \
-    --go-header-file "${SCRIPTPATH}/header.txt" \
-    "$@"
+TMPBASE="$(mktemp -d)"
+TMPPROJ="$TMPBASE/github.com/enmasseproject/enmasse"
+
+cleanup() {
+    echo "Cleaning up: $TMPBASE"
+    rm -rf "$TMPBASE"
+}
+
+echo "Using tmp base: $TMPBASE"
+
+trap "cleanup" EXIT SIGINT
+
+mkdir -p "$TMPPROJ"
+
+"$SCRIPTPATH/run-codegen.sh" --output-base "$TMPBASE"
+
+cp -av "$TMPPROJ"/. .

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -26,7 +26,7 @@ trap "cleanup" EXIT SIGINT
 mkdir -p "$TMPPROJ"
 cp -dR "$SCRIPTPATH/../" "$TMPPROJ"
 
-"$SCRIPTPATH/update-codegen.sh" --output-base "$TMPBASE"
+"$SCRIPTPATH/run-codegen.sh" --output-base "$TMPBASE"
 
 echo "Comparing existing generated code with temporarily generated code"
 if diff -Nur --no-dereference "$SCRIPTPATH/.." "$TMPPROJ" -x "go-bin"; then


### PR DESCRIPTION
### Type of change

After fixing the code validation on the CI, the update script is still broken and generates stuff into `github.com/…` in the local directory. As the generator is unaware of go modules, there is no proper fix. I saw others firing up containers for doing this, but I think a simple `cp` should do the trick just fine.

I also experimented with `go generate`. The "deep copy" part could be done by `controller-gen`, but they removed the `clientset`, `lister`, … from that.

### Description

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
