### PR TITLE
fix type/plan icon to display as a single element for mobile view

### DIFF
--- a/console/console-init/ui/src/Components/Common/TypePlan.tsx
+++ b/console/console-init/ui/src/Components/Common/TypePlan.tsx
@@ -53,8 +53,7 @@ export const TypeBadge: React.FunctionComponent<ITypeString> = ({ type }) => {
         paddingRight: 15,
         paddingTop: 5,
         paddingBottom: 5
-      }}
-    >
+      }}>
       {type[0].toUpperCase()}
     </Badge>
   );
@@ -65,21 +64,19 @@ export const TypePlan: React.FunctionComponent<ITypePlanProps> = address => {
   const labelItem = (
     <Badge
       id="type-plan-badge"
-      style={{ backgroundColor: iconColor, fontSize: 12, padding: 5 }}
-    >
+      style={{ backgroundColor: iconColor, fontSize: 12, padding: 5 }}>
       {address.type[0].toUpperCase() + " "}
     </Badge>
   );
   return (
-    <>
+    <div>
       <Tooltip
         id="type-tooltip"
         position={TooltipPosition.top}
-        content={<div>{address.type}</div>}
-      >
+        content={<div>{address.type}</div>}>
         {labelItem}
       </Tooltip>
       {" " + address.plan}
-    </>
+    </div>
   );
 };


### PR DESCRIPTION
### Description 
Show type/plan in a single line in address list for mobile view.
Before :- 
![image](https://user-images.githubusercontent.com/29524461/73426792-3f38e680-435b-11ea-982f-d0ac6b2fee0d.png)
After :-
![image](https://user-images.githubusercontent.com/29524461/73426821-54157a00-435b-11ea-8dcb-58266d579633.png)

