### PR TITLE
Add operator and product version custom metric

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -11,9 +11,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/enmasseproject/enmasse/pkg/util"
 	"os"
 	"runtime"
+
+	"github.com/enmasseproject/enmasse/pkg/util"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	"github.com/enmasseproject/enmasse/pkg/cache"
@@ -42,6 +43,8 @@ import (
 	enmassescheme "github.com/enmasseproject/enmasse/pkg/client/clientset/versioned/scheme"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	customMetrics "github.com/enmasseproject/enmasse/pkg/custom-metrics"
 )
 
 // Change below variables to serve metrics on different host or port.
@@ -96,6 +99,9 @@ func main() {
 		log.Error(err, "")
 		os.Exit(1)
 	}
+
+	// Register custom metrics
+	customMetrics.Init()
 
 	// Install monitoring resources
 	monitoringEnabled := os.Getenv("ENABLE_MONITORING")

--- a/pkg/custom-metrics/custom_metrics.go
+++ b/pkg/custom-metrics/custom_metrics.go
@@ -1,0 +1,24 @@
+package custom_metrics
+
+import (
+	"github.com/enmasseproject/enmasse/version"
+	"github.com/prometheus/client_golang/prometheus"
+	"os"
+	customMetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// Custom metrics
+var (
+	versionInfo = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name:        "enmasse_version_info",
+			Help:        "Enmasse Operator version and product version",
+			ConstLabels: prometheus.Labels{"operator_version": version.Version, "version": os.Getenv("VERSION")},
+		},
+	)
+)
+
+func Init() {
+	// Register custom metrics with the global prometheus registry
+	customMetrics.Registry.MustRegister(versionInfo)
+}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Relevant issue - https://issues.redhat.com/browse/INTLY-5106

### Verification Steps

Verification can be completed with Enmasse deployed in cluster, or running locally.

#### Cluster

- Install the operator
- Replace operator image with `quay.io/robrien/controller-manager:add-custom-metrics`. This image was built from this feature branch
- Within the operator pod, run the following command:
  `curl http://<pod_ip_address>:8383/metrics`
- Ensure the the output of the preceding step contains a custom metric that displays both the operator version, and product version. The operator version in this instance is `latest`, with the product version being `0.31-SNAPSHOT`.

   ```
  # HELP enmasse_version_info Enmasse Operator version and product version
  # TYPE enmasse_version_info gauge
  enmasse_version_info{operator_version="latest",version="0.31-SNAPSHOT"} 0
   ```

**Locally**

- Install and run the operator locally, using this feature branch
- Run the following command in a local terminal, with the operator running:
  `curl localhost:8383/metrics`
- Verify that the metrics exist, with the correct values assigned.

### Checklist

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
