### PR TITLE
Fix: hide topic in address comd preview when it is not available

### DIFF
--- a/console/console-init/ui/src/Pages/CreateAddress/PreviewAddress.tsx
+++ b/console/console-init/ui/src/Pages/CreateAddress/PreviewAddress.tsx
@@ -22,7 +22,7 @@ import { StyleSheet, css } from "@patternfly/react-styles";
 import AceEditor from "react-ace";
 import "ace-builds/src-noconflict/mode-java";
 import "ace-builds/src-noconflict/theme-github";
-import { ADDRESS_COMMAND_PRIVEW_DETAIL } from "src/Queries/Queries";
+import { ADDRESS_COMMAND_PRIVIEW_DETAIL } from "src/Queries/Queries";
 
 export interface IAddressPreview {
   name?: string;
@@ -52,7 +52,7 @@ export const PreviewAddress: React.FunctionComponent<IAddressPreview> = ({
   const [keepInViewChecked, setKeepInViewChecked] = React.useState<boolean>(
     false
   );
-  const { data, loading, error } = useQuery(ADDRESS_COMMAND_PRIVEW_DETAIL, {
+  const { data, loading, error } = useQuery(ADDRESS_COMMAND_PRIVIEW_DETAIL, {
     variables: {
       a: {
         ObjectMeta: {
@@ -62,7 +62,7 @@ export const PreviewAddress: React.FunctionComponent<IAddressPreview> = ({
         Spec: {
           Plan: plan ? plan.toLowerCase() : "",
           Type: type ? type.toLowerCase() : "",
-          Topic: topic,
+          ...(topic && topic.trim() != "" && { Topic: topic }),
           AddressSpace: addressspace,
           Address: name
         }

--- a/console/console-init/ui/src/Queries/Queries.tsx
+++ b/console/console-init/ui/src/Queries/Queries.tsx
@@ -671,7 +671,7 @@ export const EDIT_ADDRESS = gql`
   }
 `;
 
-export const ADDRESS_COMMAND_PRIVEW_DETAIL = gql`
+export const ADDRESS_COMMAND_PRIVIEW_DETAIL = gql`
   query cmd($a: Address_enmasse_io_v1beta1_Input!) {
     addressCommand(input: $a)
   }


### PR DESCRIPTION
Earlier the address command preview didn't check if topic was available to be previewed and displayed a null string. This bug has been fixed by conditionally adding the key. It also fixes a typo.

Current preview for a non-subscription address type : 

![Screenshot from 2020-01-31 01-14-11](https://user-images.githubusercontent.com/23582438/73485514-3979ea00-43c9-11ea-90ce-de7839793a9d.png)

