### PR TITLE
refactor link processing

### DIFF
--- a/pkg/consolegraphql/watchers/resource_watcher_agent_test.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_agent_test.go
@@ -378,7 +378,7 @@ type MockAgentCollector struct {
 	addressSpaceNamespace string
 }
 
-func (m *MockAgentCollector) CommandDelegate(bearerToken string) (agent.CommandDelegate, error) {
+func (m *MockAgentCollector) CommandDelegate(_ string) (agent.CommandDelegate, error) {
 	panic("unused")
 }
 


### PR DESCRIPTION
existing algorithm used two nested loops to process each link, which could have resulted in n^2 iterations (where n is the number of links) which could be costly for a connection with many links.

the intent is the new code is functionally equal to the old.
