### PR TITLE
Fix #3764: validate the topic refenced by a subscription actually exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * #3729: Add relatedImages to operator manifest for disconnected install
 
 * #3673: Add support for pod disruption budgets
+* #3764: validate the topic refenced by a subscription actually exists
 
 ## 0.30.2
 *  #2714: Allow setting security context of pods using persistent volumes


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When creating an address of type subscription, the topic field of its spec should reference a topic address by its address.  If it does not, the subscription address's status will now report the fact that it is absent.

### Checklist

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
