### PR TITLE
Fix: handle dropdowns witth no items

### DIFF
--- a/console/console-init/ui/src/Pages/CreateAddress/CreateAddressDefinition.tsx
+++ b/console/console-init/ui/src/Pages/CreateAddress/CreateAddressDefinition.tsx
@@ -102,7 +102,7 @@ export const AddressDefinitaion: React.FunctionComponent<IAddressDefinition> = (
   const client = useApolloClient();
 
   const onTypeSelect = async (event: any) => {
-    if (event.currentTarget.childNodes[0].value) {
+    if (event.currentTarget.childNodes[0] && event.currentTarget.childNodes[0].value) {
       const type = event.currentTarget.childNodes[0].value;
       setType(type);
       const addressPlans = await client.query<IAddressPlans>({
@@ -150,11 +150,11 @@ export const AddressDefinitaion: React.FunctionComponent<IAddressDefinition> = (
 
   const [isPlanOpen, setIsPlanOpen] = React.useState(false);
   const onPlanSelect = (event: any) => {
-    setPlan(event.currentTarget.childNodes[0].value);
+    event.currentTarget.childNodes[0] && setPlan(event.currentTarget.childNodes[0].value);
     setIsPlanOpen(!isPlanOpen);
   };
   const onTopicSelect = (event: any) => {
-    setTopic(event.currentTarget.childNodes[0].value);
+    event.currentTarget.childNodes[0] && setTopic(event.currentTarget.childNodes[0].value);
     setIsTopicOpen(!isTopicOpen);
   };
   const { loading, error, data } = useQuery<IAddressTypes>(
@@ -192,11 +192,11 @@ export const AddressDefinitaion: React.FunctionComponent<IAddressDefinition> = (
                 !isNameValid ? (
                   <small>
                     Only digits (0-9), lower case letters (a-z), -, and .
-                    allowed, and should start with alpha-numeric characters. 
+                    allowed, and should start with alpha-numeric characters.
                   </small>
                 ) : (
-                  ""
-                )
+                    ""
+                  )
               }
             >
               <TextInput

--- a/console/console-init/ui/src/Pages/CreateAddressSpace/CreateAddressSpaceConfiguration.tsx
+++ b/console/console-init/ui/src/Pages/CreateAddressSpace/CreateAddressSpaceConfiguration.tsx
@@ -102,12 +102,12 @@ export const AddressSpaceConfiguration: React.FunctionComponent<IAddressSpaceCon
   const [isStandardChecked, setIsStandardChecked] = React.useState(false);
   const [isBrokeredChecked, setIsBrokeredChecked] = React.useState(false);
   const onNameSpaceSelect = (event: any) => {
-    setNamespace(event.currentTarget.childNodes[0].value);
+    event.currentTarget.childNodes[0] && setNamespace(event.currentTarget.childNodes[0].value);
     setIsNameSpaceOpen(!isNameSpaceOpen);
   };
   const [isPlanOpen, setIsPlanOpen] = React.useState(false);
   const onPlanSelect = (event: any) => {
-    setPlan(event.currentTarget.childNodes[0].value);
+    event.currentTarget.childNodes[0] && setPlan(event.currentTarget.childNodes[0].value);
     setIsPlanOpen(!isPlanOpen);
   };
 
@@ -116,7 +116,7 @@ export const AddressSpaceConfiguration: React.FunctionComponent<IAddressSpaceCon
     setIsAuthenticationServiceOpen
   ] = React.useState(false);
   const onAuthenticationServiceSelect = (event: any) => {
-    setAuthenticationService(event.currentTarget.childNodes[0].value);
+    event.currentTarget.childNodes[0] && setAuthenticationService(event.currentTarget.childNodes[0].value);
     setIsAuthenticationServiceOpen(!isAuthenticationServiceOpen);
   };
 


### PR DESCRIPTION
The app was breaking for cases in which the DropDownItems was an empty array as we were trying to get the value of an undefined element. In this scenario, event.currentTarget.childNodes[0] was undefined, from which we were trying to extract the value.