### PR TITLE
Add pdb creation to example infra config

### DIFF
--- a/templates/example-plans/020-StandardInfraConfig-default-with-mqtt.yaml
+++ b/templates/example-plans/020-StandardInfraConfig-default-with-mqtt.yaml
@@ -15,8 +15,10 @@ spec:
       memory: 512Mi
       storage: 2Gi
     addressFullPolicy: FAIL
+    maxUnavailable: 1
   router:
     minReplicas: 2
     resources:
       memory: 512Mi
     linkCapacity: 250
+    maxUnavailable: 1

--- a/templates/example-plans/020-StandardInfraConfig-default.yaml
+++ b/templates/example-plans/020-StandardInfraConfig-default.yaml
@@ -13,8 +13,10 @@ spec:
       memory: 512Mi
       storage: 2Gi
     addressFullPolicy: FAIL
+    maxUnavailable: 1
   router:
     minReplicas: 2
     resources:
       memory: 512Mi
     linkCapacity: 250
+    maxUnavailable: 1


### PR DESCRIPTION
### Type of change
- Enhancement / new feature

### Description
Adding a maxUnavailable: 1 setting to the default standard infra config examples. This will create a pod disruption budget for the brokers and routers in address spaces created with this standard infra config. 

This is building on the work by @lulf in these two PRs:
https://github.com/EnMasseProject/enmasse/pull/3694
https://github.com/EnMasseProject/enmasse/pull/3698

The PDB with a maxUnavailable of 1 will still work with a setup of a single broker and/or single router. Since one pod is allowed to be unavailable, having a single replica offline does not violate the pod disruption budget.

### Checklist

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
