### PR TITLE
Reduce image footprint by using fedora minimal image as base image

### DIFF
--- a/address-space-controller/Dockerfile
+++ b/address-space-controller/Dockerfile
@@ -1,6 +1,4 @@
-FROM quay.io/enmasse/java-base:11-1
-
-RUN yum -y install openssl && yum -y clean all
+FROM quay.io/enmasse/java-base:11-3
 
 ARG version
 ARG commit

--- a/broker-plugin/Dockerfile
+++ b/broker-plugin/Dockerfile
@@ -1,6 +1,6 @@
-FROM quay.io/enmasse/java-base:11-1
+FROM quay.io/enmasse/java-base:11-3
 
-RUN yum -y install which python gettext hostname iputils apr openssl && yum clean all -y && mkdir -p /var/run/artemis/
+RUN microdnf install which python gettext hostname iputils && microdnf clean all && mkdir -p /var/run/artemis/
 
 ARG version
 ARG maven_version

--- a/console/console-init/Dockerfile
+++ b/console/console-init/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora-minimal:31
+FROM quay.io/enmasse/fedora-minimal:31
 RUN microdnf install gettext && microdnf clean all
 
 ARG version

--- a/console/console-init/Dockerfile
+++ b/console/console-init/Dockerfile
@@ -1,5 +1,5 @@
-FROM centos:7
-RUN yum -y install gettext && yum -y clean all
+FROM registry.fedoraproject.org/fedora-minimal:31
+RUN microdnf install gettext && microdnf clean all
 
 ARG version
 ARG maven_version

--- a/console/console-init/Dockerfile
+++ b/console/console-init/Dockerfile
@@ -1,5 +1,5 @@
 FROM quay.io/enmasse/fedora-minimal:31
-RUN microdnf install gettext && microdnf clean all
+RUN microdnf install gettext python findutils coreutils tar && microdnf clean all
 
 ARG version
 ARG maven_version

--- a/console/console-init/oauth-proxy/bin/init.sh
+++ b/console/console-init/oauth-proxy/bin/init.sh
@@ -17,7 +17,7 @@ TARGET_DIR=${1-/apps}
 
 SSO_COOKIE_SECRET=$(python -c \
 'import os,base64; \
- print base64.urlsafe_b64encode(os.environ["SSO_COOKIE_SECRET"] if "SSO_COOKIE_SECRET" in os.environ and os.environ["SSO_COOKIE_SECRET"] else os.urandom(32))')
+ print(base64.urlsafe_b64encode(bytes(os.environ["SSO_COOKIE_SECRET"], "utf-8") if "SSO_COOKIE_SECRET" in os.environ and os.environ["SSO_COOKIE_SECRET"] else os.urandom(32)).decode())')
 
 WELLKNOWN_DIR=${TARGET_DIR}/.well-known
 mkdir -p ${WELLKNOWN_DIR}

--- a/controller-manager/Dockerfile
+++ b/controller-manager/Dockerfile
@@ -3,7 +3,7 @@
 # License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
 #
 
-FROM centos:7
+FROM registry.fedoraproject.org/fedora-minimal:31
 
 ARG version
 ARG commit

--- a/controller-manager/Dockerfile
+++ b/controller-manager/Dockerfile
@@ -3,7 +3,7 @@
 # License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
 #
 
-FROM registry.fedoraproject.org/fedora-minimal:31
+FROM quay.io/enmasse/fedora-minimal:31
 
 ARG version
 ARG commit

--- a/iot/iot-auth-service/Dockerfile
+++ b/iot/iot-auth-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/enmasse/java-base:11-1
+FROM quay.io/enmasse/java-base:11-3
 
 ARG version
 ARG maven_version

--- a/iot/iot-device-registry-file/Dockerfile
+++ b/iot/iot-device-registry-file/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/enmasse/java-base:11-1
+FROM quay.io/enmasse/java-base:11-3
 
 ARG version
 ARG maven_version

--- a/iot/iot-device-registry-infinispan/Dockerfile
+++ b/iot/iot-device-registry-infinispan/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/enmasse/java-base:11-1
+FROM quay.io/enmasse/java-base:11-3
 
 ARG version
 ARG maven_version

--- a/iot/iot-device-registry-jdbc/Dockerfile
+++ b/iot/iot-device-registry-jdbc/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/enmasse/java-base:11-1
+FROM quay.io/enmasse/java-base:11-3
 
 ARG version
 ARG maven_version

--- a/iot/iot-http-adapter/Dockerfile
+++ b/iot/iot-http-adapter/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/enmasse/java-base:11-1
+FROM quay.io/enmasse/java-base:11-3
 
 ARG version
 ARG maven_version

--- a/iot/iot-lorawan-adapter/Dockerfile
+++ b/iot/iot-lorawan-adapter/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/enmasse/java-base:11-1
+FROM quay.io/enmasse/java-base:11-3
 
 ARG version
 ARG maven_version

--- a/iot/iot-mqtt-adapter/Dockerfile
+++ b/iot/iot-mqtt-adapter/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/enmasse/java-base:11-1
+FROM quay.io/enmasse/java-base:11-3
 
 ARG version
 ARG maven_version

--- a/iot/iot-sigfox-adapter/Dockerfile
+++ b/iot/iot-sigfox-adapter/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/enmasse/java-base:11-1
+FROM quay.io/enmasse/java-base:11-3
 
 ARG version
 ARG maven_version

--- a/iot/iot-tenant-cleaner/Dockerfile
+++ b/iot/iot-tenant-cleaner/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/enmasse/java-base:11-1
+FROM quay.io/enmasse/java-base:11-3
 
 ARG version
 ARG maven_version

--- a/iot/iot-tenant-service/Dockerfile
+++ b/iot/iot-tenant-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/enmasse/java-base:11-1
+FROM quay.io/enmasse/java-base:11-3
 
 ARG version
 ARG maven_version

--- a/keycloak-plugin/Dockerfile
+++ b/keycloak-plugin/Dockerfile
@@ -1,6 +1,4 @@
-FROM quay.io/enmasse/java-base:11-1
-
-RUN yum -y install openssl && yum -y clean all
+FROM quay.io/enmasse/java-base:11-3
 
 ARG version
 ARG maven_version

--- a/mqtt-gateway/Dockerfile
+++ b/mqtt-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/enmasse/java-base:11-1
+FROM quay.io/enmasse/java-base:11-3
 
 ARG version
 ARG maven_version

--- a/mqtt-lwt/Dockerfile
+++ b/mqtt-lwt/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/enmasse/java-base:11-1
+FROM quay.io/enmasse/java-base:11-3
 
 ARG version
 ARG maven_version

--- a/none-authservice/Dockerfile
+++ b/none-authservice/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/enmasse/java-base:11-1
+FROM quay.io/enmasse/java-base:11-3
 
 ARG version
 ARG maven_version

--- a/service-broker/Dockerfile
+++ b/service-broker/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/enmasse/java-base:11-1
+FROM quay.io/enmasse/java-base:11-3
 
 ARG version
 ARG maven_version

--- a/standard-controller/Dockerfile
+++ b/standard-controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/enmasse/java-base:11-1
+FROM quay.io/enmasse/java-base:11-3
 
 ARG version
 ARG maven_version

--- a/topic-forwarder/Dockerfile
+++ b/topic-forwarder/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/enmasse/java-base:11-1
+FROM quay.io/enmasse/java-base:11-3
 
 ARG version
 ARG maven_version


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Given that fedora-minimal has been available for a while now and seems to be a common upstream for rhel-based images, I propose that we move to this. This should:

a) Hopefully fix CI issues with missing docker images
b) Reduce the image size

It would also change from installing jdk-devel to jdk-headless.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
