### PR TITLE
Set default behavior of rejects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 *  Upgrade to Infinispan 9.4.16
 * #3729: Add relatedImages to operator manifest for disconnected install
 * #3824: Bump netty to 4.1.45.Final
+* Change default behavior of handling REJECT outcome in broker from putting on DLQ to retrying
+  indefinitely.
+* Change default behavior of responding with MODIFIED outcome for transient delivery errors.
 
 
 * #3673: Add support for pod disruption budgets

--- a/broker-plugin/amqp-connector/src/main/java/org/apache/activemq/artemis/integration/amqp/AMQPConnectorService.java
+++ b/broker-plugin/amqp-connector/src/main/java/org/apache/activemq/artemis/integration/amqp/AMQPConnectorService.java
@@ -105,6 +105,12 @@ public class AMQPConnectorService implements ConnectorService, BaseConnectionLif
       scheduledExecutorService.submit(() -> {
          ActiveMQAMQPLogger.LOGGER.infov("Starting connector {0}", name);
          ProtonClientProtocolManager protocolManager = new ProtonClientProtocolManager(new ProtonProtocolManagerFactory(), server);
+
+         // These settings have the desired semantics when working in a cloud environment and for the built-in message
+         // forwarding.
+         protocolManager.setAmqpTreatRejectAsUnmodifiedDeliveryFailed(true);
+         protocolManager.setAmqpUseModifiedForTransientDeliveryErrors(true);
+
          NettyConnector connector = new NettyConnector(connectorConfig, lifecycleHandler, AMQPConnectorService.this, closeExecutor, nettyThreadPool, server.getScheduledPool(), protocolManager);
          connector.start();
          Connection connection = connector.createConnection();

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <junit.platform.runner.version>1.5.2</junit.platform.runner.version>
         <junit.platform.launcher.version>1.5.2</junit.platform.launcher.version>
         <rerunner-jupiter.version>2.1.3</rerunner-jupiter.version>
-        <artemis.version>2.10.1</artemis.version>
+        <artemis.version>2.11.0</artemis.version>
         <ngwebdriver.version>1.1.4</ngwebdriver.version>
         <paho.version>1.2.1</paho.version>
         <netty.version>4.1.45.Final</netty.version>


### PR DESCRIPTION

### Type of change

<!--

_Select the type of your PR_

-->

- Refactoring

### Description

* Ensure that MODIFIED outcome is used for transient errors
* Ensure that REJECT outcome causes a retry instead of ending up on the
  global DLQ

@k-wall Should we make this option (especially the REJECT behavior) configurable in the infra configs?

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
