### PR TITLE
Put default affinity spec under podTemplate spec

### DIFF
--- a/address-space-controller/src/main/resources/templates/brokered-space-infra.yaml
+++ b/address-space-controller/src/main/resources/templates/brokered-space-infra.yaml
@@ -44,16 +44,6 @@ objects:
       infraUuid: ${INFRA_UUID}
     name: broker.${INFRA_UUID}
   spec:
-    affinity:
-      nodeAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            preference:
-              matchExpressions:
-                - key: node-role.enmasse.io/messaging-infra
-                  operator: In
-                  values:
-                    - "true"
     replicas: 1
     strategy:
       type: Recreate
@@ -73,6 +63,16 @@ objects:
           role: broker
           infraUuid: ${INFRA_UUID}
       spec:
+        affinity:
+          nodeAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                preference:
+                  matchExpressions:
+                    - key: node-role.enmasse.io/messaging-infra
+                      operator: In
+                      values:
+                        - "true"
         containers:
         - env:
           - name: INFRA_UUID
@@ -247,16 +247,6 @@ objects:
       infraUuid: ${INFRA_UUID}
     name: agent.${INFRA_UUID}
   spec:
-    affinity:
-      nodeAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            preference:
-              matchExpressions:
-                - key: node-role.enmasse.io/operator-infra
-                  operator: In
-                  values:
-                    - "true"
     replicas: 1
     strategy:
       type: Recreate
@@ -277,6 +267,16 @@ objects:
           role: agent
           infraUuid: ${INFRA_UUID}
       spec:
+        affinity:
+          nodeAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                preference:
+                  matchExpressions:
+                    - key: node-role.enmasse.io/operator-infra
+                      operator: In
+                      values:
+                        - "true"
         containers:
         - env:
           - name: BROKER_SERVICE_HOST

--- a/address-space-controller/src/main/resources/templates/standard-space-infra.yaml
+++ b/address-space-controller/src/main/resources/templates/standard-space-infra.yaml
@@ -64,28 +64,6 @@ objects:
       infraUuid: ${INFRA_UUID}
     name: qdrouterd-${INFRA_UUID}
   spec:
-    affinity:
-      podAntiAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: enmasse
-                  capability: router
-                  name: qdrouterd
-                  infraType: standard
-                  infraUuid: ${INFRA_UUID}
-              topologyKey: kubernetes.io/hostname
-      nodeAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            preference:
-              matchExpressions:
-                - key: node-role.enmasse.io/operator-infra
-                  operator: In
-                  values:
-                    - "true"
     serviceName: qdrouterd-headless-${INFRA_UUID}
     replicas: 1
     selector:
@@ -106,6 +84,28 @@ objects:
           infraType: standard
           infraUuid: ${INFRA_UUID}
       spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                podAffinityTerm:
+                  labelSelector:
+                    matchLabels:
+                      app: enmasse
+                      capability: router
+                      name: qdrouterd
+                      infraType: standard
+                      infraUuid: ${INFRA_UUID}
+                  topologyKey: kubernetes.io/hostname
+          nodeAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                preference:
+                  matchExpressions:
+                    - key: node-role.enmasse.io/operator-infra
+                      operator: In
+                      values:
+                        - "true"
         containers:
         - env:
           - name: QDROUTERD_CONF_TYPE
@@ -209,16 +209,6 @@ objects:
       infraUuid: ${INFRA_UUID}
     name: admin.${INFRA_UUID}
   spec:
-    affinity:
-      nodeAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            preference:
-              matchExpressions:
-                - key: node-role.enmasse.io/operator-infra
-                  operator: In
-                  values:
-                    - "true"
     replicas: 1
     strategy:
       type: Recreate
@@ -238,6 +228,16 @@ objects:
           infraType: standard
           infraUuid: ${INFRA_UUID}
       spec:
+        affinity:
+          nodeAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                preference:
+                  matchExpressions:
+                    - key: node-role.enmasse.io/operator-infra
+                      operator: In
+                      values:
+                        - "true"
         containers:
         - env:
           - name: MESSAGING_SERVICE_HOST

--- a/standard-controller/src/main/resources/templates/queue-persisted.yaml
+++ b/standard-controller/src/main/resources/templates/queue-persisted.yaml
@@ -45,27 +45,6 @@ objects:
       infraUuid: ${INFRA_UUID}
     name: ${NAME}
   spec:
-    affinity:
-      podAntiAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: enmasse
-                  role: broker
-                  infraType: standard
-                  infraUuid: ${INFRA_UUID}
-              topologyKey: kubernetes.io/hostname
-      nodeAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            preference:
-              matchExpressions:
-                - key: node-role.enmasse.io/messaging-infra
-                  operator: In
-                  values:
-                    - "true"
     replicas: 1
     serviceName: ${NAME}
     selector:
@@ -90,6 +69,27 @@ objects:
           infraType: standard
           infraUuid: ${INFRA_UUID}
       spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                podAffinityTerm:
+                  labelSelector:
+                    matchLabels:
+                      app: enmasse
+                      role: broker
+                      infraType: standard
+                      infraUuid: ${INFRA_UUID}
+                  topologyKey: kubernetes.io/hostname
+          nodeAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                preference:
+                  matchExpressions:
+                    - key: node-role.enmasse.io/messaging-infra
+                      operator: In
+                      values:
+                        - "true"
         containers:
         - env:
           - name: MESSAGING_SERVICE_HOST

--- a/standard-controller/src/main/resources/templates/topic-persisted.yaml
+++ b/standard-controller/src/main/resources/templates/topic-persisted.yaml
@@ -45,16 +45,6 @@ objects:
       infraUuid: ${INFRA_UUID}
     name: ${NAME}
   spec:
-    affinity:
-      nodeAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            preference:
-              matchExpressions:
-                - key: node-role.enmasse.io/messaging-infra
-                  operator: In
-                  values:
-                    - "true"
     replicas: 1
     serviceName: ${NAME}
     selector:
@@ -79,6 +69,16 @@ objects:
           infraType: standard
           infraUuid: ${INFRA_UUID}
       spec:
+        affinity:
+          nodeAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                preference:
+                  matchExpressions:
+                    - key: node-role.enmasse.io/messaging-infra
+                      operator: In
+                      values:
+                        - "true"
         serviceAccountName: address-space-admin
         containers:
         - env:


### PR DESCRIPTION

### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description
The current affinity settings does not get applied as they are placed
directly under deployment.spec and statefulset.spec

Fixes #3646

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
