### PR TITLE
Fix: edit auth service

### DIFF
--- a/console/console-init/ui/src/Components/AddressSpaceList/AddressSpaceList.tsx
+++ b/console/console-init/ui/src/Components/AddressSpaceList/AddressSpaceList.tsx
@@ -34,6 +34,7 @@ export interface IAddressSpace {
   status?: "creating" | "deleting" | "running";
   selected?: boolean;
   messages: Array<string>;
+  authenticationService: string;
 }
 
 interface IAddressListProps {

--- a/console/console-init/ui/src/Pages/AddressSpaceList/AddressSpaceListPage.tsx
+++ b/console/console-init/ui/src/Pages/AddressSpaceList/AddressSpaceListPage.tsx
@@ -92,11 +92,16 @@ export const AddressSpaceListPage: React.FunctionComponent<AddressSpaceListPageP
           jsonPatch:
             '[{"op":"replace","path":"/Plan","value":"' +
             addressSpaceBeingEdited.planValue +
-            '"}]',
+            '"},' +
+            '{"op":"replace","path":"/AuthenticationService/Name","value":"' +
+            addressSpaceBeingEdited.authenticationService +
+            '"}' +
+            "]",
           patchType: "application/json-patch+json"
         }
       }));
     setAddressSpaceBeingEdited(null);
+    refetch();
   };
 
   const handleEditChange = (addressSpace: IAddressSpace) =>
@@ -134,6 +139,13 @@ export const AddressSpaceListPage: React.FunctionComponent<AddressSpaceListPageP
     }
   };
 
+  const handleAuthServiceChanged = (authService: string) => {
+    if (addressSpaceBeingEdited) {
+      addressSpaceBeingEdited.authenticationService = authService;
+      setAddressSpaceBeingEdited({ ...addressSpaceBeingEdited });
+    }
+  };
+
   const { loading, error, data, refetch } = useQuery<IAddressSpacesResponse>(
     RETURN_ALL_ADDRESS_SPACES(
       page,
@@ -162,6 +174,7 @@ export const AddressSpaceListPage: React.FunctionComponent<AddressSpaceListPageP
     addressSpaces: { Total: 0, AddressSpaces: [] }
   };
   setTotalAddressSpaces(addressSpaces.Total);
+  console.log(addressSpaces);
   const addressSpacesList: IAddressSpace[] = addressSpaces.AddressSpaces.map(
     addSpace => ({
       name: addSpace.ObjectMeta.Name,
@@ -177,6 +190,7 @@ export const AddressSpaceListPage: React.FunctionComponent<AddressSpaceListPageP
         addSpace.Status && addSpace.Status.Messages
           ? addSpace.Status.Messages
           : [],
+      authenticationService: addSpace.Spec.AuthenticationService.Name,
       selected:
         selectedAddressSpaces.filter(({ name, nameSpace }) =>
           compareTwoAddress(
@@ -239,6 +253,7 @@ export const AddressSpaceListPage: React.FunctionComponent<AddressSpaceListPageP
         >
           <EditAddressSpace
             addressSpace={addressSpaceBeingEdited}
+            onAuthServiceChanged={handleAuthServiceChanged}
             onPlanChange={handlePlanChange}
           ></EditAddressSpace>
         </Modal>

--- a/console/console-init/ui/src/Queries/Queries.tsx
+++ b/console/console-init/ui/src/Queries/Queries.tsx
@@ -163,6 +163,9 @@ export const RETURN_ALL_ADDRESS_SPACES = (
                 DisplayName
               }
             }
+            AuthenticationService{
+              Name
+            }
           }
           Status {
             IsReady
@@ -1358,6 +1361,19 @@ export const RETURN_ALL_CONNECTIONS_HOSTNAME_AND_CONTAINERID_OF_ADDRESS_SPACES_F
 export const RETURN_AUTHENTICATION_SERVICES = gql`
   query addressspace_schema {
     addressSpaceSchema_v2 {
+      ObjectMeta {
+        Name
+      }
+      Spec {
+        AuthenticationServices
+      }
+    }
+  }
+`;
+
+export const RETURN_FILTERED_AUTHENTICATION_SERVICES = gql`
+  query filtered_addressspace_schema($t: AddressSpaceType = standard) {
+    addressSpaceSchema_v2(addressSpaceType: $t) {
       ObjectMeta {
         Name
       }

--- a/console/console-init/ui/src/Types/ResponseTypes.tsx
+++ b/console/console-init/ui/src/Types/ResponseTypes.tsx
@@ -174,6 +174,9 @@ export interface IAddressSpacesResponse {
             DisplayName: string;
           };
         };
+        AuthenticationService: {
+          Name: string;
+        };
       };
       Status: {
         IsReady: boolean;

--- a/console/console-init/ui/src/stories/AddressSpaceList.stories.tsx
+++ b/console/console-init/ui/src/stories/AddressSpaceList.stories.tsx
@@ -26,7 +26,8 @@ const rows: IAddressSpace[] = [
     planValue: "standard-small",
     isReady: false,
     phase: "Configuring",
-    messages: []
+    messages: [],
+    authenticationService: "none-authservice"
   },
   {
     name: "saturn-as2",
@@ -37,7 +38,8 @@ const rows: IAddressSpace[] = [
     planValue: "brokered-small",
     isReady: true,
     phase: "Active",
-    messages: []
+    messages: [],
+    authenticationService: "standard-authservice"
   },
   {
     name: "mars_as2",
@@ -48,7 +50,8 @@ const rows: IAddressSpace[] = [
     planValue: "standard-large",
     isReady: false,
     phase: "Failed",
-    messages: []
+    messages: [],
+    authenticationService: "standard-authservice"
   },
   {
     name: "earth_as3",
@@ -59,7 +62,8 @@ const rows: IAddressSpace[] = [
     planValue: "brokered-medium",
     isReady: false,
     phase: "Configuring",
-    messages: []
+    messages: [],
+    authenticationService: "standard-authservice"
   }
 ];
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The authentication service of address spaces can now be edited. The auth service is now being fetched with the all_address_spaces query, and populated accordingly in the AddressSpaceEdit component. Saving handles the patch for auth_service.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
