### PR TITLE
Updating service admin cluster role to include AuthenticationService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Change default behavior of handling REJECT outcome in broker from putting on DLQ to retrying
   indefinitely.
 * Change default behavior of responding with MODIFIED outcome for transient delivery errors.
+* Change the service admin example role so it can modify authenticationservices custom resources.
 
 
 * #3673: Add support for pod disruption budgets

--- a/documentation/modules/ref-example-roles.adoc
+++ b/documentation/modules/ref-example-roles.adoc
@@ -23,7 +23,7 @@ endif::SingleBookLink[]
 |Role |Description
 |enmasse.io:tenant-view|Specifies `get` and `list` permissions for `addresses`, `addressspaces`, `addressspaceschemas`, and `messagingusers`
 |enmasse.io:tenant-edit|Specifies `create`, `get`, `update`, `delete`, `list`, `watch`, and `patch` permissions for `addresses`, `addressspaces`, and `messagingusers`; `get` and `list` permissions for `addressspaceschemas`
-|`service-admin` cluster role|Specifies `create`, `get`, `update`, `delete`, `list`, `watch`, and `patch` permissions for `addressplans`, `addressspaceplans`, `brokeredinfraconfigs`, and `standardinfraconfigs`
+|`service-admin` cluster role|Specifies `create`, `get`, `update`, `delete`, `list`, `watch`, and `patch` permissions for `addressplans`, `addressspaceplans`, `brokeredinfraconfigs`, `standardinfraconfigs` and `authenticationservices`
 |===
 
 :context: {parent-context}

--- a/templates/example-roles/020-ClusterRole-service-admin.yaml
+++ b/templates/example-roles/020-ClusterRole-service-admin.yaml
@@ -7,5 +7,5 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
   - apiGroups: [ "admin.enmasse.io" ]
-    resources: [ "addressplans", "addressspaceplans", "brokeredinfraconfigs", "standardinfraconfigs" ]
+    resources: [ "addressplans", "addressspaceplans", "brokeredinfraconfigs", "standardinfraconfigs", "authenticationservices" ]
     verbs: [ "create", "get", "update", "delete", "list", "watch", "patch" ]


### PR DESCRIPTION
### Type of change
- Enhancement / new feature

### Description
Allow the service admin example role the ability to modify authenticationservices.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
