### PR TITLE
Add missing json tags to connections, link objects etc

### DIFF
--- a/pkg/consolegraphql/non_kubernetes_types.go
+++ b/pkg/consolegraphql/non_kubernetes_types.go
@@ -16,14 +16,14 @@ import (
 )
 
 type HasMetrics interface {
-	GetMetrics() ([]*Metric)
+	GetMetrics() []*Metric
 }
 
 type Connection struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ObjectMeta
-	Spec    ConnectionSpec
-	Metrics []*Metric
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              ConnectionSpec `json:"spec,omitempty"`
+	Metrics           []*Metric      `json:"metrics"`
 }
 
 func (c *Connection) GetControllingResourceAttributes() *authv1.ResourceAttributes {
@@ -40,19 +40,19 @@ func (c *Connection) GetMetrics() []*Metric {
 }
 
 type ConnectionSpec struct {
-	AddressSpace string
-	Hostname     string
-	ContainerId  string
-	Protocol     string
-	Encrypted    bool
-	Properties   map[string]string
+	AddressSpace string            `json:"addressSpace,omitempty"`
+	Hostname     string            `json:"hostname,omitempty"`
+	ContainerId  string            `json:"containerId,omitempty"`
+	Protocol     string            `json:"proptocol,omitempty"`
+	Encrypted    bool              `json:"encrypted,omitempty"`
+	Properties   map[string]string `json:"properties,omitempty"`
 }
 
 type Link struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ObjectMeta
-	Spec LinkSpec
-	Metrics []*Metric
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              LinkSpec  `json:"spec,omitempty"`
+	Metrics           []*Metric `json:"metrics"`
 }
 
 func (l *Link) GetMetrics() []*Metric {
@@ -60,18 +60,18 @@ func (l *Link) GetMetrics() []*Metric {
 }
 
 type LinkSpec struct {
-	Connection   string
-	AddressSpace string
-	Address      string
-	Role         string
+	Connection   string `json:"connection,omitempty"`
+	AddressSpace string `json:"addressSpace,omitempty"`
+	Address      string `json:"address,omitempty"`
+	Role         string `json:"role,omitempty"`
 }
 
 type Metric struct {
-	Name  string
-	Type  string
-	Value float64
-	Unit  string
-	Time  time.Time
+	Name       string    `json:"name,omitempty"`
+	Type       string    `json:"type,omitempty"`
+	Value      float64   `json:"value,omitempty"`
+	Unit       string    `json:"unit,omitempty"`
+	Time       time.Time `json:"time,omitempty"`
 	timeseries *ring.Ring
 }
 
@@ -117,11 +117,10 @@ func FindOrCreateRateCalculatingMetric(existing []*Metric, n string, t string, u
 	return m, existing
 }
 
-
 func NewSimpleMetric(n string, t string) *SimpleMetric {
 	metric := SimpleMetric{
-		Name:  n,
-		Type:  t,
+		Name: n,
+		Type: t,
 	}
 	return &metric
 }
@@ -150,8 +149,8 @@ func (m *RateCalculatingMetric) Update(v float64, ts time.Time) {
 }
 
 type AddressSpaceHolder struct {
-	v1beta1.AddressSpace
-	Metrics     []*Metric
+	v1beta1.AddressSpace `json:",inline"`
+	Metrics              []*Metric `json:"metrics"`
 }
 
 func (ash *AddressSpaceHolder) GetMetrics() []*Metric {
@@ -164,8 +163,8 @@ func (ash *AddressSpaceHolder) GetControllingResourceAttributes() *authv1.Resour
 }
 
 type AddressHolder struct {
-	v1beta1.Address
-	Metrics     []*Metric
+	v1beta1.Address `json:",inline"`
+	Metrics         []*Metric `json:"metrics"`
 }
 
 func (ah *AddressHolder) GetMetrics() []*Metric {
@@ -191,4 +190,3 @@ func kindToResource(gvk schema.GroupVersionKind) string {
 	resource := plural.Resource
 	return resource
 }
-

--- a/pkg/consolegraphql/non_kubernetes_types.go
+++ b/pkg/consolegraphql/non_kubernetes_types.go
@@ -43,7 +43,7 @@ type ConnectionSpec struct {
 	AddressSpace string            `json:"addressSpace,omitempty"`
 	Hostname     string            `json:"hostname,omitempty"`
 	ContainerId  string            `json:"containerId,omitempty"`
-	Protocol     string            `json:"proptocol,omitempty"`
+	Protocol     string            `json:"protocol,omitempty"`
 	Encrypted    bool              `json:"encrypted,omitempty"`
 	Properties   map[string]string `json:"properties,omitempty"`
 }


### PR DESCRIPTION
The JSON tags were missing on the fields of the data types used to back the GraphQL API.  This prevented JSON path expressions being written in terms of the json fields names.  With this change expressions in terms of Go field names and JSON field names are supported for both order by and filter clauses.