### PR TITLE
Example infinispan deployment remove cpu limits

### DIFF
--- a/templates/iot/examples/infinispan/manual/050-StatefulSet.yaml
+++ b/templates/iot/examples/infinispan/manual/050-StatefulSet.yaml
@@ -86,7 +86,6 @@ spec:
           timeoutSeconds: 80
         resources:
           requests:
-            cpu: "0.5"
             memory: 512Mi
         volumeMounts:
         - mountPath: /opt/jboss/infinispan-server/standalone/configuration/custom


### PR DESCRIPTION
Currently our tests fail to deploy our infinispan example deployment in Openshift 4.4 because of the limits on cpu we have on that deployment.
Just removing the limits work, I also tried to reduce the limits to 0.25 and also work.