### PR TITLE
Fix Console server typeahead

### DIFF
--- a/console/console-init/ui/src/pages/AddressDetail/AddressLinksFilter.tsx
+++ b/console/console-init/ui/src/pages/AddressDetail/AddressLinksFilter.tsx
@@ -73,6 +73,7 @@ export const AddressLinksFilter: React.FunctionComponent<IAddressLinksFilterProp
   addressSpaceName,
   namespace
 }) => {
+  const TYPEAHEAD_REQUIRED_LENGTH: number = 5;
   const { width } = useWindowDimensions();
   const client = useApolloClient();
   const [filterIsExpanded, setFilterIsExpanded] = React.useState<boolean>(
@@ -174,7 +175,7 @@ export const AddressLinksFilter: React.FunctionComponent<IAddressLinksFilterProp
   };
   const onChangeNameData = async (value: string) => {
     setNameOptions(undefined);
-    if (value.trim().length < 6) {
+    if (value.trim().length < TYPEAHEAD_REQUIRED_LENGTH) {
       setNameOptions([]);
       return;
     }
@@ -386,7 +387,7 @@ export const AddressLinksFilter: React.FunctionComponent<IAddressLinksFilterProp
                       nameOptions.map((option, index) => (
                         <SelectOption key={index} value={option} />
                       ))
-                    ) : nameInput.trim().length < 5 ? (
+                    ) : nameInput.trim().length < TYPEAHEAD_REQUIRED_LENGTH ? (
                       <SelectOption
                         key={"invalid-input-length"}
                         value={"Enter more characters"}
@@ -444,7 +445,8 @@ export const AddressLinksFilter: React.FunctionComponent<IAddressLinksFilterProp
                       containerOptions.map((option, index) => (
                         <SelectOption key={index} value={option} />
                       ))
-                    ) : containerInput.trim().length < 5 ? (
+                    ) : containerInput.trim().length <
+                      TYPEAHEAD_REQUIRED_LENGTH ? (
                       <SelectOption
                         key={"invalid-input-length"}
                         value={"Enter more characters"}


### PR DESCRIPTION
If you search text was exactly 5 characters, it was returning 'No results Found'.
Changed it so it would lookup the results if it was 5 characters or more.

Signed-off-by: Vanessa <vbusch@redhat.com>

### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
