### PR TITLE
Ensure that logged user name appears next to avatar in the UI

### DIFF
--- a/cmd/console-server/main.go
+++ b/cmd/console-server/main.go
@@ -129,7 +129,7 @@ func authHandler(next http.Handler, sessionManager *scs.SessionManager) http.Han
 		if sessionManager.Exists(req.Context(), loggedOnUserSessionAttribute) {
 			loggedOnUser = sessionManager.GetString(req.Context(), loggedOnUserSessionAttribute)
 		} else {
-			if util.IsOpenshift() {
+			if util.HasApi(util.UserGVK) {
 				usr, err := userClient.Users().Get("~", metav1.GetOptions{})
 				if err == nil {
 					loggedOnUser = usr.ObjectMeta.Name

--- a/console/console-init/ui/mock-console-server/mock-console-server.js
+++ b/console/console-init/ui/mock-console-server/mock-console-server.js
@@ -1508,7 +1508,7 @@ const mocks = {
       name: "vtereshkova"
     },
     identities: ["vtereshkova"],
-    fullname: "Valentina Tereshkova",
+    fullName: "Valentina Tereshkova",
     groups: ["admin"]
   })
 };

--- a/pkg/consolegraphql/resolvers/resolver_user.go
+++ b/pkg/consolegraphql/resolvers/resolver_user.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (r *queryResolver) Whoami(ctx context.Context) (*v1.User, error) {
-	if util.IsOpenshift() {
+	if util.HasApi(util.UserGVK) {
 		requestState := server.GetRequestStateFromContext(ctx)
 		return requestState.UserInterface.Get("~", metav1.GetOptions{})
 	} else {

--- a/pkg/controller/consoleservice/consoleservice_controller.go
+++ b/pkg/controller/consoleservice/consoleservice_controller.go
@@ -730,6 +730,13 @@ func applyDeployment(consoleservice *v1beta1.ConsoleService, deployment *appsv1.
 			envvar.Value = "9090"
 		})
 
+		namespace, err := util.GetInfrastructureNamespace()
+		if err == nil {
+			install.ApplyEnv(container, "NAMESPACE", func(envvar *corev1.EnvVar) {
+				envvar.Value = namespace
+			})
+		}
+
 		// TODO use https
 		// TODO add health probe
 		container.Ports = []corev1.ContainerPort{{

--- a/pkg/controller/consoleservice/domain.go
+++ b/pkg/controller/consoleservice/domain.go
@@ -12,7 +12,7 @@ import (
 func GetCommonDomain(all_fqdns []string) (*string, int) {
 
 	if len(all_fqdns) <= 1 {
-		return nil, 0;
+		return nil, 0
 	}
 
 	first_fqdn := strings.Split(all_fqdns[0], ".")
@@ -22,8 +22,8 @@ func GetCommonDomain(all_fqdns []string) (*string, int) {
 
 	matching := true
 	for len(first_fqdn) > 0 && matching {
-		common = append(first_fqdn[len(first_fqdn) - 1:], common...)
-		first_fqdn = first_fqdn[:len(first_fqdn) -1 ]
+		common = append(first_fqdn[len(first_fqdn)-1:], common...)
+		first_fqdn = first_fqdn[:len(first_fqdn)-1]
 
 		trial_common_subdomain := "." + strings.Join(common, ".")
 		for _, other_fqdn := range remaining_fqdns {
@@ -38,7 +38,7 @@ func GetCommonDomain(all_fqdns []string) (*string, int) {
 	if len(common) == 0 {
 		return nil, 0
 	} else {
-		common_sub := "." + strings.Join(common,".")
+		common_sub := "." + strings.Join(common, ".")
 		return &common_sub, len(common)
 	}
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Switched console-server code to use new HasApi() call and fix the HasApi) implementation
to cope the the user GVK object (special case required).  Also propagated the
`NAMESPACE` environment var from EnMasse controller to console-server.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
