### PR TITLE
Issue #3582 - fix swagger documentation for auth ops

### DIFF
--- a/documentation/common/restapi-reference.adoc
+++ b/documentation/common/restapi-reference.adoc
@@ -1672,7 +1672,7 @@ __required__||enum (password, serviceaccount)
 |**addresses** +
 __optional__|< string > array
 |**operations** +
-__required__|< enum (send, receive, view, manage) > array
+__required__|< enum (send, recv, view, manage) > array
 |===
 
 

--- a/documentation/src/main/resources/swagger.json
+++ b/documentation/src/main/resources/swagger.json
@@ -835,7 +835,7 @@
                                 "items": {
                                     "enum": [
                                         "send",
-                                        "receive",
+                                        "recv",
                                         "view",
                                         "manage"
                                     ],


### PR DESCRIPTION
### Type of change

- Documentation

### Description

In the swagger based documentation, the authorisation operation is documented as "receive" whereas in the code the value is "recv".


### Checklist

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
