### PR TITLE
Add wakeup event to trigger resync on outdated resource version

### DIFF
--- a/k8s-api/src/main/java/io/enmasse/k8s/api/cache/EventCache.java
+++ b/k8s-api/src/main/java/io/enmasse/k8s/api/cache/EventCache.java
@@ -8,6 +8,7 @@ import static io.enmasse.k8s.api.cache.EventCache.EventType.Added;
 import static io.enmasse.k8s.api.cache.EventCache.EventType.Deleted;
 import static io.enmasse.k8s.api.cache.EventCache.EventType.Sync;
 import static io.enmasse.k8s.api.cache.EventCache.EventType.Updated;
+import static io.enmasse.k8s.api.cache.EventCache.EventType.Wakeup;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -33,7 +34,8 @@ public class EventCache<T> implements WorkQueue<T> {
         Added,
         Updated,
         Deleted,
-        Sync
+        Sync,
+        Wakeup
     }
 
     private static class Event<T> {
@@ -53,7 +55,7 @@ public class EventCache<T> implements WorkQueue<T> {
     @Override
     public void pop(Processor<T> processor, long timeout, TimeUnit timeUnit) throws Exception {
         Event<T> firstEvent = queue.poll(timeout, timeUnit);
-        if (firstEvent == null) {
+        if (firstEvent == null || Wakeup.equals(firstEvent.eventType)) {
             log.debug("Woke up but queue is empty");
             return;
         }
@@ -122,6 +124,11 @@ public class EventCache<T> implements WorkQueue<T> {
     @Override
     public void delete(T t) throws InterruptedException {
         queueEvent(Deleted, t);
+    }
+
+    @Override
+    public void wakeup() throws InterruptedException {
+        queue.put(new Event<>(Wakeup, null));
     }
 
     @Override

--- a/k8s-api/src/main/java/io/enmasse/k8s/api/cache/EventCache.java
+++ b/k8s-api/src/main/java/io/enmasse/k8s/api/cache/EventCache.java
@@ -55,7 +55,7 @@ public class EventCache<T> implements WorkQueue<T> {
     @Override
     public void pop(Processor<T> processor, long timeout, TimeUnit timeUnit) throws Exception {
         Event<T> firstEvent = queue.poll(timeout, timeUnit);
-        if (firstEvent == null || Wakeup.equals(firstEvent.eventType)) {
+        if (firstEvent == null || Wakeup == firstEvent.eventType) {
             log.debug("Woke up but queue is empty");
             return;
         }
@@ -72,6 +72,8 @@ public class EventCache<T> implements WorkQueue<T> {
                 }
 
                 switch (event.eventType) {
+                    case Wakeup:
+                        continue;
                     case Deleted:
                         store.remove(key);
                         break;

--- a/k8s-api/src/main/java/io/enmasse/k8s/api/cache/WorkQueue.java
+++ b/k8s-api/src/main/java/io/enmasse/k8s/api/cache/WorkQueue.java
@@ -8,5 +8,6 @@ import java.util.concurrent.TimeUnit;
 
 public interface WorkQueue<T> extends Store<T> {
     void pop(Processor<T> processor, long timeout, TimeUnit timeUnit) throws Exception;
+    void wakeup() throws InterruptedException;
     boolean hasSynced();
 }

--- a/k8s-api/src/test/java/io/enmasse/k8s/api/cache/EventCacheTest.java
+++ b/k8s-api/src/test/java/io/enmasse/k8s/api/cache/EventCacheTest.java
@@ -101,6 +101,16 @@ public class EventCacheTest {
     }
 
     @Test
+    public void testWakeup() throws Exception {
+        WorkQueue<ConfigMap> queue = new EventCache<>(new HasMetadataFieldExtractor<>());
+        queue.wakeup();
+        Processor<ConfigMap> mockProc = mockProcessor();
+        queue.pop(mockProc, 1, TimeUnit.DAYS);
+        verifyZeroInteractions(mockProc);
+        assertFalse(queue.hasSynced());
+    }
+
+    @Test
     public void testSync() throws Exception {
         WorkQueue<ConfigMap> queue = new EventCache<>(new HasMetadataFieldExtractor<>());
         queue.replace(Arrays.asList(map("ns", "k1"), map("ns", "k2"), map("ns", "k3")), "33");


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

If the resourceVersion of objects may change between list and watch, the
watch may be closed immediately after creation. To avoid waiting for the
next resync, trigger a new resync if the exception has the 410 Gone
status.


### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
