### PR TITLE
Add console-server readiness/liveness probe

### DIFF
--- a/console/console-server/src/assembly/unix-dist.xml
+++ b/console/console-server/src/assembly/unix-dist.xml
@@ -37,6 +37,14 @@
             <outputDirectory></outputDirectory>
             <directory>src/main/resources/</directory>
             <includes>
+                <include>*.sh</include>
+            </includes>
+            <fileMode>0755</fileMode>
+        </fileSet>
+        <fileSet>
+            <outputDirectory></outputDirectory>
+            <directory>src/main/resources/</directory>
+            <includes>
                 <include>*.json</include>
             </includes>
         </fileSet>

--- a/console/console-server/src/main/resources/probe.sh
+++ b/console/console-server/src/main/resources/probe.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Copyright 2020, EnMasse authors.
+# License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+#
+
+# Verifies that the console-server is minimally functional
+
+KUBE_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+
+curl 'http://localhost:9090/graphql/query' \
+-H 'Accept-Encoding: gzip, deflate, br' \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+-H 'Origin: http://localhost:9090' \
+-H "X-Forwarded-Access-Token: ${KUBE_TOKEN}" \
+--data-binary '{"query":"query whoami {\n  whoami {\n    metadata {\n      name\n    }\n  }\n}"}' \
+--compressed \
+--fail

--- a/pkg/controller/consoleservice/consoleservice_controller.go
+++ b/pkg/controller/consoleservice/consoleservice_controller.go
@@ -738,7 +738,27 @@ func applyDeployment(consoleservice *v1beta1.ConsoleService, deployment *appsv1.
 		}
 
 		// TODO use https
-		// TODO add health probe
+
+		probeHandler := corev1.Handler{
+			Exec: &corev1.ExecAction{
+				Command: []string{
+					"sh",
+					"-c",
+					"/probe.sh",
+				},
+			},
+		}
+
+		container.ReadinessProbe = &corev1.Probe{
+			InitialDelaySeconds: 30,
+			Handler:             probeHandler,
+		}
+
+		container.LivenessProbe = &corev1.Probe{
+			InitialDelaySeconds: 30,
+			Handler:             probeHandler,
+		}
+
 		container.Ports = []corev1.ContainerPort{{
 			ContainerPort: 9090,
 			Name:          "http",


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Adds a readiness/liveness probe to the console-server to ensure that it is minimally functional.

### Checklist

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
