### PR TITLE
Fix: close the dialogue after address delete/patch

### DIFF
--- a/console/console-init/ui/src/pages/AddressSpaceDetail/AddressList/AddressListPage.tsx
+++ b/console/console-init/ui/src/pages/AddressSpaceDetail/AddressList/AddressListPage.tsx
@@ -210,7 +210,7 @@ export const AddressListPage: React.FunctionComponent<IAddressListPageProps> = (
           }
         }
       });
-      if (deletedData.data && deletedData.data.deletedAddress === true) {
+      if (deletedData.data && deletedData.data.deleteAddress === true) {
         refetch();
         setAddressBeingDeleted(null);
       }
@@ -219,16 +219,16 @@ export const AddressListPage: React.FunctionComponent<IAddressListPageProps> = (
 
   const handlePurgeChange = async () => {
     if (addressBeingPurged) {
-      const purgeData = await client.mutate({
+      const { data } = await client.mutate({
         mutation: PURGE_ADDRESS,
         variables: {
           a: {
-            Name: addressBeingPurged.name,
-            Namespace: addressBeingPurged.namespace
+            name: addressBeingPurged.name,
+            namespace: addressBeingPurged.namespace
           }
         }
       });
-      if (purgeData && purgeData.data && purgeData.data.purgeAddress === true) {
+      if (data && data.purgeAddress) {
         refetch();
         setAddressBeingPurged(null);
       }

--- a/console/console-init/ui/src/queries/index.ts
+++ b/console/console-init/ui/src/queries/index.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
 export * from "./User";
 export * from "./Address";
 export * from "./AddressSpace";


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix
- Documentation

### Description

The dialogues in address list page weren't closing after a successful patch or delete operation. The issues were arising due to typos. This commit also adds copyright statement to one of the source file.

### Checklist

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
