### PR TITLE
If the filter is passed to query, use it to construct the longest hierarchy key

### DIFF
--- a/cmd/console-server/main.go
+++ b/cmd/console-server/main.go
@@ -377,7 +377,7 @@ http://localhost:` + port + `/graphql
 	queryServer := http.NewServeMux()
 
 	queryEndpoint := "/graphql/query"
-	if graphqlPlayground {
+	if graphqlPlayground || *developmentMode {
 		playground := handler.Playground("GraphQL playground", queryEndpoint)
 		queryServer.Handle("/graphql/", playground)
 	}

--- a/console/console-init/ui/src/queries/Address.ts
+++ b/console/console-init/ui/src/queries/Address.ts
@@ -190,7 +190,7 @@ const CURRENT_ADDRESS_SPACE_PLAN = (name?: string, namespace?: string) => {
   const ADDRESS_SPACE_PLAN = gql`
       query all_address_spaces {
         addressSpaces(
-          filter: "\`$..Name\` = '${name}' AND \`$..Namespace\` = '${namespace}'"
+          filter: "\`$.metadata.name\` = '${name}' AND \`$.metadata.namespace\` = '${namespace}'"
         ) {
           addressSpaces {
             spec {

--- a/console/console-init/ui/src/queries/AddressSpace.ts
+++ b/console/console-init/ui/src/queries/AddressSpace.ts
@@ -178,7 +178,7 @@ const RETURN_ADDRESS_SPACE_DETAIL = (name?: string, namespace?: string) => {
   const ADDRESS_SPACE_DETAIL = gql`
       query all_address_spaces {
         addressSpaces(
-          filter: "\`$..name\` = '${name}' AND \`$..namespace\` = '${namespace}'"
+          filter: "\`$.metadata.name\` = '${name}' AND \`$.metadata.namespace\` = '${namespace}'"
         ) {
           addressSpaces {
             metadata {

--- a/pkg/consolegraphql/cache/console_cache.go
+++ b/pkg/consolegraphql/cache/console_cache.go
@@ -49,8 +49,7 @@ func primaryUniqueKeyCreator(obj interface{}) (b bool, s string, err error) {
 		if i < 0 {
 			return false, "", fmt.Errorf("unexpected address name formation '%s', expected dot separator", o.Name)
 		}
-		addressSpaceName := o.Name[:i]
-		return true, o.Kind + "/" + o.Namespace + "/" + addressSpaceName + "/" + o.Name, nil
+		return true, o.Kind + "/" + o.Namespace + "/" + o.Name, nil
 	case *consolegraphql.Connection:
 		return true, o.Kind + "/" + o.Namespace + "/" + o.Spec.AddressSpace + "/" + o.Name, nil
 	case *consolegraphql.Link:

--- a/pkg/consolegraphql/filter/lex.go
+++ b/pkg/consolegraphql/filter/lex.go
@@ -684,14 +684,14 @@ execFuncs:
  lex.te = ( lex.p)
 ( lex.p)--
 {
-            val := "{" + strings.Replace(string(lex.data[lex.ts+1:lex.te-1]), "```", "`", -1) + "}"
+            val := strings.Replace(string(lex.data[lex.ts+1:lex.te-1]), "```", "`", -1)
             tok = JSON_PATH
             jsonPath := jsonpath.New("filter expr").AllowMissingKeys(true)
-            err := jsonPath.Parse(val)
+            err := jsonPath.Parse("{" + val + "}")
             if err != nil {
                 lex.e = err
             }
-            out.jsonPathValue = NewJSONPathVal(jsonPath)
+            out.jsonPathValue = NewJSONPathVal(jsonPath, val)
             ( lex.p)++; goto _out
  }
 		case 28:
@@ -723,14 +723,14 @@ execFuncs:
 //line pkg/consolegraphql/filter/lex.rl:97
 ( lex.p) = ( lex.te) - 1
 {
-            val := "{" + strings.Replace(string(lex.data[lex.ts+1:lex.te-1]), "```", "`", -1) + "}"
+            val := strings.Replace(string(lex.data[lex.ts+1:lex.te-1]), "```", "`", -1)
             tok = JSON_PATH
             jsonPath := jsonpath.New("filter expr").AllowMissingKeys(true)
-            err := jsonPath.Parse(val)
+            err := jsonPath.Parse("{" + val + "}")
             if err != nil {
                 lex.e = err
             }
-            out.jsonPathValue = NewJSONPathVal(jsonPath)
+            out.jsonPathValue = NewJSONPathVal(jsonPath, val)
             ( lex.p)++; goto _out
  }
 		case 32:
@@ -751,14 +751,14 @@ goto _again
 	case 4:
 	{( lex.p) = ( lex.te) - 1
 
-            val := "{" + strings.Replace(string(lex.data[lex.ts+1:lex.te-1]), "```", "`", -1) + "}"
+            val := strings.Replace(string(lex.data[lex.ts+1:lex.te-1]), "```", "`", -1)
             tok = JSON_PATH
             jsonPath := jsonpath.New("filter expr").AllowMissingKeys(true)
-            err := jsonPath.Parse(val)
+            err := jsonPath.Parse("{" + val + "}")
             if err != nil {
                 lex.e = err
             }
-            out.jsonPathValue = NewJSONPathVal(jsonPath)
+            out.jsonPathValue = NewJSONPathVal(jsonPath, val)
             ( lex.p)++; goto _out
  }
 	}

--- a/pkg/consolegraphql/filter/lex.rl
+++ b/pkg/consolegraphql/filter/lex.rl
@@ -95,14 +95,14 @@ func (lex *lexer) Lex(out *FilterSymType) int {
             fbreak; };
 
             bquoted_string => {
-            val := "{" + strings.Replace(string(lex.data[lex.ts+1:lex.te-1]), "```", "`", -1) + "}"
+            val := strings.Replace(string(lex.data[lex.ts+1:lex.te-1]), "```", "`", -1)
             tok = JSON_PATH
             jsonPath := jsonpath.New("filter expr").AllowMissingKeys(true)
-            err := jsonPath.Parse(val)
+            err := jsonPath.Parse("{" + val + "}")
             if err != nil {
                 lex.e = err
             }
-            out.jsonPathValue = NewJSONPathVal(jsonPath)
+            out.jsonPathValue = NewJSONPathVal(jsonPath, val)
             fbreak; };
 
             /AND/i => { tok = AND; fbreak;};

--- a/pkg/consolegraphql/filter/parser.go
+++ b/pkg/consolegraphql/filter/parser.go
@@ -540,7 +540,7 @@ Filterdefault:
 		FilterDollar = FilterS[Filterpt-3 : Filterpt+1]
 //line pkg/consolegraphql/filter/parser.y:95
 		{
-			FilterVAL.expr = NewBoolExpr(FilterDollar[2].expr)
+			FilterVAL.expr = FilterDollar[2].expr
 		}
 	case 5:
 		FilterDollar = FilterS[Filterpt-3 : Filterpt+1]

--- a/pkg/consolegraphql/filter/parser.y
+++ b/pkg/consolegraphql/filter/parser.y
@@ -93,7 +93,7 @@ expression:
   }
 |  '(' expression ')'
   {
-    $$ = NewBoolExpr($2)
+    $$ = $2
   }
 | expression AND expression
   {

--- a/pkg/consolegraphql/metric/metric_updater_test.go
+++ b/pkg/consolegraphql/metric/metric_updater_test.go
@@ -46,7 +46,7 @@ func TestMetricUpdater(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 1, updated)
 
-	objs, err := objectCache.Get(cache.PrimaryObjectIndex, fmt.Sprintf("Address/%s/%s/%s", namespace, addressspace, addressname), nil)
+	objs, err := objectCache.Get(cache.PrimaryObjectIndex, fmt.Sprintf("Address/%s/%s", namespace, addressname), nil)
 	assert.NoError(t, err)
 
 	assert.Equal(t, 1, len(objs), "unexpected number of addresses")

--- a/pkg/consolegraphql/resolvers/resolver.go
+++ b/pkg/consolegraphql/resolvers/resolver.go
@@ -81,7 +81,6 @@ func BuildFilter(f *string, orderedKeyElements ...string) (cache.ObjectFilter, s
 func buildKey(expression filter.Expr, orderedKeyElements ...string) string {
 	keyElements := make([]string, 0)
 
-
 	for i, keyElement := range orderedKeyElements {
 		foundTerm := false
 

--- a/pkg/consolegraphql/resolvers/resolver.go
+++ b/pkg/consolegraphql/resolvers/resolver.go
@@ -13,6 +13,7 @@ import (
 	"github.com/enmasseproject/enmasse/pkg/consolegraphql/agent"
 	"github.com/enmasseproject/enmasse/pkg/consolegraphql/cache"
 	"github.com/enmasseproject/enmasse/pkg/consolegraphql/filter"
+	"strings"
 )
 
 type Resolver struct {
@@ -53,11 +54,15 @@ func Min(x, y int) int {
 	return y
 }
 
-func BuildFilter(f *string) (cache.ObjectFilter, error) {
+func BuildFilter(f *string, orderedKeyElements ...string) (cache.ObjectFilter, string, error) {
 	if f != nil && *f != "" {
+		key := ""
 		expression, err := filter.ParseFilterExpression(*f)
 		if err != nil {
-			return nil, err
+			return nil, "", err
+		}
+		if len(orderedKeyElements) > 0 {
+			key = buildKey(expression, orderedKeyElements...)
 		}
 		return func(i interface{}) (match bool, cont bool, e error) {
 			rv, e := expression.Eval(i)
@@ -65,9 +70,81 @@ func BuildFilter(f *string) (cache.ObjectFilter, error) {
 				return false, false, e
 			}
 			return rv.(bool), true, nil
-		}, nil
+		}, key, nil
 	}
-	return nil, nil
+	return nil, "", nil
+}
+
+// builds the longest possible hierarchical key, in key element order, that matches the filter.
+// The filter tree traversal is pruned whenever boolean logic other from an "and" is encountered.
+// (This allows the indices provided by hashicorp memdb to be used efficiently).
+func buildKey(expression filter.Expr, orderedKeyElements ...string) string {
+	keyElements := make([]string, 0)
+
+
+	for i, keyElement := range orderedKeyElements {
+		foundTerm := false
+
+		doCmp := func(left, right filter.Expr,
+			fltKeyElement func(string) bool,
+			fltStrVal func(string) (string, bool)) bool {
+			if jpv, jpok := left.(filter.JSONPathVal); jpok && fltKeyElement(jpv.JSONPathExpr) {
+				if stv, stok := right.(filter.StringVal); stok {
+					if sv, ok := fltStrVal(string(stv)); ok {
+						keyElements = append(keyElements, sv)
+						return true
+					}
+				}
+			}
+			return false
+		}
+
+		accept := func(e filter.Expr) bool {
+			if foundTerm {
+				return false
+			}
+			switch e.(type) {
+			case filter.AndExpr:
+				return true
+			case filter.ComparisonExpr:
+				return true
+			}
+			return false
+		}
+		visit := func(e filter.Expr) {
+			if ce, ceok := e.(filter.ComparisonExpr); ceok {
+				fltKeyElement := func(jp string) bool { return jp == keyElement }
+
+				if ce.Operator == filter.EqualStr {
+					fltStrVal := func(sv string) (string, bool) { return sv, true }
+					if doCmp(ce.Left, ce.Right, fltKeyElement, fltStrVal) || doCmp(ce.Right, ce.Left, fltKeyElement, fltStrVal) {
+						foundTerm = true
+					}
+				} else if ce.Operator == filter.LikeStr && i == len(orderedKeyElements)-1 {
+					// Like eligible for last key element only
+					fltStrVal := func(sv string) (string, bool) {
+						// Allow only a single trailing % and no _
+						return strings.TrimSuffix(sv, "%"),
+							strings.Index(sv, "%") == len(sv)-1 && strings.Index(sv, "_") == -1
+					}
+					if doCmp(ce.Left, ce.Right, fltKeyElement, fltStrVal) || doCmp(ce.Right, ce.Left, fltKeyElement, fltStrVal) {
+						foundTerm = true
+					}
+				}
+			}
+		}
+		expression.Traverse(accept, visit)
+
+		if !foundTerm {
+			break
+		}
+	}
+
+	if len(orderedKeyElements) > len(keyElements) {
+		keyElements = append(keyElements, "")
+	}
+
+	return strings.Join(keyElements, "/")
 }
 
 func BuildOrderer(o *string) (func(interface{}) error, error) {

--- a/pkg/consolegraphql/resolvers/resolver_connection.go
+++ b/pkg/consolegraphql/resolvers/resolver_connection.go
@@ -23,7 +23,8 @@ func (r *Resolver) Connection_consoleapi_enmasse_io_v1beta1() Connection_console
 
 func (cr connectionK8sResolver) Links(ctx context.Context, obj *consolegraphql.Connection, first *int, offset *int, filter *string, orderBy *string) (*LinkQueryResultConsoleapiEnmasseIoV1beta1, error) {
 	if obj != nil {
-		fltrfunc, e := BuildFilter(filter)
+
+		fltrfunc, keyElements, e := BuildFilter(filter, "$.metadata.name")
 		if e != nil {
 			return nil, e
 		}
@@ -33,7 +34,7 @@ func (cr connectionK8sResolver) Links(ctx context.Context, obj *consolegraphql.C
 			return nil, e
 		}
 
-		links, e := cr.Cache.Get(cache.PrimaryObjectIndex, fmt.Sprintf("Link/%s/%s/%s/", obj.ObjectMeta.Namespace, obj.Spec.AddressSpace, obj.ObjectMeta.Name), fltrfunc)
+		links, e := cr.Cache.Get(cache.PrimaryObjectIndex, fmt.Sprintf("Link/%s/%s/%s/%s", obj.ObjectMeta.Namespace, obj.Spec.AddressSpace, obj.ObjectMeta.Name, keyElements), fltrfunc)
 		if e != nil {
 			return nil, e
 		}
@@ -121,7 +122,7 @@ func (r *queryResolver) Connections(ctx context.Context, first *int, offset *int
 	requestState := server.GetRequestStateFromContext(ctx)
 	viewFilter := requestState.AccessController.ViewFilter()
 
-	fltrfunc, e := BuildFilter(filter)
+	fltrfunc, keyElements, e := BuildFilter(filter, "$.metadata.namespace", "$.spec.addressSpace", "$.metadata.name")
 	if e != nil {
 		return nil, e
 	}
@@ -131,7 +132,7 @@ func (r *queryResolver) Connections(ctx context.Context, first *int, offset *int
 		return nil, e
 	}
 
-	objects, e := r.Cache.Get(cache.PrimaryObjectIndex, "Connection/", cache.And(viewFilter, fltrfunc))
+	objects, e := r.Cache.Get(cache.PrimaryObjectIndex, fmt.Sprintf("Connection/%s", keyElements), cache.And(viewFilter, fltrfunc))
 	if e != nil {
 		return nil, e
 	}

--- a/pkg/consolegraphql/resolvers/resolver_test.go
+++ b/pkg/consolegraphql/resolvers/resolver_test.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ *
+ */
+
+package resolvers
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestBuildFilter(t *testing.T) {
+	testCases := []struct {
+		name        string
+		filter      string
+		keyElements []string
+		expected    string
+	}{
+		{"one element", "`$.metadata.namespace` = 'foo'", []string{"$.metadata.namespace"}, "foo"},
+		{"reversed operands", "'foo' = `$.metadata.namespace`", []string{"$.metadata.namespace"}, "foo"},
+		{"element and element", "`$.metadata.namespace` = 'foo' AND `$.metadata.name` = 'bar'", []string{"$.metadata.namespace", "$.metadata.name"}, "foo/bar"},
+		{"element and (element)", "`$.metadata.namespace` = 'foo' AND (`$.metadata.name` = 'bar')", []string{"$.metadata.namespace", "$.metadata.name"}, "foo/bar"},
+		{"element or element", "`$.metadata.namespace` = 'foo' OR `$.metadata.name` = 'bar'", []string{"$.metadata.namespace", "$.metadata.name"}, ""},
+		{"element and (element or element)", "`$.metadata.namespace` = 'foo' AND (`$.metadata.name` = 'bar' OR `$.metadata.foo` = 'baz')", []string{"$.metadata.namespace", "$.metadata.name"}, "foo/"},
+		{"unexpected operand type", "`$.metadata.namespace` = 123", []string{"$.metadata.namespace"}, ""},
+		{"missing leading element disallowed", "`$.metadata.name` = 'bar'", []string{"$.metadata.namespace", "$.metadata.name"}, ""},
+		{"missing trailing element allowed", "`$.metadata.namespace` = 'foo'", []string{"$.metadata.namespace", "$.metadata.name"}, "foo/"},
+		{"duplicate elements", "`$.metadata.namespace` = 'foo' AND `$.metadata.namespace` LIKE 'fo%'", []string{"$.metadata.namespace"}, "foo"},
+
+		{"like element", "`$.metadata.namespace` LIKE 'fo%'", []string{"$.metadata.namespace"}, "fo"},
+		{"element and like element", "`$.metadata.namespace` = 'foo' AND `$.metadata.name` LIKE 'ba%'", []string{"$.metadata.namespace", "$.metadata.name"}, "foo/ba"},
+		{"leading like element disallowed", "`$.metadata.namespace` LIKE 'fo%' AND `$.metadata.name` = 'bar'", []string{"$.metadata.namespace", "$.metadata.name"}, ""},
+
+		{"missing element", "`$.metadata.namespace` = 'foo'", []string{"$.metadata.namespace", "$.metadata.name"}, "foo/"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, actual, err := BuildFilter(&tc.filter, tc.keyElements...)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, actual)
+
+		})
+	}
+}

--- a/pkg/consolegraphql/watchers/resource_watcher_agent.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_agent.go
@@ -415,7 +415,7 @@ func (clw *AgentWatcher) handleEvent(event agent.AgentEvent) error {
 			}
 
 		case *agent.AgentAddress:
-			objs, err := clw.Cache.Get(cache.PrimaryObjectIndex, fmt.Sprintf("Address/%s/%s/%s", target.AddressSpaceNamespace, target.AddressSpace, target.Name), nil)
+			objs, err := clw.Cache.Get(cache.PrimaryObjectIndex, fmt.Sprintf("Address/%s/%s", target.AddressSpaceNamespace, target.Name), nil)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

If the filter query is passed, use it to construct the longest hierarchy key to maximise use of the index.  This is helpful on the addressspace/address/connection 'detail' pages where otherwise the resolver may need to filter all (worst case) addressspace/address/connection to locate the subject of the page.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
