### PR TITLE
Disable the npm maven plugin in Eclipse M2E

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -807,6 +807,19 @@
                                         <ignore/>
                                     </action>
                                 </pluginExecution>
+                                <pluginExecution>
+                                  <pluginExecutionFilter>
+                                    <groupId>com.github.eirslett</groupId>
+                                    <artifactId>frontend-maven-plugin</artifactId>
+                                    <versionRange>[1.6.0,)</versionRange>
+                                    <goals>
+                                      <goal>npm</goal>
+                                    </goals>
+                                  </pluginExecutionFilter>
+                                  <action>
+                                    <ignore/>
+                                  </action>
+                                </pluginExecution>
                             </pluginExecutions>
                         </lifecycleMappingMetadata>
                     </configuration>


### PR DESCRIPTION
When using the Eclipse IDE, having M2E (maven integration) configured, it already took a while to process the console project, due to the npm maven integration.

After merging the new console branch, it took for me around 10 minutes on 100% CPU every time it made a change to a resource in the console project, including things likes switching a branch.

This PR disables the npm targets in the Eclipse IDE. I don't think anybody will miss it.