### PR TITLE
In broker address space, include session id in the formation of the consumer uuid

### DIFF
--- a/agent/lib/broker_controller.js
+++ b/agent/lib/broker_controller.js
@@ -205,11 +205,12 @@ function transform_producer_stats(raw) {
 
 function transform_consumer_stats(raw) {
     return {
-        uuid: generateStableUuid(raw.connectionID, raw.consumerID),
+        uuid: generateStableUuid(raw.connectionID, raw.sessionID, raw.consumerID),
         name: raw.consumerID,
         connection_id: raw.connectionID,
         address: raw.queueName,//mapped to address in later step
         deliveries: 0,//TODO: not yet available from broker
+
         lastUpdated: Date.now()
     };
 }
@@ -271,6 +272,7 @@ BrokerController.prototype.retrieve_stats = function () {
 
                 for(var c in connection_stats) {
                     connection_stats[c].messages_in = connection_stats[c].senders.reduce(function (total, sender) { return total + sender.deliveries; }, 0);
+                    // there is currently insufficient data exposed by the consumer to compute a messages_out
                 }
 
                 self.retrieve_count++;

--- a/agent/lib/router_stats.js
+++ b/agent/lib/router_stats.js
@@ -289,8 +289,7 @@ function get_normal_connections (results) {
                 },
                 senders: [],
                 receivers: [],
-                // DISPATCH-1439 - remove conditional once we have 1.10.0
-                creationTimestamp:  Math.floor(Date.now() / 1000) - (c.uptimeSeconds ? c.uptimeSeconds : 0),
+                creationTimestamp:  Math.floor(Date.now() / 1000) - c.uptimeSeconds,
             };
         });
     });


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In the brokered address space, the agent generated consumer uuids were colliding, resulting in missing receiver links on the connection and address detail pages.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
