### PR TITLE
fix leaking watches in systemtests

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/listener/JunitCallbackListener.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/listener/JunitCallbackListener.java
@@ -218,7 +218,7 @@ public class JunitCallbackListener implements TestExecutionExceptionHandler, Lif
                         }
                     }
                 } catch (Exception ex) {
-                    LOGGER.warn("Cannot access logs from container: ", ex);
+                    LOGGER.warn("Cannot access logs from pod {} ", p.getMetadata().getName(), ex);
                 }
             }
 

--- a/systemtests/src/main/java/io/enmasse/systemtest/logs/GlobalLogCollector.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/logs/GlobalLogCollector.java
@@ -53,13 +53,12 @@ public class GlobalLogCollector {
         collectorMap.put(AddressSpaceUtils.getAddressSpaceInfraUuid(addressSpace), new LogCollector(kubernetes, logDir.resolve(AddressSpaceUtils.getAddressSpaceInfraUuid(addressSpace)), AddressSpaceUtils.getAddressSpaceInfraUuid(addressSpace)));
     }
 
-    public synchronized void stopCollecting(String namespace) throws Exception {
-        log.info("Stop collecting logs for pods in namespace {}", namespace);
-        LogCollector collector = collectorMap.get(namespace);
+    public synchronized void stopCollecting(AddressSpace addressSpace) throws Exception {
+        log.info("Stop collecting logs for address space {}", AddressSpaceUtils.getAddressSpaceInfraUuid(addressSpace));
+        LogCollector collector = collectorMap.remove(AddressSpaceUtils.getAddressSpaceInfraUuid(addressSpace));
         if (collector != null) {
             collector.close();
         }
-        collectorMap.remove(namespace);
     }
 
     public void collectConfigMaps() {

--- a/systemtests/src/main/java/io/enmasse/systemtest/manager/ResourceManager.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/manager/ResourceManager.java
@@ -300,6 +300,7 @@ public abstract class ResourceManager {
     public void deleteAddressSpace(AddressSpace addressSpace) throws Exception {
         if (AddressSpaceUtils.existAddressSpace(addressSpace.getMetadata().getNamespace(), addressSpace.getMetadata().getName())) {
             AddressSpaceUtils.deleteAddressSpaceAndWait(addressSpace, logCollector);
+            logCollector.stopCollecting(addressSpace);
         } else {
             LOGGER.info("Address space '" + addressSpace.getMetadata().getName() + "' doesn't exists!");
         }


### PR DESCRIPTION
This should fix the EOFException we are getting in shared tests jobs because in the case of creating and deleteing lots of address space systemetsts will leak lots of watches