### PR TITLE
Add k8s loadBalancer instead of route when not on openshift

### DIFF
--- a/pkg/controller/add_authenticationservice.go
+++ b/pkg/controller/add_authenticationservice.go
@@ -1,4 +1,4 @@
-/*
+/*https://github.com/EnMasseProject/enmasse/pull/3920
  * Copyright 2018, EnMasse authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */

--- a/pkg/controller/iotconfig/utils.go
+++ b/pkg/controller/iotconfig/utils.go
@@ -22,6 +22,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 )
 
 // This sets the default Hono probes
@@ -181,6 +182,23 @@ func updateEndpointStatus(protocol string, forcePort bool, service *routev1.Rout
 	}
 
 	status.URI = protocol + "://" + service.Spec.Host
+
+	if forcePort {
+		status.URI += ":443"
+	}
+
+}
+
+
+func updateEndpointStatusWithLoadBalancer(protocol string, forcePort bool, service *networkingv1beta1.Ingress, status *iotv1alpha1.EndpointStatus) {
+
+	status.URI = ""
+
+	if service.Spec.Backend.ServiceName == "" {
+		return
+	}
+
+	status.URI = protocol + "://" + service.Spec.Backend.ServiceName
 
 	if forcePort {
 		status.URI += ":443"


### PR DESCRIPTION
### Type of change


- Bugfix
- Enhancement / new feature

### Description

When not on openshift, a kubernetes loadbalancer should be used. This is a first draft to add this in iot compenents.

@lulf there are still a few types errors here and there but I wanted your feedback on the general approach. WDYT ? 
Aslo, according to [1] we need an Ingress controller. Any opinion on which one we should use ? 

[1]: https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/

### Checklist

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
