### PR TITLE
Log reason for watch restart / improve handling of watch channel read failure

### DIFF
--- a/hack/generate_resource_watchers.go
+++ b/hack/generate_resource_watchers.go
@@ -182,7 +182,7 @@ func (kw *{{ .Name }}Watcher) Watch() error {
 		for running {
 			err := kw.doWatch(resource)
 			if err != nil {
-				log.Printf("{{ .Name }} - Restarting watch")
+				log.Printf("{{ .Name }} - Restarting watch - %s", err)
 			} else {
 				running = false
 			}
@@ -288,10 +288,10 @@ func (kw *{{ .Name }}Watcher) doWatch(resource cp.{{ .Name }}Interface) error {
 			if event.Type == watch.Error {
 				err = fmt.Errorf("Watch ended in error")
 			} else {
-				res, ok := event.Object.(*tp.{{ .Name }})
 				log.Printf("{{ .Name }} - Received event type %s", event.Type)
+				res, ok := event.Object.(*tp.{{ .Name }})
 				if !ok {
-					err = fmt.Errorf("Watch error - object of unexpected type received")
+					err = fmt.Errorf("Watch error - object of unexpected type, %T, received", event.Object)
 				} else {
 					copy := res.DeepCopy()
 					kw.updateKind(copy)

--- a/hack/generate_resource_watchers.go
+++ b/hack/generate_resource_watchers.go
@@ -182,7 +182,7 @@ func (kw *{{ .Name }}Watcher) Watch() error {
 		for running {
 			err := kw.doWatch(resource)
 			if err != nil {
-				log.Printf("{{ .Name }} - Restarting watch - %s", err)
+				log.Printf("{{ .Name }} - Restarting watch - %v", err)
 			} else {
 				running = false
 			}
@@ -283,35 +283,38 @@ func (kw *{{ .Name }}Watcher) doWatch(resource cp.{{ .Name }}Interface) error {
 	ch := resourceWatch.ResultChan()
 	for {
 		select {
-		case event := <-ch:
+		case event, chok := <-ch:
+			if !chok {
+				return fmt.Errorf("watch ended due to channel error")
+			} else if event.Type == watch.Error {
+				return fmt.Errorf("watch ended in error")
+			}
+
 			var err error
-			if event.Type == watch.Error {
-				err = fmt.Errorf("Watch ended in error")
+			log.Printf("{{ .Name }} - Received event type %s", event.Type)
+			res, ok := event.Object.(*tp.{{ .Name }})
+			if !ok {
+				err = fmt.Errorf("Watch error - object of unexpected type, %T, received", event.Object)
 			} else {
-				log.Printf("{{ .Name }} - Received event type %s", event.Type)
-				res, ok := event.Object.(*tp.{{ .Name }})
-				if !ok {
-					err = fmt.Errorf("Watch error - object of unexpected type, %T, received", event.Object)
-				} else {
-					copy := res.DeepCopy()
-					kw.updateKind(copy)
-					switch event.Type {
-					case watch.Added:
-						err = kw.Cache.Add(kw.create(copy))
-					case watch.Modified:
-						updatingKey := kw.create(copy)
-						err = kw.Cache.Update(func(current interface{}) (interface{}, error) {
-							if kw.update(copy, current) {
-								return copy, nil
-							} else {
-								return nil, nil
-							}
-						}, updatingKey)
-					case watch.Deleted:
-						err = kw.Cache.Delete(kw.create(copy))
-					}
+				copy := res.DeepCopy()
+				kw.updateKind(copy)
+				switch event.Type {
+				case watch.Added:
+					err = kw.Cache.Add(kw.create(copy))
+				case watch.Modified:
+					updatingKey := kw.create(copy)
+					err = kw.Cache.Update(func(current interface{}) (interface{}, error) {
+						if kw.update(copy, current) {
+							return copy, nil
+						} else {
+							return nil, nil
+						}
+					}, updatingKey)
+				case watch.Deleted:
+					err = kw.Cache.Delete(kw.create(copy))
 				}
 			}
+
 			if err != nil {
 				return err
 			}

--- a/pkg/consolegraphql/watchers/resource_watcher_address.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_address.go
@@ -111,7 +111,7 @@ func (kw *AddressWatcher) Watch() error {
 		for running {
 			err := kw.doWatch(resource)
 			if err != nil {
-				log.Printf("Address - Restarting watch")
+				log.Printf("Address - Restarting watch - %s", err)
 			} else {
 				running = false
 			}
@@ -217,10 +217,10 @@ func (kw *AddressWatcher) doWatch(resource cp.AddressInterface) error {
 			if event.Type == watch.Error {
 				err = fmt.Errorf("Watch ended in error")
 			} else {
-				res, ok := event.Object.(*tp.Address)
 				log.Printf("Address - Received event type %s", event.Type)
+				res, ok := event.Object.(*tp.Address)
 				if !ok {
-					err = fmt.Errorf("Watch error - object of unexpected type received")
+					err = fmt.Errorf("Watch error - object of unexpected type, %T, received", event.Object)
 				} else {
 					copy := res.DeepCopy()
 					kw.updateKind(copy)

--- a/pkg/consolegraphql/watchers/resource_watcher_address.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_address.go
@@ -111,7 +111,7 @@ func (kw *AddressWatcher) Watch() error {
 		for running {
 			err := kw.doWatch(resource)
 			if err != nil {
-				log.Printf("Address - Restarting watch - %s", err)
+				log.Printf("Address - Restarting watch - %v", err)
 			} else {
 				running = false
 			}
@@ -212,35 +212,38 @@ func (kw *AddressWatcher) doWatch(resource cp.AddressInterface) error {
 	ch := resourceWatch.ResultChan()
 	for {
 		select {
-		case event := <-ch:
+		case event, chok := <-ch:
+			if !chok {
+				return fmt.Errorf("watch ended due to channel error")
+			} else if event.Type == watch.Error {
+				return fmt.Errorf("watch ended in error")
+			}
+
 			var err error
-			if event.Type == watch.Error {
-				err = fmt.Errorf("Watch ended in error")
+			log.Printf("Address - Received event type %s", event.Type)
+			res, ok := event.Object.(*tp.Address)
+			if !ok {
+				err = fmt.Errorf("Watch error - object of unexpected type, %T, received", event.Object)
 			} else {
-				log.Printf("Address - Received event type %s", event.Type)
-				res, ok := event.Object.(*tp.Address)
-				if !ok {
-					err = fmt.Errorf("Watch error - object of unexpected type, %T, received", event.Object)
-				} else {
-					copy := res.DeepCopy()
-					kw.updateKind(copy)
-					switch event.Type {
-					case watch.Added:
-						err = kw.Cache.Add(kw.create(copy))
-					case watch.Modified:
-						updatingKey := kw.create(copy)
-						err = kw.Cache.Update(func(current interface{}) (interface{}, error) {
-							if kw.update(copy, current) {
-								return copy, nil
-							} else {
-								return nil, nil
-							}
-						}, updatingKey)
-					case watch.Deleted:
-						err = kw.Cache.Delete(kw.create(copy))
-					}
+				copy := res.DeepCopy()
+				kw.updateKind(copy)
+				switch event.Type {
+				case watch.Added:
+					err = kw.Cache.Add(kw.create(copy))
+				case watch.Modified:
+					updatingKey := kw.create(copy)
+					err = kw.Cache.Update(func(current interface{}) (interface{}, error) {
+						if kw.update(copy, current) {
+							return copy, nil
+						} else {
+							return nil, nil
+						}
+					}, updatingKey)
+				case watch.Deleted:
+					err = kw.Cache.Delete(kw.create(copy))
 				}
 			}
+
 			if err != nil {
 				return err
 			}

--- a/pkg/consolegraphql/watchers/resource_watcher_addressplan.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_addressplan.go
@@ -111,7 +111,7 @@ func (kw *AddressPlanWatcher) Watch() error {
 		for running {
 			err := kw.doWatch(resource)
 			if err != nil {
-				log.Printf("AddressPlan - Restarting watch")
+				log.Printf("AddressPlan - Restarting watch - %s", err)
 			} else {
 				running = false
 			}
@@ -217,10 +217,10 @@ func (kw *AddressPlanWatcher) doWatch(resource cp.AddressPlanInterface) error {
 			if event.Type == watch.Error {
 				err = fmt.Errorf("Watch ended in error")
 			} else {
-				res, ok := event.Object.(*tp.AddressPlan)
 				log.Printf("AddressPlan - Received event type %s", event.Type)
+				res, ok := event.Object.(*tp.AddressPlan)
 				if !ok {
-					err = fmt.Errorf("Watch error - object of unexpected type received")
+					err = fmt.Errorf("Watch error - object of unexpected type, %T, received", event.Object)
 				} else {
 					copy := res.DeepCopy()
 					kw.updateKind(copy)

--- a/pkg/consolegraphql/watchers/resource_watcher_addressplan.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_addressplan.go
@@ -111,7 +111,7 @@ func (kw *AddressPlanWatcher) Watch() error {
 		for running {
 			err := kw.doWatch(resource)
 			if err != nil {
-				log.Printf("AddressPlan - Restarting watch - %s", err)
+				log.Printf("AddressPlan - Restarting watch - %v", err)
 			} else {
 				running = false
 			}
@@ -212,35 +212,38 @@ func (kw *AddressPlanWatcher) doWatch(resource cp.AddressPlanInterface) error {
 	ch := resourceWatch.ResultChan()
 	for {
 		select {
-		case event := <-ch:
+		case event, chok := <-ch:
+			if !chok {
+				return fmt.Errorf("watch ended due to channel error")
+			} else if event.Type == watch.Error {
+				return fmt.Errorf("watch ended in error")
+			}
+
 			var err error
-			if event.Type == watch.Error {
-				err = fmt.Errorf("Watch ended in error")
+			log.Printf("AddressPlan - Received event type %s", event.Type)
+			res, ok := event.Object.(*tp.AddressPlan)
+			if !ok {
+				err = fmt.Errorf("Watch error - object of unexpected type, %T, received", event.Object)
 			} else {
-				log.Printf("AddressPlan - Received event type %s", event.Type)
-				res, ok := event.Object.(*tp.AddressPlan)
-				if !ok {
-					err = fmt.Errorf("Watch error - object of unexpected type, %T, received", event.Object)
-				} else {
-					copy := res.DeepCopy()
-					kw.updateKind(copy)
-					switch event.Type {
-					case watch.Added:
-						err = kw.Cache.Add(kw.create(copy))
-					case watch.Modified:
-						updatingKey := kw.create(copy)
-						err = kw.Cache.Update(func(current interface{}) (interface{}, error) {
-							if kw.update(copy, current) {
-								return copy, nil
-							} else {
-								return nil, nil
-							}
-						}, updatingKey)
-					case watch.Deleted:
-						err = kw.Cache.Delete(kw.create(copy))
-					}
+				copy := res.DeepCopy()
+				kw.updateKind(copy)
+				switch event.Type {
+				case watch.Added:
+					err = kw.Cache.Add(kw.create(copy))
+				case watch.Modified:
+					updatingKey := kw.create(copy)
+					err = kw.Cache.Update(func(current interface{}) (interface{}, error) {
+						if kw.update(copy, current) {
+							return copy, nil
+						} else {
+							return nil, nil
+						}
+					}, updatingKey)
+				case watch.Deleted:
+					err = kw.Cache.Delete(kw.create(copy))
 				}
 			}
+
 			if err != nil {
 				return err
 			}

--- a/pkg/consolegraphql/watchers/resource_watcher_addressspace.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_addressspace.go
@@ -111,7 +111,7 @@ func (kw *AddressSpaceWatcher) Watch() error {
 		for running {
 			err := kw.doWatch(resource)
 			if err != nil {
-				log.Printf("AddressSpace - Restarting watch")
+				log.Printf("AddressSpace - Restarting watch - %s", err)
 			} else {
 				running = false
 			}
@@ -217,10 +217,10 @@ func (kw *AddressSpaceWatcher) doWatch(resource cp.AddressSpaceInterface) error 
 			if event.Type == watch.Error {
 				err = fmt.Errorf("Watch ended in error")
 			} else {
-				res, ok := event.Object.(*tp.AddressSpace)
 				log.Printf("AddressSpace - Received event type %s", event.Type)
+				res, ok := event.Object.(*tp.AddressSpace)
 				if !ok {
-					err = fmt.Errorf("Watch error - object of unexpected type received")
+					err = fmt.Errorf("Watch error - object of unexpected type, %T, received", event.Object)
 				} else {
 					copy := res.DeepCopy()
 					kw.updateKind(copy)

--- a/pkg/consolegraphql/watchers/resource_watcher_addressspace.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_addressspace.go
@@ -111,7 +111,7 @@ func (kw *AddressSpaceWatcher) Watch() error {
 		for running {
 			err := kw.doWatch(resource)
 			if err != nil {
-				log.Printf("AddressSpace - Restarting watch - %s", err)
+				log.Printf("AddressSpace - Restarting watch - %v", err)
 			} else {
 				running = false
 			}
@@ -212,35 +212,38 @@ func (kw *AddressSpaceWatcher) doWatch(resource cp.AddressSpaceInterface) error 
 	ch := resourceWatch.ResultChan()
 	for {
 		select {
-		case event := <-ch:
+		case event, chok := <-ch:
+			if !chok {
+				return fmt.Errorf("watch ended due to channel error")
+			} else if event.Type == watch.Error {
+				return fmt.Errorf("watch ended in error")
+			}
+
 			var err error
-			if event.Type == watch.Error {
-				err = fmt.Errorf("Watch ended in error")
+			log.Printf("AddressSpace - Received event type %s", event.Type)
+			res, ok := event.Object.(*tp.AddressSpace)
+			if !ok {
+				err = fmt.Errorf("Watch error - object of unexpected type, %T, received", event.Object)
 			} else {
-				log.Printf("AddressSpace - Received event type %s", event.Type)
-				res, ok := event.Object.(*tp.AddressSpace)
-				if !ok {
-					err = fmt.Errorf("Watch error - object of unexpected type, %T, received", event.Object)
-				} else {
-					copy := res.DeepCopy()
-					kw.updateKind(copy)
-					switch event.Type {
-					case watch.Added:
-						err = kw.Cache.Add(kw.create(copy))
-					case watch.Modified:
-						updatingKey := kw.create(copy)
-						err = kw.Cache.Update(func(current interface{}) (interface{}, error) {
-							if kw.update(copy, current) {
-								return copy, nil
-							} else {
-								return nil, nil
-							}
-						}, updatingKey)
-					case watch.Deleted:
-						err = kw.Cache.Delete(kw.create(copy))
-					}
+				copy := res.DeepCopy()
+				kw.updateKind(copy)
+				switch event.Type {
+				case watch.Added:
+					err = kw.Cache.Add(kw.create(copy))
+				case watch.Modified:
+					updatingKey := kw.create(copy)
+					err = kw.Cache.Update(func(current interface{}) (interface{}, error) {
+						if kw.update(copy, current) {
+							return copy, nil
+						} else {
+							return nil, nil
+						}
+					}, updatingKey)
+				case watch.Deleted:
+					err = kw.Cache.Delete(kw.create(copy))
 				}
 			}
+
 			if err != nil {
 				return err
 			}

--- a/pkg/consolegraphql/watchers/resource_watcher_addressspaceplan.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_addressspaceplan.go
@@ -111,7 +111,7 @@ func (kw *AddressSpacePlanWatcher) Watch() error {
 		for running {
 			err := kw.doWatch(resource)
 			if err != nil {
-				log.Printf("AddressSpacePlan - Restarting watch")
+				log.Printf("AddressSpacePlan - Restarting watch - %s", err)
 			} else {
 				running = false
 			}
@@ -217,10 +217,10 @@ func (kw *AddressSpacePlanWatcher) doWatch(resource cp.AddressSpacePlanInterface
 			if event.Type == watch.Error {
 				err = fmt.Errorf("Watch ended in error")
 			} else {
-				res, ok := event.Object.(*tp.AddressSpacePlan)
 				log.Printf("AddressSpacePlan - Received event type %s", event.Type)
+				res, ok := event.Object.(*tp.AddressSpacePlan)
 				if !ok {
-					err = fmt.Errorf("Watch error - object of unexpected type received")
+					err = fmt.Errorf("Watch error - object of unexpected type, %T, received", event.Object)
 				} else {
 					copy := res.DeepCopy()
 					kw.updateKind(copy)

--- a/pkg/consolegraphql/watchers/resource_watcher_addressspaceplan.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_addressspaceplan.go
@@ -111,7 +111,7 @@ func (kw *AddressSpacePlanWatcher) Watch() error {
 		for running {
 			err := kw.doWatch(resource)
 			if err != nil {
-				log.Printf("AddressSpacePlan - Restarting watch - %s", err)
+				log.Printf("AddressSpacePlan - Restarting watch - %v", err)
 			} else {
 				running = false
 			}
@@ -212,35 +212,38 @@ func (kw *AddressSpacePlanWatcher) doWatch(resource cp.AddressSpacePlanInterface
 	ch := resourceWatch.ResultChan()
 	for {
 		select {
-		case event := <-ch:
+		case event, chok := <-ch:
+			if !chok {
+				return fmt.Errorf("watch ended due to channel error")
+			} else if event.Type == watch.Error {
+				return fmt.Errorf("watch ended in error")
+			}
+
 			var err error
-			if event.Type == watch.Error {
-				err = fmt.Errorf("Watch ended in error")
+			log.Printf("AddressSpacePlan - Received event type %s", event.Type)
+			res, ok := event.Object.(*tp.AddressSpacePlan)
+			if !ok {
+				err = fmt.Errorf("Watch error - object of unexpected type, %T, received", event.Object)
 			} else {
-				log.Printf("AddressSpacePlan - Received event type %s", event.Type)
-				res, ok := event.Object.(*tp.AddressSpacePlan)
-				if !ok {
-					err = fmt.Errorf("Watch error - object of unexpected type, %T, received", event.Object)
-				} else {
-					copy := res.DeepCopy()
-					kw.updateKind(copy)
-					switch event.Type {
-					case watch.Added:
-						err = kw.Cache.Add(kw.create(copy))
-					case watch.Modified:
-						updatingKey := kw.create(copy)
-						err = kw.Cache.Update(func(current interface{}) (interface{}, error) {
-							if kw.update(copy, current) {
-								return copy, nil
-							} else {
-								return nil, nil
-							}
-						}, updatingKey)
-					case watch.Deleted:
-						err = kw.Cache.Delete(kw.create(copy))
-					}
+				copy := res.DeepCopy()
+				kw.updateKind(copy)
+				switch event.Type {
+				case watch.Added:
+					err = kw.Cache.Add(kw.create(copy))
+				case watch.Modified:
+					updatingKey := kw.create(copy)
+					err = kw.Cache.Update(func(current interface{}) (interface{}, error) {
+						if kw.update(copy, current) {
+							return copy, nil
+						} else {
+							return nil, nil
+						}
+					}, updatingKey)
+				case watch.Deleted:
+					err = kw.Cache.Delete(kw.create(copy))
 				}
 			}
+
 			if err != nil {
 				return err
 			}

--- a/pkg/consolegraphql/watchers/resource_watcher_addressspaceschema.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_addressspaceschema.go
@@ -111,7 +111,7 @@ func (kw *AddressSpaceSchemaWatcher) Watch() error {
 		for running {
 			err := kw.doWatch(resource)
 			if err != nil {
-				log.Printf("AddressSpaceSchema - Restarting watch")
+				log.Printf("AddressSpaceSchema - Restarting watch - %s", err)
 			} else {
 				running = false
 			}
@@ -217,10 +217,10 @@ func (kw *AddressSpaceSchemaWatcher) doWatch(resource cp.AddressSpaceSchemaInter
 			if event.Type == watch.Error {
 				err = fmt.Errorf("Watch ended in error")
 			} else {
-				res, ok := event.Object.(*tp.AddressSpaceSchema)
 				log.Printf("AddressSpaceSchema - Received event type %s", event.Type)
+				res, ok := event.Object.(*tp.AddressSpaceSchema)
 				if !ok {
-					err = fmt.Errorf("Watch error - object of unexpected type received")
+					err = fmt.Errorf("Watch error - object of unexpected type, %T, received", event.Object)
 				} else {
 					copy := res.DeepCopy()
 					kw.updateKind(copy)

--- a/pkg/consolegraphql/watchers/resource_watcher_authenticationservice.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_authenticationservice.go
@@ -111,7 +111,7 @@ func (kw *AuthenticationServiceWatcher) Watch() error {
 		for running {
 			err := kw.doWatch(resource)
 			if err != nil {
-				log.Printf("AuthenticationService - Restarting watch - %s", err)
+				log.Printf("AuthenticationService - Restarting watch - %v", err)
 			} else {
 				running = false
 			}
@@ -212,35 +212,38 @@ func (kw *AuthenticationServiceWatcher) doWatch(resource cp.AuthenticationServic
 	ch := resourceWatch.ResultChan()
 	for {
 		select {
-		case event := <-ch:
+		case event, chok := <-ch:
+			if !chok {
+				return fmt.Errorf("watch ended due to channel error")
+			} else if event.Type == watch.Error {
+				return fmt.Errorf("watch ended in error")
+			}
+
 			var err error
-			if event.Type == watch.Error {
-				err = fmt.Errorf("Watch ended in error")
+			log.Printf("AuthenticationService - Received event type %s", event.Type)
+			res, ok := event.Object.(*tp.AuthenticationService)
+			if !ok {
+				err = fmt.Errorf("Watch error - object of unexpected type, %T, received", event.Object)
 			} else {
-				log.Printf("AuthenticationService - Received event type %s", event.Type)
-				res, ok := event.Object.(*tp.AuthenticationService)
-				if !ok {
-					err = fmt.Errorf("Watch error - object of unexpected type, %T, received", event.Object)
-				} else {
-					copy := res.DeepCopy()
-					kw.updateKind(copy)
-					switch event.Type {
-					case watch.Added:
-						err = kw.Cache.Add(kw.create(copy))
-					case watch.Modified:
-						updatingKey := kw.create(copy)
-						err = kw.Cache.Update(func(current interface{}) (interface{}, error) {
-							if kw.update(copy, current) {
-								return copy, nil
-							} else {
-								return nil, nil
-							}
-						}, updatingKey)
-					case watch.Deleted:
-						err = kw.Cache.Delete(kw.create(copy))
-					}
+				copy := res.DeepCopy()
+				kw.updateKind(copy)
+				switch event.Type {
+				case watch.Added:
+					err = kw.Cache.Add(kw.create(copy))
+				case watch.Modified:
+					updatingKey := kw.create(copy)
+					err = kw.Cache.Update(func(current interface{}) (interface{}, error) {
+						if kw.update(copy, current) {
+							return copy, nil
+						} else {
+							return nil, nil
+						}
+					}, updatingKey)
+				case watch.Deleted:
+					err = kw.Cache.Delete(kw.create(copy))
 				}
 			}
+
 			if err != nil {
 				return err
 			}

--- a/pkg/consolegraphql/watchers/resource_watcher_authenticationservice.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_authenticationservice.go
@@ -111,7 +111,7 @@ func (kw *AuthenticationServiceWatcher) Watch() error {
 		for running {
 			err := kw.doWatch(resource)
 			if err != nil {
-				log.Printf("AuthenticationService - Restarting watch")
+				log.Printf("AuthenticationService - Restarting watch - %s", err)
 			} else {
 				running = false
 			}
@@ -217,10 +217,10 @@ func (kw *AuthenticationServiceWatcher) doWatch(resource cp.AuthenticationServic
 			if event.Type == watch.Error {
 				err = fmt.Errorf("Watch ended in error")
 			} else {
-				res, ok := event.Object.(*tp.AuthenticationService)
 				log.Printf("AuthenticationService - Received event type %s", event.Type)
+				res, ok := event.Object.(*tp.AuthenticationService)
 				if !ok {
-					err = fmt.Errorf("Watch error - object of unexpected type received")
+					err = fmt.Errorf("Watch error - object of unexpected type, %T, received", event.Object)
 				} else {
 					copy := res.DeepCopy()
 					kw.updateKind(copy)

--- a/pkg/consolegraphql/watchers/resource_watcher_namespace.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_namespace.go
@@ -111,7 +111,7 @@ func (kw *NamespaceWatcher) Watch() error {
 		for running {
 			err := kw.doWatch(resource)
 			if err != nil {
-				log.Printf("Namespace - Restarting watch - %s", err)
+				log.Printf("Namespace - Restarting watch - %v", err)
 			} else {
 				running = false
 			}
@@ -212,35 +212,38 @@ func (kw *NamespaceWatcher) doWatch(resource cp.NamespaceInterface) error {
 	ch := resourceWatch.ResultChan()
 	for {
 		select {
-		case event := <-ch:
+		case event, chok := <-ch:
+			if !chok {
+				return fmt.Errorf("watch ended due to channel error")
+			} else if event.Type == watch.Error {
+				return fmt.Errorf("watch ended in error")
+			}
+
 			var err error
-			if event.Type == watch.Error {
-				err = fmt.Errorf("Watch ended in error")
+			log.Printf("Namespace - Received event type %s", event.Type)
+			res, ok := event.Object.(*tp.Namespace)
+			if !ok {
+				err = fmt.Errorf("Watch error - object of unexpected type, %T, received", event.Object)
 			} else {
-				log.Printf("Namespace - Received event type %s", event.Type)
-				res, ok := event.Object.(*tp.Namespace)
-				if !ok {
-					err = fmt.Errorf("Watch error - object of unexpected type, %T, received", event.Object)
-				} else {
-					copy := res.DeepCopy()
-					kw.updateKind(copy)
-					switch event.Type {
-					case watch.Added:
-						err = kw.Cache.Add(kw.create(copy))
-					case watch.Modified:
-						updatingKey := kw.create(copy)
-						err = kw.Cache.Update(func(current interface{}) (interface{}, error) {
-							if kw.update(copy, current) {
-								return copy, nil
-							} else {
-								return nil, nil
-							}
-						}, updatingKey)
-					case watch.Deleted:
-						err = kw.Cache.Delete(kw.create(copy))
-					}
+				copy := res.DeepCopy()
+				kw.updateKind(copy)
+				switch event.Type {
+				case watch.Added:
+					err = kw.Cache.Add(kw.create(copy))
+				case watch.Modified:
+					updatingKey := kw.create(copy)
+					err = kw.Cache.Update(func(current interface{}) (interface{}, error) {
+						if kw.update(copy, current) {
+							return copy, nil
+						} else {
+							return nil, nil
+						}
+					}, updatingKey)
+				case watch.Deleted:
+					err = kw.Cache.Delete(kw.create(copy))
 				}
 			}
+
 			if err != nil {
 				return err
 			}

--- a/pkg/consolegraphql/watchers/resource_watcher_namespace.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_namespace.go
@@ -111,7 +111,7 @@ func (kw *NamespaceWatcher) Watch() error {
 		for running {
 			err := kw.doWatch(resource)
 			if err != nil {
-				log.Printf("Namespace - Restarting watch")
+				log.Printf("Namespace - Restarting watch - %s", err)
 			} else {
 				running = false
 			}
@@ -217,10 +217,10 @@ func (kw *NamespaceWatcher) doWatch(resource cp.NamespaceInterface) error {
 			if event.Type == watch.Error {
 				err = fmt.Errorf("Watch ended in error")
 			} else {
-				res, ok := event.Object.(*tp.Namespace)
 				log.Printf("Namespace - Received event type %s", event.Type)
+				res, ok := event.Object.(*tp.Namespace)
 				if !ok {
-					err = fmt.Errorf("Watch error - object of unexpected type received")
+					err = fmt.Errorf("Watch error - object of unexpected type, %T, received", event.Object)
 				} else {
 					copy := res.DeepCopy()
 					kw.updateKind(copy)


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Ensure that the error that causes the watch to restart is written to the log.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
