### PR TITLE
Bug fix - prevent address space and address watchers spinning on resource update

### DIFF
--- a/cmd/console-server/main.go
+++ b/cmd/console-server/main.go
@@ -14,10 +14,8 @@ import (
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/handler"
 	"github.com/alexedwards/scs/v2"
-	"github.com/enmasseproject/enmasse/pkg/apis/enmasse/v1beta1"
 	adminv1beta2 "github.com/enmasseproject/enmasse/pkg/client/clientset/versioned/typed/admin/v1beta2"
 	enmassev1beta1 "github.com/enmasseproject/enmasse/pkg/client/clientset/versioned/typed/enmasse/v1beta1"
-	"github.com/enmasseproject/enmasse/pkg/consolegraphql"
 	"github.com/enmasseproject/enmasse/pkg/consolegraphql/accesscontroller"
 	"github.com/enmasseproject/enmasse/pkg/consolegraphql/agent"
 	"github.com/enmasseproject/enmasse/pkg/consolegraphql/cache"
@@ -36,7 +34,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd/api"
 	"log"
 	"net/http"
-	"reflect"
 	"time"
 )
 
@@ -252,41 +249,11 @@ http://localhost:` + port + `/graphql
 	creators := []func() (watchers.ResourceWatcher, error){
 		func() (watchers.ResourceWatcher, error) {
 			return watchers.NewAddressSpaceWatcher(objectCache, watchers.AddressSpaceWatcherConfig(config),
-				watchers.AddressSpaceWatcherFactory(
-					func(space *v1beta1.AddressSpace) interface{} {
-						return &consolegraphql.AddressSpaceHolder{
-							AddressSpace: *space,
-						}
-					},
-					func(value *v1beta1.AddressSpace, existing interface{}) bool {
-						ash := existing.(*consolegraphql.AddressSpaceHolder)
-						if reflect.DeepEqual(ash.AddressSpace, *value) {
-							return false
-						} else {
-							value.DeepCopyInto(&ash.AddressSpace)
-							return true
-						}
-					},
-				))
+				watchers.AddressSpaceWatcherFactory(watchers.AddressSpaceCreate, watchers.AddressSpaceUpdate))
 		},
 		func() (watchers.ResourceWatcher, error) {
 			return watchers.NewAddressWatcher(objectCache, watchers.AddressWatcherConfig(config),
-				watchers.AddressWatcherFactory(
-					func(space *v1beta1.Address) interface{} {
-						return &consolegraphql.AddressHolder{
-							Address: *space,
-						}
-					},
-					func(value *v1beta1.Address, existing interface{}) bool {
-						ash := existing.(*consolegraphql.AddressHolder)
-						if reflect.DeepEqual(ash.Address, *value) {
-							return false
-						} else {
-							value.DeepCopyInto(&ash.Address)
-							return true
-						}
-					},
-				))
+				watchers.AddressWatcherFactory(watchers.AddressCreate, watchers.AddressUpdate))
 		},
 		func() (watchers.ResourceWatcher, error) {
 			return watchers.NewNamespaceWatcher(objectCache, watchers.NamespaceWatcherConfig(config))

--- a/pkg/consolegraphql/cache/cache.go
+++ b/pkg/consolegraphql/cache/cache.go
@@ -143,7 +143,7 @@ func (r *MemdbCache) Update(mutator ObjectMutator, objs ...interface{}) error {
 					} else if err != nil {
 						return err
 					} else if !newIvFound {
-						return fmt.Errorf("failed to find the index value on the mutated object [original key: %s, mutated object %+v]", key, mutated)
+						return fmt.Errorf("failed to find the index value on the mutated object [original key: %s, mutated object (%T) %+v]", key, mutated, mutated)
 					} else if mutatedKey != key {
 						return fmt.Errorf("update mutator must not change the key [original: %s mutated :%s]", key, mutatedKey)
 					}

--- a/pkg/consolegraphql/watchers/resource_watcher.go
+++ b/pkg/consolegraphql/watchers/resource_watcher.go
@@ -32,12 +32,7 @@ type ResourceWatcher interface {
 type WatcherOption func(watcher ResourceWatcher) error
 
 func atomicInc(i *int32) {
-	for {
-		val := atomic.LoadInt32(i)
-		if atomic.CompareAndSwapInt32(i, val, val+1) {
-			break
-		}
-	}
+	atomic.AddInt32(i, 1)
 }
 func atomicGet(i *int32) int32 {
 	return atomic.LoadInt32(i)

--- a/pkg/consolegraphql/watchers/resource_watcher_address.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_address.go
@@ -29,6 +29,7 @@ type AddressWatcher struct {
 	stoppedchan     chan struct{}
 	create          func(*tp.Address) interface{}
 	update          func(*tp.Address, interface{}) bool
+	restartCounter  int32
 }
 
 func NewAddressWatcher(c cache.Cache, options ...WatcherOption) (ResourceWatcher, error) {
@@ -112,6 +113,7 @@ func (kw *AddressWatcher) Watch() error {
 			err := kw.doWatch(resource)
 			if err != nil {
 				log.Printf("Address - Restarting watch - %v", err)
+				atomicInc(&kw.restartCounter)
 			} else {
 				running = false
 			}
@@ -129,6 +131,10 @@ func (kw *AddressWatcher) AwaitWatching() {
 func (kw *AddressWatcher) Shutdown() {
 	close(kw.stopchan)
 	<-kw.stoppedchan
+}
+
+func (kw *AddressWatcher) GetRestartCount() int32 {
+	return atomicGet(&kw.restartCounter)
 }
 
 func (kw *AddressWatcher) doWatch(resource cp.AddressInterface) error {
@@ -168,10 +174,10 @@ func (kw *AddressWatcher) doWatch(resource cp.AddressInterface) error {
 			return fmt.Errorf("failed to generate key for new object %+v", copy)
 		}
 		if existing, ok := curr[key]; ok {
-			err = kw.Cache.Update(func(current interface{}) (interface{}, error) {
-				if kw.update(copy, current) {
+			err = kw.Cache.Update(func(target interface{}) (interface{}, error) {
+				if kw.update(copy, target) {
 					updated++
-					return copy, nil
+					return target, nil
 				} else {
 					unchanged++
 					return nil, nil
@@ -232,9 +238,9 @@ func (kw *AddressWatcher) doWatch(resource cp.AddressInterface) error {
 					err = kw.Cache.Add(kw.create(copy))
 				case watch.Modified:
 					updatingKey := kw.create(copy)
-					err = kw.Cache.Update(func(current interface{}) (interface{}, error) {
-						if kw.update(copy, current) {
-							return copy, nil
+					err = kw.Cache.Update(func(target interface{}) (interface{}, error) {
+						if kw.update(copy, target) {
+							return target, nil
 						} else {
 							return nil, nil
 						}

--- a/pkg/consolegraphql/watchers/resource_watcher_address_test.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_address_test.go
@@ -1,0 +1,207 @@
+/*
+* Copyright 2020, EnMasse authors.
+* License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package watchers
+
+import (
+	"github.com/enmasseproject/enmasse/pkg/apis/enmasse/v1beta1"
+	"github.com/enmasseproject/enmasse/pkg/client/clientset/versioned/fake"
+	"github.com/enmasseproject/enmasse/pkg/consolegraphql"
+	"github.com/enmasseproject/enmasse/pkg/consolegraphql/cache"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func newTestAddressWatcher(t *testing.T) *AddressWatcher {
+	objectCache, err := cache.CreateObjectCache()
+	assert.NoError(t, err, "failed to create object cache")
+
+	clientset := fake.NewSimpleClientset()
+
+	watcher, err := NewAddressWatcher(objectCache, AddressWatcherClient(clientset.EnmasseV1beta1()),
+		AddressWatcherFactory(AddressCreate, AddressUpdate))
+	assert.NoError(t, err, "failed to create test resolver")
+
+	return watcher.(*AddressWatcher)
+}
+
+func TestWatchAddress_ListProvidesNewValue(t *testing.T) {
+	w := newTestAddressWatcher(t)
+
+	namespace := "mynamespace"
+	addr := createAddress(namespace, "myyaddressspace.myaddr")
+
+	_, err := w.ClientInterface.Addresses(namespace).Create(&addr.Address)
+	assert.NoError(t, err, "failed to create address")
+
+	err = w.Watch()
+	assert.NoError(t, err, "failed to commence address watcher")
+	w.Shutdown()
+
+	objs, err := w.Cache.Get(cache.PrimaryObjectIndex, "Address", nil)
+	assert.NoError(t, err, "failed to query cache")
+	expected := 1
+	actual := len(objs)
+	assert.Equal(t, expected, actual, "Unexpected number of addresses")
+	assert.Equal(t, int32(0), w.GetRestartCount())
+}
+
+func TestWatchAddress_ListProvidesDifferingValues(t *testing.T) {
+	w := newTestAddressWatcher(t)
+
+	addr1 := createAddress(namespace, "myyaddressspace.myaddr1") // Will continue to exist unchanged.
+	addr2 := createAddress(namespace, "myyaddressspace.myaddr2") // Will continue to exist, but kubernetes version will carry an update
+	addr3 := createAddress(namespace, "myyaddressspace.myaddr3") // Will be provided new by kubernetes.
+	addr4 := createAddress(namespace, "myyaddressspace.myaddr4") // Wont be provided by kubernetes, so will be removed.
+
+	err := w.Cache.Add(deepCopyAddress(addr1), deepCopyAddress(addr2), deepCopyAddress(addr4))
+	assert.NoError(t, err, "failed to create address population")
+
+	annotateAddress(&addr2.Address) // give namespace2 an update
+	_, err = w.ClientInterface.Addresses(namespace).Create(&addr1.Address)
+	assert.NoError(t, err, "failed to create address1")
+	_, err = w.ClientInterface.Addresses(namespace).Create(&addr2.Address)
+	assert.NoError(t, err, "failed to create address2")
+	_, err = w.ClientInterface.Addresses(namespace).Create(&addr3.Address)
+	assert.NoError(t, err, "failed to create address3")
+
+	err = w.Watch()
+	assert.NoError(t, err, "failed to commence address watcher")
+	w.Shutdown()
+
+	objs, err := w.Cache.Get(cache.PrimaryObjectIndex, "Address", nil)
+	assert.NoError(t, err, "failed to query cache")
+
+	assert.Equal(t, 3, len(objs), "Unexpected number of addresses")
+
+	cacheAddrs := make(map[string]*consolegraphql.AddressHolder, 0)
+	for i := range objs {
+		ns := objs[i].(*consolegraphql.AddressHolder)
+		cacheAddrs[ns.Name] = ns
+	}
+
+	_, ns1present := cacheAddrs[addr1.Name]
+	updatedNs2, ns2present := cacheAddrs[addr2.Name]
+	_, ns3present := cacheAddrs[addr3.Name]
+	_, ns4present := cacheAddrs[addr4.Name]
+	assert.True(t, ns1present)
+	assert.True(t, ns2present)
+	assert.True(t, ns3present)
+	assert.False(t, ns4present)
+
+	assert.NotNil(t, updatedNs2.Annotations)
+	assert.Equal(t, "bar", updatedNs2.Annotations["foo"])
+	assert.Equal(t, int32(0), w.GetRestartCount())
+}
+
+func TestWatchAddress_WatchCreatesNewValue(t *testing.T) {
+	w := newTestAddressWatcher(t)
+
+	namespace := "mynamespace"
+	addr := createAddress(namespace, "myyaddressspace.myaddr")
+
+	err := w.Watch()
+	assert.NoError(t, err, "failed to commence address watcher")
+	w.AwaitWatching()
+
+	_, err = w.ClientInterface.Addresses(namespace).Create(&addr.Address)
+	assert.NoError(t, err, "failed to create address")
+	w.Shutdown()
+
+	objs, err := w.Cache.Get(cache.PrimaryObjectIndex, "Address", nil)
+	assert.NoError(t, err, "failed to query cache")
+	expected := 1
+	actual := len(objs)
+	assert.Equal(t, expected, actual, "Unexpected number of addresses")
+	assert.Equal(t, int32(0), w.GetRestartCount())
+}
+
+func TestWatchAddress_WatchUpdatesExistingValue(t *testing.T) {
+	w := newTestAddressWatcher(t)
+
+	namespace := "mynamespace"
+	addr := createAddress(namespace, "myyaddressspace.myaddr")
+
+	created, err := w.ClientInterface.Addresses(namespace).Create(&addr.Address)
+	assert.NoError(t, err, "failed to create address")
+
+	err = w.Watch()
+	assert.NoError(t, err, "failed to commence address watcher")
+	w.AwaitWatching()
+
+	copy := created.DeepCopy()
+	annotateAddress(copy)
+
+	_, err = w.ClientInterface.Addresses(namespace).Update(copy)
+	assert.NoError(t, err, "failed to update address")
+	w.Shutdown()
+
+	objs, err := w.Cache.Get(cache.PrimaryObjectIndex, "Address", nil)
+	assert.NoError(t, err, "failed to query cache")
+	expected := 1
+	actual := len(objs)
+	assert.Equal(t, expected, actual, "Unexpected number of addresses")
+	retrieved, ok := objs[0].(*consolegraphql.AddressHolder)
+	if !ok {
+		t.Fatalf("Unexpected type %T", retrieved)
+	}
+	if val, ok := retrieved.Annotations["foo"]; !ok {
+		t.Fatalf("Updated address lacks new annotation")
+	} else if val != "bar" {
+		t.Fatalf("Updated address has wrong annotation value")
+	}
+	assert.Equal(t, int32(0), w.GetRestartCount())
+}
+
+func TestWatchAddress_WatchDeletesExistingValue(t *testing.T) {
+	w := newTestAddressWatcher(t)
+
+	namespace := "mynamespace"
+	addr := createAddress(namespace, "myyaddressspace.myaddr")
+
+	_, err := w.ClientInterface.Addresses(namespace).Create(&addr.Address)
+	assert.NoError(t, err, "failed to create address")
+
+	err = w.Watch()
+	assert.NoError(t, err, "failed to commence address watcher")
+	w.AwaitWatching()
+
+	err = w.ClientInterface.Addresses(namespace).Delete(addr.Name, &metav1.DeleteOptions{})
+	assert.NoError(t, err, "failed to address namespace")
+	w.Shutdown()
+
+	objs, err := w.Cache.Get(cache.PrimaryObjectIndex, "Address", nil)
+	assert.NoError(t, err, "failed to query cache")
+	expected := 0
+	actual := len(objs)
+	assert.Equal(t, expected, actual, "Unexpected number of addresses")
+	assert.Equal(t, int32(0), w.GetRestartCount())
+}
+
+func annotateAddress(addr *v1beta1.Address) {
+	if addr.Annotations == nil {
+		addr.Annotations = make(map[string]string)
+	}
+	addr.Annotations["foo"] = "bar"
+}
+
+func deepCopyAddress(ah *consolegraphql.AddressHolder) *consolegraphql.AddressHolder {
+	metrics := ah.Metrics
+	object := ah.DeepCopyObject().(*v1beta1.Address)
+	if ah.Metrics != nil {
+		metrics = make([]*consolegraphql.Metric, len(ah.Metrics))
+		for i := range ah.Metrics {
+			if ah.Metrics[i] != nil {
+				metrics[i] = &consolegraphql.Metric{}
+				*metrics[i] = *ah.Metrics[i]
+			}
+		}
+	}
+	return &consolegraphql.AddressHolder{
+		Address: *object,
+		Metrics: ah.Metrics,
+	}
+}

--- a/pkg/consolegraphql/watchers/resource_watcher_addressplan.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_addressplan.go
@@ -29,6 +29,7 @@ type AddressPlanWatcher struct {
 	stoppedchan     chan struct{}
 	create          func(*tp.AddressPlan) interface{}
 	update          func(*tp.AddressPlan, interface{}) bool
+	restartCounter  int32
 }
 
 func NewAddressPlanWatcher(c cache.Cache, namespace string, options ...WatcherOption) (ResourceWatcher, error) {
@@ -112,6 +113,7 @@ func (kw *AddressPlanWatcher) Watch() error {
 			err := kw.doWatch(resource)
 			if err != nil {
 				log.Printf("AddressPlan - Restarting watch - %v", err)
+				atomicInc(&kw.restartCounter)
 			} else {
 				running = false
 			}
@@ -129,6 +131,10 @@ func (kw *AddressPlanWatcher) AwaitWatching() {
 func (kw *AddressPlanWatcher) Shutdown() {
 	close(kw.stopchan)
 	<-kw.stoppedchan
+}
+
+func (kw *AddressPlanWatcher) GetRestartCount() int32 {
+	return atomicGet(&kw.restartCounter)
 }
 
 func (kw *AddressPlanWatcher) doWatch(resource cp.AddressPlanInterface) error {
@@ -168,10 +174,10 @@ func (kw *AddressPlanWatcher) doWatch(resource cp.AddressPlanInterface) error {
 			return fmt.Errorf("failed to generate key for new object %+v", copy)
 		}
 		if existing, ok := curr[key]; ok {
-			err = kw.Cache.Update(func(current interface{}) (interface{}, error) {
-				if kw.update(copy, current) {
+			err = kw.Cache.Update(func(target interface{}) (interface{}, error) {
+				if kw.update(copy, target) {
 					updated++
-					return copy, nil
+					return target, nil
 				} else {
 					unchanged++
 					return nil, nil
@@ -232,9 +238,9 @@ func (kw *AddressPlanWatcher) doWatch(resource cp.AddressPlanInterface) error {
 					err = kw.Cache.Add(kw.create(copy))
 				case watch.Modified:
 					updatingKey := kw.create(copy)
-					err = kw.Cache.Update(func(current interface{}) (interface{}, error) {
-						if kw.update(copy, current) {
-							return copy, nil
+					err = kw.Cache.Update(func(target interface{}) (interface{}, error) {
+						if kw.update(copy, target) {
+							return target, nil
 						} else {
 							return nil, nil
 						}

--- a/pkg/consolegraphql/watchers/resource_watcher_addressspaceschema.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_addressspaceschema.go
@@ -29,6 +29,7 @@ type AddressSpaceSchemaWatcher struct {
 	stoppedchan     chan struct{}
 	create          func(*tp.AddressSpaceSchema) interface{}
 	update          func(*tp.AddressSpaceSchema, interface{}) bool
+	restartCounter  int32
 }
 
 func NewAddressSpaceSchemaWatcher(c cache.Cache, options ...WatcherOption) (ResourceWatcher, error) {
@@ -112,6 +113,7 @@ func (kw *AddressSpaceSchemaWatcher) Watch() error {
 			err := kw.doWatch(resource)
 			if err != nil {
 				log.Printf("AddressSpaceSchema - Restarting watch - %v", err)
+				atomicInc(&kw.restartCounter)
 			} else {
 				running = false
 			}
@@ -129,6 +131,10 @@ func (kw *AddressSpaceSchemaWatcher) AwaitWatching() {
 func (kw *AddressSpaceSchemaWatcher) Shutdown() {
 	close(kw.stopchan)
 	<-kw.stoppedchan
+}
+
+func (kw *AddressSpaceSchemaWatcher) GetRestartCount() int32 {
+	return atomicGet(&kw.restartCounter)
 }
 
 func (kw *AddressSpaceSchemaWatcher) doWatch(resource cp.AddressSpaceSchemaInterface) error {
@@ -168,10 +174,10 @@ func (kw *AddressSpaceSchemaWatcher) doWatch(resource cp.AddressSpaceSchemaInter
 			return fmt.Errorf("failed to generate key for new object %+v", copy)
 		}
 		if existing, ok := curr[key]; ok {
-			err = kw.Cache.Update(func(current interface{}) (interface{}, error) {
-				if kw.update(copy, current) {
+			err = kw.Cache.Update(func(target interface{}) (interface{}, error) {
+				if kw.update(copy, target) {
 					updated++
-					return copy, nil
+					return target, nil
 				} else {
 					unchanged++
 					return nil, nil
@@ -232,9 +238,9 @@ func (kw *AddressSpaceSchemaWatcher) doWatch(resource cp.AddressSpaceSchemaInter
 					err = kw.Cache.Add(kw.create(copy))
 				case watch.Modified:
 					updatingKey := kw.create(copy)
-					err = kw.Cache.Update(func(current interface{}) (interface{}, error) {
-						if kw.update(copy, current) {
-							return copy, nil
+					err = kw.Cache.Update(func(target interface{}) (interface{}, error) {
+						if kw.update(copy, target) {
+							return target, nil
 						} else {
 							return nil, nil
 						}

--- a/pkg/consolegraphql/watchers/resource_watcher_authenticationservice.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_authenticationservice.go
@@ -29,6 +29,7 @@ type AuthenticationServiceWatcher struct {
 	stoppedchan     chan struct{}
 	create          func(*tp.AuthenticationService) interface{}
 	update          func(*tp.AuthenticationService, interface{}) bool
+	restartCounter  int32
 }
 
 func NewAuthenticationServiceWatcher(c cache.Cache, namespace string, options ...WatcherOption) (ResourceWatcher, error) {
@@ -112,6 +113,7 @@ func (kw *AuthenticationServiceWatcher) Watch() error {
 			err := kw.doWatch(resource)
 			if err != nil {
 				log.Printf("AuthenticationService - Restarting watch - %v", err)
+				atomicInc(&kw.restartCounter)
 			} else {
 				running = false
 			}
@@ -129,6 +131,10 @@ func (kw *AuthenticationServiceWatcher) AwaitWatching() {
 func (kw *AuthenticationServiceWatcher) Shutdown() {
 	close(kw.stopchan)
 	<-kw.stoppedchan
+}
+
+func (kw *AuthenticationServiceWatcher) GetRestartCount() int32 {
+	return atomicGet(&kw.restartCounter)
 }
 
 func (kw *AuthenticationServiceWatcher) doWatch(resource cp.AuthenticationServiceInterface) error {
@@ -168,10 +174,10 @@ func (kw *AuthenticationServiceWatcher) doWatch(resource cp.AuthenticationServic
 			return fmt.Errorf("failed to generate key for new object %+v", copy)
 		}
 		if existing, ok := curr[key]; ok {
-			err = kw.Cache.Update(func(current interface{}) (interface{}, error) {
-				if kw.update(copy, current) {
+			err = kw.Cache.Update(func(target interface{}) (interface{}, error) {
+				if kw.update(copy, target) {
 					updated++
-					return copy, nil
+					return target, nil
 				} else {
 					unchanged++
 					return nil, nil
@@ -232,9 +238,9 @@ func (kw *AuthenticationServiceWatcher) doWatch(resource cp.AuthenticationServic
 					err = kw.Cache.Add(kw.create(copy))
 				case watch.Modified:
 					updatingKey := kw.create(copy)
-					err = kw.Cache.Update(func(current interface{}) (interface{}, error) {
-						if kw.update(copy, current) {
-							return copy, nil
+					err = kw.Cache.Update(func(target interface{}) (interface{}, error) {
+						if kw.update(copy, target) {
+							return target, nil
 						} else {
 							return nil, nil
 						}

--- a/pkg/consolegraphql/watchers/resource_watcher_namespace_test.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_namespace_test.go
@@ -41,6 +41,7 @@ func TestWatchNamespace_ListProvidesNewValue(t *testing.T) {
 	expected := 1
 	actual := len(objs)
 	assert.Equal(t, expected, actual, "Unexpected number of namespaces")
+	assert.Equal(t, int32(0), w.GetRestartCount())
 }
 
 func TestWatchNamespace_ListProvidesDifferingValues(t *testing.T) {
@@ -88,6 +89,7 @@ func TestWatchNamespace_ListProvidesDifferingValues(t *testing.T) {
 
 	assert.NotNil(t, updatedNs2.Annotations)
 	assert.Equal(t, "bar", updatedNs2.Annotations["foo"])
+	assert.Equal(t, int32(0), w.GetRestartCount())
 }
 
 func TestWatchNamespace_WatchCreatesNewValue(t *testing.T) {
@@ -108,6 +110,7 @@ func TestWatchNamespace_WatchCreatesNewValue(t *testing.T) {
 	expected := 1
 	actual := len(objs)
 	assert.Equal(t, expected, actual, "Unexpected number of namespaces")
+	assert.Equal(t, int32(0), w.GetRestartCount())
 }
 
 func TestWatchNamespace_WatchUpdatesExistingValue(t *testing.T) {
@@ -143,7 +146,7 @@ func TestWatchNamespace_WatchUpdatesExistingValue(t *testing.T) {
 	} else if val != "bar" {
 		t.Fatalf("Updated namespace has wrong annotation value")
 	}
-
+	assert.Equal(t, int32(0), w.GetRestartCount())
 }
 
 func TestWatchNamespace_WatchDeletesExistingValue(t *testing.T) {
@@ -167,6 +170,7 @@ func TestWatchNamespace_WatchDeletesExistingValue(t *testing.T) {
 	expected := 0
 	actual := len(objs)
 	assert.Equal(t, expected, actual, "Unexpected number of namespaces")
+	assert.Equal(t, int32(0), w.GetRestartCount())
 }
 
 func createNamespace(name string) *v1.Namespace {


### PR DESCRIPTION


### Type of change

- Bugfix

### Description

A defect in the update path meant that *every* update of an address (or address space) resource causes the watcher to restart.  This would cause all resources to be restarted and the watch
re-established.   This would result on unnecessary load on the kubernetes api-server and the console.

### Checklist

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
