### PR TITLE
Ensure infra uuid is not lost on replace

### DIFF
--- a/address-space-controller/src/main/java/io/enmasse/controller/AddressSpaceController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/AddressSpaceController.java
@@ -125,7 +125,7 @@ public class AddressSpaceController {
 
         Metrics metrics = new Metrics();
         controllerChain = new ControllerChain(addressSpaceApi, schemaProvider, eventLogger, options.getRecheckInterval(), options.getResyncInterval());
-        controllerChain.addController(new DefaultsController(authenticationServiceRegistry));
+        controllerChain.addController(new DefaultsController(authenticationServiceRegistry, kubernetes));
         controllerChain.addController(new AddressFinalizerController(addressSpaceApi));
         controllerChain.addController(new MessagingUserFinalizerController(controllerClient));
         controllerChain.addController(new ComponentFinalizerController(kubernetes));

--- a/address-space-controller/src/main/java/io/enmasse/controller/common/Kubernetes.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/common/Kubernetes.java
@@ -39,4 +39,6 @@ public interface Kubernetes {
 
     InfraConfig getAppliedInfraConfig(AddressSpace addressSpace) throws IOException;
     AppliedConfig getAppliedConfig(AddressSpace addressSpace) throws IOException;
+
+    String getInfraUuid(AddressSpace addressSpace);
 }

--- a/address-space-controller/src/main/resources/templates/brokered-space-infra.yaml
+++ b/address-space-controller/src/main/resources/templates/brokered-space-infra.yaml
@@ -220,6 +220,7 @@ objects:
   metadata:
     annotations:
       addressSpace: ${ADDRESS_SPACE}
+      enmasse.io/address-space-namespace: ${ADDRESS_SPACE_NAMESPACE}
       enmasse.io/service-port.amqp: 5672
       enmasse.io/service-port.amqps: 5671
     labels:

--- a/address-space-controller/src/main/resources/templates/standard-space-infra.yaml
+++ b/address-space-controller/src/main/resources/templates/standard-space-infra.yaml
@@ -10,6 +10,7 @@ objects:
   metadata:
     annotations:
       addressSpace: ${ADDRESS_SPACE}
+      enmasse.io/address-space-namespace: ${ADDRESS_SPACE_NAMESPACE}
       enmasse.io/service-port.amqp: 5672
       enmasse.io/service-port.amqps: 5671
       enmasse.io/service-port.amqp-wss: 443

--- a/api-model/src/main/java/io/enmasse/config/AnnotationKeys.java
+++ b/api-model/src/main/java/io/enmasse/config/AnnotationKeys.java
@@ -34,4 +34,5 @@ public interface AnnotationKeys {
     String VERSION = "enmasse.io/version";
     String APPLIED_CONFIGURATION = "enmasse.io/applied-configuration";
     String APPLIED_PLAN = "enmasse.io/applied-plan";
+    String ADDRESS_SPACE_NAMESPACE = "enmasse.io/address-space-namespace";
 }


### PR DESCRIPTION

### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix


### Description

This adds an extra annotation with the namespace of the address space to the 'messaging' Service resource that is created for every address space. In the event that an address space is replaced and the annotations are lost, they can be recovered from the service resource in the reconciliation loop.

This fix is a lot simpler than my original which were to introduce status subresource for address and address space, as that would have required upgrading kubernetes-client again. I think we should keep AddressSpace and Address as they are for now.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
