### PR TITLE
bug fix: unconditionally free watcher resources

### DIFF
--- a/hack/generate_resource_watchers.go
+++ b/hack/generate_resource_watchers.go
@@ -280,6 +280,10 @@ func (kw *{{ .Name }}Watcher) doWatch(resource cp.{{ .Name }}Interface) error {
 	resourceWatch, err := resource.Watch(v1.ListOptions{
 		ResourceVersion: resourceList.ResourceVersion,
 	})
+	if err != nil {
+		return err
+	}
+	defer resourceWatch.Stop()
 
 	if !kw.watchingStarted {
 		close(kw.watching)

--- a/pkg/consolegraphql/watchers/resource_watcher_address.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_address.go
@@ -209,6 +209,10 @@ func (kw *AddressWatcher) doWatch(resource cp.AddressInterface) error {
 	resourceWatch, err := resource.Watch(v1.ListOptions{
 		ResourceVersion: resourceList.ResourceVersion,
 	})
+	if err != nil {
+		return err
+	}
+	defer resourceWatch.Stop()
 
 	if !kw.watchingStarted {
 		close(kw.watching)

--- a/pkg/consolegraphql/watchers/resource_watcher_addressplan.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_addressplan.go
@@ -209,6 +209,10 @@ func (kw *AddressPlanWatcher) doWatch(resource cp.AddressPlanInterface) error {
 	resourceWatch, err := resource.Watch(v1.ListOptions{
 		ResourceVersion: resourceList.ResourceVersion,
 	})
+	if err != nil {
+		return err
+	}
+	defer resourceWatch.Stop()
 
 	if !kw.watchingStarted {
 		close(kw.watching)

--- a/pkg/consolegraphql/watchers/resource_watcher_addressspace.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_addressspace.go
@@ -209,6 +209,10 @@ func (kw *AddressSpaceWatcher) doWatch(resource cp.AddressSpaceInterface) error 
 	resourceWatch, err := resource.Watch(v1.ListOptions{
 		ResourceVersion: resourceList.ResourceVersion,
 	})
+	if err != nil {
+		return err
+	}
+	defer resourceWatch.Stop()
 
 	if !kw.watchingStarted {
 		close(kw.watching)

--- a/pkg/consolegraphql/watchers/resource_watcher_addressspaceplan.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_addressspaceplan.go
@@ -209,6 +209,10 @@ func (kw *AddressSpacePlanWatcher) doWatch(resource cp.AddressSpacePlanInterface
 	resourceWatch, err := resource.Watch(v1.ListOptions{
 		ResourceVersion: resourceList.ResourceVersion,
 	})
+	if err != nil {
+		return err
+	}
+	defer resourceWatch.Stop()
 
 	if !kw.watchingStarted {
 		close(kw.watching)

--- a/pkg/consolegraphql/watchers/resource_watcher_addressspaceschema.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_addressspaceschema.go
@@ -209,6 +209,10 @@ func (kw *AddressSpaceSchemaWatcher) doWatch(resource cp.AddressSpaceSchemaInter
 	resourceWatch, err := resource.Watch(v1.ListOptions{
 		ResourceVersion: resourceList.ResourceVersion,
 	})
+	if err != nil {
+		return err
+	}
+	defer resourceWatch.Stop()
 
 	if !kw.watchingStarted {
 		close(kw.watching)

--- a/pkg/consolegraphql/watchers/resource_watcher_agent.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_agent.go
@@ -210,6 +210,10 @@ func (clw *AgentWatcher) doWatch(resource cp.ServiceInterface) error {
 		ResourceVersion: resourceList.ResourceVersion,
 		LabelSelector:   "app=enmasse,component=agent",
 	})
+	if err != nil {
+		return err
+	}
+	defer resourceWatch.Stop()
 
 	if !clw.watchingAgentsStarted {
 		close(clw.watching)

--- a/pkg/consolegraphql/watchers/resource_watcher_authenticationservice.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_authenticationservice.go
@@ -209,6 +209,10 @@ func (kw *AuthenticationServiceWatcher) doWatch(resource cp.AuthenticationServic
 	resourceWatch, err := resource.Watch(v1.ListOptions{
 		ResourceVersion: resourceList.ResourceVersion,
 	})
+	if err != nil {
+		return err
+	}
+	defer resourceWatch.Stop()
 
 	if !kw.watchingStarted {
 		close(kw.watching)

--- a/pkg/consolegraphql/watchers/resource_watcher_namespace.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_namespace.go
@@ -209,6 +209,10 @@ func (kw *NamespaceWatcher) doWatch(resource cp.NamespaceInterface) error {
 	resourceWatch, err := resource.Watch(v1.ListOptions{
 		ResourceVersion: resourceList.ResourceVersion,
 	})
+	if err != nil {
+		return err
+	}
+	defer resourceWatch.Stop()
 
 	if !kw.watchingStarted {
 		close(kw.watching)


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

the code omitted to call `watcher.Stop()` meaning client/server resources were likely being leaked.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
