### PR TITLE
fix - Message out metric always shows 0 on the connection list/detail…

### DIFF
--- a/console/console-init/ui/src/Tests/ConnectionDetailHeader.test.tsx
+++ b/console/console-init/ui/src/Tests/ConnectionDetailHeader.test.tsx
@@ -26,7 +26,9 @@ describe("Connection Detail Header with all connection details", () => {
       messageOut: 1
     };
 
-    const { getByText } = render(<ConnectionDetailHeader {...props} />);
+    const { getByText } = render(
+      <ConnectionDetailHeader {...props} addressSpaceType={"standard"} />
+    );
     getByText(props.hostname);
     getByText(props.containerId);
     getByText(props.protocol);

--- a/console/console-init/ui/src/components/AddressSpace/Connection/ConnectionList.tsx
+++ b/console/console-init/ui/src/components/AddressSpace/Connection/ConnectionList.tsx
@@ -20,6 +20,7 @@ import { FormatDistance } from "use-patternfly";
 
 interface IConnectionListProps {
   rows: IConnection[];
+  addressSpaceType?: string;
   sortBy?: ISortBy;
   onSort?: (_event: any, index: number, direction: string) => void;
 }
@@ -40,6 +41,7 @@ export interface IConnection {
 
 export const ConnectionList: React.FunctionComponent<IConnectionListProps> = ({
   rows,
+  addressSpaceType,
   sortBy,
   onSort
 }) => {
@@ -67,7 +69,9 @@ export const ConnectionList: React.FunctionComponent<IConnectionListProps> = ({
           )
         },
         row.messageIn,
-        row.messageOut,
+        !addressSpaceType || addressSpaceType === "brokered"
+          ? ""
+          : row.messageOut,
         row.senders,
         row.receivers
       ],
@@ -94,19 +98,21 @@ export const ConnectionList: React.FunctionComponent<IConnectionListProps> = ({
         ),
       transforms: [sortable]
     },
-    {
-      title:
-        width > 769 ? (
-          <span style={{ display: "inline-flex" }}>
-            Message Out/sec
-            <br />
-            {`(over last 5 min)`}
-          </span>
-        ) : (
-          "Message Out/sec"
-        ),
-      transforms: [sortable]
-    },
+    !addressSpaceType || addressSpaceType === "brokered"
+      ? ""
+      : {
+          title:
+            width > 769 ? (
+              <span style={{ display: "inline-flex" }}>
+                Message Out/sec
+                <br />
+                {`(over last 5 min)`}
+              </span>
+            ) : (
+              "Message Out/sec"
+            ),
+          transforms: [sortable]
+        },
     {
       title: "Senders",
       transforms: [sortable]

--- a/console/console-init/ui/src/components/ConnectionDetail/ConnectionDetailHeader.tsx
+++ b/console/console-init/ui/src/components/ConnectionDetail/ConnectionDetailHeader.tsx
@@ -41,6 +41,7 @@ export interface IConnectionHeaderDetailProps {
   os?: string;
   messageIn?: number | string;
   messageOut?: number | string;
+  addressSpaceType?: string;
 }
 export const ConnectionDetailHeader: React.FunctionComponent<IConnectionHeaderDetailProps> = ({
   hostname,
@@ -53,10 +54,12 @@ export const ConnectionDetailHeader: React.FunctionComponent<IConnectionHeaderDe
   platform,
   os,
   messageIn,
-  messageOut
+  messageOut,
+  addressSpaceType
 }) => {
   const [isHidden, setIsHidden] = React.useState(true);
   const { width } = useWindowDimensions();
+  console.log("addressSpaceType", addressSpaceType);
   return (
     <Card>
       <CardHeader>
@@ -128,6 +131,7 @@ export const ConnectionDetailHeader: React.FunctionComponent<IConnectionHeaderDe
                 messageIn={messageIn}
                 messageOut={messageOut}
                 isMobileView={width < 992 ? true : false}
+                addressSpaceType={addressSpaceType}
               />
             </>
           ) : (

--- a/console/console-init/ui/src/components/ConnectionDetail/MessagesDetail.tsx
+++ b/console/console-init/ui/src/components/ConnectionDetail/MessagesDetail.tsx
@@ -18,12 +18,14 @@ const styles = StyleSheet.create({
 export interface IMessagesDetail {
   messageIn?: number | string;
   messageOut?: number | string;
+  addressSpaceType?: string;
   isMobileView: boolean;
 }
 
 export const MessagesDetail: React.FunctionComponent<IMessagesDetail> = ({
   messageIn,
   messageOut,
+  addressSpaceType,
   isMobileView
 }) => {
   return (
@@ -36,14 +38,18 @@ export const MessagesDetail: React.FunctionComponent<IMessagesDetail> = ({
         {messageIn || messageIn === "" ? messageIn : 0}
         {isMobileView ? "" : <br />} Message in/sec
       </SplitItem>
-      <SplitItem
-        id="message-detail-message-out"
-        span={6}
-        className={css(styles.message_split)}
-      >
-        {messageOut || messageOut === "" ? messageOut : 0}
-        {isMobileView ? "" : <br />} Message out/sec
-      </SplitItem>
+      {!addressSpaceType || addressSpaceType === "brokered" ? (
+        ""
+      ) : (
+        <SplitItem
+          id="message-detail-message-out"
+          span={6}
+          className={css(styles.message_split)}
+        >
+          {messageOut || messageOut === "" ? messageOut : 0}
+          {isMobileView ? "" : <br />} Message out/sec
+        </SplitItem>
+      )}
     </Split>
   );
 };

--- a/console/console-init/ui/src/pages/AddressSpaceDetail/ConnectionList/ConnectionListWithFilterAndPaginationPage.tsx
+++ b/console/console-init/ui/src/pages/AddressSpaceDetail/ConnectionList/ConnectionListWithFilterAndPaginationPage.tsx
@@ -22,7 +22,7 @@ const ConnectionListFunction = () => {
   useDocumentTitle("Connection List");
 
   useA11yRouteChange();
-  const { name, namespace } = useParams();
+  const { name, namespace, type } = useParams();
   const [filterValue, setFilterValue] = React.useState<string>("Hostname");
   const [hostnames, setHostnames] = React.useState<Array<any>>([]);
   const [containerIds, setContainerIds] = React.useState<Array<any>>([]);
@@ -108,6 +108,7 @@ const ConnectionListFunction = () => {
         perPage={perPage}
         sortValue={sortDropDownValue}
         setSortValue={setSortDropdownValue}
+        addressSpaceType={type}
       />
       {totalConnections > 0 && renderPagination(page, perPage)}
     </PageSection>

--- a/console/console-init/ui/src/pages/AddressSpaceDetail/ConnectionList/ConnectionsListPage.tsx
+++ b/console/console-init/ui/src/pages/AddressSpaceDetail/ConnectionList/ConnectionsListPage.tsx
@@ -26,6 +26,7 @@ export interface IConnectionListPageProps {
   perPage: number;
   sortValue?: ISortBy;
   setSortValue: (value?: ISortBy) => void;
+  addressSpaceType?: string;
 }
 
 export const ConnectionsListPage: React.FunctionComponent<IConnectionListPageProps> = ({
@@ -37,7 +38,8 @@ export const ConnectionsListPage: React.FunctionComponent<IConnectionListPagePro
   page,
   perPage,
   sortValue,
-  setSortValue
+  setSortValue,
+  addressSpaceType
 }) => {
   const [sortBy, setSortBy] = React.useState<ISortBy>();
   if (sortValue && sortBy !== sortValue) {
@@ -88,6 +90,7 @@ export const ConnectionsListPage: React.FunctionComponent<IConnectionListPagePro
     <>
       <ConnectionList
         rows={connectionList ? connectionList : []}
+        addressSpaceType={addressSpaceType}
         sortBy={sortBy}
         onSort={onSort}
       />

--- a/console/console-init/ui/src/pages/ConnectionDetail/ConnectionDetailPage.tsx
+++ b/console/console-init/ui/src/pages/ConnectionDetail/ConnectionDetailPage.tsx
@@ -120,7 +120,7 @@ export default function ConnectionDetailPage() {
 
   return (
     <>
-      <ConnectionDetailHeader {...connectionDetail} />
+      <ConnectionDetailHeader {...connectionDetail} addressSpaceType={type} />
       <PageSection>
         <ConnectionLinksWithFilterAndPaginationPage
           name={name}


### PR DESCRIPTION
… page for the brokered address space

### Type of change

- Bugfix

### Description

- Fix issue - #1737
- fix - Message out metric always shows 0 on the connection list/detail page for the brokered address space	

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
