### PR TITLE
display empty state page if server returns empty array for any query

### DIFF
--- a/console/console-init/ui/src/components/common/NoDataFound.tsx
+++ b/console/console-init/ui/src/components/common/NoDataFound.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+import {
+  EmptyState,
+  EmptyStateVariant,
+  EmptyStateIcon,
+  Title,
+  EmptyStateBody,
+  PageSection
+} from "@patternfly/react-core";
+import { Link } from "react-router-dom";
+import { CubesIcon, GlobeRouteIcon } from "@patternfly/react-icons";
+
+interface INoDataFoundProps {
+  type: string;
+  name: string;
+  routeLink: string;
+}
+export const NoDataFound: React.FunctionComponent<INoDataFoundProps> = ({
+  type,
+  name,
+  routeLink
+}) => {
+  return (
+    <PageSection>
+      <PageSection variant="light">
+        <EmptyState variant={EmptyStateVariant.full}>
+          <EmptyStateIcon icon={GlobeRouteIcon} />
+          <Title headingLevel="h5" size="lg">
+            {type} Not Found
+          </Title>
+          <EmptyStateBody>
+            The {type} <b>{name}</b> you are looking for, does not exist
+            anymore.
+          </EmptyStateBody>
+          <Link to={routeLink}>Go to {type} list</Link>
+        </EmptyState>
+      </PageSection>
+    </PageSection>
+  );
+};

--- a/console/console-init/ui/src/components/common/NoDataFound.tsx
+++ b/console/console-init/ui/src/components/common/NoDataFound.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
 import * as React from "react";
 import {
   EmptyState,

--- a/console/console-init/ui/src/components/common/NoDataFound.tsx
+++ b/console/console-init/ui/src/components/common/NoDataFound.tsx
@@ -29,8 +29,7 @@ export const NoDataFound: React.FunctionComponent<INoDataFoundProps> = ({
             {type} Not Found
           </Title>
           <EmptyStateBody>
-            The {type} <b>{name}</b> you are looking for, does not exist
-            anymore.
+            {type} <b>{name}</b> no longer exists.
           </EmptyStateBody>
           <Link to={routeLink}>Go to {type} list</Link>
         </EmptyState>

--- a/console/console-init/ui/src/pages/AddressDetail/AddressDetailPage.tsx
+++ b/console/console-init/ui/src/pages/AddressDetail/AddressDetailPage.tsx
@@ -30,6 +30,7 @@ import { EditAddress } from "pages/EditAddressPage";
 import { IAddressSpacePlanResponse } from "pages/AddressSpaceDetail/AddressList/AddressesListWithFilterAndPaginationPage";
 import { POLL_INTERVAL } from "constants/constants";
 import { ErrorAlert } from "components/common/ErrorAlert";
+import { NoDataFound } from "components/common/NoDataFound";
 
 export default function AddressDetailPage() {
   const { namespace, name, type, addressname } = useParams();
@@ -86,7 +87,15 @@ export default function AddressDetailPage() {
   const { addresses } = data || {
     addresses: { total: 0, addresses: [] }
   };
-
+  if (addresses.addresses.length <= 0) {
+    return (
+      <NoDataFound
+        type={"Address"}
+        name={addressname || ""}
+        routeLink={`/address-spaces/${namespace}/${name}/${type}/addresses`}
+      />
+    );
+  }
   const addressDetail = addresses && addresses.addresses[0];
   if (addressPlan === null) {
     setAddressPlan(addressDetail.spec.plan.spec.displayName);

--- a/console/console-init/ui/src/pages/AddressSpaceDetail/AddressSpaceDetailPage.tsx
+++ b/console/console-init/ui/src/pages/AddressSpaceDetail/AddressSpaceDetailPage.tsx
@@ -35,6 +35,7 @@ import {
 import { DialoguePrompt } from "components/common/DialoguePrompt";
 import { POLL_INTERVAL } from "constants/constants";
 import { ErrorAlert } from "components/common/ErrorAlert";
+import { NoDataFound } from "components/common/NoDataFound";
 const styles = StyleSheet.create({
   no_bottom_padding: {
     paddingBottom: 0
@@ -102,8 +103,10 @@ export default function AddressSpaceDetailPage() {
     addressSpaces: { total: 0, addressSpaces: [] }
   };
 
-  if (!addressSpaces || addressSpaces.addressSpaces.length <= 0) {
-    return <Loading />;
+  if (addressSpaces.addressSpaces.length <= 0) {
+    return (
+      <NoDataFound type={"Address Space"} name={name || ""} routeLink={"/"} />
+    );
   }
 
   //Download the certificate function

--- a/console/console-init/ui/src/pages/ConnectionDetail/ConnectionDetailPage.tsx
+++ b/console/console-init/ui/src/pages/ConnectionDetail/ConnectionDetailPage.tsx
@@ -27,6 +27,7 @@ import { Link } from "react-router-dom";
 import { RETURN_CONNECTION_DETAIL } from "queries";
 import { ConnectionLinksWithFilterAndPaginationPage } from "./ConnectionLinksWithFilterAndPaginationPage";
 import { POLL_INTERVAL } from "constants/constants";
+import { NoDataFound } from "components/common/NoDataFound";
 
 const getProductFilteredValue = (object: any[], value: string) => {
   if (object && object != null) {
@@ -89,6 +90,15 @@ export default function ConnectionDetailPage() {
   const { connections } = data || {
     connections: { total: 0, connections: [] }
   };
+  if (connections.connections.length <= 0) {
+    return (
+      <NoDataFound
+        type={"Connection"}
+        name={connectionname || ""}
+        routeLink={`/address-spaces/${namespace}/${name}/${type}/connections`}
+      />
+    );
+  }
   const connection = connections.connections[0];
   //Change this logic
   const jvmObject =


### PR DESCRIPTION
### Type of change
- Bugfix

### Description
- If a connection closed whilst the user is view the links of the connection, the browser goes blank. I would expect a message to display informing the user that the connection is gone and allowing them to navigate back to the address or connection list. The issue is the same for both standard and brokered address spaces.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
