### PR TITLE
Address.spec.address name validation (now allowing : .)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * #3868: Add support for specifying maxConsumers for a subscription
 * #3873: Require TLSv1.2 or newer for external TLS endpoints
 * #3867: Add addition checks for router mesh status
+#      : Address CRD now validates the spec.address field comprises permitted characters.
 
 ## 0.30.2
 *  #2714: Allow setting security context of pods using persistent volumes

--- a/console/console-init/ui/src/pages/CreateAddress/CreateAddressDefinition.tsx
+++ b/console/console-init/ui/src/pages/CreateAddress/CreateAddressDefinition.tsx
@@ -75,7 +75,7 @@ interface IAddressTypes {
     };
   }>;
 }
-export const AddressDefinitaion: React.FunctionComponent<IAddressDefinition> = ({
+export const AddressDefinition: React.FunctionComponent<IAddressDefinition> = ({
   addressspaceName,
   namespace,
   addressName,
@@ -190,15 +190,12 @@ export const AddressDefinitaion: React.FunctionComponent<IAddressDefinition> = (
         <GridItem span={6}>
           <Form>
             <FormGroup
-              label="Name"
+              label="Address"
               isRequired={true}
               fieldId="address-name"
               helperText={
                 !isNameValid ? (
-                  <small>
-                    Only digits (0-9), lower case letters (a-z), -, and .
-                    allowed, and should start with alpha-numeric characters.
-                  </small>
+                  <small>The address must not include # * or whitespace.</small>
                 ) : (
                   ""
                 )

--- a/console/console-init/ui/src/pages/CreateAddress/CreateAddressPage.tsx
+++ b/console/console-init/ui/src/pages/CreateAddress/CreateAddressPage.tsx
@@ -5,12 +5,12 @@
 
 import * as React from "react";
 import { Wizard } from "@patternfly/react-core";
-import { AddressDefinitaion } from "pages/CreateAddress/CreateAddressDefinition";
+import { AddressDefinition } from "pages/CreateAddress/CreateAddressDefinition";
 import { PreviewAddress } from "./PreviewAddress";
 import { useApolloClient } from "@apollo/react-hooks";
 import { CREATE_ADDRESS } from "queries";
 import { IDropdownOption } from "components/common/FilterDropdown";
-import { regexp } from "types/Configs";
+import { messagingAddressNameRegexp } from "types/Configs";
 interface ICreateAddressProps {
   name: string;
   namespace: string;
@@ -44,7 +44,9 @@ export const CreateAddressPage: React.FunctionComponent<ICreateAddressProps> = (
   const [isNameValid, setIsNameValid] = React.useState(true);
   const handleAddressChange = (name: string) => {
     setAddressName(name);
-    !regexp.test(name) ? setIsNameValid(false) : setIsNameValid(true);
+    !messagingAddressNameRegexp.test(name)
+      ? setIsNameValid(false)
+      : setIsNameValid(true);
   };
 
   const handleSave = async () => {
@@ -90,7 +92,7 @@ export const CreateAddressPage: React.FunctionComponent<ICreateAddressProps> = (
     {
       name: "Definition",
       component: (
-        <AddressDefinitaion
+        <AddressDefinition
           addressspaceName={name}
           namespace={namespace}
           addressSpacePlan={addressSpacePlan}

--- a/console/console-init/ui/src/pages/CreateAddress/PreviewAddress.tsx
+++ b/console/console-init/ui/src/pages/CreateAddress/PreviewAddress.tsx
@@ -22,7 +22,7 @@ import { StyleSheet, css } from "@patternfly/react-styles";
 import AceEditor from "react-ace";
 import "ace-builds/src-noconflict/mode-java";
 import "ace-builds/src-noconflict/theme-github";
-import { ADDRESS_COMMAND_PRIVIEW_DETAIL } from "queries";
+import { ADDRESS_COMMAND_PREVIEW_DETAIL } from "queries";
 
 export interface IAddressPreview {
   name?: string;
@@ -49,18 +49,16 @@ export const PreviewAddress: React.FunctionComponent<IAddressPreview> = ({
   namespace,
   addressspace
 }) => {
-  const { data, loading, error } = useQuery(ADDRESS_COMMAND_PRIVIEW_DETAIL, {
+  const { data, loading, error } = useQuery(ADDRESS_COMMAND_PREVIEW_DETAIL, {
     variables: {
       a: {
         metadata: {
-          name: addressspace + "." + name,
           namespace: namespace
         },
         spec: {
           plan: plan ? plan.toLowerCase() : "",
           type: type ? type.toLowerCase() : "",
           ...(topic && topic.trim() !== "" && { topic: topic }),
-          addressSpace: addressspace,
           address: name
         }
       },
@@ -68,7 +66,7 @@ export const PreviewAddress: React.FunctionComponent<IAddressPreview> = ({
     }
   });
   if (loading) return <Loading />;
-  if (error) console.log("Address Priview Query Error", error);
+  if (error) console.log("Address Preview Query Error", error);
 
   return (
     <PageSection variant={PageSectionVariants.light}>

--- a/console/console-init/ui/src/pages/CreateAddressSpace/CreateAddressSpaceConfiguration.tsx
+++ b/console/console-init/ui/src/pages/CreateAddressSpace/CreateAddressSpaceConfiguration.tsx
@@ -25,7 +25,7 @@ import {
 } from "queries";
 import { Loading } from "use-patternfly";
 import { css, StyleSheet } from "@patternfly/react-styles";
-import { regexp } from "types/Configs";
+import { k8NameRegexp } from "types/Configs";
 const styles = StyleSheet.create({
   capitalize_labels: {
     "text-transform": "capitalize"
@@ -205,7 +205,7 @@ export const AddressSpaceConfiguration: React.FunctionComponent<IAddressSpaceCon
 
   const handleNameChange = (name: string) => {
     setName(name);
-    !regexp.test(name) ? setIsNameValid(false) : setIsNameValid(true);
+    !k8NameRegexp.test(name) ? setIsNameValid(false) : setIsNameValid(true);
   };
 
   return (

--- a/console/console-init/ui/src/queries/Address.ts
+++ b/console/console-init/ui/src/queries/Address.ts
@@ -515,9 +515,9 @@ const EDIT_ADDRESS = gql`
   }
 `;
 
-const ADDRESS_COMMAND_PRIVIEW_DETAIL = gql`
-  query cmd($a: Address_enmasse_io_v1beta1_Input!) {
-    addressCommand(input: $a)
+const ADDRESS_COMMAND_PREVIEW_DETAIL = gql`
+  query cmd($a: Address_enmasse_io_v1beta1_Input!, $as: String) {
+    addressCommand(input: $a, addressSpace: $as)
   }
 `;
 
@@ -694,7 +694,7 @@ export {
   RETURN_ADDRESS_PLANS,
   CREATE_ADDRESS,
   EDIT_ADDRESS,
-  ADDRESS_COMMAND_PRIVIEW_DETAIL,
+  ADDRESS_COMMAND_PREVIEW_DETAIL,
   RETURN_ADDRESS_TYPES,
   RETURN_ADDRESS_SPACE_PLANS,
   RETURN_TOPIC_ADDRESSES_FOR_SUBSCRIPTION,

--- a/console/console-init/ui/src/types/Configs.tsx
+++ b/console/console-init/ui/src/types/Configs.tsx
@@ -1,1 +1,2 @@
-export const regexp = new RegExp("^[0-9a-z][0-9a-z.-]*$");
+export const k8NameRegexp = new RegExp("^[0-9a-z][0-9a-z.-]*$");
+export const messagingAddressNameRegexp = new RegExp("^[^#*\\s]+$");

--- a/templates/crds/addresses.crd.yaml
+++ b/templates/crds/addresses.crd.yaml
@@ -70,6 +70,7 @@ spec:
             address:
               type: string
               description: "Messaging address."
+              pattern: "^[^#*\\s]+$"
             type:
               type: string
               description: "Address type for this address."


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Address CRD now validates that the address.spec.address field comprises only legal characters (i.e. not # * or whitespace). Same validation now applied by the create address workflow in the UI too.  The UI validation is less strict than that applied by the previous console. 

Fixed the address command preview (needed to pass the addressspace name as an argument) in order to allow the server to default

Fixed a couple of typos (misspelt names in the code).

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
