### PR TITLE
Pass timeoutSeconds param when creating resource watcher 

### DIFF
--- a/pkg/consolegraphql/watchers/resource_watcher_address_test.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_address_test.go
@@ -21,7 +21,7 @@ func newTestAddressWatcher(t *testing.T) *AddressWatcher {
 
 	clientset := fake.NewSimpleClientset()
 
-	watcher, err := NewAddressWatcher(objectCache, AddressWatcherClient(clientset.EnmasseV1beta1()),
+	watcher, err := NewAddressWatcher(objectCache, nil, AddressWatcherClient(clientset.EnmasseV1beta1()),
 		AddressWatcherFactory(AddressCreate, AddressUpdate))
 	assert.NoError(t, err, "failed to create test resolver")
 

--- a/pkg/consolegraphql/watchers/resource_watcher_addressspaceschema.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_addressspaceschema.go
@@ -16,7 +16,9 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/rest"
 	"log"
+	"math/rand"
 	"reflect"
+	"time"
 )
 
 type AddressSpaceSchemaWatcher struct {
@@ -30,16 +32,18 @@ type AddressSpaceSchemaWatcher struct {
 	create          func(*tp.AddressSpaceSchema) interface{}
 	update          func(*tp.AddressSpaceSchema, interface{}) bool
 	restartCounter  int32
+	resyncInterval  *time.Duration
 }
 
-func NewAddressSpaceSchemaWatcher(c cache.Cache, options ...WatcherOption) (ResourceWatcher, error) {
+func NewAddressSpaceSchemaWatcher(c cache.Cache, resyncInterval *time.Duration, options ...WatcherOption) (ResourceWatcher, error) {
 
 	kw := &AddressSpaceSchemaWatcher{
-		Namespace:   v1.NamespaceAll,
-		Cache:       c,
-		watching:    make(chan struct{}),
-		stopchan:    make(chan struct{}),
-		stoppedchan: make(chan struct{}),
+		Namespace:      v1.NamespaceAll,
+		Cache:          c,
+		watching:       make(chan struct{}),
+		stopchan:       make(chan struct{}),
+		stoppedchan:    make(chan struct{}),
+		resyncInterval: resyncInterval,
 		create: func(v *tp.AddressSpaceSchema) interface{} {
 			return v
 		},
@@ -204,11 +208,16 @@ func (kw *AddressSpaceSchemaWatcher) doWatch(resource cp.AddressSpaceSchemaInter
 		}
 	}
 	var stale = len(curr)
-
 	log.Printf("AddressSpaceSchema - Cache initialised population added %d, updated %d, unchanged %d, stale %d", added, updated, unchanged, stale)
-	resourceWatch, err := resource.Watch(v1.ListOptions{
+
+	watchOptions := v1.ListOptions{
 		ResourceVersion: resourceList.ResourceVersion,
-	})
+	}
+	if kw.resyncInterval != nil {
+		ts := int64(kw.resyncInterval.Seconds() * (rand.Float64() + 1.0))
+		watchOptions.TimeoutSeconds = &ts
+	}
+	resourceWatch, err := resource.Watch(watchOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/consolegraphql/watchers/resource_watcher_agent_test.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_agent_test.go
@@ -34,7 +34,7 @@ func newTestAgentWatcher(t *testing.T) (*AgentWatcher, chan agent.AgentEvent) {
 
 	eventChan := make(chan agent.AgentEvent)
 
-	watcher, err := NewAgentWatcher(objectCache, v1.NamespaceAll, MockAgentCollectorCreator(eventChan), false, AgentWatcherClient(fake.NewSimpleClientset().CoreV1()))
+	watcher, err := NewAgentWatcher(objectCache, nil, v1.NamespaceAll, MockAgentCollectorCreator(eventChan), false, AgentWatcherClient(fake.NewSimpleClientset().CoreV1()))
 	assert.NoError(t, err)
 
 	_, err = watcher.ClientInterface.Secrets("").(*fake2.FakeSecrets).Create(createCaSecret())

--- a/pkg/consolegraphql/watchers/resource_watcher_namespace.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_namespace.go
@@ -16,7 +16,9 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/rest"
 	"log"
+	"math/rand"
 	"reflect"
+	"time"
 )
 
 type NamespaceWatcher struct {
@@ -30,16 +32,18 @@ type NamespaceWatcher struct {
 	create          func(*tp.Namespace) interface{}
 	update          func(*tp.Namespace, interface{}) bool
 	restartCounter  int32
+	resyncInterval  *time.Duration
 }
 
-func NewNamespaceWatcher(c cache.Cache, options ...WatcherOption) (ResourceWatcher, error) {
+func NewNamespaceWatcher(c cache.Cache, resyncInterval *time.Duration, options ...WatcherOption) (ResourceWatcher, error) {
 
 	kw := &NamespaceWatcher{
-		Namespace:   v1.NamespaceAll,
-		Cache:       c,
-		watching:    make(chan struct{}),
-		stopchan:    make(chan struct{}),
-		stoppedchan: make(chan struct{}),
+		Namespace:      v1.NamespaceAll,
+		Cache:          c,
+		watching:       make(chan struct{}),
+		stopchan:       make(chan struct{}),
+		stoppedchan:    make(chan struct{}),
+		resyncInterval: resyncInterval,
 		create: func(v *tp.Namespace) interface{} {
 			return v
 		},
@@ -204,11 +208,16 @@ func (kw *NamespaceWatcher) doWatch(resource cp.NamespaceInterface) error {
 		}
 	}
 	var stale = len(curr)
-
 	log.Printf("Namespace - Cache initialised population added %d, updated %d, unchanged %d, stale %d", added, updated, unchanged, stale)
-	resourceWatch, err := resource.Watch(v1.ListOptions{
+
+	watchOptions := v1.ListOptions{
 		ResourceVersion: resourceList.ResourceVersion,
-	})
+	}
+	if kw.resyncInterval != nil {
+		ts := int64(kw.resyncInterval.Seconds() * (rand.Float64() + 1.0))
+		watchOptions.TimeoutSeconds = &ts
+	}
+	resourceWatch, err := resource.Watch(watchOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/consolegraphql/watchers/resource_watcher_namespace_test.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_namespace_test.go
@@ -18,7 +18,7 @@ import (
 func newTestNamespaceWatcher(t *testing.T) *NamespaceWatcher {
 	objectCache, err := cache.CreateObjectCache()
 	assert.NoError(t, err, "failed to create object cache")
-	watcher, err := NewNamespaceWatcher(objectCache, NamespaceWatcherClient(fake.NewSimpleClientset().CoreV1()))
+	watcher, err := NewNamespaceWatcher(objectCache, nil, NamespaceWatcherClient(fake.NewSimpleClientset().CoreV1()))
 	assert.NoError(t, err, "failed to create test resolver")
 
 	return watcher.(*NamespaceWatcher)


### PR DESCRIPTION
This limits the duration of the watch, regardless of any activity or inactivity.  Previously it seems a default of 1 minute was being imposed from the client causing excessive resynching.

### Type of change


- Bugfix

### Description

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
