### PR TITLE
Add address-space-controller to the list of container ids considered internal

### DIFF
--- a/agent/lib/router_stats.js
+++ b/agent/lib/router_stats.js
@@ -228,7 +228,7 @@ function is_role_normal (c) {
     return c.role === 'normal';
 }
 
-var internal_identifiers = ['standard-controller', 'agent', 'ragent', 'qdconfigd', 'subserv', 'lwt-service'];
+var internal_identifiers = ['address-space-controller', 'standard-controller', 'agent', 'ragent', 'qdconfigd', 'subserv', 'lwt-service'];
 
 function is_internal_identifier (s) {
     return internal_identifiers.indexOf(s) >= 0;


### PR DESCRIPTION
### Type of change


- Bugfix

### Description

Add address-space-controller to the list of internal_identifiers used to exclude the AMQP containers relating to internal components.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
