### PR TITLE
Ensure address-space and generated address resource names meet RFC 1123

### DIFF
--- a/console/console-init/ui/src/pages/CreateAddressSpace/CreateAddressSpaceConfiguration.tsx
+++ b/console/console-init/ui/src/pages/CreateAddressSpace/CreateAddressSpaceConfiguration.tsx
@@ -25,7 +25,7 @@ import {
 } from "queries";
 import { Loading } from "use-patternfly";
 import { css, StyleSheet } from "@patternfly/react-styles";
-import { k8NameRegexp } from "types/Configs";
+import { dnsSubDomainRfc1123NameRegexp } from "types/Configs";
 const styles = StyleSheet.create({
   capitalize_labels: {
     "text-transform": "capitalize"
@@ -205,7 +205,9 @@ export const AddressSpaceConfiguration: React.FunctionComponent<IAddressSpaceCon
 
   const handleNameChange = (name: string) => {
     setName(name);
-    !k8NameRegexp.test(name) ? setIsNameValid(false) : setIsNameValid(true);
+    !dnsSubDomainRfc1123NameRegexp.test(name)
+      ? setIsNameValid(false)
+      : setIsNameValid(true);
   };
 
   return (
@@ -253,8 +255,8 @@ export const AddressSpaceConfiguration: React.FunctionComponent<IAddressSpaceCon
               helperText={
                 name.trim() !== "" && !isNameValid ? (
                   <small>
-                    Only digits (0-9), lower case letters (a-z), -, and .
-                    allowed, and should start with alpha-numeric characters.
+                    Only lowercase alphanumeric characters, -, and . allowed,
+                    and should start and end with an alpha-numeric character.
                   </small>
                 ) : (
                   ""

--- a/console/console-init/ui/src/types/Configs.tsx
+++ b/console/console-init/ui/src/types/Configs.tsx
@@ -1,2 +1,4 @@
-export const k8NameRegexp = new RegExp("^[0-9a-z][0-9a-z.-]*$");
+export const dnsSubDomainRfc1123NameRegexp = new RegExp(
+  "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+);
 export const messagingAddressNameRegexp = new RegExp("^[^#*\\s]+$");

--- a/pkg/consolegraphql/resolvers/resolver_address.go
+++ b/pkg/consolegraphql/resolvers/resolver_address.go
@@ -21,7 +21,7 @@ import (
 )
 
 // From https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-var validNameRegexp = regexp.MustCompile("^[a-z0-9][-a-z0-9_.]*[a-z0-9]$")
+var validDnsSubDomainRfc1123NameRegexp = regexp.MustCompile("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
 var legalNameCharRegexp = regexp.MustCompile("[^-a-z0-9_.]")
 var separators = []string{"_", ".", "-"}
 
@@ -314,7 +314,7 @@ func defaultResourceNameFromAddress(input *v1beta1.Address, addressSpace *string
 }
 
 func isValidName(name string, maxLength int) bool {
-	return validNameRegexp.MatchString(name) && maxLength >= len(name)
+	return validDnsSubDomainRfc1123NameRegexp.MatchString(name) && maxLength >= len(name)
 }
 
 func cleanName(name string, qualifier string, maxLength int) string {
@@ -328,6 +328,11 @@ func cleanName(name string, qualifier string, maxLength int) string {
 	if len(name) > maxLength {
 		name = name[:maxLength]
 	}
+
+	if !validDnsSubDomainRfc1123NameRegexp.MatchString(name) {
+		name = ""
+	}
+
 	if name == "" {
 		return qualifier
 	} else {

--- a/pkg/consolegraphql/resolvers/resolver_address_test.go
+++ b/pkg/consolegraphql/resolvers/resolver_address_test.go
@@ -600,19 +600,37 @@ func TestCreateAddressUsingAddressToFormResourceName(t *testing.T) {
 				assert.Equal(t, 253, len(name))
 			},
 		},
+		{
+			"only DNS-1123 dot separators",
+			addressspace,
+			"...",
+			func(name string) {
+				assert.Regexp(t, "^myaddressspace\\.[-a-z0-9]{36}$", name)
+			},
+		},
+		{
+			"only DNS-1123 dash separators",
+			addressspace,
+			"-",
+			func(name string) {
+				assert.Regexp(t, "^myaddressspace\\.[-a-z0-9]{36}$", name)
+			},
+		},
 	}
 	for _, testCase := range testCases {
-		r, ctx := newTestAddressResolver(t)
-		ah := createAddress(namespace, "",
-			withAddress(testCase.address))
+		t.Run(testCase.name, func(t *testing.T) {
+			r, ctx := newTestAddressResolver(t)
+			ah := createAddress(namespace, "",
+				withAddress(testCase.address))
 
-		meta, err := r.Mutation().CreateAddress(ctx, ah.Address, &testCase.addressSpace)
-		assert.NoError(t, err)
+			meta, err := r.Mutation().CreateAddress(ctx, ah.Address, &testCase.addressSpace)
+			assert.NoError(t, err)
 
-		retrieved, err := server.GetRequestStateFromContext(ctx).EnmasseV1beta1Client.Addresses(meta.Namespace).Get(meta.Name, metav1.GetOptions{})
-		assert.NoError(t, err)
+			retrieved, err := server.GetRequestStateFromContext(ctx).EnmasseV1beta1Client.Addresses(meta.Namespace).Get(meta.Name, metav1.GetOptions{})
+			assert.NoError(t, err)
 
-		testCase.assertExpectedName(retrieved.Name)
+			testCase.assertExpectedName(retrieved.Name)
+		})
 	}
 }
 


### PR DESCRIPTION
### Type of change


- Bugfix

### Description

When the user supplies an address space name through the UI, the UI should ensure it meets the specification [1].  Also when the backend generates an address resource name from an address it must ensure that the resulting name conforms to the same.

https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
