### PR TITLE
Weaken address validation to permit router wildcards

### DIFF
--- a/templates/crds/addresses.crd.yaml
+++ b/templates/crds/addresses.crd.yaml
@@ -70,7 +70,7 @@ spec:
             address:
               type: string
               description: "Messaging address."
-              pattern: "^[^#*\\s]+$"
+              pattern: "^[^\\s]+$"
             type:
               type: string
               description: "Address type for this address."


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

To avoid a behavioural change, weaken the address validation imposed by the server to permit the router # and * wildcards.   I left the UI validation unchanged.

### Checklist

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
