### PR TITLE
Remove consoleservice from KubeSchemaApi (dead code)

### DIFF
--- a/api-model/src/main/java/io/enmasse/address/model/Schema.java
+++ b/api-model/src/main/java/io/enmasse/address/model/Schema.java
@@ -35,7 +35,6 @@ import io.sundr.builder.annotations.Inline;
 public class Schema {
     private List<@Valid AddressSpaceType> addressSpaceTypes = new ArrayList<>();
     private List<io.enmasse.admin.model.v1.AuthenticationService> authenticationServices = new ArrayList<>();
-    private List<io.enmasse.admin.model.v1.ConsoleService> consoleServices = new ArrayList<>();
     private String creationTimestamp;
 
     public Schema() {
@@ -63,14 +62,6 @@ public class Schema {
         this.authenticationServices = authenticationServices;
     }
 
-    public List<ConsoleService> getConsoleServices() {
-        return Collections.unmodifiableList(consoleServices);
-    }
-
-    public void setConsoleServices(List<ConsoleService> consoleServices) {
-        this.consoleServices = consoleServices;
-    }
-
     public Optional<AddressSpaceType> findAddressSpaceType(String name) {
         for (AddressSpaceType type : addressSpaceTypes) {
             if (type.getName().equals(name)) {
@@ -84,15 +75,6 @@ public class Schema {
         for (AuthenticationService authenticationService : authenticationServices) {
             if (authenticationService.getMetadata().getName().equals(name)) {
                 return Optional.of(authenticationService);
-            }
-        }
-        return Optional.empty();
-    }
-
-    public Optional<io.enmasse.admin.model.v1.ConsoleService> findConsoleService(String name) {
-        for (ConsoleService consoleService : consoleServices) {
-            if (consoleService.getMetadata().getName().equals(name)) {
-                return Optional.of(consoleService);
             }
         }
         return Optional.empty();
@@ -136,7 +118,6 @@ public class Schema {
         return "Schema{" +
                 "addressSpaceTypes=" + addressSpaceTypes +
                 ", authenticationServices=" + authenticationServices +
-                ", consoleServices=" + consoleServices +
                 ", creationTimestamp='" + creationTimestamp + '\'' +
                 '}';
     }

--- a/k8s-api/src/test/java/io/enmasse/k8s/api/KubeSchemaApiTest.java
+++ b/k8s-api/src/test/java/io/enmasse/k8s/api/KubeSchemaApiTest.java
@@ -47,7 +47,7 @@ public class KubeSchemaApiTest {
 
     @Test
     public void testSchemaAssemble() {
-        KubeSchemaApi schemaApi = new KubeSchemaApi(addressSpacePlanApi, addressPlanApi, brokeredInfraConfigApi, standardInfraConfigApi, authenticationServiceApi, consoleServiceApi, "1.0", Clock.systemUTC(), false, true);
+        KubeSchemaApi schemaApi = new KubeSchemaApi(addressSpacePlanApi, addressPlanApi, brokeredInfraConfigApi, standardInfraConfigApi, authenticationServiceApi, "1.0", Clock.systemUTC(), false, true);
 
         List<AddressSpacePlan> addressSpacePlans = Arrays.asList(
                 new AddressSpacePlanBuilder()
@@ -145,7 +145,7 @@ public class KubeSchemaApiTest {
                         .endMetadata()
                         .build());
 
-        Schema schema = schemaApi.assembleSchema(addressSpacePlans, addressPlans, standardInfraConfigs, brokeredInfraConfigs, authenticationServices, consoleServices);
+        Schema schema = schemaApi.assembleSchema(addressSpacePlans, addressPlans, standardInfraConfigs, brokeredInfraConfigs, authenticationServices);
 
         assertTrue(schema.findAddressSpaceType("standard").isPresent());
         assertTrue(schema.findAddressSpaceType("brokered").isPresent());
@@ -207,7 +207,7 @@ public class KubeSchemaApiTest {
         when(standardInfraConfigApi.watchResources(any(), any())).thenReturn(mockWatch);
         when(authenticationServiceApi.watchResources(any(), any())).thenReturn(mockWatch);
 
-        SchemaApi schemaApi = new KubeSchemaApi(addressSpacePlanApi, addressPlanApi, brokeredInfraConfigApi, standardInfraConfigApi, authenticationServiceApi, consoleServiceApi, "1.0", Clock.systemUTC(), true, false);
+        SchemaApi schemaApi = new KubeSchemaApi(addressSpacePlanApi, addressPlanApi, brokeredInfraConfigApi, standardInfraConfigApi, authenticationServiceApi, "1.0", Clock.systemUTC(), true, false);
 
         schemaApi.watchSchema(items -> { }, Duration.ofSeconds(5));
         verify(addressSpacePlanApi).watchResources(any(), eq(Duration.ofSeconds(5)));

--- a/olm-manifest/src/main/resources/latest/enmasse.clusterserviceversion.yaml
+++ b/olm-manifest/src/main/resources/latest/enmasse.clusterserviceversion.yaml
@@ -539,7 +539,7 @@ spec:
       - serviceAccountName: address-space-controller
         rules:
         - apiGroups: [ "admin.enmasse.io" ]
-          resources: [ "addressplans", "addressspaceplans", "brokeredinfraconfigs", "standardinfraconfigs", "authenticationservices", "consoleservices"]
+          resources: [ "addressplans", "addressspaceplans", "brokeredinfraconfigs", "standardinfraconfigs", "authenticationservices"]
           verbs: [ "patch", "get", "list", "watch" ]
         - apiGroups: [ "" ]
           resources: [ "pods" ]
@@ -568,7 +568,7 @@ spec:
       - serviceAccountName: address-space-admin
         rules:
         - apiGroups: [ "admin.enmasse.io" ]
-          resources: [ "addressplans", "addressspaceplans", "brokeredinfraconfigs", "standardinfraconfigs", "authenticationservices", "consoleservices"]
+          resources: [ "addressplans", "addressspaceplans", "brokeredinfraconfigs", "standardinfraconfigs", "authenticationservices"]
           verbs: [ "get", "list", "watch" ]
         - apiGroups: [ "" ]
           resources: [ "pods", "secrets" ]

--- a/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
@@ -578,8 +578,6 @@ public class TestUtils {
     }
 
     public static String getGlobalConsoleRoute() throws Exception {
-//        String clusterIp = Kubernetes.getInstance().getClient().services().inNamespace(Kubernetes.getInstance().getInfraNamespace()).withName("console").get().getSpec().getClusterIP();
-//        return String.format("https://%s:%d", clusterIp, 8443);
         return Kubernetes.getInstance().getConsoleServiceClient().withName("console").get().getStatus().getUrl();
     }
 

--- a/templates/address-space-controller/020-Role-address-space-admin.yaml
+++ b/templates/address-space-controller/020-Role-address-space-admin.yaml
@@ -6,7 +6,7 @@ metadata:
   name: enmasse.io:address-space-admin
 rules:
   - apiGroups: [ "admin.enmasse.io" ]
-    resources: [ "addressplans", "addressspaceplans", "brokeredinfraconfigs", "standardinfraconfigs", "authenticationservices", "consoleservices"]
+    resources: [ "addressplans", "addressspaceplans", "brokeredinfraconfigs", "standardinfraconfigs", "authenticationservices"]
     verbs: [ "get", "list", "watch" ]
   - apiGroups: [ "" ]
     resources: [ "pods", "secrets" ]

--- a/templates/address-space-controller/020-Role-address-space-controller.yaml
+++ b/templates/address-space-controller/020-Role-address-space-controller.yaml
@@ -6,7 +6,7 @@ metadata:
   name: enmasse.io:address-space-controller
 rules:
   - apiGroups: [ "admin.enmasse.io" ]
-    resources: [ "addressplans", "addressspaceplans", "brokeredinfraconfigs", "standardinfraconfigs", "authenticationservices", "consoleservices"]
+    resources: [ "addressplans", "addressspaceplans", "brokeredinfraconfigs", "standardinfraconfigs", "authenticationservices"]
     verbs: [ "patch", "get", "list", "watch" ]
   - apiGroups: [ "" ]
     resources: [ "pods" ]


### PR DESCRIPTION
### Type of change


- Refactoring

### Description

Removes consoleservice from KubeSchemaApi and its associated watcher. This was required only to propagate console information to the addressspace agents. With the removal of the address space specific consoles, this code is redundant.

Removed the address-space-controller roles that supported the read of this resource too.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
