### PR TITLE
Ensure that GVK is set all objects in the cache.

### DIFF
--- a/hack/generate_resource_watchers.go
+++ b/hack/generate_resource_watchers.go
@@ -239,7 +239,7 @@ func (kw *{{ .Name }}Watcher) doWatch(resource cp.{{ .Name }}Interface) error {
 	var unchanged = 0
 	for _, res := range resourceList.Items {
 		copy := res.DeepCopy()
-		kw.updateKind(copy)
+		kw.updateGroupVersionKind(copy)
 
 		candidate := kw.create(copy)
 		gen, key, err := keyCreator(candidate)
@@ -316,7 +316,7 @@ func (kw *{{ .Name }}Watcher) doWatch(resource cp.{{ .Name }}Interface) error {
 				err = fmt.Errorf("Watch error - object of unexpected type, %T, received", event.Object)
 			} else {
 				copy := res.DeepCopy()
-				kw.updateKind(copy)
+				kw.updateGroupVersionKind(copy)
 				switch event.Type {
 				case watch.Added:
 					err = kw.Cache.Add(kw.create(copy))
@@ -344,9 +344,11 @@ func (kw *{{ .Name }}Watcher) doWatch(resource cp.{{ .Name }}Interface) error {
 	}
 }
 
-func (kw *{{ .Name }}Watcher) updateKind(o *tp.{{ .Name }}) {
-	if o.TypeMeta.Kind == "" {
-		o.TypeMeta.Kind = "{{ .Name }}"
+// KubernetesRBACAccessController relies on the GVK information to be set on objects.
+// List provides GVK (https://github.com/kubernetes/kubernetes/pull/63972) but Watch does not not so we set it ourselves.
+func (kw *{{ .Name }}Watcher) updateGroupVersionKind(o *tp.{{ .Name }}) {
+	if o.TypeMeta.Kind == "" || o.TypeMeta.APIVersion == "" {
+		o.TypeMeta.SetGroupVersionKind(tp.SchemeGroupVersion.WithKind("{{ .Name }}"))
 	}
 }
 `))

--- a/pkg/consolegraphql/watchers/resource_watcher_address.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_address.go
@@ -168,7 +168,7 @@ func (kw *AddressWatcher) doWatch(resource cp.AddressInterface) error {
 	var unchanged = 0
 	for _, res := range resourceList.Items {
 		copy := res.DeepCopy()
-		kw.updateKind(copy)
+		kw.updateGroupVersionKind(copy)
 
 		candidate := kw.create(copy)
 		gen, key, err := keyCreator(candidate)
@@ -245,7 +245,7 @@ func (kw *AddressWatcher) doWatch(resource cp.AddressInterface) error {
 				err = fmt.Errorf("Watch error - object of unexpected type, %T, received", event.Object)
 			} else {
 				copy := res.DeepCopy()
-				kw.updateKind(copy)
+				kw.updateGroupVersionKind(copy)
 				switch event.Type {
 				case watch.Added:
 					err = kw.Cache.Add(kw.create(copy))
@@ -273,8 +273,10 @@ func (kw *AddressWatcher) doWatch(resource cp.AddressInterface) error {
 	}
 }
 
-func (kw *AddressWatcher) updateKind(o *tp.Address) {
-	if o.TypeMeta.Kind == "" {
-		o.TypeMeta.Kind = "Address"
+// KubernetesRBACAccessController relies on the GVK information to be set on objects.
+// List provides GVK (https://github.com/kubernetes/kubernetes/pull/63972) but Watch does not not so we set it ourselves.
+func (kw *AddressWatcher) updateGroupVersionKind(o *tp.Address) {
+	if o.TypeMeta.Kind == "" || o.TypeMeta.APIVersion == "" {
+		o.TypeMeta.SetGroupVersionKind(tp.SchemeGroupVersion.WithKind("Address"))
 	}
 }

--- a/pkg/consolegraphql/watchers/resource_watcher_address_test.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_address_test.go
@@ -43,10 +43,12 @@ func TestWatchAddress_ListProvidesNewValue(t *testing.T) {
 
 	objs, err := w.Cache.Get(cache.PrimaryObjectIndex, "Address", nil)
 	assert.NoError(t, err, "failed to query cache")
-	expected := 1
-	actual := len(objs)
-	assert.Equal(t, expected, actual, "Unexpected number of addresses")
+	assert.Equal(t, 1, len(objs), "Unexpected number of addresses")
 	assert.Equal(t, int32(0), w.GetRestartCount())
+
+	received := objs[0].(*consolegraphql.AddressHolder)
+	assert.NotEmpty(t, received.TypeMeta.APIVersion)
+	assert.NotEmpty(t, received.TypeMeta.Kind)
 }
 
 func TestWatchAddress_ListProvidesDifferingValues(t *testing.T) {
@@ -113,10 +115,12 @@ func TestWatchAddress_WatchCreatesNewValue(t *testing.T) {
 
 	objs, err := w.Cache.Get(cache.PrimaryObjectIndex, "Address", nil)
 	assert.NoError(t, err, "failed to query cache")
-	expected := 1
-	actual := len(objs)
-	assert.Equal(t, expected, actual, "Unexpected number of addresses")
+	assert.Equal(t, 1, len(objs), "Unexpected number of addresses")
 	assert.Equal(t, int32(0), w.GetRestartCount())
+
+	received := objs[0].(*consolegraphql.AddressHolder)
+	assert.NotEmpty(t, received.TypeMeta.APIVersion)
+	assert.NotEmpty(t, received.TypeMeta.Kind)
 }
 
 func TestWatchAddress_WatchUpdatesExistingValue(t *testing.T) {

--- a/pkg/consolegraphql/watchers/resource_watcher_addressplan.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_addressplan.go
@@ -168,7 +168,7 @@ func (kw *AddressPlanWatcher) doWatch(resource cp.AddressPlanInterface) error {
 	var unchanged = 0
 	for _, res := range resourceList.Items {
 		copy := res.DeepCopy()
-		kw.updateKind(copy)
+		kw.updateGroupVersionKind(copy)
 
 		candidate := kw.create(copy)
 		gen, key, err := keyCreator(candidate)
@@ -245,7 +245,7 @@ func (kw *AddressPlanWatcher) doWatch(resource cp.AddressPlanInterface) error {
 				err = fmt.Errorf("Watch error - object of unexpected type, %T, received", event.Object)
 			} else {
 				copy := res.DeepCopy()
-				kw.updateKind(copy)
+				kw.updateGroupVersionKind(copy)
 				switch event.Type {
 				case watch.Added:
 					err = kw.Cache.Add(kw.create(copy))
@@ -273,8 +273,10 @@ func (kw *AddressPlanWatcher) doWatch(resource cp.AddressPlanInterface) error {
 	}
 }
 
-func (kw *AddressPlanWatcher) updateKind(o *tp.AddressPlan) {
-	if o.TypeMeta.Kind == "" {
-		o.TypeMeta.Kind = "AddressPlan"
+// KubernetesRBACAccessController relies on the GVK information to be set on objects.
+// List provides GVK (https://github.com/kubernetes/kubernetes/pull/63972) but Watch does not not so we set it ourselves.
+func (kw *AddressPlanWatcher) updateGroupVersionKind(o *tp.AddressPlan) {
+	if o.TypeMeta.Kind == "" || o.TypeMeta.APIVersion == "" {
+		o.TypeMeta.SetGroupVersionKind(tp.SchemeGroupVersion.WithKind("AddressPlan"))
 	}
 }

--- a/pkg/consolegraphql/watchers/resource_watcher_addressspace.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_addressspace.go
@@ -168,7 +168,7 @@ func (kw *AddressSpaceWatcher) doWatch(resource cp.AddressSpaceInterface) error 
 	var unchanged = 0
 	for _, res := range resourceList.Items {
 		copy := res.DeepCopy()
-		kw.updateKind(copy)
+		kw.updateGroupVersionKind(copy)
 
 		candidate := kw.create(copy)
 		gen, key, err := keyCreator(candidate)
@@ -245,7 +245,7 @@ func (kw *AddressSpaceWatcher) doWatch(resource cp.AddressSpaceInterface) error 
 				err = fmt.Errorf("Watch error - object of unexpected type, %T, received", event.Object)
 			} else {
 				copy := res.DeepCopy()
-				kw.updateKind(copy)
+				kw.updateGroupVersionKind(copy)
 				switch event.Type {
 				case watch.Added:
 					err = kw.Cache.Add(kw.create(copy))
@@ -273,8 +273,10 @@ func (kw *AddressSpaceWatcher) doWatch(resource cp.AddressSpaceInterface) error 
 	}
 }
 
-func (kw *AddressSpaceWatcher) updateKind(o *tp.AddressSpace) {
-	if o.TypeMeta.Kind == "" {
-		o.TypeMeta.Kind = "AddressSpace"
+// KubernetesRBACAccessController relies on the GVK information to be set on objects.
+// List provides GVK (https://github.com/kubernetes/kubernetes/pull/63972) but Watch does not not so we set it ourselves.
+func (kw *AddressSpaceWatcher) updateGroupVersionKind(o *tp.AddressSpace) {
+	if o.TypeMeta.Kind == "" || o.TypeMeta.APIVersion == "" {
+		o.TypeMeta.SetGroupVersionKind(tp.SchemeGroupVersion.WithKind("AddressSpace"))
 	}
 }

--- a/pkg/consolegraphql/watchers/resource_watcher_addressspaceplan.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_addressspaceplan.go
@@ -168,7 +168,7 @@ func (kw *AddressSpacePlanWatcher) doWatch(resource cp.AddressSpacePlanInterface
 	var unchanged = 0
 	for _, res := range resourceList.Items {
 		copy := res.DeepCopy()
-		kw.updateKind(copy)
+		kw.updateGroupVersionKind(copy)
 
 		candidate := kw.create(copy)
 		gen, key, err := keyCreator(candidate)
@@ -245,7 +245,7 @@ func (kw *AddressSpacePlanWatcher) doWatch(resource cp.AddressSpacePlanInterface
 				err = fmt.Errorf("Watch error - object of unexpected type, %T, received", event.Object)
 			} else {
 				copy := res.DeepCopy()
-				kw.updateKind(copy)
+				kw.updateGroupVersionKind(copy)
 				switch event.Type {
 				case watch.Added:
 					err = kw.Cache.Add(kw.create(copy))
@@ -273,8 +273,10 @@ func (kw *AddressSpacePlanWatcher) doWatch(resource cp.AddressSpacePlanInterface
 	}
 }
 
-func (kw *AddressSpacePlanWatcher) updateKind(o *tp.AddressSpacePlan) {
-	if o.TypeMeta.Kind == "" {
-		o.TypeMeta.Kind = "AddressSpacePlan"
+// KubernetesRBACAccessController relies on the GVK information to be set on objects.
+// List provides GVK (https://github.com/kubernetes/kubernetes/pull/63972) but Watch does not not so we set it ourselves.
+func (kw *AddressSpacePlanWatcher) updateGroupVersionKind(o *tp.AddressSpacePlan) {
+	if o.TypeMeta.Kind == "" || o.TypeMeta.APIVersion == "" {
+		o.TypeMeta.SetGroupVersionKind(tp.SchemeGroupVersion.WithKind("AddressSpacePlan"))
 	}
 }

--- a/pkg/consolegraphql/watchers/resource_watcher_addressspaceschema.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_addressspaceschema.go
@@ -168,7 +168,7 @@ func (kw *AddressSpaceSchemaWatcher) doWatch(resource cp.AddressSpaceSchemaInter
 	var unchanged = 0
 	for _, res := range resourceList.Items {
 		copy := res.DeepCopy()
-		kw.updateKind(copy)
+		kw.updateGroupVersionKind(copy)
 
 		candidate := kw.create(copy)
 		gen, key, err := keyCreator(candidate)
@@ -245,7 +245,7 @@ func (kw *AddressSpaceSchemaWatcher) doWatch(resource cp.AddressSpaceSchemaInter
 				err = fmt.Errorf("Watch error - object of unexpected type, %T, received", event.Object)
 			} else {
 				copy := res.DeepCopy()
-				kw.updateKind(copy)
+				kw.updateGroupVersionKind(copy)
 				switch event.Type {
 				case watch.Added:
 					err = kw.Cache.Add(kw.create(copy))
@@ -273,8 +273,10 @@ func (kw *AddressSpaceSchemaWatcher) doWatch(resource cp.AddressSpaceSchemaInter
 	}
 }
 
-func (kw *AddressSpaceSchemaWatcher) updateKind(o *tp.AddressSpaceSchema) {
-	if o.TypeMeta.Kind == "" {
-		o.TypeMeta.Kind = "AddressSpaceSchema"
+// KubernetesRBACAccessController relies on the GVK information to be set on objects.
+// List provides GVK (https://github.com/kubernetes/kubernetes/pull/63972) but Watch does not not so we set it ourselves.
+func (kw *AddressSpaceSchemaWatcher) updateGroupVersionKind(o *tp.AddressSpaceSchema) {
+	if o.TypeMeta.Kind == "" || o.TypeMeta.APIVersion == "" {
+		o.TypeMeta.SetGroupVersionKind(tp.SchemeGroupVersion.WithKind("AddressSpaceSchema"))
 	}
 }

--- a/pkg/consolegraphql/watchers/resource_watcher_authenticationservice.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_authenticationservice.go
@@ -168,7 +168,7 @@ func (kw *AuthenticationServiceWatcher) doWatch(resource cp.AuthenticationServic
 	var unchanged = 0
 	for _, res := range resourceList.Items {
 		copy := res.DeepCopy()
-		kw.updateKind(copy)
+		kw.updateGroupVersionKind(copy)
 
 		candidate := kw.create(copy)
 		gen, key, err := keyCreator(candidate)
@@ -245,7 +245,7 @@ func (kw *AuthenticationServiceWatcher) doWatch(resource cp.AuthenticationServic
 				err = fmt.Errorf("Watch error - object of unexpected type, %T, received", event.Object)
 			} else {
 				copy := res.DeepCopy()
-				kw.updateKind(copy)
+				kw.updateGroupVersionKind(copy)
 				switch event.Type {
 				case watch.Added:
 					err = kw.Cache.Add(kw.create(copy))
@@ -273,8 +273,10 @@ func (kw *AuthenticationServiceWatcher) doWatch(resource cp.AuthenticationServic
 	}
 }
 
-func (kw *AuthenticationServiceWatcher) updateKind(o *tp.AuthenticationService) {
-	if o.TypeMeta.Kind == "" {
-		o.TypeMeta.Kind = "AuthenticationService"
+// KubernetesRBACAccessController relies on the GVK information to be set on objects.
+// List provides GVK (https://github.com/kubernetes/kubernetes/pull/63972) but Watch does not not so we set it ourselves.
+func (kw *AuthenticationServiceWatcher) updateGroupVersionKind(o *tp.AuthenticationService) {
+	if o.TypeMeta.Kind == "" || o.TypeMeta.APIVersion == "" {
+		o.TypeMeta.SetGroupVersionKind(tp.SchemeGroupVersion.WithKind("AuthenticationService"))
 	}
 }

--- a/pkg/consolegraphql/watchers/resource_watcher_namespace.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_namespace.go
@@ -168,7 +168,7 @@ func (kw *NamespaceWatcher) doWatch(resource cp.NamespaceInterface) error {
 	var unchanged = 0
 	for _, res := range resourceList.Items {
 		copy := res.DeepCopy()
-		kw.updateKind(copy)
+		kw.updateGroupVersionKind(copy)
 
 		candidate := kw.create(copy)
 		gen, key, err := keyCreator(candidate)
@@ -245,7 +245,7 @@ func (kw *NamespaceWatcher) doWatch(resource cp.NamespaceInterface) error {
 				err = fmt.Errorf("Watch error - object of unexpected type, %T, received", event.Object)
 			} else {
 				copy := res.DeepCopy()
-				kw.updateKind(copy)
+				kw.updateGroupVersionKind(copy)
 				switch event.Type {
 				case watch.Added:
 					err = kw.Cache.Add(kw.create(copy))
@@ -273,8 +273,10 @@ func (kw *NamespaceWatcher) doWatch(resource cp.NamespaceInterface) error {
 	}
 }
 
-func (kw *NamespaceWatcher) updateKind(o *tp.Namespace) {
-	if o.TypeMeta.Kind == "" {
-		o.TypeMeta.Kind = "Namespace"
+// KubernetesRBACAccessController relies on the GVK information to be set on objects.
+// List provides GVK (https://github.com/kubernetes/kubernetes/pull/63972) but Watch does not not so we set it ourselves.
+func (kw *NamespaceWatcher) updateGroupVersionKind(o *tp.Namespace) {
+	if o.TypeMeta.Kind == "" || o.TypeMeta.APIVersion == "" {
+		o.TypeMeta.SetGroupVersionKind(tp.SchemeGroupVersion.WithKind("Namespace"))
 	}
 }

--- a/pkg/consolegraphql/watchers/resource_watcher_namespace_test.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_namespace_test.go
@@ -38,10 +38,12 @@ func TestWatchNamespace_ListProvidesNewValue(t *testing.T) {
 
 	objs, err := w.Cache.Get(cache.PrimaryObjectIndex, "Namespace", nil)
 	assert.NoError(t, err, "failed to query cache")
-	expected := 1
-	actual := len(objs)
-	assert.Equal(t, expected, actual, "Unexpected number of namespaces")
+	assert.Equal(t, 1, len(objs), "Unexpected number of namespaces")
 	assert.Equal(t, int32(0), w.GetRestartCount())
+
+	received := objs[0].(*v1.Namespace)
+	assert.NotEmpty(t, received.TypeMeta.APIVersion)
+	assert.NotEmpty(t, received.TypeMeta.Kind)
 }
 
 func TestWatchNamespace_ListProvidesDifferingValues(t *testing.T) {
@@ -107,10 +109,12 @@ func TestWatchNamespace_WatchCreatesNewValue(t *testing.T) {
 
 	objs, err := w.Cache.Get(cache.PrimaryObjectIndex, "Namespace", nil)
 	assert.NoError(t, err, "failed to query cache")
-	expected := 1
-	actual := len(objs)
-	assert.Equal(t, expected, actual, "Unexpected number of namespaces")
+	assert.Equal(t, 1, len(objs), "Unexpected number of namespaces")
 	assert.Equal(t, int32(0), w.GetRestartCount())
+
+	received := objs[0].(*v1.Namespace)
+	assert.NotEmpty(t, received.TypeMeta.APIVersion)
+	assert.NotEmpty(t, received.TypeMeta.Kind)
 }
 
 func TestWatchNamespace_WatchUpdatesExistingValue(t *testing.T) {


### PR DESCRIPTION

### Type of change

- Bugfix

### Description

The console's Accesscontrol mechanism requires that GVK is available on all objects in the cache.   While the go-client lists populate the GVK, unfortunately watches do not.  We now set the GVK if it is absent before placing the object in the cache.

### Checklist


- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
