### PR TITLE
Remove spurious creationTimestamp from address space command preview

### DIFF
--- a/pkg/consolegraphql/resolvers/resolver_addressspace_test.go
+++ b/pkg/consolegraphql/resolvers/resolver_addressspace_test.go
@@ -278,8 +278,6 @@ metadata:
 	expectedSpec := `
 spec:
   authenticationService:
-    metadata:
-      creationTimestamp: null
     name: auth
   plan: standard-small-queue
   type: queue`

--- a/pkg/consolegraphql/resolvers/utils.go
+++ b/pkg/consolegraphql/resolvers/utils.go
@@ -31,9 +31,8 @@ func generateApplyCommand(object interface{}, namespace string) (string, error) 
 	}
 
 	delete(jsonMap, "status")
-	delete(jsonMap["metadata"].(map[string]interface{}), "creationTimestamp")
 	delete(jsonMap["metadata"].(map[string]interface{}), "uid")
-
+	pruneEmpty(&jsonMap)
 	bytes, err = yaml.Marshal(jsonMap)
 
 	kubectl := "kubectl"
@@ -46,5 +45,21 @@ func generateApplyCommand(object interface{}, namespace string) (string, error) 
 		return shell, nil
 	} else {
 		return "", err
+	}
+}
+
+func pruneEmpty(m *map[string]interface{}) {
+	for k, v := range *m {
+		if v == nil {
+			delete(*m, k)
+		} else {
+			switch t := v.(type) {
+			case map[string]interface{}:
+				pruneEmpty(&t)
+				if len(t) == 0 {
+					delete(*m, k)
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Remove spurious `creationTimestamp: null` (and the metadata container, which will be empty) from address space command preview.

![SpuriousCreationTimestampNullInCmdPreview](https://user-images.githubusercontent.com/18440250/75153929-773a0c00-5704-11ea-9e98-60c2ca75b288.png)

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
