### PR TITLE
Wait for pods to be removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,9 @@
 * #3764: validate the topic refenced by a subscription actually exists
 * #3868: Add support for specifying maxConsumers for a subscription
 * #3873: Require TLSv1.2 or newer for external TLS endpoints
-* #3867: Add addition checks for router mesh status
-#      : Address CRD now validates the spec.address field comprises permitted characters.
-# #3949: Address unsafe publication to volatiles used to form the schema
+* #3867: Add addition checks for router mesh status: Address CRD now validates the spec.address field comprises permitted characters.
+* #3949: Address unsafe publication to volatiles used to form the schema
+* #3981: Timeout when deleting address space
 
 ## 0.30.2
 *  #2714: Allow setting security context of pods using persistent volumes

--- a/address-space-controller/src/main/java/io/enmasse/controller/common/Kubernetes.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/common/Kubernetes.java
@@ -28,7 +28,7 @@ public interface Kubernetes {
     void apply(KubernetesList resourceList, boolean patchPersistentVolumeClaims);
     KubernetesList processTemplate(String templateName, Map<String, String> parameters);
 
-    void deleteResources(String infraUuid);
+    void deleteResources(String infraUuid) throws InterruptedException;
 
     Set<Deployment> getReadyDeployments(AddressSpace addressSpace);
     Set<StatefulSet> getReadyStatefulSets(AddressSpace addressSpace);

--- a/address-space-controller/src/main/java/io/enmasse/controller/common/KubernetesHelper.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/common/KubernetesHelper.java
@@ -140,7 +140,7 @@ public class KubernetesHelper implements Kubernetes {
     public void deleteResources(String infraUuid) throws InterruptedException {
         // Delete and await deployments to be deleted so that the per-address space controllers are not re-creating any resources
         for (Deployment deployment : client.apps().deployments().withLabel(LabelKeys.INFRA_UUID, infraUuid).list().getItems()) {
-            if (!client.apps().deployments().delete(deployment)) {
+            if (!client.apps().deployments().inNamespace(deployment.getMetadata().getNamespace()).withName(deployment.getMetadata().getName()).withPropagationPolicy("Background").delete()) {
                 throw new RuntimeException("Failed to delete infra with uuid " + infraUuid + ": failed to delete deployment " + deployment.getMetadata().getName());
             }
             waitForZeroPods(infraUuid, deployment.getSpec().getTemplate().getMetadata().getLabels(), 300_000);

--- a/address-space-controller/src/main/java/io/enmasse/controller/common/KubernetesHelper.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/common/KubernetesHelper.java
@@ -122,12 +122,33 @@ public class KubernetesHelper implements Kubernetes {
         return res.getKind().equals("StatefulSet");  // TODO: is there an existing constant for this somewhere?
     }
 
+    private void waitForZeroPods(String infraUuid, Map<String, String> labels, long timeoutInMillis) throws InterruptedException {
+        long end = System.currentTimeMillis() + timeoutInMillis;
+        int podsLeft = client.pods().withLabels(labels).list().getItems().size();
+        while (podsLeft > 0 && System.currentTimeMillis() < end) {
+            Thread.sleep(5000);
+            podsLeft = client.pods().withLabels(labels).list().getItems().size();
+        }
+        podsLeft = client.pods().withLabels(labels).list().getItems().size();
+        if (podsLeft > 0) {
+            String message = String.format("Failed to delete infra with uuid %s: %d pods still exists", infraUuid, podsLeft);
+            throw new RuntimeException(message);
+        }
+    }
+
     @Override
-    public void deleteResources(String infraUuid) {
+    public void deleteResources(String infraUuid) throws InterruptedException {
+        // Delete and await deployments to be deleted so that the per-address space controllers are not re-creating any resources
+        for (Deployment deployment : client.apps().deployments().withLabel(LabelKeys.INFRA_UUID, infraUuid).list().getItems()) {
+            if (!client.apps().deployments().delete(deployment)) {
+                throw new RuntimeException("Failed to delete infra with uuid " + infraUuid + ": failed to delete deployment " + deployment.getMetadata().getName());
+            }
+            waitForZeroPods(infraUuid, deployment.getSpec().getTemplate().getMetadata().getLabels(), 300_000);
+        }
         client.apps().statefulSets().withLabel(LabelKeys.INFRA_UUID, infraUuid).withPropagationPolicy("Background").delete();
+
         client.secrets().withLabel(LabelKeys.INFRA_UUID, infraUuid).withPropagationPolicy("Background").delete();
         client.configMaps().withLabel(LabelKeys.INFRA_UUID, infraUuid).withPropagationPolicy("Background").delete();
-        client.apps().deployments().withLabel(LabelKeys.INFRA_UUID, infraUuid).withPropagationPolicy("Background").delete();
         client.network().networkPolicies().withLabel(LabelKeys.INFRA_UUID, infraUuid).withPropagationPolicy("Background").delete();
         client.services().withLabel(LabelKeys.INFRA_UUID, infraUuid).withPropagationPolicy("Background").delete();
         client.persistentVolumeClaims().withLabel(LabelKeys.INFRA_UUID, infraUuid).withPropagationPolicy("Background").delete();

--- a/address-space-controller/src/test/java/io/enmasse/controller/ComponentFinalizerControllerTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/ComponentFinalizerControllerTest.java
@@ -39,7 +39,7 @@ public class ComponentFinalizerControllerTest {
     }
 
     @Test
-    public void testFinalizerSuccess() {
+    public void testFinalizerSuccess() throws Exception {
         AbstractFinalizerController.Result result = controller.processFinalizer(createTestSpace());
         assertNotNull(result);
         assertTrue(result.isFinalized());
@@ -47,7 +47,7 @@ public class ComponentFinalizerControllerTest {
     }
 
     @Test
-    public void testFinalizerFailure() {
+    public void testFinalizerFailure() throws Exception {
         doThrow(new RuntimeException("ERROR")).when(client).deleteResources(any());
         AbstractFinalizerController.Result result = controller.processFinalizer(createTestSpace());
         assertNotNull(result);


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description
Wait for deployment pods to be deleted
    
This prevents the standard-controller from re-creating resources that  gets deleted after the deployments are deleted.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
