### PR TITLE
Docs: add parent context to assemblies to fix build errors

### DIFF
--- a/documentation/assemblies/assembly-metrics-rules.adoc
+++ b/documentation/assemblies/assembly-metrics-rules.adoc
@@ -2,6 +2,8 @@
 //
 // assembly-monitoring.adoc
 
+:parent-context: {context}
+
 [id='assembly-metrics-rules-{context}]
 = Metrics and rules
 
@@ -12,4 +14,6 @@ include::../modules/ref-metrics-address-space-controller.adoc[leveloffset=+1]
 include::../modules/ref-metrics-standard-controller-agent.adoc[leveloffset=+1]
 
 include::assembly-rules.adoc[leveloffset=+1]
+
+:context: {parent-context}
 

--- a/documentation/assemblies/assembly-monitoring.adoc
+++ b/documentation/assemblies/assembly-monitoring.adoc
@@ -4,7 +4,6 @@
 
 :parent-context: {context}
 [id='monitoring-{context}']
-
 = Monitoring {ProductName}
 
 You can monitor {ProductName} by deploying built-in monitoring tools or using your pre-existing monitoring infrastructure.


### PR DESCRIPTION
### Type of change
- Documentation

### Description
Docs fix to add parent context to two assemblies

### Checklist
- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
