### PR TITLE
Create console alert only when console is created

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -194,6 +194,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err := monitoringv1.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Error(err, "Failed to register monitoring schema")
+		os.Exit(1)
+	}
+
 	if err := controller.CheckUpgrade(mgr); err != nil {
 		log.Error(err, "Failed to upgrade")
 		os.Exit(1)

--- a/controller-manager/src/main/resources/templates/PrometheusRules-enmasse.yaml
+++ b/controller-manager/src/main/resources/templates/PrometheusRules-enmasse.yaml
@@ -19,8 +19,6 @@ spec:
 
     - record: enmasse_component_health
       expr: up{job="address-space-controller"} or on(namespace) (1- absent(up{job="address-space-controller"}) )
-    - record: enmasse_component_health
-      expr: up{job="console",namespace='{{ index .Params "Namespace" }}'} or on(namespace) (1- absent(up{job="console",namespace='{{ index .Params "Namespace" }}'}) )
 
     - alert: ComponentHealth
       annotations:

--- a/pkg/controller/address_space_controller/controller.go
+++ b/pkg/controller/address_space_controller/controller.go
@@ -264,7 +264,7 @@ func (r *ReconcileAddressSpaceController) ensureService(ctx context.Context, req
 
 func applyService(service *corev1.Service) error {
 	install.ApplyServiceDefaults(service, service.Name, service.Name)
-	install.CreateCustomLabel(service, "monitoring-key", "enmasse-tenants")
+	install.ApplyCustomLabel(&service.ObjectMeta, "monitoring-key", "enmasse-tenants")
 	service.Spec.Ports = []corev1.ServicePort{
 		{
 			Port:       8080,

--- a/pkg/util/install/utils.go
+++ b/pkg/util/install/utils.go
@@ -37,8 +37,8 @@ func CreateDefaultLabels(labels map[string]string, component string, name string
 }
 
 // Apply a custom label
-func CreateCustomLabel(service *corev1.Service, key string, value string) {
-	service.ObjectMeta.Labels[key] = value
+func ApplyCustomLabel(meta *v1.ObjectMeta, key string, value string) {
+	meta.Labels[key] = value
 }
 
 // Apply standard set of labels


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Modified the console Prometheus rule to only be created when the console is created

### Checklist

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
