### PR TITLE
Bump hibernate-validator from 6.0.17.Final -> 6.0.18.Final (CVE-2019-10219)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <slf4j.version>1.7.21</slf4j.version>
         <logback.version>1.2.3</logback.version>
         <lucene.version>7.7.1</lucene.version>
-        <hibernate.validator.version>6.0.17.Final</hibernate.validator.version>
+        <hibernate.validator.version>6.0.18.Final</hibernate.validator.version>
         <jackson-annotations.version>2.10.0</jackson-annotations.version>
         <jackson-core.version>2.10.0</jackson-core.version>
         <jackson-databind.version>2.10.0</jackson-databind.version>


### PR DESCRIPTION
### Type of change



- Bugfix

### Description

hibernate-validator  6.0.17.Final  contains vulnerability CVE-2019-10219.  Whilst it is believed this vulnerability is not exploitable from EnMasse (it does not use the HTML validation feature), it makes sense to upgrade to fixed version on the 6.0 line.

We tried this before #3629, but at that point a vulnerability fix on the 6.0 release line was not available.


### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
