### PR TITLE
Allow addresses field to be optional

### DIFF
--- a/pkg/apis/user/v1beta1/types.go
+++ b/pkg/apis/user/v1beta1/types.go
@@ -72,7 +72,7 @@ var Operations = map[string]AuthorizationOperation{
 }
 
 type AuthorizationSpec struct {
-	Addresses  []string                 `json:"addresses"`
+	Addresses  []string                 `json:"addresses,omitempty"`
 	Operations []AuthorizationOperation `json:"operations"`
 }
 


### PR DESCRIPTION
This caused a lot of logging in enmasse-operator during upgrade tests which created users with operation 'manage' without any addresses