### PR TITLE
Chore: show visual feedback upon sccessful copy to clipboard

### DIFF
--- a/console/console-init/ui/src/pages/CreateAddress/PreviewAddress.tsx
+++ b/console/console-init/ui/src/pages/CreateAddress/PreviewAddress.tsx
@@ -49,6 +49,7 @@ export const PreviewAddress: React.FunctionComponent<IAddressPreview> = ({
   namespace,
   addressspace
 }) => {
+  const [isCopied, setIsCopied] = React.useState<boolean>(false);
   const { data, loading, error } = useQuery(ADDRESS_COMMAND_PREVIEW_DETAIL, {
     variables: {
       a: {
@@ -133,20 +134,38 @@ export const PreviewAddress: React.FunctionComponent<IAddressPreview> = ({
           <Title size={"lg"} className={css(Style.bottom_padding)}>
             {`Configuration details  `}
             <Tooltip
+              id="preview-addr-feedback-tooltip"
               position={TooltipPosition.top}
               enableFlip={false}
-              content={<div>Copy the configuration details on clipboard</div>}
+              trigger={"manual"}
+              content={<div>Succesfully copied to the clipboard</div>}
+              isVisible={isCopied}
             >
-              <Button
-                id="preview-addr-copy-configuration-button"
-                variant={ButtonVariant.link}
-                aria-label="copy-configuration"
-                onClick={() => {
-                  navigator.clipboard.writeText(data.addressCommand);
-                }}
-              >
-                <OutlinedCopyIcon id="preview-addr-copy-btn" size="md" />
-              </Button>
+              <span>
+                <Tooltip
+                  id="preview-addr-copy-tooltip"
+                  position={TooltipPosition.top}
+                  enableFlip={false}
+                  content={
+                    <div>Copy the configuration details to the clipboard</div>
+                  }
+                >
+                  <Button
+                    id="preview-addr-copy-configuration-button"
+                    variant={ButtonVariant.link}
+                    aria-label="copy-configuration"
+                    onClick={() => {
+                      navigator.clipboard.writeText(data.addressCommand);
+                      setIsCopied(true);
+                    }}
+                    onMouseLeave={() => {
+                      setIsCopied(false);
+                    }}
+                  >
+                    <OutlinedCopyIcon id="preview-addr-copy-btn" size="md" />
+                  </Button>
+                </Tooltip>
+              </span>
             </Tooltip>
           </Title>
           <AceEditor

--- a/console/console-init/ui/src/pages/CreateAddressSpace/ReviewAddressSpace.tsx
+++ b/console/console-init/ui/src/pages/CreateAddressSpace/ReviewAddressSpace.tsx
@@ -11,7 +11,9 @@ import {
   PageSection,
   PageSectionVariants,
   TooltipPosition,
-  Tooltip
+  Tooltip,
+  Button,
+  ButtonVariant
 } from "@patternfly/react-core";
 import { Loading } from "use-patternfly";
 import { useQuery } from "@apollo/react-hooks";
@@ -45,6 +47,7 @@ export const ReviewAddressSpace: React.FunctionComponent<IAddressSpaceReview> = 
   namespace,
   authenticationService
 }) => {
+  const [isCopied, setIsCopied] = React.useState<boolean>(false);
   const { data, loading, error } = useQuery(
     ADDRESS_SPACE_COMMAND_REVIEW_DETAIL,
     {
@@ -142,19 +145,38 @@ export const ReviewAddressSpace: React.FunctionComponent<IAddressSpaceReview> = 
           <Title size={"lg"} className={css(Style.bottom_padding)}>
             {`Configuration details  `}
             <Tooltip
-              id="preview-addr-copy-tooltip"
+              id="preview-as-feedback-tooltip"
               position={TooltipPosition.top}
               enableFlip={false}
-              content={<div>Copy the configuration details on clipboard</div>}
+              trigger={"manual"}
+              content={<div>Succesfully copied to the clipboard</div>}
+              isVisible={isCopied}
             >
-              <OutlinedCopyIcon
-                id="preview-addr-copy-btn"
-                size="md"
-                color="blue"
-                onClick={() => {
-                  navigator.clipboard.writeText(data.addressSpaceCommand);
-                }}
-              />
+              <span>
+                <Tooltip
+                  id="preview-as-copy-tooltip"
+                  position={TooltipPosition.top}
+                  enableFlip={false}
+                  content={
+                    <div>Copy the configuration details to the clipboard</div>
+                  }
+                >
+                  <Button
+                    id="preview-addr-copy-configuration-button"
+                    variant={ButtonVariant.link}
+                    aria-label="copy-configuration"
+                    onClick={() => {
+                      navigator.clipboard.writeText(data.addressCommand);
+                      setIsCopied(true);
+                    }}
+                    onMouseLeave={() => {
+                      setIsCopied(false);
+                    }}
+                  >
+                    <OutlinedCopyIcon id="preview-addr-copy-btn" size="md" />
+                  </Button>
+                </Tooltip>
+              </span>
             </Tooltip>
           </Title>
           <AceEditor


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

The preview of AddressSpace and Address creation wizards now show visual feedback upon successful copy to clipboard.

The feedback is looking something like this : 

![Screenshot from 2020-02-26 23-45-42](https://user-images.githubusercontent.com/23582438/75375043-584d9c80-58f3-11ea-8437-0dca7babb2f5.png)