### PR TITLE
Add timeout flag when deleting CRDs

### DIFF
--- a/ansible/playbooks/openshift/uninstall.yml
+++ b/ansible/playbooks/openshift/uninstall.yml
@@ -4,7 +4,7 @@
     - name: Delete IoT CRDs
       shell: oc delete crd -l app=enmasse,enmasse-component=iot
     - name: Delete core CRDs
-      shell: oc delete crd -l app=enmasse
+      shell: oc delete crd -l app=enmasse --timeout=600s
     - name: Delete rolebindings for the kube-system namespace
       shell: oc delete rolebindings -l app=enmasse -n kube-system
     - name: Delete clusterrolebindings

--- a/documentation/modules/proc-uninstalling-using-olm.adoc
+++ b/documentation/modules/proc-uninstalling-using-olm.adoc
@@ -23,7 +23,7 @@ endif::[]
 [options="nowrap",subs="+quotes,attributes"]
 ----
 {cmdcli} delete iotprojects -A --all
-{cmdcli} delete addressspaces -A --all
+{cmdcli} delete addressspaces -A --all --timeout=600s
 ----
 
 . Remove the Subscription (replace the name with the name of the subscription used in the install):

--- a/documentation/modules/proc-uninstalling.adoc
+++ b/documentation/modules/proc-uninstalling.adoc
@@ -24,7 +24,7 @@ ifeval::["{cmdcli}" == "oc"]
 [options="nowrap",subs="attributes"]
 ----
 {cmdcli} delete crd -l app=enmasse,enmasse-component=iot
-{cmdcli} delete crd -l app=enmasse
+{cmdcli} delete crd -l app=enmasse --timeout=600s
 {cmdcli} delete clusterrolebindings -l app=enmasse
 {cmdcli} delete clusterroles -l app=enmasse
 {cmdcli} delete apiservices -l app=enmasse

--- a/systemtests/src/main/java/io/enmasse/systemtest/operator/OperatorManager.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/operator/OperatorManager.java
@@ -267,7 +267,7 @@ public class OperatorManager {
 
     private void cleanCRDs() {
         KubeCMDClient.runOnCluster("delete", "crd", "-l", "app=enmasse,enmasse-component=iot");
-        KubeCMDClient.runOnCluster("delete", "crd", "-l", "app=enmasse");
+        KubeCMDClient.runOnCluster("delete", "crd", "-l", "app=enmasse", "--timeout=600s");
     }
 
     public void waitUntilOperatorReadyOlm() throws Exception {

--- a/systemtests/src/main/java/io/enmasse/systemtest/operator/OperatorManager.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/operator/OperatorManager.java
@@ -267,7 +267,7 @@ public class OperatorManager {
 
     private void cleanCRDs() {
         KubeCMDClient.runOnCluster("delete", "crd", "-l", "app=enmasse,enmasse-component=iot");
-        KubeCMDClient.runOnCluster("delete", "crd", "-l", "app=enmasse", "--timeout=600s");
+        KubeCMDClient.runOnClusterWithTimeout(600_000, "delete", "crd", "-l", "app=enmasse", "--timeout=600s");
     }
 
     public void waitUntilOperatorReadyOlm() throws Exception {

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/KubeCMDClient.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/KubeCMDClient.java
@@ -363,10 +363,14 @@ public class KubeCMDClient {
     }
 
     public static ExecutionResultData runOnCluster(String... args) {
+        return runOnClusterWithTimeout(ONE_MINUTE_TIMEOUT, args);
+    }
+
+    public static ExecutionResultData runOnClusterWithTimeout(long timeoutMillis, String... args) {
         List<String> command = new LinkedList<>();
         command.add(CMD);
         command.addAll(Arrays.asList(args));
-        return Exec.execute(command, ONE_MINUTE_TIMEOUT, true);
+        return Exec.execute(command, timeoutMillis, true);
     }
 
     public static ExecutionResultData runOnClusterWithoutLogger(String... args) {

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/KubeCMDClient.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/KubeCMDClient.java
@@ -366,7 +366,7 @@ public class KubeCMDClient {
         return runOnClusterWithTimeout(ONE_MINUTE_TIMEOUT, args);
     }
 
-    public static ExecutionResultData runOnClusterWithTimeout(long timeoutMillis, String... args) {
+    public static ExecutionResultData runOnClusterWithTimeout(int timeoutMillis, String... args) {
         List<String> command = new LinkedList<>();
         command.add(CMD);
         command.addAll(Arrays.asList(args));


### PR DESCRIPTION

### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description
The finalizer now waits until pods are
terminated before marking an address space finalized, therefore
finalization is taking longer.

Setting the timeout flag prevents the delete command to timeout when waiting for address spaces to be finalized.


### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
