### PR TITLE
Create address-space-controller service

### DIFF
--- a/pkg/controller/address_space_controller/controller.go
+++ b/pkg/controller/address_space_controller/controller.go
@@ -86,7 +86,10 @@ func add(mgr manager.Manager, r *ReconcileAddressSpaceController) error {
 			if err != nil {
 				return err
 			}
-			return r.client.Create(context.TODO(), deployment)
+			err = r.client.Create(context.TODO(), deployment)
+			if err != nil {
+				return err
+			}
 		} else {
 			return err
 		}
@@ -106,7 +109,10 @@ func add(mgr manager.Manager, r *ReconcileAddressSpaceController) error {
 			if err != nil {
 				return err
 			}
-			return r.client.Create(context.TODO(), service)
+			err = r.client.Create(context.TODO(), service)
+			if err != nil {
+				return err
+			}
 		} else {
 			return err
 		}


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fixed a bug which was causing the service for the address-space-controller to not be created.

### Checklist

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
