### PR TITLE
Add finalizer for addresses

### DIFF
--- a/amqp-utils/src/main/java/io/enmasse/amqp/Artemis.java
+++ b/amqp-utils/src/main/java/io/enmasse/amqp/Artemis.java
@@ -140,6 +140,24 @@ public class Artemis implements AutoCloseable {
         doRequestResponse(10, TimeUnit.SECONDS, request);
     }
 
+    public Set<String> getAddressNames() throws TimeoutException {
+        log.info("Retrieving address names for broker {}", syncRequestClient.getRemoteContainer());
+        Message response = doOperation("broker", "getAddressNames");
+
+        Set<String> addressNames = new LinkedHashSet<>();
+        JsonArray payload = new JsonArray((String)((AmqpValue)response.getBody()).getValue());
+        for (int i = 0; i < payload.size(); i++) {
+            JsonArray inner = payload.getJsonArray(i);
+            for (int j = 0; j < inner.size(); j++) {
+                String addressName = inner.getString(j);
+                if (!addressName.equals(syncRequestClient.getReplyTo())) {
+                    addressNames.add(addressName);
+                }
+            }
+        }
+        return addressNames;
+    }
+
     public Set<String> getQueueNames() throws TimeoutException {
         log.info("Retrieving queue names for broker {}", syncRequestClient.getRemoteContainer());
         Message response = doOperation("broker", "getQueueNames");

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/AddressController.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/AddressController.java
@@ -818,7 +818,7 @@ public class AddressController implements Watcher<Address> {
                     clusterOk.put(clusterId, 0);
                 } else {
                     if (!clusterAddresses.containsKey(clusterId)) {
-                        clusterAddresses.put(clusterId, brokerStatusCollector.getAddressNames(brokerStatus.getClusterId()));
+                        clusterAddresses.put(clusterId, brokerStatusCollector.getAddressNames(clusterId));
                     }
 
                     Set<String> addressNames = clusterAddresses.get(clusterId);

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/AddressController.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/AddressController.java
@@ -677,7 +677,7 @@ public class AddressController implements Watcher<Address> {
                 .collect(Collectors.toSet());
     }
 
-    private static final String STANDARD_CONTROLLER_FINALIZER = "standard-controller";
+    static final String STANDARD_CONTROLLER_FINALIZER = "standard-controller";
     private void garbageCollectTerminating(Set<Address> addresses, AddressResolver addressResolver, List<RouterStatus> routerStatusList, Set<String> subserveTopics, boolean withMqtt) throws Exception {
         Map<Address, Integer> okMap = checkAddressStatuses(addresses, addressResolver, routerStatusList, subserveTopics, withMqtt);
         for (Map.Entry<Address, Integer> entry : okMap.entrySet()) {

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/AddressController.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/AddressController.java
@@ -818,7 +818,14 @@ public class AddressController implements Watcher<Address> {
                     clusterOk.put(clusterId, 0);
                 } else {
                     if (!clusterAddresses.containsKey(clusterId)) {
-                        clusterAddresses.put(clusterId, brokerStatusCollector.getAddressNames(clusterId));
+                        try {
+                            clusterAddresses.put(clusterId, brokerStatusCollector.getAddressNames(clusterId));
+                        } catch (Exception e) {
+                            address.getStatus().setReady(false);
+                            address.getStatus().appendMessage("Error checking address status on broker " + clusterId);
+                            clusterOk.put(clusterId, 0);
+                            clusterAddresses.put(clusterId, Collections.emptySet());
+                        }
                     }
 
                     Set<String> addressNames = clusterAddresses.get(clusterId);

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/AddressController.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/AddressController.java
@@ -805,7 +805,7 @@ public class AddressController implements Watcher<Address> {
         return numOk;
     }
 
-    private int checkBrokerStatus(BrokerStatusCollector brokerStatusCollector, Address address, Map<String, Integer> clusterOk, Map<String, Set<String>> clusterAddresses) {
+    private int checkBrokerStatus(BrokerStatusCollector brokerStatusCollector, Address address, Map<String, Integer> clusterOk, Map<String, Set<String>> clusterAddresses) throws Exception {
         Set<String> clusterIds = address.getStatus().getBrokerStatuses().stream()
                 .map(BrokerStatus::getClusterId)
                 .collect(Collectors.toSet());

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/BrokerStatusCollector.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/BrokerStatusCollector.java
@@ -11,7 +11,9 @@ import io.fabric8.kubernetes.client.internal.readiness.Readiness;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 class BrokerStatusCollector {
     private static final Logger log = LoggerFactory.getLogger(BrokerStatusCollector.class);
@@ -24,6 +26,28 @@ class BrokerStatusCollector {
         this.kubernetes = kubernetes;
         this.brokerClientFactory = brokerClientFactory;
         this.options = options;
+    }
+
+    Set<String> getAddressNames(String clusterId) throws Exception {
+        Set<String> addressNames = new HashSet<>();
+        List<Pod> pods = kubernetes.listBrokers(clusterId);
+        for (Pod broker : pods) {
+            if (Readiness.isPodReady(broker)) {
+                try (
+                        SyncRequestClient brokerClient = brokerClientFactory.connectBrokerManagementClient(broker.getStatus().getPodIP(), 5673);
+                        Artemis artemis = new Artemis(brokerClient, options.getManagementQueryTimeout().toMillis());
+                        ) {
+                    addressNames.addAll(artemis.getAddressNames());
+                }
+            } else {
+                throw new IllegalStateException(String.format("Broker pod '%s' in cluster '%s' is not ready (%s), cannot get address names at this time.",
+                        broker.getMetadata().getName(),
+                        clusterId,
+                        broker.getStatus()));
+            }
+        }
+        log.info("Cluster '{}' ({} replica(s)) has the following addresses: {}", clusterId, pods.size(), addressNames);
+        return addressNames;
     }
 
     long getQueueMessageCount(String queue, String clusterId) throws Exception {


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Enhancement / new feature

### Description

This ensures that addresses are not deleted until the router and broker
configuration for that address is no longer present.

This involves an extra query per broker to retrieve the list of
addresses during the status check.


### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
