### PR TITLE
Docs: fix missing single quote on module ID

### DIFF
--- a/documentation/assemblies/assembly-metrics-rules.adoc
+++ b/documentation/assemblies/assembly-metrics-rules.adoc
@@ -4,7 +4,7 @@
 
 :parent-context: {context}
 
-[id='assembly-metrics-rules-{context}]
+[id='assembly-metrics-rules-{context}']
 = Metrics and rules
 
 include::../modules/ref-metrics-common.adoc[leveloffset=+1]


### PR DESCRIPTION
### Type of change
- Documentation

### Description

Add missing closing single quote on module ID

### Checklist
- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [X ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
