### PR TITLE
Add missing promise catch in broker stats retrieval

### DIFF
--- a/agent/lib/broker_stats.js
+++ b/agent/lib/broker_stats.js
@@ -15,10 +15,6 @@
  */
 'use strict';
 
-var log = require("./log.js").logger();
-var util = require('util');
-var events = require('events');
-var rhea = require('rhea');
 var create_podgroup = require('./podgroup.js');
 var pod_watcher = require('./pod_watcher.js');
 
@@ -65,6 +61,8 @@ BrokerStats.prototype.retrieve = function(addresses) {
         for (var s in stats) {
             addresses.update_stats(s, stats[s]);
         }
+    }).catch(function (error) {
+        console.error('Failed to retrieve broker stats: %s', error);
     });
 };
 


### PR DESCRIPTION
### Type of change


- Bugfix

### Description

There's a missing catch block on the broker stats path.   I would expect that control would flow down this path when a broker pod is going away during stats retrieval.   As the broker stats ae triggered by a timer, I don't think the absence of this block would give rise to a functional defect.

Could explain the `UnhandledPromiseRejectionWarning` (#3739) warnings we occasionally see in the agent's log.

### Checklist

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
