### PR TITLE
Docs: fix missing closing single quote on assembly IDs

### DIFF
--- a/documentation/assemblies/assembly-iot-device-developer-guide.adoc
+++ b/documentation/assemblies/assembly-iot-device-developer-guide.adoc
@@ -4,7 +4,7 @@
 
 :context: {context}-iot
 
-[id='iot-device-developers-{context}]
+[id='iot-device-developers-{context}']
 = IoT for device developers
 
 Device developers are typically responsible for either connecting existing devices to the cloud platform or writing software for devices.

--- a/documentation/assemblies/assembly-iot-device-manager-guide.adoc
+++ b/documentation/assemblies/assembly-iot-device-manager-guide.adoc
@@ -4,7 +4,7 @@
 
 :context: {context}-iot
 
-[id='iot-device-managers-{context}]
+[id='iot-device-managers-{context}']
 = IoT for device managers
 
 Device managers are typically responsible for creating and managing device identities and credentials in the system.

--- a/documentation/assemblies/assembly-iot-getting-started.adoc
+++ b/documentation/assemblies/assembly-iot-getting-started.adoc
@@ -4,7 +4,7 @@
 
 :context: {context}-iot
 
-[id='iot-getting-started-{context}]
+[id='iot-getting-started-{context}']
 = Getting started using IoT
 
 The following information describes how to set up and manage {ProductName} IoT features.

--- a/documentation/assemblies/assembly-iot-guide.adoc
+++ b/documentation/assemblies/assembly-iot-guide.adoc
@@ -4,7 +4,7 @@
 
 :context: {context}-iot
 
-[id='iot-guide-{context}]
+[id='iot-guide-{context}']
 = Internet of Things (IoT) guide
 
 The IoT guide provides resources on how to set up and manage {ProductName} IoT features.

--- a/documentation/assemblies/assembly-iot-project-owner-guide.adoc
+++ b/documentation/assemblies/assembly-iot-project-owner-guide.adoc
@@ -4,7 +4,7 @@
 
 :context: {context}-iot
 
-[id='iot-project-owner-{context}]
+[id='iot-project-owner-{context}']
 = IoT for projects owners
 
 == IoT project configuration examples

--- a/documentation/assemblies/assembly-iot-service-admin-guide.adoc
+++ b/documentation/assemblies/assembly-iot-service-admin-guide.adoc
@@ -4,7 +4,7 @@
 
 :context: {context}-iot
 
-[id='iot-service-admin-{context}]
+[id='iot-service-admin-{context}']
 = IoT for service administrators
 
 Service administrators typically install and configure the Internet of Things (IoT) services for {ProductName}.

--- a/documentation/assemblies/assembly-iot-solution-developers-guide.adoc
+++ b/documentation/assemblies/assembly-iot-solution-developers-guide.adoc
@@ -4,7 +4,7 @@
 
 :context: {context}-iot
 
-[id='iot-solution-developers-{context}]
+[id='iot-solution-developers-{context}']
 = IoT for solution developers
 
 IoT solution developers are typically responsible for writing IoT cloud applications.

--- a/documentation/assemblies/assembly-iot-tenant-guide.adoc
+++ b/documentation/assemblies/assembly-iot-tenant-guide.adoc
@@ -4,7 +4,7 @@
 
 :context: {context}-iot
 
-[id='iot-tenant-{context}]
+[id='iot-tenant-{context}']
 = IoT for messaging tenants
 
 Messaging tenants are typically responsible for managing devices and writing device and back-end applications for IoT solutions.

--- a/documentation/assemblies/assembly-rules.adoc
+++ b/documentation/assemblies/assembly-rules.adoc
@@ -2,7 +2,9 @@
 //
 // assembly-metrics-rules.adoc
 
-[id='assembly-rules-{context}]
+:parent-context: {context}
+
+[id='assembly-rules-{context}']
 = Rules
 
 This section details Prometheus rules installed using the PrometheusRule CRD with {ProductName}. Two types of Prometheus rules are available in {ProductName}:
@@ -13,4 +15,6 @@ This section details Prometheus rules installed using the PrometheusRule CRD wit
 include::../modules/ref-rules-records.adoc[leveloffset=+1]
 
 include::../modules/ref-rules-alerts.adoc[leveloffset=+1]
+
+:context: {parent-context}
 

--- a/documentation/assemblies/assembly-service-admin-guide.adoc
+++ b/documentation/assemblies/assembly-service-admin-guide.adoc
@@ -3,7 +3,7 @@
 // master-kubernetes.adoc
 // master-openshift.adoc
 
-[id='service-admin-guide-{context}]
+[id='service-admin-guide-{context}']
 = Service admin guide
 
 The service administrator guide provides resources on how to set up and manage {ProductName},


### PR DESCRIPTION
### Type of change
- Documentation

### Description

Missing closing single quote on assembly IDs

### Checklist
- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
