### PR TITLE
fix-issue delete space modal doesn't pop down

### DIFF
--- a/console/console-init/ui/src/pages/AddressSpaceDetail/AddressSpaceDetailPage.tsx
+++ b/console/console-init/ui/src/pages/AddressSpaceDetail/AddressSpaceDetailPage.tsx
@@ -125,6 +125,7 @@ export default function AddressSpaceDetailPage() {
   };
   const [setDeleteAddressSpaceQueryVariables] = useMutationQuery(
     DELETE_ADDRESS_SPACE,
+    resetFormState,
     resetFormState
   );
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description
- FIx - delete address space space dialogue doesn't pop down