### PR TITLE
Unable to delete address space filter chip by type

### DIFF
--- a/console/console-init/ui/src/components/AddressSpaceList/AddressSpaceListFilter.tsx
+++ b/console/console-init/ui/src/components/AddressSpaceList/AddressSpaceListFilter.tsx
@@ -171,7 +171,7 @@ export const AddressSpaceListFilter: React.FunctionComponent<IAddressSpaceListFi
         }
         setFilterNamespaces([...filterNamespaces]);
         break;
-      case "type":
+      case "Type":
         setFilterType(null);
         break;
     }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

- Fix - unable to delete address space filter chip for type