### PR TITLE
fix ExternalMessagingClient cmd line for ServiceCatalogWebTest#testSendReceiveInsideCluster

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/catalog/ServiceCatalogWebTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/catalog/ServiceCatalogWebTest.java
@@ -305,13 +305,13 @@ class ServiceCatalogWebTest extends TestBase implements ITestIsolatedStandard {
         consolePage.openConsolePage();
         consolePage.createAddress(queue);
 
-        ExternalMessagingClient senderClient = new ExternalMessagingClient()
+            ExternalMessagingClient senderClient = new ExternalMessagingClient()
                 .withClientEngine(new ProtonJMSClientSender())
                 .withMessagingRoute(String.format("%s:%s", credentials.getMessagingHost(), credentials.getMessagingAmqpsPort()))
                 .withAddress(queue)
                 .withCredentials(credentials.getUsername(), credentials.getPassword())
                 .withCount(10)
-                .withMessageBody("msg no. %d")
+                .withMessageBody("body")
                 .withTimeout(30);
 
         assertTrue(senderClient.run());


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fix ExternalMessagingClient cmd line for ServiceCatalogWebTest#testSendReceiveInsideCluster
### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
