### PR TITLE
Fix ServiceCatalogWebTest#testConsoleErrorOnDeleteAddressSpace

### DIFF
--- a/console/console-init/ui/src/components/common/NoDataFound.tsx
+++ b/console/console-init/ui/src/components/common/NoDataFound.tsx
@@ -33,7 +33,7 @@ export const NoDataFound: React.FunctionComponent<INoDataFoundProps> = ({
           <Title headingLevel="h5" size="lg">
             {type} Not Found
           </Title>
-          <EmptyStateBody>
+          <EmptyStateBody id="empty-no-longer-exists">
             {type} <b>{name}</b> no longer exists.
           </EmptyStateBody>
           <Link to={routeLink}>Go to {type} list</Link>

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/catalog/ServiceCatalogWebTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/catalog/ServiceCatalogWebTest.java
@@ -359,16 +359,8 @@ class ServiceCatalogWebTest extends TestBase implements ITestIsolatedStandard {
         isolatedResourcesManager.deleteAddressSpaceCreatedBySC(addressSpace);
 
         WebElement errorLog = selenium.getWebElement(() ->
-                selenium.getDriver().findElement(By.id("peerLostErrorDialogLabel")));
+                selenium.getDriver().findElement(By.id("empty-no-longer-exists")));
         assertTrue(errorLog.isDisplayed());
         log.info("error banner is displayed showing addr space is deleted");
-
-        //refresh page, console is no longer available
-        selenium.refreshPage();
-        WebElement errorPageText = selenium.getWebElement(() ->
-                selenium.getDriver().findElement(By.className("alert-info")));
-        assertTrue(errorPageText.isDisplayed());
-        log.info("application is not available page is displayed");
-
     }
 }


### PR DESCRIPTION

### Type of change

- Bugfix

### Description

Test was still looked for the behaviour from the old console.  I needed to add an id to the NoDataFound tsx to be able to detect the content from the test.

### Checklist


- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
