### PR TITLE
Ensure that router status cache is consistent

### DIFF
--- a/address-space-controller/src/test/java/io/enmasse/controller/RouterStatusCacheTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/RouterStatusCacheTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.controller;
+
+import io.enmasse.address.model.AddressSpace;
+import io.enmasse.address.model.AddressSpaceBuilder;
+import io.enmasse.k8s.api.LogEventLogger;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class RouterStatusCacheTest {
+
+    private KubernetesServer server = new KubernetesServer(true, true);
+    private NamespacedKubernetesClient client;
+
+    @BeforeEach
+    public void setup() {
+        server.before();
+        client = server.getClient();
+    }
+
+    @AfterEach
+    public void teardown() {
+        server.after();
+    }
+
+    @Test
+    public void testResetCache() {
+        AddressSpace a1 = new AddressSpaceBuilder()
+                .editOrNewMetadata()
+                .withName("a1")
+                .withNamespace("n")
+                .endMetadata()
+                .editOrNewSpec()
+                .withType("standard")
+                .withPlan("small")
+                .endSpec()
+                .build();
+
+        AddressSpace a2 = new AddressSpaceBuilder()
+                .editOrNewMetadata()
+                .withName("a2")
+                .withNamespace("n")
+                .endMetadata()
+                .editOrNewSpec()
+                .withType("standard")
+                .withPlan("small")
+                .endSpec()
+                .build();
+
+        RouterStatusCache cache = new RouterStatusCache(new LogEventLogger(), Duration.ofDays(1), client, "n", Duration.ofSeconds(1), Duration.ofSeconds(1));
+        cache.reconcileAll(List.of(a1, a2));
+
+        assertNull(cache.getLatestResult(a1));
+        assertNull(cache.getLatestResult(a2));
+
+        cache.checkRouterStatus(addressSpace -> Collections.singletonList(new RouterStatus("r1",
+                new RouterConnections(Collections.singletonList("example.com"), Collections.singletonList(true), Collections.singletonList("up")),
+                Collections.emptyList(),
+                0)));
+
+        assertNotNull(cache.getLatestResult(a1));
+        assertNotNull(cache.getLatestResult(a2));
+
+        cache.reconcileAll(List.of(a1, a2));
+
+        assertNotNull(cache.getLatestResult(a1));
+        assertNotNull(cache.getLatestResult(a2));
+
+        cache.reconcileAll(List.of(a1));
+
+        assertNotNull(cache.getLatestResult(a1));
+        assertNull(cache.getLatestResult(a2));
+    }
+}


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

Fix a potential race where the status cache would get updated
with an entry after an address space has been deleted. This fix ensures
that the current list of address spaces known and the router status
cache is in sync.

Add unit test for router status cache to ensure correct behavior.


### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
