### PR TITLE
Return username in 'sub' field

### DIFF
--- a/keycloak-plugin/sasl-plugin/src/main/java/io/enmasse/keycloak/spi/AmqpServer.java
+++ b/keycloak-plugin/sasl-plugin/src/main/java/io/enmasse/keycloak/spi/AmqpServer.java
@@ -100,7 +100,7 @@ public class AmqpServer extends AbstractVerticle {
                 LOG.info("Responding with user data " + userData);
                 Map<Symbol, Object> props = new HashMap<>();
                 Map<String, Object> authUserMap = new HashMap<>();
-                authUserMap.put("sub", userData.getId());
+                authUserMap.put("sub", userData.getUsername());
                 authUserMap.put("preferred_username", userData.getUsername());
                 props.put(Symbol.valueOf("authenticated-identity"), authUserMap);
                 props.put(Symbol.valueOf("groups"), new ArrayList<>(userData.getGroups()));


### PR DESCRIPTION
This ensures that we display expected usernames and don't leak internal
uuids.