### PR TITLE
Fix improperly applied resyncinterval

### DIFF
--- a/pkg/consolegraphql/watchers/resource_watcher_agent.go
+++ b/pkg/consolegraphql/watchers/resource_watcher_agent.go
@@ -37,11 +37,10 @@ type AgentWatcher struct {
 	watchingAgentsStarted bool
 	stopchan              chan struct{}
 	stoppedchan           chan struct{}
-
-	developmentMode      bool
-	RouteClientInterface *routev1.RouteV1Client
-	restartCounter       int32
-	resyncInterval       *time.Duration
+	developmentMode       bool
+	RouteClientInterface  *routev1.RouteV1Client
+	restartCounter        int32
+	resyncInterval        *time.Duration
 }
 
 func NewAgentWatcher(c cache.Cache, resyncInterval *time.Duration, namespace string, creator AgentCollectorCreator, developmentMode bool, options ...WatcherOption) (*AgentWatcher, error) {
@@ -52,6 +51,7 @@ func NewAgentWatcher(c cache.Cache, resyncInterval *time.Duration, namespace str
 		watching:              make(chan struct{}),
 		stopchan:              make(chan struct{}),
 		stoppedchan:           make(chan struct{}),
+		resyncInterval:        resyncInterval,
 		AgentCollectorCreator: creator,
 		collectors:            make(map[string]agent.Delegate),
 		developmentMode:       developmentMode,


### PR DESCRIPTION
### Type of change


- Bugfix

### Description

The watcher responsible for agents was incorrectly applying its resyncinterval to the underlying kubernetes watch call, so the services were never being resync.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
