### PR TITLE
console server - log using UTC time-stamps to millisecond precision

### DIFF
--- a/cmd/console-server/main.go
+++ b/cmd/console-server/main.go
@@ -8,6 +8,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/handler"
 	adminv1beta2 "github.com/enmasseproject/enmasse/pkg/client/clientset/versioned/typed/admin/v1beta2"
@@ -34,7 +35,17 @@ connections and links.
 For development purposes, you can run the console backend outside the container.  See the Makefile target 'run'.
 */
 
+type logWriter struct {
+}
+
+func (writer logWriter) Write(bytes []byte) (int, error) {
+	return fmt.Print(time.Now().UTC().Format("2006-01-02T15:04:05.999Z") + " " + string(bytes))
+}
+
 func main() {
+	log.SetFlags(0)
+	log.SetOutput(new(logWriter))
+
 	infraNamespace := util.GetEnvOrDefault("NAMESPACE", "enmasse-infra")
 	port := util.GetEnvOrDefault("PORT", "8080")
 	metricsPort := util.GetEnvOrDefault("METRICS_PORT", "8889")


### PR DESCRIPTION

### Type of change
- Bugfix

### Description

Change the console-server to log using UTC time-stamps using millisecond precision to facilitate easy correlation with the logs of other components which already use the same format.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
