### PR TITLE
add netork-only as fetch policy for all queries

### DIFF
--- a/console/console-init/ui/src/components/AddressSpaceList/AddressSpaceListFilter.tsx
+++ b/console/console-init/ui/src/components/AddressSpaceList/AddressSpaceListFilter.tsx
@@ -38,7 +38,8 @@ import {
   TypeAheadMessage,
   MAX_ITEM_TO_DISPLAY_IN_TYPEAHEAD_DROPDOWN,
   NUMBER_OF_RECORDS_TO_DISPLAY_IF_SERVER_HAS_MORE_DATA,
-  TYPEAHEAD_REQUIRED_LENGTH
+  TYPEAHEAD_REQUIRED_LENGTH,
+  FetchPolicy
 } from "constants/constants";
 import { ISelectOption, getSelectOptionList } from "utils";
 
@@ -217,7 +218,11 @@ export const AddressSpaceListFilter: React.FunctionComponent<IAddressSpaceListFi
     const response = await client.query<
       ISearchNameOrNameSpaceAddressSpaceListResponse
     >({
-      query: RETURN_ALL_ADDRESS_SPACES_FOR_NAME_OR_NAMESPACE(true, value.trim())
+      query: RETURN_ALL_ADDRESS_SPACES_FOR_NAME_OR_NAMESPACE(
+        true,
+        value.trim()
+      ),
+      fetchPolicy: FetchPolicy.NETWORK_ONLY
     });
     if (
       response &&

--- a/console/console-init/ui/src/pages/AddressDetail/AddressLinksFilter.tsx
+++ b/console/console-init/ui/src/pages/AddressDetail/AddressLinksFilter.tsx
@@ -190,7 +190,8 @@ export const AddressLinksFilter: React.FunctionComponent<IAddressLinksFilterProp
         addressName,
         namespace,
         value.trim()
-      )
+      ),
+      fetchPolicy: FetchPolicy.NETWORK_ONLY
     });
     if (
       response &&

--- a/console/console-init/ui/src/pages/AddressDetail/AddressLinksFilter.tsx
+++ b/console/console-init/ui/src/pages/AddressDetail/AddressLinksFilter.tsx
@@ -43,7 +43,8 @@ import {
   TypeAheadMessage,
   TYPEAHEAD_REQUIRED_LENGTH,
   MAX_ITEM_TO_DISPLAY_IN_TYPEAHEAD_DROPDOWN,
-  NUMBER_OF_RECORDS_TO_DISPLAY_IF_SERVER_HAS_MORE_DATA
+  NUMBER_OF_RECORDS_TO_DISPLAY_IF_SERVER_HAS_MORE_DATA,
+  FetchPolicy
 } from "constants/constants";
 import { getSelectOptionList, ISelectOption } from "utils";
 
@@ -237,7 +238,8 @@ export const AddressLinksFilter: React.FunctionComponent<IAddressLinksFilterProp
         addressName,
         namespace,
         value.trim()
-      )
+      ),
+      fetchPolicy: FetchPolicy.NETWORK_ONLY
     });
     if (
       response &&

--- a/console/console-init/ui/src/pages/AddressDetail/AddressLinksListPage.tsx
+++ b/console/console-init/ui/src/pages/AddressDetail/AddressLinksListPage.tsx
@@ -12,7 +12,7 @@ import { getFilteredValue } from "components/common/ConnectionListFormatter";
 import { EmptyLinks } from "components/common/EmptyLinks";
 import { ISortBy } from "@patternfly/react-table";
 import { Loading } from "use-patternfly";
-import { POLL_INTERVAL } from "constants/constants";
+import { POLL_INTERVAL, FetchPolicy } from "constants/constants";
 
 export interface IAddressLinksListProps {
   page: number;
@@ -58,7 +58,7 @@ export const AddressLinksListPage: React.FunctionComponent<IAddressLinksListProp
       sortBy,
       filterRole
     ),
-    { pollInterval: POLL_INTERVAL }
+    { pollInterval: POLL_INTERVAL, fetchPolicy: FetchPolicy.NETWORK_ONLY }
   );
   if (loading && !data) return <Loading />;
   if (error) console.log(error);

--- a/console/console-init/ui/src/pages/AddressSpaceDetail/AddressList/AddressListFilter.tsx
+++ b/console/console-init/ui/src/pages/AddressSpaceDetail/AddressList/AddressListFilter.tsx
@@ -38,7 +38,8 @@ import {
   TypeAheadMessage,
   TYPEAHEAD_REQUIRED_LENGTH,
   MAX_ITEM_TO_DISPLAY_IN_TYPEAHEAD_DROPDOWN,
-  NUMBER_OF_RECORDS_TO_DISPLAY_IF_SERVER_HAS_MORE_DATA
+  NUMBER_OF_RECORDS_TO_DISPLAY_IF_SERVER_HAS_MORE_DATA,
+  FetchPolicy
 } from "constants/constants";
 import { getSelectOptionList, ISelectOption } from "utils";
 
@@ -157,7 +158,8 @@ export const AddressListFilter: React.FunctionComponent<IAddressListFilterProps>
         addressspaceName,
         namespace,
         value.trim()
-      )
+      ),
+      fetchPolicy: FetchPolicy.NETWORK_ONLY
     });
     if (
       response &&

--- a/console/console-init/ui/src/pages/AddressSpaceDetail/AddressList/AddressListFilterPage.tsx
+++ b/console/console-init/ui/src/pages/AddressSpaceDetail/AddressList/AddressListFilterPage.tsx
@@ -22,6 +22,7 @@ import {
 import useWindowDimensions from "components/common/WindowDimension";
 import { SortForMobileView } from "components/common/SortForMobileView";
 import { ISortBy } from "@patternfly/react-table";
+import { FetchPolicy } from "constants/constants";
 
 interface AddressListFilterProps {
   filterValue: string | null;
@@ -88,7 +89,8 @@ export const AddressListFilterPage: React.FunctionComponent<AddressListFilterPro
     setIsCreateWizardOpen(!isCreateWizardOpen);
     if (name && namespace) {
       const addressSpace = await client.query<IAddressSpacesResponse>({
-        query: RETURN_ADDRESS_SPACE_DETAIL(name, namespace)
+        query: RETURN_ADDRESS_SPACE_DETAIL(name, namespace),
+        fetchPolicy: FetchPolicy.NETWORK_ONLY
       });
       if (
         addressSpace.data &&

--- a/console/console-init/ui/src/pages/AddressSpaceDetail/AddressSpaceDetailPage.tsx
+++ b/console/console-init/ui/src/pages/AddressSpaceDetail/AddressSpaceDetailPage.tsx
@@ -175,7 +175,8 @@ export default function AddressSpaceDetailPage() {
           name: data.name,
           namespace: data.namespace
         }
-      }
+      },
+      fetchPolicy: FetchPolicy.NETWORK_ONLY
     });
     if (dataToDownload.errors) {
       console.log("Error while download", dataToDownload.errors);

--- a/console/console-init/ui/src/pages/AddressSpaceDetail/ConnectionList/ConnectionListFilter.tsx
+++ b/console/console-init/ui/src/pages/AddressSpaceDetail/ConnectionList/ConnectionListFilter.tsx
@@ -37,7 +37,8 @@ import {
   TypeAheadMessage,
   TYPEAHEAD_REQUIRED_LENGTH,
   MAX_ITEM_TO_DISPLAY_IN_TYPEAHEAD_DROPDOWN,
-  NUMBER_OF_RECORDS_TO_DISPLAY_IF_SERVER_HAS_MORE_DATA
+  NUMBER_OF_RECORDS_TO_DISPLAY_IF_SERVER_HAS_MORE_DATA,
+  FetchPolicy
 } from "constants/constants";
 import { getSelectOptionList, ISelectOption } from "utils";
 
@@ -188,7 +189,8 @@ export const ConnectionListFilter: React.FunctionComponent<IConnectionListFilter
         value.trim(),
         addressSpaceName,
         namespace
-      )
+      ),
+      fetchPolicy: FetchPolicy.NETWORK_ONLY
     });
     if (
       response &&
@@ -236,7 +238,8 @@ export const ConnectionListFilter: React.FunctionComponent<IConnectionListFilter
         value.trim(),
         addressSpaceName,
         namespace
-      )
+      ),
+      fetchPolicy: FetchPolicy.NETWORK_ONLY
     });
     if (
       response &&

--- a/console/console-init/ui/src/pages/AddressSpaceDetail/ConnectionList/ConnectionsListPage.tsx
+++ b/console/console-init/ui/src/pages/AddressSpaceDetail/ConnectionList/ConnectionsListPage.tsx
@@ -14,7 +14,7 @@ import { getFilteredValue } from "components/common/ConnectionListFormatter";
 import { IConnectionListResponse } from "types/ResponseTypes";
 import { RETURN_ALL_CONECTION_LIST } from "queries";
 import { ISortBy } from "@patternfly/react-table";
-import { POLL_INTERVAL } from "constants/constants";
+import { POLL_INTERVAL, FetchPolicy } from "constants/constants";
 
 export interface IConnectionListPageProps {
   name?: string;
@@ -55,7 +55,7 @@ export const ConnectionsListPage: React.FunctionComponent<IConnectionListPagePro
       namespace,
       sortBy
     ),
-    { pollInterval: POLL_INTERVAL }
+    { pollInterval: POLL_INTERVAL, fetchPolicy: FetchPolicy.NETWORK_ONLY }
   );
 
   if (error) {

--- a/console/console-init/ui/src/pages/AddressSpaceList/AddressSpaceListFilterPage.tsx
+++ b/console/console-init/ui/src/pages/AddressSpaceList/AddressSpaceListFilterPage.tsx
@@ -64,7 +64,10 @@ export const AddressSpaceListFilterPage: React.FunctionComponent<IAddressSpaceLi
   const createAddressSpaceOnClick = async () => {
     setIsCreateWizardOpen(!isCreateWizardOpen);
   };
-  const sortMenuItems = [{ key: "name", value: "Name", index: 1 }];
+  const sortMenuItems = [
+    { key: "name", value: "Name", index: 1 },
+    { key: "creationTimestamp", value: "Time Created", index: 4 }
+  ];
   const toolbarItems = (
     <>
       <AddressSpaceListFilter

--- a/console/console-init/ui/src/pages/AddressSpaceList/AddressSpaceListPage.tsx
+++ b/console/console-init/ui/src/pages/AddressSpaceList/AddressSpaceListPage.tsx
@@ -203,7 +203,8 @@ export const AddressSpaceListPage: React.FunctionComponent<AddressSpaceListPageP
           name: data.name,
           namespace: data.namespace
         }
-      }
+      },
+      fetchPolicy: FetchPolicy.NETWORK_ONLY
     });
     if (dataToDownload.errors) {
       console.log("Error while download", dataToDownload.errors);

--- a/console/console-init/ui/src/pages/ConnectionDetail/ConnectionDetailPage.tsx
+++ b/console/console-init/ui/src/pages/ConnectionDetail/ConnectionDetailPage.tsx
@@ -26,7 +26,7 @@ import { IConnectionDetailResponse } from "types/ResponseTypes";
 import { Link } from "react-router-dom";
 import { RETURN_CONNECTION_DETAIL } from "queries";
 import { ConnectionLinksWithFilterAndPaginationPage } from "./ConnectionLinksWithFilterAndPaginationPage";
-import { POLL_INTERVAL } from "constants/constants";
+import { POLL_INTERVAL, FetchPolicy } from "constants/constants";
 import { NoDataFound } from "components/common/NoDataFound";
 
 const getProductFilteredValue = (object: any[], value: string) => {
@@ -81,7 +81,7 @@ export default function ConnectionDetailPage() {
   useA11yRouteChange();
   const { loading, error, data } = useQuery<IConnectionDetailResponse>(
     RETURN_CONNECTION_DETAIL(name || "", namespace || "", connectionname || ""),
-    { pollInterval: POLL_INTERVAL }
+    { pollInterval: POLL_INTERVAL, fetchPolicy: FetchPolicy.NETWORK_ONLY }
   );
   if (loading) return <Loading />;
   if (error) {

--- a/console/console-init/ui/src/pages/ConnectionDetail/ConnectionLinksFilter.tsx
+++ b/console/console-init/ui/src/pages/ConnectionDetail/ConnectionLinksFilter.tsx
@@ -43,7 +43,8 @@ import {
   TypeAheadMessage,
   MAX_ITEM_TO_DISPLAY_IN_TYPEAHEAD_DROPDOWN,
   TYPEAHEAD_REQUIRED_LENGTH,
-  NUMBER_OF_RECORDS_TO_DISPLAY_IF_SERVER_HAS_MORE_DATA
+  NUMBER_OF_RECORDS_TO_DISPLAY_IF_SERVER_HAS_MORE_DATA,
+  FetchPolicy
 } from "constants/constants";
 import { getSelectOptionList, ISelectOption } from "utils";
 
@@ -197,7 +198,8 @@ export const ConnectionLinksFilter: React.FunctionComponent<IConnectionLinksFilt
         connectionName,
         namespace,
         value.trim()
-      )
+      ),
+      fetchPolicy: FetchPolicy.NETWORK_ONLY
     });
     if (
       response &&
@@ -245,7 +247,8 @@ export const ConnectionLinksFilter: React.FunctionComponent<IConnectionLinksFilt
         connectionName,
         namespace,
         value.trim()
-      )
+      ),
+      fetchPolicy: FetchPolicy.NETWORK_ONLY
     });
     if (
       response &&

--- a/console/console-init/ui/src/pages/ConnectionDetail/ConnectionsLinksListPage.tsx
+++ b/console/console-init/ui/src/pages/ConnectionDetail/ConnectionsLinksListPage.tsx
@@ -11,7 +11,7 @@ import { Loading } from "use-patternfly";
 import { ILink, LinkList } from "components/ConnectionDetail/LinkList";
 import { getFilteredValue } from "components/common/ConnectionListFormatter";
 import { ISortBy } from "@patternfly/react-table";
-import { POLL_INTERVAL } from "constants/constants";
+import { POLL_INTERVAL, FetchPolicy } from "constants/constants";
 import { EmptyLinks } from "components/common/EmptyLinks";
 
 interface IConnectionLinksListPageProps {
@@ -56,7 +56,7 @@ export const ConnectionLinksListPage: React.FunctionComponent<IConnectionLinksLi
       sortBy,
       filterRole
     ),
-    { pollInterval: POLL_INTERVAL }
+    { pollInterval: POLL_INTERVAL, fetchPolicy: FetchPolicy.NETWORK_ONLY }
   );
   if (loading && !data) return <Loading />;
   if (error) {


### PR DESCRIPTION
### Type of change
- Bugfix

### Description
- add fetchPoilcy as network-only for all graphql query to avoid caching