### PR TITLE
Use user.openshift.io to make the determination about openshift rather than route.openshift.io

### DIFF
--- a/pkg/controller/consoleservice/consoleservice_controller.go
+++ b/pkg/controller/consoleservice/consoleservice_controller.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"os"
 	"reflect"
 	"strconv"
 
@@ -31,7 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	rest "k8s.io/client-go/rest"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -798,6 +799,11 @@ func applyDeployment(consoleservice *v1beta1.ConsoleService, deployment *appsv1.
 			install.ApplyEnv(container, "NAMESPACE", func(envvar *corev1.EnvVar) {
 				envvar.Value = namespace
 			})
+		}
+
+		value, ok := os.LookupEnv(util.EnMasseOpenshiftEnvVar)
+		if ok {
+			install.ApplyEnvSimple(container, util.EnMasseOpenshiftEnvVar, value)
 		}
 
 		// TODO use https

--- a/pkg/util/openshift.go
+++ b/pkg/util/openshift.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	userapiv1 "github.com/openshift/api/user/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -19,7 +20,6 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
-	routeapiv1 "github.com/openshift/api/route/v1"
 	routev1 "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
@@ -31,12 +31,9 @@ var (
 )
 
 const ConnectsTo = "app.openshift.io/connects-to"
+const EnMasseOpenshiftEnvVar = "ENMASSE_OPENSHIFT"
 
-var UserGVK = schema.GroupVersionKind{
-	Group:   "user.openshift.io",
-	Version: "v1",
-	Kind:    "User",
-}
+var UserGVK = userapiv1.GroupVersion.WithKind("User")
 
 func IsOpenshift() bool {
 
@@ -144,13 +141,13 @@ func detectOpenshift() bool {
 
 	log.Info("Detect if openshift is running")
 
-	value, ok := os.LookupEnv("ENMASSE_OPENSHIFT")
+	value, ok := os.LookupEnv(EnMasseOpenshiftEnvVar)
 	if ok {
-		log.Info("Set by env-var 'ENMASSE_OPENSHIFT': " + value)
+		log.Info("Set by env-var '" + EnMasseOpenshiftEnvVar + "': " + value)
 		return strings.ToLower(value) == "true"
 	}
 
-	return HasApi(routeapiv1.GroupVersion.WithKind("Route"))
+	return HasApi(UserGVK)
 }
 
 func OpenshiftUri() (*url.URL, bool, error) {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

For 0.31, we changed the way openshift was detected to use make an API refactoring the `detectOpenshift` function in the process to use `Route`.  Unfortunately, this brought with it an implict requirement that the service account running the code had access to that API.  For the console-server process, this wasn't the case.

* Switched `detectOpenshift` to use `user.openshift.io`.
* also propagared ENMASSE_OPENSHIFT from the enmasse-operator to the console-server to allow the check to the short circuited in environments where OpenShift is a certainty.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
