### PR TITLE
Add console-server to upstream urls for Kubernetes

### DIFF
--- a/console/console-init/oauth-proxy/cfg/oauth-proxy-kubernetes.cfg
+++ b/console/console-init/oauth-proxy/cfg/oauth-proxy-kubernetes.cfg
@@ -14,6 +14,7 @@ tls_cert_file = "/etc/tls/private/tls.crt"
 tls_key_file = "/etc/tls/private/tls.key"
 
 upstreams = [
+    "http://127.0.0.1:9090/graphql/",
     "file:/apps/www/#/",
 ]
 


### PR DESCRIPTION
@k-wall This fixes an issue for me attempting to run the console on Kubernetes where I see the oauth proxy getting 404, whereas adding this same line that exists in the oauth-proxy-openshift.cfg, I get a 401 instead (which I think might is a separate issue). Thought I'd raise this PR in case this should be added.