### PR TITLE
Fix - console does not show custom address plan properly

### DIFF
--- a/console/console-init/ui/src/pages/AddressDetail/AddressDetailPage.tsx
+++ b/console/console-init/ui/src/pages/AddressDetail/AddressDetailPage.tsx
@@ -211,7 +211,10 @@ export default function AddressDetailPage() {
         <AddressDetailHeader
           type={addressDetail.spec.plan.spec.addressType}
           name={addressDetail.spec.address}
-          plan={addressDetail.spec.plan.spec.displayName}
+          plan={
+            addressDetail.spec.plan.spec.displayName ||
+            addressDetail.spec.plan.metadata.name
+          }
           topic={addressDetail.spec.topic}
           storedMessages={getFilteredValue(
             addressDetail.metrics,

--- a/console/console-init/ui/src/pages/AddressSpaceDetail/AddressList/AddressListPage.tsx
+++ b/console/console-init/ui/src/pages/AddressSpaceDetail/AddressList/AddressListPage.tsx
@@ -158,7 +158,8 @@ export const AddressListPage: React.FunctionComponent<IAddressListPageProps> = (
     displayName: address.spec.address,
     namespace: address.metadata.namespace,
     type: address.spec.type,
-    planLabel: address.spec.plan.spec.displayName,
+    planLabel:
+      address.spec.plan.spec.displayName || address.spec.plan.metadata.name,
     planValue: address.spec.plan.metadata.name,
     messageIn: getFilteredValue(address.metrics, "enmasse_messages_in"),
     messageOut: getFilteredValue(address.metrics, "enmasse_messages_out"),

--- a/console/console-init/ui/src/pages/CreateAddress/CreateAddressDefinition.tsx
+++ b/console/console-init/ui/src/pages/CreateAddress/CreateAddressDefinition.tsx
@@ -115,7 +115,7 @@ export const AddressDefinition: React.FunctionComponent<IAddressDefinition> = ({
         const planOptions = addressPlans.data.addressPlans.map(plan => {
           return {
             value: plan.metadata.name,
-            label: plan.spec.displayName,
+            label: plan.spec.displayName || plan.metadata.name,
             description: plan.spec.shortDescription
           };
         });

--- a/console/console-init/ui/src/pages/CreateAddress/CreateAddressDefinition.tsx
+++ b/console/console-init/ui/src/pages/CreateAddress/CreateAddressDefinition.tsx
@@ -63,6 +63,7 @@ interface IAddressPlans {
       addressType: string;
       displayName: string;
       shortDescription: string;
+      longDescription: string;
     };
   }>;
 }
@@ -116,7 +117,7 @@ export const AddressDefinition: React.FunctionComponent<IAddressDefinition> = ({
           return {
             value: plan.metadata.name,
             label: plan.spec.displayName || plan.metadata.name,
-            description: plan.spec.shortDescription
+            description: plan.spec.shortDescription || plan.spec.longDescription
           };
         });
         setPlan(" ");

--- a/console/console-init/ui/src/pages/EditAddressPage.tsx
+++ b/console/console-init/ui/src/pages/EditAddressPage.tsx
@@ -56,7 +56,7 @@ export const EditAddress: React.FunctionComponent<IEditAddressProps> = ({
     .map(plan => {
       return {
         value: plan.metadata.name,
-        label: plan.spec.displayName,
+        label: plan.spec.displayName || plan.metadata.name,
         disabled: false
       };
     })


### PR DESCRIPTION

### Type of change
- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description
- fix issue - console does not show custom address plan properly.
- show metadata.name as label for plan if spec.displayName is not present in response of addressPlan


### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
