### PR TITLE
Ensure finalizers are persisted immediately

### DIFF
--- a/address-space-controller/src/main/java/io/enmasse/controller/AddressSpaceController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/AddressSpaceController.java
@@ -139,7 +139,7 @@ public class AddressSpaceController {
         controllerChain.addController(new RealmFinalizerController(keycloakRealmApi, authenticationServiceRegistry));
         controllerChain.addController(new StatusInitializer());
         controllerChain.addController(new CreateController(kubernetes, schemaProvider, infraResourceFactory, eventLogger, authController.getDefaultCertProvider(), options.getVersion(), addressSpaceApi, authenticationServiceResolver));
-        controllerChain.addController(new RouterConfigController(controllerClient, controllerClient.getNamespace(), authenticationServiceResolver));
+        controllerChain.addController(new RouterConfigController(controllerClient, controllerClient.getNamespace(), authenticationServiceResolver, routerStatusCache));
         controllerChain.addController(new PodDisruptionBudgetController(controllerClient, controllerClient.getNamespace()));
         controllerChain.addController(new RealmController(keycloakRealmApi, authenticationServiceRegistry));
         controllerChain.addController(new NetworkPolicyController(controllerClient));

--- a/address-space-controller/src/main/java/io/enmasse/controller/AddressSpaceController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/AddressSpaceController.java
@@ -125,11 +125,19 @@ public class AddressSpaceController {
 
         Metrics metrics = new Metrics();
         controllerChain = new ControllerChain(addressSpaceApi, schemaProvider, eventLogger, options.getRecheckInterval(), options.getResyncInterval());
+        /*
+         * Add controllers managing a separate of the reconciliation. The order between some of these are important:
+         * - DefaultsController should always be first to ensure defaults are set
+         * - Finalizers should run next to ensure finalizers are added and persisted
+         * - StatusInitializer should then run to clear the status and messages before the remaining controllers run.
+         * - The remaining controllers can be added in any order
+         */
         controllerChain.addController(new DefaultsController(authenticationServiceRegistry, kubernetes));
         controllerChain.addController(new AddressFinalizerController(addressSpaceApi));
         controllerChain.addController(new MessagingUserFinalizerController(controllerClient));
         controllerChain.addController(new ComponentFinalizerController(kubernetes));
         controllerChain.addController(new RealmFinalizerController(keycloakRealmApi, authenticationServiceRegistry));
+        controllerChain.addController(new StatusInitializer());
         controllerChain.addController(new CreateController(kubernetes, schemaProvider, infraResourceFactory, eventLogger, authController.getDefaultCertProvider(), options.getVersion(), addressSpaceApi, authenticationServiceResolver));
         controllerChain.addController(new RouterConfigController(controllerClient, controllerClient.getNamespace(), authenticationServiceResolver));
         controllerChain.addController(new PodDisruptionBudgetController(controllerClient, controllerClient.getNamespace()));

--- a/address-space-controller/src/main/java/io/enmasse/controller/StatusInitializer.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/StatusInitializer.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.controller;
+
+import io.enmasse.address.model.AddressSpace;
+
+public class StatusInitializer implements Controller {
+
+    public AddressSpace reconcileActive(AddressSpace addressSpace) {
+            addressSpace.getStatus().setReady(true);
+            addressSpace.getStatus().clearMessages();
+            return addressSpace;
+    }
+}

--- a/address-space-controller/src/main/java/io/enmasse/controller/StatusInitializer.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/StatusInitializer.java
@@ -13,4 +13,9 @@ public class StatusInitializer implements Controller {
             addressSpace.getStatus().clearMessages();
             return addressSpace;
     }
+
+    @Override
+    public String toString() {
+        return "StatusInitializer";
+    }
 }

--- a/address-space-controller/src/test/java/io/enmasse/controller/AddressFinalizerControllerTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/AddressFinalizerControllerTest.java
@@ -7,7 +7,9 @@ package io.enmasse.controller;
 import static org.hamcrest.core.IsCollectionContaining.hasItems;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -60,7 +62,9 @@ public class AddressFinalizerControllerTest {
 
         // when calling the reconcile method of the finalizer controller
 
-        addressSpace = controller.reconcileAnyState(addressSpace);
+        Controller.ReconcileResult result = controller.reconcileAnyState(addressSpace);
+        assertTrue(result.isPersistAndRequeue());
+        addressSpace = result.getAddressSpace();
 
         // it should add the finalizer, but not remove existing finalizers
 
@@ -131,7 +135,9 @@ public class AddressFinalizerControllerTest {
 
         // when running the reconcile method
 
-        addressSpace = controller.reconcileAnyState(addressSpace);
+        Controller.ReconcileResult result = controller.reconcileAnyState(addressSpace);
+        assertFalse(result.isPersistAndRequeue());
+        addressSpace = result.getAddressSpace();
 
         // then the finalizer of this controller should be removed, and the address should be deleted
 

--- a/address-space-controller/src/test/java/io/enmasse/controller/ControllerChainTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/ControllerChainTest.java
@@ -64,8 +64,8 @@ public class ControllerChainTest {
                 .withNewStatus(false)
                 .build();
 
-        when(mockController.reconcileAnyState(eq(a1))).thenReturn(a1);
-        when(mockController.reconcileAnyState(eq(a2))).thenReturn(a2);
+        when(mockController.reconcileAnyState(eq(a1))).thenReturn(Controller.ReconcileResult.create(a1));
+        when(mockController.reconcileAnyState(eq(a2))).thenReturn(Controller.ReconcileResult.create(a2));
 
         controllerChain.onUpdate(Arrays.asList(a1, a2));
 

--- a/address-space-controller/src/test/java/io/enmasse/controller/CreateControllerTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/CreateControllerTest.java
@@ -156,7 +156,7 @@ public class CreateControllerTest {
 
         CreateController createController = new CreateController(kubernetes, testSchema, null, eventLogger, null, "1.0", addressSpaceApi, mock(AuthenticationServiceResolver.class));
 
-        addressSpace = createController.reconcileAnyState(addressSpace);
+        addressSpace = createController.reconcileAnyState(addressSpace).getAddressSpace();
 
         assertThat(addressSpace.getStatus().getMessages().size(), is(1));
         assertTrue(addressSpace.getStatus().getMessages().iterator().next().contains("quota exceeded for resource broker"));

--- a/address-space-controller/src/test/java/io/enmasse/controller/EndpointControllerTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/EndpointControllerTest.java
@@ -83,7 +83,7 @@ public class EndpointControllerTest extends JULInitializingTest {
 
         EndpointController controller = new EndpointController(client, false, false);
 
-        AddressSpace newspace = controller.reconcileAnyState(addressSpace);
+        AddressSpace newspace = controller.reconcileAnyState(addressSpace).getAddressSpace();
 
         assertThat(newspace.getStatus().getEndpointStatuses().size(), is(1));
         assertThat(newspace.getStatus().getEndpointStatuses().get(0).getName(), is("myendpoint"));
@@ -139,7 +139,7 @@ public class EndpointControllerTest extends JULInitializingTest {
 
         EndpointController controller = new EndpointController(client, true, false);
 
-        AddressSpace newspace = controller.reconcileAnyState(addressSpace);
+        AddressSpace newspace = controller.reconcileAnyState(addressSpace).getAddressSpace();
 
         assertThat(newspace.getStatus().getEndpointStatuses().size(), is(1));
         assertThat(newspace.getStatus().getEndpointStatuses().get(0).getName(), is("myendpoint"));
@@ -195,7 +195,7 @@ public class EndpointControllerTest extends JULInitializingTest {
 
         EndpointController controller = new EndpointController(client, true, true);
 
-        AddressSpace newspace = controller.reconcileAnyState(addressSpace);
+        AddressSpace newspace = controller.reconcileAnyState(addressSpace).getAddressSpace();
 
         assertThat(newspace.getStatus().getEndpointStatuses().size(), is(1));
         assertThat(newspace.getStatus().getEndpointStatuses().get(0).getName(), is("myendpoint"));
@@ -272,7 +272,7 @@ public class EndpointControllerTest extends JULInitializingTest {
 
         EndpointController controller = new EndpointController(client, false, false);
 
-        AddressSpace newspace = controller.reconcileAnyState(addressSpace);
+        AddressSpace newspace = controller.reconcileAnyState(addressSpace).getAddressSpace();
 
         assertThat(newspace.getSpec().getEndpoints().size(), is(0));
 
@@ -351,7 +351,7 @@ public class EndpointControllerTest extends JULInitializingTest {
 
         EndpointController controller = new EndpointController(client, false, false);
 
-        AddressSpace newspace = controller.reconcileAnyState(addressSpace);
+        AddressSpace newspace = controller.reconcileAnyState(addressSpace).getAddressSpace();
 
         assertThat(newspace.getSpec().getEndpoints().size(), is(0));
 
@@ -394,7 +394,7 @@ public class EndpointControllerTest extends JULInitializingTest {
 
         EndpointController controller = new EndpointController(client, false, false);
 
-        AddressSpace newspace = controller.reconcileAnyState(addressSpace);
+        AddressSpace newspace = controller.reconcileAnyState(addressSpace).getAddressSpace();
 
         assertThat(newspace.getSpec().getEndpoints().size(), is(0));
 

--- a/address-space-controller/src/test/java/io/enmasse/controller/StatusControllerTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/StatusControllerTest.java
@@ -4,29 +4,28 @@
  */
 package io.enmasse.controller;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import io.enmasse.address.model.AddressSpace;
+import io.enmasse.address.model.AddressSpaceBuilder;
+import io.enmasse.address.model.AuthenticationService;
+import io.enmasse.address.model.AuthenticationServiceType;
+import io.enmasse.config.AnnotationKeys;
+import io.enmasse.controller.common.Kubernetes;
+import io.enmasse.k8s.api.AuthenticationServiceRegistry;
+import io.enmasse.k8s.api.LogEventLogger;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Optional;
 
-import io.enmasse.address.model.AuthenticationService;
-import io.enmasse.address.model.AuthenticationServiceType;
-import io.enmasse.k8s.api.AuthenticationServiceRegistry;
-import io.enmasse.k8s.api.EventLogger;
-import io.enmasse.k8s.api.LogEventLogger;
-import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
-import org.junit.jupiter.api.Test;
-
-import io.enmasse.address.model.AddressSpace;
-import io.enmasse.address.model.AddressSpaceBuilder;
-import io.enmasse.config.AnnotationKeys;
-import io.enmasse.controller.common.Kubernetes;
-import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class StatusControllerTest {
 


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

This change ensures that finalizers are persisted immediately and that
we don't orphan resources created if address space was deleted before
finalizers are persisted.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
