### PR TITLE
Correct filter used to support type ahead address search

### DIFF
--- a/console/console-init/ui/mock-console-server/README.md
+++ b/console/console-init/ui/mock-console-server/README.md
@@ -26,7 +26,7 @@ object. A JSON-path operand in the expression are enclosed in backticks.
 e.g.
 
 ```
- `$.Spec.AddressSpace` = 'jupiter_as1' AND `$.ObjectMeta.Namespace` = 'app1_ns'
+ `$.metadata.name` = 'jupiter_as1' AND `$.ObjectMeta.Namespace` = 'app1_ns'
 ```
 
 # Sorting
@@ -38,7 +38,7 @@ result that is to be subjected to the sort. Sort order can be `ASC` (ascending -
 An ascending sort:
 
 ```
-"`$.ObjectMeta.Name`"
+"`$.metadata.name`"
 ```
 
 Multiple sort clauses are supported. Separate each clause with a comma.
@@ -46,7 +46,7 @@ Multiple sort clauses are supported. Separate each clause with a comma.
 A two clause sort:
 
 ```
-"`$.Spec.Type` ,`$.ObjectMeta.Name` desc"
+"`$.spec.type` ,`$.metadata.name` desc"
 ```
 
 # Paging
@@ -136,7 +136,7 @@ query all_address_spaces {
 ```
 query all_addresses_for_addressspace_view {
   addresses(
-    filter: "`$.spec.addressSpace` = 'jupiter_as1' AND `$.metadata.namespace` = 'app1_ns'"
+    filter: "`$.metadata.name` LIKE 'jupiter_as1.%' AND `$.metadata.namespace` = 'app1_ns'"
   ) {
     total
     addresses {

--- a/console/console-init/ui/mock-console-server/test/graphql.js
+++ b/console/console-init/ui/mock-console-server/test/graphql.js
@@ -19,7 +19,7 @@ const allAddressesForAddressspace = {
     query: `
         query all_addresses_for_addressspace {
           addresses(
-            filter: "\`$.spec.addressSpace\` = 'mars_as2' AND \`$.metadata.namespace\` = 'app2_ns'",
+            filter: "\`$.metadata.name\` LIKE 'mars_as2.%' AND \`$.metadata.namespace\` = 'app2_ns'",
             orderBy: "\`$.metadata.name\` DESC"
           ) {
             total

--- a/console/console-init/ui/src/pages/CreateAddress/CreateAddressPage.tsx
+++ b/console/console-init/ui/src/pages/CreateAddress/CreateAddressPage.tsx
@@ -103,8 +103,7 @@ export const CreateAddressPage: React.FunctionComponent<ICreateAddressProps> = (
           spec: {
             type: addressType.toLowerCase(),
             plan: plan,
-            address: addressName,
-            addressSpace: addressSpace
+            address: addressName
           }
         };
         if (addressType && addressType.trim().toLowerCase() === "subscription")

--- a/console/console-init/ui/src/queries/Address.ts
+++ b/console/console-init/ui/src/queries/Address.ts
@@ -668,7 +668,7 @@ const RETURN_ALL_ADDRESS_NAMES_OF_ADDRESS_SPACES_FOR_TYPEAHEAD_SEARCH = (
 ) => {
   let filter = "";
   if (addressspaceName && addressspaceName.trim() !== "") {
-    filter += "`$.spec.addressSpace` = '" + addressspaceName + "' AND";
+    filter += "`$.metadata.name` LIKE '" + addressspaceName + ".%' AND";
   }
   if (namespace && namespace.trim() !== "") {
     filter += "`$.metadata.namespace` = '" + namespace + "'";


### PR DESCRIPTION

### Type of change

- Bugfix

### Description

* The filter was assuming the addresses have spec.addressSpace populated. this is not the case.
* Changed address creation not to set the spec.addressSpace field when creating new addresses

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
