### PR TITLE
Console Server - fallback to authorization header if X-Forwarded-Access-Token is not populated

### DIFF
--- a/cmd/console-server/main.go
+++ b/cmd/console-server/main.go
@@ -61,7 +61,7 @@ func main() {
 		log.Printf("Running in DEVELOPMENT MODE.  This mode is not intended for use within the container.\n")
 		log.Printf(`Expose addressspace agents to the console server by *manually* running:
 
-oc create route passthrough  --service=console-4f5fcdf
+oc create route passthrough  --service=agent-<infrauuid>
 
 The GraphQL playground is available:
 http://localhost:` + port + `/graphql

--- a/pkg/consolegraphql/server/handler_test.go
+++ b/pkg/consolegraphql/server/handler_test.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ *
+ */
+
+package server
+
+import (
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
+)
+
+func TestAccessTokenFromXForwarded(t *testing.T) {
+	req := &http.Request{
+		Header: map[string][]string{
+			forwardedHeader: {"tok"},
+		},
+	}
+
+	assert.Equal(t, "tok", getAccessToken(req))
+}
+
+func TestAccessTokenFromAuthBearerFormatted(t *testing.T) {
+	req := &http.Request{
+		Header: map[string][]string{
+			authHeader: {"Bearer tok"},
+		},
+	}
+
+	assert.Equal(t, "tok", getAccessToken(req))
+}
+
+func TestAccessTokenFromAuthUnexpectedFormat(t *testing.T) {
+	req := &http.Request{
+		Header: map[string][]string{
+			authHeader: {"tok"},
+		},
+	}
+
+	assert.Equal(t, "tok", getAccessToken(req))
+}


### PR DESCRIPTION

### Type of change

- Enhancement / new feature

### Description

To support the kubernetes case (when pusher's oauth-proxy is in use), take the bearer token from the `Authorization` header if `X-Forwarded-Access-Token` is not set.

### Checklist


- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
