### PR TITLE
add label and description in plan for address space

### DIFF
--- a/console/console-init/ui/src/pages/CreateAddressSpace/CreateAddressSpaceConfiguration.tsx
+++ b/console/console-init/ui/src/pages/CreateAddressSpace/CreateAddressSpaceConfiguration.tsx
@@ -49,6 +49,9 @@ export interface IAddressSpacePlans {
     };
     spec: {
       addressSpaceType: string;
+      displayName: string;
+      longDescription: string;
+      shortDescription: string;
     };
   }>;
 }
@@ -159,7 +162,9 @@ export const AddressSpaceConfiguration: React.FunctionComponent<IAddressSpaceCon
           if (plan.spec.addressSpaceType === type) {
             return {
               value: plan.metadata.name,
-              label: plan.metadata.name
+              label: plan.spec.displayName || plan.metadata.name,
+              description:
+                plan.spec.shortDescription || plan.spec.longDescription
             };
           }
         })

--- a/console/console-init/ui/src/queries/Address.ts
+++ b/console/console-init/ui/src/queries/Address.ts
@@ -556,6 +556,9 @@ const RETURN_ADDRESS_SPACE_PLANS = gql`
       }
       spec {
         addressSpaceType
+        displayName
+        longDescription
+        shortDescription
       }
     }
   }


### PR DESCRIPTION
### Type of change
- Bugfix
- Enhancement
### Description
- fix - Mismatch in contents of dropdown for plan in address and address space
- add label and short description for address space plan dropdown similar to address plan dropdown.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
