### PR TITLE
Fix #4076: avoid memory leak if connected router is disconnected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## 1.0.0
 
 * #4044: Ensure agent uses bi-directional AMQP idle-time-out for all connections
+* #4076: Avoid memory leak if connected router is disconnected
 
 
 ## 0.31.0

--- a/agent/lib/qdr.js
+++ b/agent/lib/qdr.js
@@ -140,6 +140,7 @@ Router.prototype.closed = function (context) {
     log.info('[%s] router closed ', this.get_id(), this.target);
     this.address = undefined;
     this._abort_requests('closed');
+    this._clear_timer();
 };
 
 Router.prototype._abort_requests = function (error) {
@@ -317,10 +318,17 @@ Router.prototype.incoming = function (context) {
     this._send_pending_requests();
 };
 
+Router.prototype._clear_timer  = function () {
+    if (this.timer) {
+        clearInterval(this.timer);
+        this.timer = null;
+    }
+};
+
 Router.prototype.close = function () {
     if (this.connection) this.connection.close();
-    if (this.timer) clearInterval(this.timer);
-}
+    this._clear_timer();
+};
 
 function add_resource_type (name, typename, plural) {
     var resource_type = typename || name;

--- a/agent/lib/router.js
+++ b/agent/lib/router.js
@@ -47,7 +47,7 @@ var KnownRouter = function (container_id, listeners) {
 
 /**
  * A ConnectedRouter represents a router this process is connected to
- * and is therefore resonsible for configuring.
+ * and is therefore responsible for configuring.
  */
 var ConnectedRouter = function (connection) {
     events.EventEmitter.call(this);


### PR DESCRIPTION
### Type of change


- Bugfix

### Description

Avoid memory leak if connected router is disconnected.

### Checklist


- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
