### PR TITLE
Increase the AMQP idle timeout

### DIFF
--- a/agent/bin/agent.js
+++ b/agent/bin/agent.js
@@ -49,7 +49,10 @@ function start(env) {
                     bind_event(bc, 'connection_stats_retrieved', console_server.connections, 'set');
                     bind_event(address_source, 'addresses_defined', bc);
                     bind_event(bc, 'address_stats_retrieved', address_source, 'check_status');
-                    bc.connect(tls_options.get_client_options({host:env.BROKER_SERVICE_HOST, port:env.BROKER_SERVICE_PORT,username:'console', idle_time_out: 8000}));
+                    bc.connect(tls_options.get_client_options({
+                        host: env.BROKER_SERVICE_HOST, port: env.BROKER_SERVICE_PORT, username: 'console',
+                        idle_time_out: 'AMQP_IDLE_TIMEOUT' in process.env ? process.env.AMQP_IDLE_TIMEOUT : 300000
+                    }));
                 } else {
                     //assume standard address space for now
                     var StandardStats = require('../lib/standard_stats.js');

--- a/agent/lib/qdr.js
+++ b/agent/lib/qdr.js
@@ -137,7 +137,7 @@ Router.prototype.closed = function (context) {
     if (context.connection.error) {
         log.error('[%s] ERROR: router closed connection with %s', this.get_id(), context.connection.error.description);
     }
-    log.info('[%s] router closed ', this.get_id(), this.target);
+    log.info('[%s] router closed %s, abort_idle: %s', this.get_id(), this.target, context.connection.abort_idle);
     this.address = undefined;
     this._abort_requests('closed');
 };
@@ -161,6 +161,7 @@ Router.prototype.on_sender_error = function (context) {
 
 Router.prototype.disconnected = function (context) {
     this.address = undefined;
+    log.info('[%s] router disconnected %s, abort_idle: %s', this.get_id(), this.target, context.connection.abort_idle);
     this._abort_requests('disconnected');
 }
 

--- a/agent/lib/ragent.js
+++ b/agent/lib/ragent.js
@@ -335,12 +335,6 @@ Ragent.prototype.configure_handlers = function () {
     this.container.on('connection_open', function(context) {
         var product = get_product(context.connection);
 
-        var idleTimeout = 8000;
-        if ('idle_time_out' in context.connection.remote.open && context.connection.remote.open.idle_time_out > 0) {
-            idleTimeout = context.connection.remote.open.idle_time_out;
-        }
-        context.connection.local.open.idle_time_out = idleTimeout;
-
         if (product === 'qpid-dispatch-router') {
             var r = rtr.connected(context.connection);
             log.info('Router connected from ' + r.container_id);
@@ -426,7 +420,10 @@ Ragent.prototype.listen_health = function (env) {
 };
 
 Ragent.prototype.start_listening = function (env, callback) {
-    var options = {properties:connection_properties};
+    var options = {
+        properties: connection_properties,
+        idle_time_out: 'AMQP_IDLE_TIMEOUT' in process.env ? process.env.AMQP_IDLE_TIMEOUT : 300000
+    };
     try {
         options = tls_options.get_server_options(options, env);
         options.port = env.AMQP_PORT === undefined ? 55671 : env.AMQP_PORT;


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

#4040 added an idle timeout to the Agent's container when connecting to the Brokers and Routers. Testing showed the the the idle timeout was too short, and this resulted in spurious connection aborts (which triggered #4077)

Increased the idle timeout.
Corrects the use of Rhea API to pass the idle_time_out as an option.

### Checklist

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
