### PR TITLE
Fix calling the check_doc, define default target, fix doc issues

### DIFF
--- a/documentation/Makefile
+++ b/documentation/Makefile
@@ -4,6 +4,10 @@ include ../Makefile.env.mk
 ASCIIDOCTOR_EXTRA_FLAGS ?= --failure-level WARN
 ASCIIDOCTOR_FLAGS       ?= -v -a EnMasseVersion=$(VERSION) -t -dbook $(ASCIIDOCTOR_EXTRA_FLAGS)
 
+# first target, default target
+.PHONY: all
+all: build
+
 .PHONY: swagger
 swagger: build/swagger2markup.jar
 	mvn process-resources
@@ -40,4 +44,4 @@ clean:
 
 .PHONY: check
 check:
-	$(TOPDIR)/scripts/check_docs.sh
+	cd $(TOPDIR) && $(TOPDIR)/scripts/check_docs.sh

--- a/documentation/modules/con-standard-subscription.adoc
+++ b/documentation/modules/con-standard-subscription.adoc
@@ -13,6 +13,6 @@ topic `mytopic` the consumer consumes from the address `mytopic::mysub`. By defa
 consumer is allowed per subscription. This can be specified using `maxConsumers` setting of
 the subscription address.
 
-NOTE: The `maxConsumers` setting can not be modified for existing subscriptions at present.
+NOTE: The `maxConsumers` setting cannot be modified for existing subscriptions at present.
 // !standard.address.subscription.longDescription:stop
 

--- a/scripts/check_docs.sh
+++ b/scripts/check_docs.sh
@@ -6,7 +6,7 @@ function grep_check {
   local pattern=$1
   local description=$2
   local fatalness=${3:-1}
-  x=$(grep -i -E -r -Hn "$pattern" --exclude="*.gif" --exclude="*.png" --exclude="*.svg" --exclude-dir="design" --exclude-dir="contributing" --exclude-dir="build" documentation)
+  x=$(grep -i -E -r -Hn "$pattern" --exclude="*.gif" --exclude="*.png" --exclude="*.svg" --exclude-dir="design" --exclude-dir="contributing" --exclude-dir="build" --exclude-dir="html" documentation)
   if [ -n "$x" ]; then
     echo "$description:"
     echo "$x"


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix
- Documentation

### Description

The check_docs.sh script never checked anything the way it got called. Also did it check all excluded files again via the "html" folder. There was an actual issue discovered when it finally ran.

I also changed the default target of the makefile from "fetch swagger" to "build", which makes more sense to me.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
