### PR TITLE
Enhanced BrokerController's error handling for unhandled socket errors

### DIFF
--- a/agent/lib/artemis.js
+++ b/agent/lib/artemis.js
@@ -42,6 +42,7 @@ var Artemis = function (connection) {
     connection.on('connection_error', this.on_connection_error.bind(this));
     connection.on('connection_close', this.on_connection_close.bind(this));
     connection.on('disconnected', this.disconnected.bind(this));
+    connection.on('error', this.on_error.bind(this));
     this.handlers = [];
     this.requests = [];
     this.pushed = 0;
@@ -135,6 +136,11 @@ Artemis.prototype.on_connection_close = function (context) {
     var error = this.connection.container_id + ' connection closed';
     log.info('[' + this.connection.container_id + '] connection closed');
     this.abort_requests(error);
+};
+
+Artemis.prototype.on_error = function (error) {
+    var err = this.connection.container_id + ' socket error ' + JSON.stringify(error);
+    log.info('[' + this.connection.container_id + '] socket error: ' + JSON.stringify(error));
 };
 
 Artemis.prototype._send_pending_requests = function () {

--- a/agent/lib/artemis.js
+++ b/agent/lib/artemis.js
@@ -139,8 +139,7 @@ Artemis.prototype.on_connection_close = function (context) {
 };
 
 Artemis.prototype.on_error = function (error) {
-    var err = this.connection.container_id + ' socket error ' + JSON.stringify(error);
-    log.info('[' + this.connection.container_id + '] socket error: ' + JSON.stringify(error));
+    log.error('[%s] socket error: %s', this.connection.container_id, JSON.stringify(error));
 };
 
 Artemis.prototype._send_pending_requests = function () {


### PR DESCRIPTION
Fixes #4081 

### Type of change

- Bugfix

### Description

Added the error handler to 'connection'. Used for both brokered and standard controller.
A 'connection_close' event will follow.  Therefore only logging the error.  See: https://github.com/amqp/rhea#error

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

Signed-off-by: Vanessa <vbusch@redhat.com>
