### PR TITLE
Fix- orientation issue in dropdown for plan in create address space

### DIFF
--- a/console/console-init/ui/src/pages/CreateAddress/CreateAddressDefinition.tsx
+++ b/console/console-init/ui/src/pages/CreateAddress/CreateAddressDefinition.tsx
@@ -25,6 +25,7 @@ import {
 import { Loading } from "use-patternfly";
 import { css, StyleSheet } from "@patternfly/react-styles";
 import { IAddressResponse } from "types/ResponseTypes";
+import { dropdown_item_styles } from "pages/CreateAddressSpace/CreateAddressSpaceConfiguration";
 
 const styles = StyleSheet.create({
   capitalize_labels: {
@@ -277,7 +278,9 @@ export const AddressDefinition: React.FunctionComponent<IAddressDefinition> = ({
                   >
                     <b>{option.label}</b>
                     <br />
-                    {option.description}
+                    <div className={css(dropdown_item_styles.format_item)}>
+                      {option.description}
+                    </div>
                   </DropdownItem>
                 ))}
               />

--- a/console/console-init/ui/src/pages/CreateAddressSpace/CreateAddressSpaceConfiguration.tsx
+++ b/console/console-init/ui/src/pages/CreateAddressSpace/CreateAddressSpaceConfiguration.tsx
@@ -25,7 +25,6 @@ import {
 } from "queries";
 import { Loading } from "use-patternfly";
 import { dnsSubDomainRfc1123NameRegexp } from "types/Configs";
-
 export interface IAddressSpaceConfiguration {
   name: string;
   setName: (name: string) => void;
@@ -239,8 +238,6 @@ export const AddressSpaceConfiguration: React.FunctionComponent<IAddressSpaceCon
                     component={"button"}
                   >
                     <b>{option.label}</b>
-                    <br />
-                    {option.description ? option.description : ""}
                   </DropdownItem>
                 ))}
               />
@@ -299,7 +296,7 @@ export const AddressSpaceConfiguration: React.FunctionComponent<IAddressSpaceCon
               <br />
               <Dropdown
                 id="cas-dropdown-plan"
-                position={DropdownPosition.right}
+                position={DropdownPosition.left}
                 onSelect={onPlanSelect}
                 isOpen={isPlanOpen}
                 style={{ display: "flex" }}
@@ -335,7 +332,7 @@ export const AddressSpaceConfiguration: React.FunctionComponent<IAddressSpaceCon
               <br />
               <Dropdown
                 id="cas-dropdown-auth-service"
-                position={DropdownPosition.right}
+                position={DropdownPosition.left}
                 onSelect={onAuthenticationServiceSelect}
                 isOpen={isAuthenticationServiceOpen}
                 style={{ display: "flex" }}

--- a/console/console-init/ui/src/pages/CreateAddressSpace/CreateAddressSpaceConfiguration.tsx
+++ b/console/console-init/ui/src/pages/CreateAddressSpace/CreateAddressSpaceConfiguration.tsx
@@ -25,6 +25,11 @@ import {
 } from "queries";
 import { Loading } from "use-patternfly";
 import { dnsSubDomainRfc1123NameRegexp } from "types/Configs";
+import { StyleSheet, css } from "@patternfly/react-styles";
+
+export const dropdown_item_styles = StyleSheet.create({
+  format_item: { whiteSpace: "normal", textAlign: "justify" }
+});
 export interface IAddressSpaceConfiguration {
   name: string;
   setName: (name: string) => void;
@@ -319,7 +324,9 @@ export const AddressSpaceConfiguration: React.FunctionComponent<IAddressSpaceCon
                   >
                     <b>{option.label}</b>
                     <br />
-                    {option.description}
+                    <div className={css(dropdown_item_styles.format_item)}>
+                      {option.description}
+                    </div>
                   </DropdownItem>
                 ))}
               />


### PR DESCRIPTION
### Type of change

- Bugfix

### Description
- add orientation for plan dropdown in create address space
- temporary fix using custom styles to avoid - data get hidden in right side if is too large(working with PF guys to fix this in PF4 Dropdown component)
- fix for this PR - https://github.com/EnMasseProject/enmasse/pull/4074
![Screenshot from 2020-03-11 15-49-37](https://user-images.githubusercontent.com/29524461/76406647-10794b80-63b0-11ea-887d-a50f22393add.png)



