### PR TITLE
Test fix: Allow more time for deletion of multiple address spaces

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/selenium/page/ConsoleWebPage.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/selenium/page/ConsoleWebPage.java
@@ -802,8 +802,10 @@ public class ConsoleWebPage implements IWebPage {
         selenium.clickOnItem(getAddressSpacesTableDropDown(), "Main dropdown");
         selenium.clickOnItem(getAddressSpacesDeleteAllButton());
         selenium.clickOnItem(getConfirmButton());
+
+        int timeAllowed = 30*addressSpaces.length;
         for (AddressSpace space : addressSpaces) {
-            selenium.waitUntilItemNotPresent(30, () -> getAddressSpaceItem(space));
+            selenium.waitUntilItemNotPresent(timeAllowed, () -> getAddressSpaceItem(space));
         }
     }
 


### PR DESCRIPTION
### Type of change

- Test fix

### Description

Fix for: ChromeConsoleTest.testFilterAddressSpace
When deleting 2 or more address spaces, the time allowed isn't always enough.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
