### PR TITLE
Fix handling of requests for resources that do not exist in api-server RequestLogger.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.30.3
+*  #4119: Use @PreMatching annotation of the api-server request log to ensure that 404 are processed without NPE.
+
 ## 0.30.2
 *  #2714: Allow setting security context of pods using persistent volumes
 *  #3547: Network policies not deleted when address space is deleted

--- a/api-server/src/main/java/io/enmasse/api/server/RequestLogger.java
+++ b/api-server/src/main/java/io/enmasse/api/server/RequestLogger.java
@@ -18,6 +18,7 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.container.PreMatching;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -27,6 +28,7 @@ import java.util.concurrent.atomic.AtomicLongArray;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+@PreMatching
 public class RequestLogger implements ContainerRequestFilter, ContainerResponseFilter {
     private static final Logger log = LoggerFactory.getLogger(RequestLogger.class);
     private static final String PROP_NAME = "request.start";


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Use JAX-RS `@PreMatching` annotation of the api-server RequestLogger to ensure that 404 are processed without NPE

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
