### PR TITLE
Docs: fix cmdcli not resolving to oc issue

### DIFF
--- a/documentation/modules/proc-logging-in-console.adoc
+++ b/documentation/modules/proc-logging-in-console.adoc
@@ -2,6 +2,8 @@
 //
 // assembly-using-console.adoc
 
+:cmdcli: oc
+
 [id='logging-into-console-{context}']
 = Accessing the {ConsoleName}
 
@@ -34,3 +36,4 @@ endif::Asciidoctor[]
 ifndef::Asciidoctor[]
 image::{imagesdir}/console-screenshot.png[{ConsoleName}]
 endif::Asciidoctor[]
+


### PR DESCRIPTION
### Type of change
- Documentation

### Description
Docs: Fixes problem with Accessing the {ConsoleName} procedure not displaying `oc` value for {cmdcli} attribute

### Checklist
- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
