### PR TITLE
Fix console access cmd formatting and add the two address/connection screenshots

### DIFF
--- a/documentation/modules/proc-logging-in-console.adoc
+++ b/documentation/modules/proc-logging-in-console.adoc
@@ -8,11 +8,15 @@
 .Prerequisites
 ifeval::["{cmdcli}" == "oc"]
 * On OpenShift Container Platform 3.x, obtain the host name for the {ConsoleName} by running the following command:
++
+[options="nowrap",subs="attributes,+quotes"]
 ----
 {cmdcli} get routes console -o jsonpath={.spec.host}
 ----
 
 * On OpenShift Container Platform 4.x, obtain the host name for the {ConsoleName} by running the following command:
++
+[options="nowrap",subs="attributes,+quotes"]
 ----
 {cmdcli} get consolelink -l app=enmasse -o jsonpath={.spec.href}
 ----

--- a/documentation/modules/ref-view-message-conn-stats-table.adoc
+++ b/documentation/modules/ref-view-message-conn-stats-table.adoc
@@ -8,6 +8,14 @@
 .Prerequisites
 * You must be logged into the {ConsoleName}.
 
+ifdef::Asciidoctor[]
+image::console-screenshot-addr.png[{ConsoleName}]
+endif::Asciidoctor[]
+
+ifndef::Asciidoctor[]
+image::{imagesdir}/console-screenshot-addr.png[{ConsoleName}]
+endif::Asciidoctor[]
+
 .Message statistics reference table
 [cols="50%a,50%a",options="header"]
 |===
@@ -26,6 +34,15 @@
 
 
 .Application connection statistics reference table
+
+ifdef::Asciidoctor[]
+image::console-screenshot-conns.png[{ConsoleName}]
+endif::Asciidoctor[]
+
+ifndef::Asciidoctor[]
+image::{imagesdir}/console-screenshot-conns.png[{ConsoleName}]
+endif::Asciidoctor[]
+
 [cols="50%a,50%a",options="header"]
 |===
 |To view... |On the Connections page...

--- a/documentation/modules/ref-view-message-conn-stats-table.adoc
+++ b/documentation/modules/ref-view-message-conn-stats-table.adoc
@@ -20,14 +20,14 @@ endif::Asciidoctor[]
 [cols="50%a,50%a",options="header"]
 |===
 |To view... |On the Addresses page...
-|Address status | See the third column, *Status*
 |Address type |See the first icon in the second column, *Type/plan*
 |Address plan |See the string that follows the icon in the second column, *Type/plan*
+|Address status | See the third column, *Status*
 |Messages received per second (computed over the last 5 minutes) |See *Messages In/sec*
 |Messages sent per second (computed over the last 5 minutes) |See *Messages Out/sec*
+|Queue and topic address types only: Number of stored messages on the broker or brokers |*Stored Messages*
 |Number of senders attached |See *Senders*
 |Number of receivers attached |See *Receivers*
-|Queue and topic address types only: Number of stored messages on the broker or brokers |*Stored Messages*
 |Standard address space only: Message deliveries per second |Click the desired address, which then shows the links page for that address; see the *Delivery Rate* column.
 // |Standard address space and queue address type only: Number of rejected messages stored in the global dead-letter queue (DLQ) |*Global DLQ*
 |===
@@ -46,8 +46,8 @@ endif::Asciidoctor[]
 [cols="50%a,50%a",options="header"]
 |===
 |To view... |On the Connections page...
-|Messages received per second (computed over the last 5 minutes) |See *Messages In*
-|Standard address space only: Messages sent per second (computed over the last 5 minutes) |See *Messages Out*
+|Messages received per second (computed over the last 5 minutes) |See *Messages In/sec*
+|Standard address space only: Messages sent per second (computed over the last 5 minutes) |See *Messages Out/sec*
 |Total number of messages delivered |Click the desired host name to show the list of senders and receivers; see the *Deliveries* column.
 // |Standard address space only: Username used by the client to connect |See the third column
 |===


### PR DESCRIPTION

### Type of change

- Documentation

### Description

Fix console access cmd formatting and add the two address/connection screenshots

### Checklist


- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
