### PR TITLE
Fix firefox console test test purge address

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/web/ConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/web/ConsoleTest.java
@@ -708,6 +708,9 @@ public abstract class ConsoleTest extends TestBase {
 
         consolePage.purgeSelectedAddresses(queue1, queue3);
 
+        selenium.waitUntilPropertyPresent(60, 0, () -> consolePage.getAddressItem(queue1).getMessagesStored());
+        selenium.waitUntilPropertyPresent(60, 0, () -> consolePage.getAddressItem(queue3).getMessagesStored());
+
         assertTrue(client.withAddress(queue2).withClientEngine(new RheaClientReceiver()).run(false));
         assertThat(client.getMessages().size(), is(1000));
         assertTrue(client.withAddress(queue3).withTimeout(10).withClientEngine(new RheaClientReceiver()).run(false));


### PR DESCRIPTION
### Type of change


- Bugfix

### Description

Purging a queue is an asynchronous operation.  Control may return to the UI before the operation completes.  Test needs to await the metric reaching zero before making the observation using the client.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
