### PR TITLE
Add timeout to agent watches

### DIFF
--- a/agent/lib/kubernetes.js
+++ b/agent/lib/kubernetes.js
@@ -77,7 +77,7 @@ function get_path(base, resource, options) {
     if (options.requestTimeout) {
         queryParams.timeoutSeconds = options.requestTimeout;
     }
-    if (Object.keys(queryParams).length) {
+    if (Object.keys(queryParams).length > 0) {
         path += '?' + querystring.stringify(queryParams);
     }
     return path;


### PR DESCRIPTION
# Type of change

- Bugfix

### Description

Fixes #4134
Copies requestTimeout into timeoutSeconds on the query params

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
