### PR TITLE
Docs issue 4143: minor edits to the subscription address type description

### DIFF
--- a/documentation/modules/con-standard-subscription.adoc
+++ b/documentation/modules/con-standard-subscription.adoc
@@ -6,13 +6,9 @@
 = Subscription
 // !standard.address.subscription.shortDescription:A subscription on a specified topic
 // !standard.address.subscription.longDescription:start
-The subscription address type allows a subscription to be created for a topic that holds messages
-published to the topic even if the subscriber is not attached. The subscription is accessed by the
-consumer using <topic-address>::<subscription-address>. For example, for a subscription `mysub` on a
-topic `mytopic` the consumer consumes from the address `mytopic::mysub`. By default, only a single
-consumer is allowed per subscription. This can be specified using `maxConsumers` setting of
-the subscription address.
+Using the subscription address type you can create a subscription for a topic that holds messages
+published to the topic even if the subscriber is not attached. The consumer accesses the subscription  using the following address syntax: <topic-address>::<subscription-address>. For example, for a subscription `mysub` on a topic `mytopic` the consumer accesses the subscription from the address `mytopic::mysub`. The default setting permits only a single consumer per subscription. This setting can be changed by editing the `maxConsumers` attribute of the subscription address.
 
-NOTE: The `maxConsumers` setting cannot be modified for existing subscriptions at present.
+NOTE: The `maxConsumers` setting cannot be modified for existing subscriptions.
 // !standard.address.subscription.longDescription:stop
 


### PR DESCRIPTION
### Type of change
- Documentation

### Description

Docs: Minor edits to the subscription address type concept file to make it more clear

### Checklist
- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
