### PR TITLE
fix scale results filename and fix logger used in some tests

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/bases/ITestSeparator.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/bases/ITestSeparator.java
@@ -20,7 +20,7 @@ import java.util.Map;
 
 @ExtendWith(ExtensionContextParameterResolver.class)
 public interface ITestSeparator {
-    Logger log = CustomLogger.getLogger();
+    Logger testSeparatorLogger = CustomLogger.getLogger();
     String separatorChar = "#";
 
     static void printThreadDump() {
@@ -33,7 +33,7 @@ public interface ITestSeparator {
             for (StackTraceElement aTrace : trace) {
                 sb.append(" ").append(aTrace).append("\r\n");
             }
-            log.error(sb.toString());
+            testSeparatorLogger.error(sb.toString());
         }
     }
 
@@ -41,8 +41,8 @@ public interface ITestSeparator {
     default void beforeEachTest(TestInfo testInfo) {
         TimeMeasuringSystem.setTestName(testInfo.getTestClass().get().getName(), testInfo.getDisplayName());
         TimeMeasuringSystem.startOperation(SystemtestsOperation.TEST_EXECUTION);
-        log.info(String.join("", Collections.nCopies(100, separatorChar)));
-        log.info(String.format("%s.%s-STARTED", testInfo.getTestClass().get().getName(), testInfo.getDisplayName()));
+        testSeparatorLogger.info(String.join("", Collections.nCopies(100, separatorChar)));
+        testSeparatorLogger.info(String.format("%s.%s-STARTED", testInfo.getTestClass().get().getName(), testInfo.getDisplayName()));
     }
 
     @AfterEach
@@ -50,14 +50,14 @@ public interface ITestSeparator {
         if (context.getExecutionException().isPresent()) { // on failed
             Throwable ex = context.getExecutionException().get();
             if (ex instanceof OutOfMemoryError) {
-                log.error("Got OOM, dumping thread info");
+                testSeparatorLogger.error("Got OOM, dumping thread info");
                 printThreadDump();
             } else {
-                log.error("Caught exception", ex);
+                testSeparatorLogger.error("Caught exception", ex);
             }
         }
         TimeMeasuringSystem.stopOperation(SystemtestsOperation.TEST_EXECUTION);
-        log.info(String.format("%s.%s-FINISHED", testInfo.getTestClass().get().getName(), testInfo.getDisplayName()));
-        log.info(String.join("", Collections.nCopies(100, separatorChar)));
+        testSeparatorLogger.info(String.format("%s.%s-FINISHED", testInfo.getTestClass().get().getName(), testInfo.getDisplayName()));
+        testSeparatorLogger.info(String.join("", Collections.nCopies(100, separatorChar)));
     }
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/iot/isolated/registry/H2DeviceRegistryTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/iot/isolated/registry/H2DeviceRegistryTest.java
@@ -18,13 +18,17 @@ import java.util.concurrent.TimeoutException;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
 
 import io.enmasse.iot.model.v1.IoTConfigBuilder;
 import io.enmasse.iot.model.v1.Mode;
+import io.enmasse.systemtest.logs.CustomLogger;
 import io.enmasse.systemtest.platform.Kubernetes;
 import io.enmasse.systemtest.platform.apps.SystemtestsKubernetesApps;
 
 class H2DeviceRegistryTest extends DeviceRegistryTest {
+
+    private final Logger log = CustomLogger.getLogger();
 
     @Override
     protected IoTConfigBuilder provideIoTConfig() throws Exception {

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/api/CustomResourceDefinitionAddressSpacesTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/api/CustomResourceDefinitionAddressSpacesTest.java
@@ -16,6 +16,7 @@ import io.enmasse.systemtest.bases.TestBase;
 import io.enmasse.systemtest.bases.isolated.ITestIsolatedStandard;
 import io.enmasse.systemtest.executor.ExecutionResultData;
 import io.enmasse.systemtest.isolated.Credentials;
+import io.enmasse.systemtest.logs.CustomLogger;
 import io.enmasse.systemtest.model.addressplan.DestinationPlan;
 import io.enmasse.systemtest.model.addressspace.AddressSpacePlans;
 import io.enmasse.systemtest.model.addressspace.AddressSpaceType;
@@ -32,6 +33,7 @@ import io.enmasse.user.model.v1.UserAuthorizationBuilder;
 import io.enmasse.user.model.v1.UserBuilder;
 import io.vertx.core.json.JsonObject;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
 
 import java.util.Collections;
 import java.util.Optional;
@@ -47,6 +49,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CustomResourceDefinitionAddressSpacesTest extends TestBase implements ITestIsolatedStandard {
+
+    private final Logger log = CustomLogger.getLogger();
 
     @Test
     void testAddressSpaceCreateViaCmdRemoveViaApi() throws Exception {

--- a/systemtests/src/test/java/io/enmasse/systemtest/scale/ScaleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/scale/ScaleTest.java
@@ -297,8 +297,8 @@ class ScaleTest extends TestBase implements ITestBaseIsolated {
                 checkMetrics(manager.getMonitoringResult());
             } catch (Exception | AssertionError ex) {
                 manager.stopMonitoring();
-                log.error("Failed to wait for addresses/connections");
-                log.error(ex.getMessage());
+                LOGGER.error("Failed to wait for addresses/connections");
+                LOGGER.error(ex.getMessage());
                 operableAddresses = (int) kubernetes.getAddressClient().inNamespace(namespace).list().getItems().stream()
                         .filter(address -> address.getStatus().getPhase().equals(Phase.Active)).count();
                 LOGGER.info("#######################################");
@@ -598,7 +598,7 @@ class ScaleTest extends TestBase implements ITestBaseIsolated {
         LOGGER.info("Saving results into {}", logsPath);
         var mapper = new ObjectMapper().writerWithDefaultPrettyPrinter();
         Files.createDirectories(logsPath);
-        Files.write(logsPath.resolve("messaging_performance_results.json"), mapper.writeValueAsBytes(resultsObject));
+        Files.write(logsPath.resolve(filename), mapper.writeValueAsBytes(resultsObject));
     }
 
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/scale/ScaleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/scale/ScaleTest.java
@@ -594,7 +594,7 @@ class ScaleTest extends TestBase implements ITestBaseIsolated {
     }
 
     private void saveResultsFile(String filename, Object resultsObject) throws Exception {
-        var logsPath = TestUtils.getScaleTestLogsPath(TestInfo.getInstance().getActualTest());
+        var logsPath = TestUtils.getScaleTestLogsPath(TestInfo.getInstance().getActualTest()).resolve("result");
         LOGGER.info("Saving results into {}", logsPath);
         var mapper = new ObjectMapper().writerWithDefaultPrettyPrinter();
         Files.createDirectories(logsPath);


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

The scale tests results file wasn't using the correct filename and some tests were using a logger that shouldn't be used 
<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
