### PR TITLE
Run systemtests as tekton pipeline

### DIFF
--- a/.tekton/test/enmasse-repo.yaml
+++ b/.tekton/test/enmasse-repo.yaml
@@ -1,0 +1,13 @@
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: enmasse-repo
+  labels:
+    app: enmasse-test
+spec:
+  type: git
+  params:
+    - name: revision
+      value: master
+    - name: url
+      value: https://github.com/enmasseproject/enmasse

--- a/.tekton/test/systemtest-pipeline.yaml
+++ b/.tekton/test/systemtest-pipeline.yaml
@@ -1,0 +1,44 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: systemtest-pipeline
+  labels:
+    app: enmasse-test
+spec:
+  params:
+    - name: profile
+      description: profile of test
+      default: systemtests
+    - name: testcase
+      description: testcases to run
+      default: "''"
+    - name: kube_api_url
+      description: url of cluster for running tests
+      default: ""
+    - name: kube_token
+      description: login token
+    - name: kube_namespace
+      description: namespace for enmasse infra deployment
+      default: "enmasse-infra"
+  resources:
+    - name: enmasse-repo
+      type: git
+  tasks:
+    - name: systemtest-task
+      taskRef:
+        name: systemtest-task
+      params:
+        - name: profile
+          value: $(params.profile)
+        - name: testcase
+          value: $(params.testcase)
+        - name: kube_api_url
+          value: $(params.kube_api_url)
+        - name: kube_token
+          value: $(params.kube_token)
+        - name: kube_namespace
+          value: $(params.kube_namespace)
+      resources:
+        inputs:
+          - name: enmasse-repo
+            resource: enmasse-repo

--- a/.tekton/test/systemtest-task.yaml
+++ b/.tekton/test/systemtest-task.yaml
@@ -1,0 +1,52 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: systemtest-task
+  labels:
+    app: enmasse-test
+spec:
+  inputs:
+    params:
+      - name: profile
+        type: string
+      - name: testcase
+        type: string
+      - name: kube_api_url
+        type: string
+      - name: kube_token
+        type: string
+      - name: kube_namespace
+        type: string
+    resources:
+      - name: enmasse-repo
+        type: git
+  steps:
+    - name: maven-test
+      securityContext:
+        privileged: true
+      image: docker.io/library/maven:3.6.3-jdk-11
+      command:
+        - /bin/bash
+      env:
+        - name: GOROOT
+          value: /usr/local/go
+      workingDir: /workspace/enmasse-repo
+      args:
+        - -c
+        - |
+          apt -qq update
+          apt -qq install make gcc -y
+
+          wget https://dl.google.com/go/go1.13.3.linux-amd64.tar.gz -q
+          tar xf go1.13.3.linux-amd64.tar.gz
+          mv go /usr/local
+          export PATH=$PATH:/usr/local/go/bin
+
+          wget https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz -q
+          tar xf oc.tar.gz
+          mv oc /usr/bin/oc
+          oc login --token $(inputs.params.kube_token) $(inputs.params.kube_api_url) --insecure-skip-tls-verify=true
+
+          export KUBERNETES_NAMESPACE=$(inputs.params.kube_namespace)
+          mvn test -pl systemtests -am -P$(inputs.params.profile) -Djava.net.preferIPv4Stack=true -DfailIfNoTests=false -Dstyle.color=always -DskipTests --no-transfer-progress -Dtest=$(inputs.params.testcase)
+

--- a/Makefile
+++ b/Makefile
@@ -127,8 +127,8 @@ $(DOCKER_DIRS):
 systemtests:
 	make -C systemtests
 
-tekton-test:
-	make -C systemtests tekton-test
+systemtests-tekton:
+	make -C systemtests systemtests-tekton
 
 docu_html:
 	make -C documentation build

--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,9 @@ $(DOCKER_DIRS):
 systemtests:
 	make -C systemtests
 
+tekton-test:
+	make -C systemtests tekton-test
+
 docu_html:
 	make -C documentation build
 

--- a/systemtests/Makefile
+++ b/systemtests/Makefile
@@ -8,12 +8,14 @@ $(error "No oc or kubectl in $(PATH)")
 endif
 endif
 
+PROFILE ?= systemtests
+PIPELINE_NAMESPACE ?= enmasse-pipelines
+KUBERNETES_NAMESPACE ?= enmasse-infra
+
 ifeq (oc, $(CMDTOOL))
-KUBERNETES_NAMESPACE  ?= $(shell oc project -q)
 KUBERNETES_API_TOKEN  ?= $(shell oc whoami -t)
 KUBERNETES_API_URL    ?= $(shell oc whoami --show-server=true)
 else
-KUBERNETES_NAMESPACE ?= enmasse-infra
 KUBERNETES_API_URL=$(shell kubectl config view --minify | grep server | cut -f 2- -d ":" | tr -d " ")
 KUBERNETES_API_TOKEN=$(shell kubectl describe secret $(kubectl get secrets | grep ^default | cut -f1 -d ' ') | grep -E '^token' | cut -f2 -d':' | tr -d " ")
 
@@ -34,3 +36,14 @@ systemtests:
 		KUBERNETES_API_TOKEN=$(KUBERNETES_API_TOKEN) \
 		KUBERNETES_API_URL=$(KUBERNETES_API_URL) \
 		./scripts/run_tests.sh '$(PROFILE)' '$(TESTCASE)'
+
+tekton-test:
+		$(CMDTOOL) create namespace $(PIPELINE_NAMESPACE) || true
+		$(CMDTOOL) apply -f ../.tekton/test/ -n $(PIPELINE_NAMESPACE)
+		tkn pipeline start systemtest-pipeline \
+				--param kube_api_url=$(KUBERNETES_API_URL) \
+				--param kube_token=$(KUBERNETES_API_TOKEN) \
+				--param kube_namespace=$(KUBERNETES_NAMESPACE) \
+				--param profile=$(PROFILE) \
+				--param testcase='$(TESTCASE)' \
+				--showlog -n $(PIPELINE_NAMESPACE)

--- a/systemtests/Makefile
+++ b/systemtests/Makefile
@@ -37,7 +37,7 @@ systemtests:
 		KUBERNETES_API_URL=$(KUBERNETES_API_URL) \
 		./scripts/run_tests.sh '$(PROFILE)' '$(TESTCASE)'
 
-tekton-test:
+systemtests-tekton:
 		$(CMDTOOL) create namespace $(PIPELINE_NAMESPACE) || true
 		$(CMDTOOL) apply -f ../.tekton/test/ -n $(PIPELINE_NAMESPACE)
 		tkn pipeline start systemtest-pipeline \


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Enhancement / new feature

### Description

<!--

_Please describe your pull request_

-->

Ability to run enmasse systemtests as tekton pipeline on ocp4, this is only draft, it contains only fer params and it can test only master right now. But I will work more on that.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [x] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
