### PR TITLE
Enable vertx native also for vanilla hono components

### DIFF
--- a/pkg/controller/iotconfig/auth_service.go
+++ b/pkg/controller/iotconfig/auth_service.go
@@ -188,6 +188,8 @@ func (r *ReconcileIoTConfig) reconcileAuthServiceConfigMap(config *iotv1alpha1.I
 hono:
   app:
     maxInstances: 1
+  vertx:
+    preferNative: true
   healthCheck:
     insecurePortBindAddress: 0.0.0.0
     insecurePortEnabled: true

--- a/pkg/controller/iotconfig/http_adapter.go
+++ b/pkg/controller/iotconfig/http_adapter.go
@@ -231,6 +231,8 @@ func (r *ReconcileIoTConfig) reconcileHttpAdapterConfigMap(config *iotv1alpha1.I
 hono:
   app:
     maxInstances: 1
+  vertx:
+    preferNative: true
   healthCheck:
     insecurePortBindAddress: 0.0.0.0
     insecurePortEnabled: true

--- a/pkg/controller/iotconfig/lorawan_adapter.go
+++ b/pkg/controller/iotconfig/lorawan_adapter.go
@@ -231,6 +231,8 @@ func (r *ReconcileIoTConfig) reconcileLoraWanAdapterConfigMap(config *iotv1alpha
 hono:
   app:
     maxInstances: 1
+  vertx:
+    preferNative: true
   healthCheck:
     insecurePortBindAddress: 0.0.0.0
     insecurePortEnabled: true

--- a/pkg/controller/iotconfig/mqtt_adapter.go
+++ b/pkg/controller/iotconfig/mqtt_adapter.go
@@ -233,6 +233,8 @@ func (r *ReconcileIoTConfig) reconcileMqttAdapterConfigMap(config *iotv1alpha1.I
 hono:
   app:
     maxInstances: 1
+  vertx:
+    preferNative: true
   healthCheck:
     insecurePortBindAddress: 0.0.0.0
     insecurePortEnabled: true

--- a/pkg/controller/iotconfig/sigfox_adapter.go
+++ b/pkg/controller/iotconfig/sigfox_adapter.go
@@ -232,6 +232,8 @@ func (r *ReconcileIoTConfig) reconcileSigfoxAdapterConfigMap(config *iotv1alpha1
 hono:
   app:
     maxInstances: 1
+  vertx:
+    preferNative: true
   healthCheck:
     insecurePortBindAddress: 0.0.0.0
     insecurePortEnabled: true


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Vertx native support was only enabled for EnMasse IoT components, but not for vanilla Hono components. TLS native support was already enabled for all components.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
