### PR TITLE
Scale tests - set number of senders and receivers in tenant client

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/apps/SystemtestsKubernetesApps.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/apps/SystemtestsKubernetesApps.java
@@ -1264,6 +1264,12 @@ public class SystemtestsKubernetesApps {
         if (c.getSendMessagePeriod()!=null) {
             env.add(new EnvVarBuilder().withName("amqp-send-msg-period").withValue(Integer.toString(c.getSendMessagePeriod())).build());
         }
+        if (c.getReceiversPerTenant()!=null) {
+            env.add(new EnvVarBuilder().withName("amqp-receivers-per-tenant").withValue(Integer.toString(c.getReceiversPerTenant())).build());
+        }
+        if (c.getSendersPerTenant()!=null) {
+            env.add(new EnvVarBuilder().withName("amqp-senders-per-tenant").withValue(Integer.toString(c.getSendersPerTenant())).build());
+        }
 
         return new DeploymentBuilder()
                 .withNewMetadata()

--- a/systemtests/src/main/java/io/enmasse/systemtest/scale/ScaleTestClientConfiguration.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/scale/ScaleTestClientConfiguration.java
@@ -27,6 +27,8 @@ public class ScaleTestClientConfiguration {
     //tenant-client
     private Integer addressesPerTenant;
     private Integer sendMessagePeriod; //milliseconds
+    private Integer receiversPerTenant = 1;
+    private Integer sendersPerTenant = 1;
 
     public ScaleTestClientConfiguration() {
 		// empty
@@ -121,6 +123,22 @@ public class ScaleTestClientConfiguration {
 
     public void setSendMessagePeriod(Integer sendMessagePeriod) {
         this.sendMessagePeriod = sendMessagePeriod;
+    }
+
+    public Integer getReceiversPerTenant() {
+        return receiversPerTenant;
+    }
+
+    public void setReceiversPerTenant(Integer receiversPerTenant) {
+        this.receiversPerTenant = receiversPerTenant;
+    }
+
+    public Integer getSendersPerTenant() {
+        return sendersPerTenant;
+    }
+
+    public void setSendersPerTenant(Integer sendersPerTenant) {
+        this.sendersPerTenant = sendersPerTenant;
     }
 
 }

--- a/systemtests/src/main/java/io/enmasse/systemtest/scale/ScaleTestEnvironment.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/scale/ScaleTestEnvironment.java
@@ -31,6 +31,8 @@ public class ScaleTestEnvironment {
     private static final String SCALE_PERF_INIT_QUEUE_LINKS_PER_CONN = "SCALE_PERF_INIT_QUEUE_LINKS_PER_CONN";
     private static final String SCALE_PERF_QUEUE_LINKS_PER_CONN_INC = "SCALE_PERF_QUEUE_LINKS_PER_CONN_INC";
     private static final String SCALE_PERF_SEND_MSG_PERIOD_MILLIS = "SCALE_PERF_SEND_MSG_PERIOD_MILLIS";
+    private static final String SCALE_PERF_RECEIVERS_PER_TENANT = "SCALE_PERF_RECEIVERS_PER_TENANT";
+    private static final String SCALE_PERF_SENDERS_PER_TENANT = "SCALE_PERF_SENDERS_PER_TENANT";
 
     private static final String SCALE_HA_ADDRESSES = "SCALE_HA_ADDRESSES";
     private static final String SCALE_HA_ADDRESSES_PER_GROUP = "SCALE_HA_ADDRESSES_PER_GROUP";
@@ -65,6 +67,8 @@ public class ScaleTestEnvironment {
      * that this value is less than  the metrics scrapping period
      */
     private final int performanceSendMessagesPeriod = getOrDefault(SCALE_PERF_SEND_MSG_PERIOD_MILLIS, Integer::parseInt, 10_000);
+    private final int performanceReceiversPerTenant = getOrDefault(SCALE_PERF_RECEIVERS_PER_TENANT, Integer::parseInt, 1);
+    private final int performanceSendersPerTenant = getOrDefault(SCALE_PERF_SENDERS_PER_TENANT, Integer::parseInt, 1);
 
     //fault tolerance constants
     private final int faultToleranceInitialAddresses = getOrDefault(SCALE_HA_ADDRESSES, Integer::parseInt, 8_000);
@@ -142,6 +146,15 @@ public class ScaleTestEnvironment {
     public int getPerfSendMessagesPeriod() {
         return performanceSendMessagesPeriod;
     }
+
+    public int getPerfReceiversPerTenant() {
+        return performanceReceiversPerTenant;
+    }
+
+    public int getPerfSendersPerTenant() {
+        return performanceSendersPerTenant;
+    }
+
 
     public int getFaultToleranceInitialAddresses() {
         return faultToleranceInitialAddresses;


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->
- Enhancement 


### Description

Comes from suggestion, to be prepared for representing iot usecase this PR adds ability to set the number of senders and receivers to create by the tenant client 
<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
