### PR TITLE
Adds tests verifying the api server validates the plan of address spaces/addresses

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/manager/ResourceManager.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/manager/ResourceManager.java
@@ -361,6 +361,10 @@ public abstract class ResourceManager {
         AddressUtils.replaceAddress(destination, true, new TimeoutBudget(3, TimeUnit.MINUTES));
     }
 
+    public Address getAddress(String namespace, Address destination) {
+        return kubernetes.getAddressClient().inNamespace(namespace).withName(destination.getMetadata().getName()).get();
+    }
+
     //================================================================================================
     //======================================= User methods ===========================================
     //================================================================================================

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/plans/brokered/PlansTestBrokered.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/plans/brokered/PlansTestBrokered.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PlansTestBrokered extends TestBase implements ITestIsolatedBrokered {
@@ -129,14 +130,12 @@ public class PlansTestBrokered extends TestBase implements ITestIsolatedBrokered
                 .endSpec()
                 .build();
 
-        try {
+
+        KubernetesClientException exception = assertThrows(KubernetesClientException.class, () -> {
             kubernetes.getAddressSpaceClient(addressSpace.getMetadata().getNamespace()).create(addressSpace);
-            fail("exception not thrown");
-        } catch (KubernetesClientException e) {
-            String message = e.getMessage();
-            assertTrue(message.contains(String.format("Unknown address space plan %s", unknownPlan)), "Unexpected exception message : " + message);
-            // PASS
-        }
+        });
+        String message = exception.getMessage();
+        assertTrue(message.contains(String.format("Unknown address space plan %s", unknownPlan)), "Unexpected exception message : " + message);
     }
 
     @Test
@@ -155,15 +154,12 @@ public class PlansTestBrokered extends TestBase implements ITestIsolatedBrokered
 
         resourcesManager.createAddressSpace(addressSpace);
 
-        try {
+        KubernetesClientException exception = assertThrows(KubernetesClientException.class, () -> {
             AddressSpace upd = new AddressSpaceBuilder(addressSpace).editSpec().withPlan(unknownPlan).endSpec().build();
             kubernetes.getAddressSpaceClient(addressSpace.getMetadata().getNamespace()).createOrReplace(upd);
-            fail("exception not thrown");
-        } catch (KubernetesClientException e) {
-            String message = e.getMessage();
-            assertTrue(message.contains(String.format("Unknown address space plan %s", unknownPlan)), "Unexpected exception message : " + message);
-            // PASS
-        }
+        });
+        String message = exception.getMessage();
+        assertTrue(message.contains(String.format("Unknown address space plan %s", unknownPlan)), "Unexpected exception message : " + message);
     }
 
     @Test
@@ -194,14 +190,11 @@ public class PlansTestBrokered extends TestBase implements ITestIsolatedBrokered
                 .endSpec()
                 .build();
 
-        try {
+        KubernetesClientException exception = assertThrows(KubernetesClientException.class, () -> {
             kubernetes.getAddressClient(addressSpace.getMetadata().getNamespace()).create(addr);
-            fail("exception not thrown");
-        } catch (KubernetesClientException e) {
-            String message = e.getMessage();
-            assertTrue(message.contains(String.format("Unknown address plan %s", unknownPlan)), "Unexpected exception message : " + message);
-            // PASS
-        }
+        });
+        String message = exception.getMessage();
+        assertTrue(message.contains(String.format("Unknown address plan %s", unknownPlan)), "Unexpected exception message : " + message);
     }
 
     @Test
@@ -232,15 +225,12 @@ public class PlansTestBrokered extends TestBase implements ITestIsolatedBrokered
                 .build();
 
         String unknownPlan = "unknown";
-        try {
+        KubernetesClientException exception = assertThrows(KubernetesClientException.class, () -> {
             Address upd = new AddressBuilder(addr).editSpec().withPlan(unknownPlan).endSpec().build();
             kubernetes.getAddressClient(addressSpace.getMetadata().getNamespace()).createOrReplace(upd);
-            fail("exception not thrown");
-        } catch (KubernetesClientException e) {
-            String message = e.getMessage();
-            assertTrue(message.contains(String.format("Unknown address plan %s", unknownPlan)), "Unexpected exception message : " + message);
-            // PASS
-        }
+        });
+        String message = exception.getMessage();
+        assertTrue(message.contains(String.format("Unknown address plan %s", unknownPlan)), "Unexpected exception message : " + message);
     }
 
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/plans/standard/PlansTestStandard.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/plans/standard/PlansTestStandard.java
@@ -58,10 +58,7 @@ import java.util.stream.IntStream;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 class PlansTestStandard extends TestBase implements ITestIsolatedStandard {
@@ -1219,14 +1216,11 @@ class PlansTestStandard extends TestBase implements ITestIsolatedStandard {
                 .endSpec()
                 .build();
 
-        try {
+        KubernetesClientException exception = assertThrows(KubernetesClientException.class, () -> {
             kubernetes.getAddressSpaceClient(addressSpace.getMetadata().getNamespace()).create(addressSpace);
-            fail("exception not thrown");
-        } catch (KubernetesClientException e) {
-            String message = e.getMessage();
-            assertTrue(message.contains(String.format("Unknown address space plan %s", unknownPlan)), "Unexpected exception message : " + message);
-            // PASS
-        }
+        });
+        String message = exception.getMessage();
+        assertTrue(message.contains(String.format("Unknown address space plan %s", unknownPlan)), "Unexpected exception message : " + message);
     }
 
     @Test
@@ -1245,15 +1239,12 @@ class PlansTestStandard extends TestBase implements ITestIsolatedStandard {
 
         resourcesManager.createAddressSpace(addressSpace);
 
-        try {
+        KubernetesClientException exception = assertThrows(KubernetesClientException.class, () -> {
             AddressSpace upd = new AddressSpaceBuilder(addressSpace).editSpec().withPlan(unknownPlan).endSpec().build();
             kubernetes.getAddressSpaceClient(addressSpace.getMetadata().getNamespace()).createOrReplace(upd);
-            fail("exception not thrown");
-        } catch (KubernetesClientException e) {
-            String message = e.getMessage();
-            assertTrue(message.contains(String.format("Unknown address space plan %s", unknownPlan)), "Unexpected exception message : " + message);
-            // PASS
-        }
+        });
+        String message = exception.getMessage();
+        assertTrue(message.contains(String.format("Unknown address space plan %s", unknownPlan)), "Unexpected exception message : " + message);
     }
 
     @Test
@@ -1284,14 +1275,11 @@ class PlansTestStandard extends TestBase implements ITestIsolatedStandard {
                 .endSpec()
                 .build();
 
-        try {
+        KubernetesClientException exception = assertThrows(KubernetesClientException.class, () -> {
             kubernetes.getAddressClient(addressSpace.getMetadata().getNamespace()).create(addr);
-            fail("exception not thrown");
-        } catch (KubernetesClientException e) {
-            String message = e.getMessage();
-            assertTrue(message.contains(String.format("Unknown address plan %s", unknownPlan)), "Unexpected exception message : " + message);
-            // PASS
-        }
+        });
+        String message = exception.getMessage();
+        assertTrue(message.contains(String.format("Unknown address plan %s", unknownPlan)), "Unexpected exception message : " + message);
     }
 
     @Test
@@ -1322,15 +1310,13 @@ class PlansTestStandard extends TestBase implements ITestIsolatedStandard {
                 .build();
 
         String unknownPlan = "unknown";
-        try {
+
+        KubernetesClientException exception = assertThrows(KubernetesClientException.class, () -> {
             Address upd = new AddressBuilder(addr).editSpec().withPlan(unknownPlan).endSpec().build();
             kubernetes.getAddressClient(addressSpace.getMetadata().getNamespace()).createOrReplace(upd);
-            fail("exception not thrown");
-        } catch (KubernetesClientException e) {
-            String message = e.getMessage();
-            assertTrue(message.contains(String.format("Unknown address plan %s", unknownPlan)), "Unexpected exception message : " + message);
-            // PASS
-        }
+        });
+        String message = exception.getMessage();
+        assertTrue(message.contains(String.format("Unknown address plan %s", unknownPlan)), "Unexpected exception message : " + message);
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

Adds tests verifying the api server validates the plan of address spaces/addresses

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
