### PR TITLE
Prevent address with invalid plan from blocking standard controller reconcile loop

### DIFF
--- a/standard-controller/src/main/java/io/enmasse/controller/standard/AddressController.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/AddressController.java
@@ -18,6 +18,7 @@ import io.enmasse.address.model.BrokerState;
 import io.enmasse.address.model.BrokerStatus;
 import io.enmasse.address.model.Phase;
 import io.enmasse.address.model.Schema;
+import io.enmasse.address.model.UnresolvedAddressException;
 import io.enmasse.admin.model.AddressPlan;
 import io.enmasse.admin.model.AddressSpacePlan;
 import io.enmasse.admin.model.v1.InfraConfig;
@@ -265,6 +266,14 @@ public class AddressController implements Watcher<Address> {
                             .build());
                 }
                 address.getStatus().setForwarders(forwarderStatuses);
+            }
+
+            try {
+                addressResolver.getDesiredPlan(address);
+            } catch (UnresolvedAddressException e) {
+                address.getStatus().setPhase(Pending);
+                address.getStatus().appendMessage("Unknown address plan '" + address.getSpec().getPlan() + "'");
+                continue;
             }
 
             Address existing = validAddresses.get(address.getSpec().getAddress());


### PR DESCRIPTION
### Type of change

- Bugfix
### Description

#4147 didn't completely eliminate the problem.  If the address space plan changes leaving an existing address with an illegal plan ref, the standard controller's processing loop aborts, leaving new addresses unprocessed.

This chnage prevent address with invalid plan from blocking standard controller reconcile loop

### Checklist

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
