### PR TITLE
Add --url=true to the minikube service cmd line to ensure compatibility

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/Minikube.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/Minikube.java
@@ -58,12 +58,12 @@ public class Minikube extends Kubernetes {
     }
 
     private String getIp(String namespace, String serviceName) {
-        String [] output = runCommand("minikube", "service", "-n", namespace, "--format", "{{.IP}}", serviceName).split(" ");
+        String [] output = runCommand("minikube", "service", "-n", namespace, "--format", "{{.IP}}", serviceName, "--url=true").split(" ");
         return output[output.length - 1];
     }
 
     private String getPort(String namespace, String serviceName) {
-        String [] output = runCommand("minikube", "service", "-n", namespace, "--format", "{{.Port}}", serviceName).split(" ");
+        String [] output = runCommand("minikube", "service", "-n", namespace, "--format", "{{.Port}}", serviceName, "--url=true").split(" ");
         return output[output.length - 1];
     }
 


### PR DESCRIPTION


### Type of change


- Bugfix

### Description

Adds `--url=true` to the minikube service cmd line to ensure compatibility with Minikube v1.8.


### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
