### PR TITLE
Systemtests olm upgrade

### DIFF
--- a/.jenkins/Jenkinsfile-pr
+++ b/.jenkins/Jenkinsfile-pr
@@ -93,8 +93,10 @@ pipeline {
                     } else {
                         env.TEST_ONLY = false
                         if (env.OC_VERSION == "4") {
-                            env.DOCKER_REGISTRY = 'default-route-openshift-image-registry.apps-crc.testing'
-                            env.INTERNAL_REGISTRY = 'image-registry.openshift-image-registry.svc:5000'
+                            env.OCP4_EXTERNAL_IMAGE_REGISTRY = 'default-route-openshift-image-registry.apps-crc.testing'
+                            env.OCP4_INTERNAL_IMAGE_REGISTRY = 'image-registry.openshift-image-registry.svc:5000'
+                            env.DOCKER_REGISTRY = "${OCP4_EXTERNAL_IMAGE_REGISTRY}"
+                            env.INTERNAL_REGISTRY = "${OCP4_INTERNAL_IMAGE_REGISTRY}"
                         } else {
                             env.DOCKER_REGISTRY = '172.30.1.1:5000'
                             env.INTERNAL_REGISTRY = '172.30.1.1:5000'

--- a/systemtests/.gitignore
+++ b/systemtests/.gitignore
@@ -15,3 +15,4 @@
 
 # Test requirement specific
 client_executable
+.env

--- a/systemtests/Makefile
+++ b/systemtests/Makefile
@@ -28,6 +28,10 @@ $(error "Environment variable $$KUBERNETES_API_URL not set")
 endif
 endif
 
+ifneq (, $(wildcard .env))
+include .env
+endif
+
 all: systemtests
 
 systemtests:

--- a/systemtests/custom-operator-registry/.gitignore
+++ b/systemtests/custom-operator-registry/.gitignore
@@ -1,0 +1,1 @@
+manifests

--- a/systemtests/custom-operator-registry/Dockerfile
+++ b/systemtests/custom-operator-registry/Dockerfile
@@ -1,0 +1,8 @@
+FROM quay.io/operator-framework/upstream-registry-builder:latest
+
+COPY manifests manifests
+RUN /bin/initializer -o ./bundles.db
+
+EXPOSE 50051
+ENTRYPOINT ["/bin/registry-server"]
+CMD ["--database", "/build/bundles.db"]

--- a/systemtests/custom-operator-registry/Makefile
+++ b/systemtests/custom-operator-registry/Makefile
@@ -1,2 +1,2 @@
 build_push_registry:
-	./build_push_registry.sh ${FROM} ${TAG} ${REGISTRY}
+	./build_push_registry.sh ${FROM} ${TAG}

--- a/systemtests/custom-operator-registry/Makefile
+++ b/systemtests/custom-operator-registry/Makefile
@@ -1,0 +1,2 @@
+build_push_registry:
+	./build_push_registry.sh ${FROM} ${TAG} ${REGISTRY}

--- a/systemtests/custom-operator-registry/build_push_registry.sh
+++ b/systemtests/custom-operator-registry/build_push_registry.sh
@@ -2,21 +2,23 @@
 FROM=${1}
 CUSTOM_IMAGE=${2}
 
+DOCKER=${DOCKER:-docker}
+
 rm -rf manifests
-id=$(docker create $FROM)
-docker cp $id:/manifests $PWD
+id=$($DOCKER create $FROM)
+$DOCKER cp $id:/manifests $PWD
 echo "manifests copied"
 MANIFESTS_CONTENT_REPLACER=./manifests_replacer.sh
 if [ -f "$MANIFESTS_CONTENT_REPLACER" ]; then
     echo "executing $MANIFESTS_CONTENT_REPLACER"
     bash $MANIFESTS_CONTENT_REPLACER
 fi
-docker rm -v $id
+$DOCKER rm -v $id
 
-docker build -t $CUSTOM_IMAGE .
+$DOCKER build -t $CUSTOM_IMAGE .
 
 rm -rf manifests
 
-docker login $OCP4_EXTERNAL_IMAGE_REGISTRY -u $(oc whoami) -p $(oc whoami -t)
+$DOCKER login $OCP4_EXTERNAL_IMAGE_REGISTRY -u $(oc whoami) -p $(oc whoami -t)
 
-docker push $CUSTOM_IMAGE
+$DOCKER push $CUSTOM_IMAGE

--- a/systemtests/custom-operator-registry/build_push_registry.sh
+++ b/systemtests/custom-operator-registry/build_push_registry.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+FROM=${1}
+CUSTOM_IMAGE=${2}
+REGISTRY=${3}
+
+rm -rf manifests
+id=$(docker create $FROM)
+docker cp $id:/manifests $PWD
+if [ "${REGISTRY}" != "" ]; then
+    find manifests -name "*.yaml" | xargs sed -e "s,registry.redhat.io/amq7/amq-online-,${REGISTRY}/rh-osbs/amq7-amq-online-,g" -i
+    find manifests -name "*.yaml" | xargs sed -e "s,registry.redhat.io/amq7-tech-preview/amq-online-,${REGISTRY}/rh-osbs/amq7-tech-preview-amq-online-,g" -i
+fi
+docker rm -v $id
+
+docker build -t $CUSTOM_IMAGE .
+
+rm -rf manifests
+
+docker login $OCP4_EXTERNAL_IMAGE_REGISTRY -u $(oc whoami) -p $(oc whoami -t)
+
+docker push $CUSTOM_IMAGE

--- a/systemtests/custom-operator-registry/build_push_registry.sh
+++ b/systemtests/custom-operator-registry/build_push_registry.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 FROM=${1}
 CUSTOM_IMAGE=${2}
-REGISTRY=${3}
 
 rm -rf manifests
 id=$(docker create $FROM)
 docker cp $id:/manifests $PWD
-if [ "${REGISTRY}" != "" ]; then
-    find manifests -name "*.yaml" | xargs sed -e "s,registry.redhat.io/amq7/amq-online-,${REGISTRY}/rh-osbs/amq7-amq-online-,g" -i
-    find manifests -name "*.yaml" | xargs sed -e "s,registry.redhat.io/amq7-tech-preview/amq-online-,${REGISTRY}/rh-osbs/amq7-tech-preview-amq-online-,g" -i
+echo "manifests copied"
+MANIFESTS_CONTENT_REPLACER=./manifests_replacer.sh
+if [ -f "$MANIFESTS_CONTENT_REPLACER" ]; then
+    echo "executing $MANIFESTS_CONTENT_REPLACER"
+    bash $MANIFESTS_CONTENT_REPLACER
 fi
 docker rm -v $id
 

--- a/systemtests/custom-operator-registry/catalog-source.yaml
+++ b/systemtests/custom-operator-registry/catalog-source.yaml
@@ -1,0 +1,12 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: ${CATALOG_SOURCE_NAME}
+  namespace: ${OPERATOR_NAMESPACE}
+  labels:
+    app: enmasse
+spec:
+  displayName: EnMasse Operator Source
+  image: ${REGISTRY_IMAGE}
+  publisher: enmasse
+  sourceType: grpc

--- a/systemtests/custom-operator-registry/example_manifests_replacer.sh
+++ b/systemtests/custom-operator-registry/example_manifests_replacer.sh
@@ -1,0 +1,1 @@
+find manifests -name "*.yaml" | xargs sed -e "s,quay.io/enmasse,dummy-registry/test,g" -i

--- a/systemtests/custom-operator-registry/operator-group.yaml
+++ b/systemtests/custom-operator-registry/operator-group.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: enmasse-group
+  namespace: ${OPERATOR_NAMESPACE}
+  labels:
+    app: enmasse
+spec:
+  targetNamespaces:
+  - ${OPERATOR_NAMESPACE}

--- a/systemtests/custom-operator-registry/subscription.yaml
+++ b/systemtests/custom-operator-registry/subscription.yaml
@@ -1,0 +1,14 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: enmasse-sub
+  namespace: ${OPERATOR_NAMESPACE}
+  labels:
+    app: enmasse
+spec:
+  name: enmasse
+  source: ${CATALOG_SOURCE_NAME}
+  sourceNamespace: ${CATALOG_NAMESPACE}
+  startingCSV: ${CSV}
+  channel: alpha
+  installPlanApproval: Automatic

--- a/systemtests/pom.xml
+++ b/systemtests/pom.xml
@@ -167,6 +167,7 @@
                         <enmasse.olm.about.url>${olm.csv.about.url}</enmasse.olm.about.url>
                         <enmasse.olm.doc.configure.url>${olm.csv.doc.configure.url}</enmasse.olm.doc.configure.url>
                         <enmasse.olm.doc.iot.url>${olm.csv.doc.iot.url}</enmasse.olm.doc.iot.url>
+                        <enmasse.olm.replaces>${olm.csv.replaces}</enmasse.olm.replaces>
                     </systemProperties>
                     <includes>
                         <include>io.enmasse.systemtest.**</include>

--- a/systemtests/src/main/java/io/enmasse/systemtest/Environment.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/Environment.java
@@ -48,6 +48,8 @@ public class Environment {
     private static final String POSTGRESQL_PROJECT = "POSTGRESQL_PROJECT";
     private static final String H2_PROJECT = "H2_PROJECT";
     private static final String SCALE_CONFIG = "SCALE_CONFIG";
+    private static final String OCP4_EXTERNAL_IMAGE_REGISTRY = "OCP4_EXTERNAL_IMAGE_REGISTRY";
+    private static final String OCP4_INTERNAL_IMAGE_REGISTRY = "OCP4_INTERNAL_IMAGE_REGISTRY";
     private static Logger log = CustomLogger.getLogger();
     private static Environment instance;
     private final String namespace = System.getenv().getOrDefault(K8S_NAMESPACE_ENV, "enmasse-infra");
@@ -83,6 +85,8 @@ public class Environment {
             .map(OLMInstallationType::valueOf).orElse(OLMInstallationType.SPECIFIC);
     protected String templatesPath = System.getenv().getOrDefault(TEMPLATES_PATH,
             Paths.get(System.getProperty("user.dir"), "..", "templates", "build", "enmasse-latest").toString());
+    private final String clusterExternalImageRegistry = System.getenv().getOrDefault(OCP4_EXTERNAL_IMAGE_REGISTRY, "");
+    private final String clusterInternalImageRegistry = System.getenv().getOrDefault(OCP4_INTERNAL_IMAGE_REGISTRY, "");
     protected UserCredentials managementCredentials = new UserCredentials(null, null);
     protected UserCredentials defaultCredentials = new UserCredentials(null, null);
     protected UserCredentials sharedManagementCredentials = new UserCredentials("artemis-admin", "artemis-admin");
@@ -299,5 +303,13 @@ public class Environment {
 
     public String getScaleConfig() {
         return scaleConfig;
+    }
+
+    public String getClusterExternalImageRegistry() {
+        return clusterExternalImageRegistry;
+    }
+
+    public String getClusterInternalImageRegistry() {
+        return clusterInternalImageRegistry;
     }
 }

--- a/systemtests/src/main/java/io/enmasse/systemtest/Environment.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/Environment.java
@@ -24,6 +24,7 @@ public class Environment {
     public static final String K8S_API_TOKEN_ENV = "KUBERNETES_API_TOKEN";
     public static final String ENMASSE_VERSION_SYSTEM_PROPERTY = "enmasse.version";
     public static final String ENMASSE_DOCS_SYSTEM_PROPERTY = "enmasse.docs";
+    public static final String ENMASSE_OLM_REPLACES_SYSTEM_PROPERTY = "enmasse.olm.replaces";
     public static final String K8S_DOMAIN_ENV = "KUBERNETES_DOMAIN";
     public static final String K8S_API_CONNECT_TIMEOUT = "KUBERNETES_API_CONNECT_TIMEOUT";
     public static final String K8S_API_READ_TIMEOUT = "KUBERNETES_API_READ_TIMEOUT";
@@ -61,6 +62,7 @@ public class Environment {
     private final String enmasseOlmAboutUrl = System.getProperty("enmasse.olm.about.url");
     private final String enmasseOlmDocConfigUrl = System.getProperty("enmasse.olm.doc.configure.url");
     private final String enmasseOlmDocIotUrl = System.getProperty("enmasse.olm.doc.iot.url");
+    private final String enmasseOlmReplaces = System.getProperty(ENMASSE_OLM_REPLACES_SYSTEM_PROPERTY);
     private String kubernetesDomain = System.getenv(K8S_DOMAIN_ENV);
     private final String startTemplates = System.getenv().getOrDefault(START_TEMPLATES_ENV,
             Paths.get(System.getProperty("user.dir"), "..", "templates", "build", "enmasse-latest").toString());
@@ -211,6 +213,10 @@ public class Environment {
 
     public String enmasseOlmDocIotUrl() {
         return enmasseOlmDocIotUrl;
+    }
+    
+    public String enmasseOlmReplaces() {
+        return enmasseOlmReplaces;
     }
 
     public String kubernetesDomain() {

--- a/systemtests/src/main/java/io/enmasse/systemtest/bases/ITestBase.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/bases/ITestBase.java
@@ -10,6 +10,7 @@ import io.enmasse.systemtest.manager.ResourceManager;
 import io.enmasse.systemtest.model.address.AddressType;
 import io.enmasse.systemtest.model.addressspace.AddressSpaceType;
 import io.enmasse.systemtest.platform.Kubernetes;
+
 import org.slf4j.Logger;
 
 public interface ITestBase {

--- a/systemtests/src/main/java/io/enmasse/systemtest/manager/ResourceManager.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/manager/ResourceManager.java
@@ -240,7 +240,8 @@ public abstract class ResourceManager {
     }
 
     public void removeAuthService(AuthenticationService authService) throws Exception {
-        Kubernetes.getInstance().getAuthenticationServiceClient().withName(authService.getMetadata().getName()).cascading(true).delete();
+        Kubernetes.getInstance().getAuthenticationServiceClient(authService.getMetadata().getNamespace())
+            .withName(authService.getMetadata().getName()).cascading(true).delete();
         TestUtils.waitUntilCondition("Auth service is deleted: " + authService.getMetadata().getName(), (phase) ->
                         TestUtils.listReadyPods(Kubernetes.getInstance(), authService.getMetadata().getNamespace()).stream().noneMatch(pod ->
                                 pod.getMetadata().getName().contains(authService.getMetadata().getName())),

--- a/systemtests/src/main/java/io/enmasse/systemtest/operator/OperatorManager.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/operator/OperatorManager.java
@@ -199,7 +199,7 @@ public class OperatorManager {
         KubeCMDClient.deleteFromFile(namespace, Paths.get(Environment.getInstance().getTemplatesPath(), "install", "components", "example-plans"));
     }
 
-    public void removeOlm() throws Exception {
+    public boolean removeOlm() throws Exception {
         Consumer<String> remover = (namespace) -> {
             KubeCMDClient.runOnCluster("delete", "subscriptions", "-l", "app=enmasse", "-n", namespace);
             KubeCMDClient.runOnCluster("delete", "operatorgroups", "-l", "app=enmasse", "-n", namespace);
@@ -218,7 +218,7 @@ public class OperatorManager {
         if (isEnmasseOlmDeployed(kube.getInfraNamespace())) {
             remover.accept(kube.getInfraNamespace());
         }
-        clean();
+        return clean();
     }
 
     public void removeExampleRoles(String namespace) {

--- a/systemtests/src/main/java/io/enmasse/systemtest/operator/OperatorManager.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/operator/OperatorManager.java
@@ -22,6 +22,7 @@ import org.slf4j.Logger;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -267,7 +268,7 @@ public class OperatorManager {
         }
         KubeCMDClient.runOnCluster("delete", "clusterservicebrokers", "-l", "app=enmasse");
         if (!kube.getInfraNamespace().equals(kube.getOlmNamespace())) {
-            kube.deleteNamespace(kube.getInfraNamespace());
+            kube.deleteNamespace(kube.getInfraNamespace(), Duration.ofMinutes(kube.getOcpVersion() == OpenShiftVersion.OCP4 ? 10 : 5));
         }
         return true;
     }

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/KubeCMDClient.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/KubeCMDClient.java
@@ -301,6 +301,9 @@ public class KubeCMDClient {
                 .replaceAll(System.getProperty("line.separator"), "");
     }
 
+    /**
+     * Note: there are lots of kubernetes components creating events with "<nil>" timestamps, so I'm forced to remove the sorting by this values
+     */
     public static ExecutionResultData getEvents(String namespace) {
         List<String> command = Arrays.asList(CMD, "get", "events",
                 "--namespace", namespace,
@@ -309,6 +312,9 @@ public class KubeCMDClient {
         return Exec.execute(command, ONE_MINUTE_TIMEOUT, false);
     }
 
+    /**
+     * Note: there are lots of kubernetes components creating events with "<nil>" timestamps, so I'm forced to remove the sorting by this values
+     */
     public static ExecutionResultData getAllEvents() {
         List<String> command = Arrays.asList(CMD, "get", "events",
                 "--all-namespaces=true",

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/Kubernetes.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/Kubernetes.java
@@ -559,6 +559,10 @@ public abstract class Kubernetes {
     }
 
     public void deleteNamespace(String namespace) throws Exception {
+        deleteNamespace(namespace, Duration.ofMinutes(5));
+    }
+
+    public void deleteNamespace(String namespace, Duration timeout) throws Exception {
         if (verboseLog) {
             log.info("Following namespace will be removed - {}", namespace);
         }
@@ -566,7 +570,7 @@ public abstract class Kubernetes {
             client.namespaces().withName(namespace).cascading(true).delete();
 
             TestUtils.waitUntilCondition("Namespace will be deleted", phase ->
-                    !namespaceExists(namespace), new TimeoutBudget(5, TimeUnit.MINUTES));
+                    !namespaceExists(namespace), TimeoutBudget.ofDuration(timeout));
         } else {
             log.info("Namespace {} already removed", namespace);
         }

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/Kubernetes.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/Kubernetes.java
@@ -787,9 +787,9 @@ public abstract class Kubernetes {
      * @param podName name of pod
      * @return list of containers
      */
-    public List<Container> getContainersFromPod(String podName) {
+    public List<Container> getContainersFromPod(String namespace, String podName) {
         Objects.requireNonNull(podName);
-        return client.pods().inNamespace(infraNamespace).withName(podName).get().getSpec().getContainers();
+        return client.pods().inNamespace(namespace).withName(podName).get().getSpec().getContainers();
     }
 
     /***
@@ -798,10 +798,10 @@ public abstract class Kubernetes {
      * @param containerName name of container in pod
      * @return log
      */
-    public String getLog(String podName, String containerName) {
+    public String getLog(String namespace, String podName, String containerName) {
         Objects.requireNonNull(podName);
         Objects.requireNonNull(containerName);
-        return client.pods().inNamespace(infraNamespace).withName(podName).inContainer(containerName).getLog();
+        return client.pods().inNamespace(namespace).withName(podName).inContainer(containerName).getLog();
     }
 
     /***

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/Kubernetes.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/Kubernetes.java
@@ -956,10 +956,10 @@ public abstract class Kubernetes {
 
     public abstract String getOlmNamespace();
 
-    public void awaitPodsReady(TimeoutBudget budget) throws InterruptedException {
+    public void awaitPodsReady(String namespace, TimeoutBudget budget) throws InterruptedException {
         List<Pod> unready;
         do {
-            unready = new ArrayList<>(listPods());
+            unready = new ArrayList<>(listPods(namespace));
             unready.removeIf(p -> TestUtils.isPodReady(p, true));
 
             if (!unready.isEmpty()) {

--- a/systemtests/src/main/java/io/enmasse/systemtest/utils/AddressSpaceUtils.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/utils/AddressSpaceUtils.java
@@ -4,6 +4,7 @@
  */
 package io.enmasse.systemtest.utils;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -193,6 +194,8 @@ public class AddressSpaceUtils {
         waitForItems(addressSpace, budget, () -> kube.listStatefulSets(Collections.singletonMap("infraUuid", getAddressSpaceInfraUuid(addressSpace))));
         waitForItems(addressSpace, budget, () -> kube.listServiceAccounts(Collections.singletonMap("infraUuid", getAddressSpaceInfraUuid(addressSpace))));
         waitForItems(addressSpace, budget, () -> kube.listPersistentVolumeClaims(Collections.singletonMap("infraUuid", getAddressSpaceInfraUuid(addressSpace))));
+        var addressSpaceClient = kube.getAddressSpaceClient(addressSpace.getMetadata().getNamespace());
+        waitForItems(addressSpace, budget, () -> Optional.ofNullable(addressSpaceClient.withName(addressSpace.getMetadata().getName()).get()).map(Arrays::asList).orElse(Collections.emptyList()));
     }
 
     private static <T> void waitForItems(AddressSpace addressSpace, TimeoutBudget budget, Callable<List<T>> callable) throws Exception {

--- a/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
@@ -710,6 +710,10 @@ public class TestUtils {
         return getLogsPath(extensionContext, "scale_test");
     }
 
+    public static Path getUpgradeTestLogsPath(ExtensionContext extensionContext) {
+        return getLogsPath(extensionContext, "upgrade_test");
+    }
+
     public static Path getLogsPath(ExtensionContext extensionContext, String rootFolder) {
         String testMethod = extensionContext.getDisplayName();
         Class<?> testClass = extensionContext.getRequiredTestClass();

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/CommonTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/CommonTest.java
@@ -120,11 +120,12 @@ class CommonTest extends TestBase implements ITestBaseIsolated {
 
         Multimap<String, String> podsContainersWithNoLog = HashMultimap.create();
 
-        kubernetes.listPods().stream().filter(pod -> !pod.getMetadata().getName().contains("none-authservice")).forEach(pod -> kubernetes.getContainersFromPod(pod.getMetadata().getName()).forEach(container -> {
+        kubernetes.listPods().stream().filter(pod -> !pod.getMetadata().getName().contains("none-authservice")).forEach(pod -> kubernetes.getContainersFromPod(pod.getMetadata().getNamespace(), pod.getMetadata().getName()).forEach(container -> {
+            String podNamespace = pod.getMetadata().getNamespace();
             String podName = pod.getMetadata().getName();
             String containerName = container.getName();
             log.info("Getting log from pod: {}, for container: {}", podName, containerName);
-            String podlog = kubernetes.getLog(podName, containerName);
+            String podlog = kubernetes.getLog(podNamespace, podName, containerName);
 
             // Retry - diagnostic code to help understand a sporadic Ci failure.
             if (podlog.isEmpty()) {
@@ -134,7 +135,7 @@ class CommonTest extends TestBase implements ITestBaseIsolated {
                     Thread.currentThread().interrupt();
                 }
                 log.info("(Retry) Getting log from pod: {}, for container: {}", podName, containerName);
-                podlog = kubernetes.getLog(podName, containerName);
+                podlog = kubernetes.getLog(podNamespace, podName, containerName);
             }
 
             if (podlog.isEmpty()) {

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/CommonTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/CommonTest.java
@@ -116,7 +116,7 @@ class CommonTest extends TestBase implements ITestBaseIsolated {
                 .build();
         resourcesManager.setAddresses(dest);
 
-        kubernetes.awaitPodsReady(new TimeoutBudget(5, TimeUnit.MINUTES));
+        kubernetes.awaitPodsReady(standard.getMetadata().getNamespace(), new TimeoutBudget(5, TimeUnit.MINUTES));
 
         Multimap<String, String> podsContainersWithNoLog = HashMultimap.create();
 

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/upgrade/UpgradeTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/upgrade/UpgradeTest.java
@@ -133,6 +133,11 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
         if (this.type.equals(EnmasseInstallType.ANSIBLE)) {
             installEnmasseAnsible(Paths.get(templates), false);
         } else if(this.type.equals(EnmasseInstallType.OLM)) {
+            String csvVersionNumber = environment.enmasseOlmReplaces().substring(environment.enmasseOlmReplaces().indexOf(".")+1);
+            if (!version.equals(csvVersionNumber)) {
+                log.warn("Skipping OLM test from version {} , because replaces version is {}", version, environment.enmasseOlmReplaces());
+                return;
+            }
             installEnmasseOLM(Paths.get(templates), version);
         } else {
             installEnmasseBundle(Paths.get(templates), version);
@@ -395,8 +400,6 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
 
     private void installEnmasseOLM(Path templateDir, String version) throws Exception {
 
-//        String installationNamespace = OperatorManager.getInstance().getNamespaceByOlmInstallationType(olmType);
-
         if (olmType == OLMInstallationType.SPECIFIC) {
             kubernetes.createNamespace(infraNamespace, Collections.singletonMap("allowed", "true"));
         }
@@ -522,4 +525,5 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
             return yaml.get("spec").get("startingCSV").asText();
         }
     }
+
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/upgrade/UpgradeTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/upgrade/UpgradeTest.java
@@ -104,8 +104,8 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
                         throw e;
                     }
                 }
-                assertTrue(OperatorManager.getInstance().removeOlm());
             }
+            assertTrue(OperatorManager.getInstance().removeOlm());
             if (olmType != null && olmType == OLMInstallationType.DEFAULT) {
                 waitForNamespace = false;
             }

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/upgrade/UpgradeTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/upgrade/UpgradeTest.java
@@ -12,6 +12,7 @@ import io.enmasse.admin.model.v1.AuthenticationServiceSpecStandardStorage;
 import io.enmasse.admin.model.v1.AuthenticationServiceSpecStandardType;
 import io.enmasse.systemtest.EnmasseInstallType;
 import io.enmasse.systemtest.Environment;
+import io.enmasse.systemtest.OLMInstallationType;
 import io.enmasse.systemtest.UserCredentials;
 import io.enmasse.systemtest.bases.TestBase;
 import io.enmasse.systemtest.bases.isolated.ITestIsolatedStandard;
@@ -40,11 +41,16 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
@@ -61,7 +67,9 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
     private static final int MESSAGE_COUNT = 50;
     private static Logger log = CustomLogger.getLogger();
     private static String productName;
+    private String infraNamespace;
     private EnmasseInstallType type;
+    private OLMInstallationType olmType;
 
     @BeforeAll
     void prepareUpgradeEnv() throws Exception {
@@ -73,6 +81,8 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
     void removeEnmasse() throws Exception {
         if (this.type.equals(EnmasseInstallType.BUNDLE)) {
             assertTrue(OperatorManager.getInstance().clean());
+        } else if (this.type.equals(EnmasseInstallType.OLM)) {
+            assertTrue(OperatorManager.getInstance().removeOlm());
         } else {
             OperatorManager.getInstance().deleteEnmasseAnsible();
         }
@@ -82,6 +92,7 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
     @MethodSource("provideVersions")
     void testUpgradeBundle(String version, String templates) throws Exception {
         this.type = EnmasseInstallType.BUNDLE;
+        this.infraNamespace = kubernetes.getInfraNamespace();
         doTestUpgrade(templates, version);
     }
 
@@ -90,9 +101,29 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
     @OpenShift
     void testUpgradeAnsible(String version, String templates) throws Exception {
         this.type = EnmasseInstallType.ANSIBLE;
+        this.infraNamespace = kubernetes.getInfraNamespace();
         doTestUpgrade(templates, version);
     }
 
+    @ParameterizedTest(name = "testUpgradeOLMSpecific-{0}")
+    @MethodSource("provideVersions")
+    @OpenShift(version = OpenShiftVersion.OCP4)
+    void testUpgradeOLMSpecific(String version, String templates) throws Exception {
+        this.type = EnmasseInstallType.OLM;
+        this.olmType = OLMInstallationType.SPECIFIC;
+        this.infraNamespace = OperatorManager.getInstance().getNamespaceByOlmInstallationType(olmType);
+        doTestUpgrade(templates, version);
+    }
+
+    @ParameterizedTest(name = "testUpgradeOLMDefault-{0}")
+    @MethodSource("provideVersions")
+    @OpenShift(version = OpenShiftVersion.OCP4)
+    void testUpgradeOLMDefault(String version, String templates) throws Exception {
+        this.type = EnmasseInstallType.OLM;
+        this.olmType = OLMInstallationType.DEFAULT;
+        this.infraNamespace = OperatorManager.getInstance().getNamespaceByOlmInstallationType(olmType);
+        doTestUpgrade(templates, version);
+    }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////
     // Help methods
@@ -101,6 +132,8 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
     private void doTestUpgrade(String templates, String version) throws Exception {
         if (this.type.equals(EnmasseInstallType.ANSIBLE)) {
             installEnmasseAnsible(Paths.get(templates), false);
+        } else if(this.type.equals(EnmasseInstallType.OLM)) {
+            installEnmasseOLM(Paths.get(templates), version);
         } else {
             installEnmasseBundle(Paths.get(templates), version);
         }
@@ -111,34 +144,34 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
             ensurePersistentAuthService(authServiceName);
         }
 
-        createAddressSpaceCMD(kubernetes.getInfraNamespace(), "brokered", "brokered", "brokered-single-broker", authServiceName, getApiVersion(version));
+        createAddressSpaceCMD(infraNamespace, "brokered", "brokered", "brokered-single-broker", authServiceName, getApiVersion(version));
         Thread.sleep(30_000);
-        resourcesManager.waitForAddressSpaceReady(resourcesManager.getAddressSpace("brokered"));
+        resourcesManager.waitForAddressSpaceReady(resourcesManager.getAddressSpace(infraNamespace, "brokered"));
 
-        createAddressSpaceCMD(kubernetes.getInfraNamespace(), "standard", "standard", "standard-unlimited", authServiceName, getApiVersion(version));
+        createAddressSpaceCMD(infraNamespace, "standard", "standard", "standard-unlimited", authServiceName, getApiVersion(version));
         Thread.sleep(30_000);
-        resourcesManager.waitForAddressSpaceReady(resourcesManager.getAddressSpace("standard"));
+        resourcesManager.waitForAddressSpaceReady(resourcesManager.getAddressSpace(infraNamespace, "standard"));
 
-        createUserCMD(kubernetes.getInfraNamespace(), "test-brokered", "test", "brokered", getApiVersion(version));
-        createUserCMD(kubernetes.getInfraNamespace(), "test-standard", "test", "standard", getApiVersion(version));
+        createUserCMD(infraNamespace, "test-brokered", "test", "brokered", getApiVersion(version));
+        createUserCMD(infraNamespace, "test-standard", "test", "standard", getApiVersion(version));
         Thread.sleep(30_000);
 
-        createAddressCMD(kubernetes.getInfraNamespace(), "brokered-queue", "brokered-queue", "brokered", "queue", "brokered-queue", getApiVersion(version));
-        createAddressCMD(kubernetes.getInfraNamespace(), "brokered-topic", "brokered-topic", "brokered", "topic", "brokered-topic", getApiVersion(version));
+        createAddressCMD(infraNamespace, "brokered-queue", "brokered-queue", "brokered", "queue", "brokered-queue", getApiVersion(version));
+        createAddressCMD(infraNamespace, "brokered-topic", "brokered-topic", "brokered", "topic", "brokered-topic", getApiVersion(version));
         Thread.sleep(30_000);
-        AddressUtils.waitForDestinationsReady(AddressUtils.getAddresses(resourcesManager.getAddressSpace("brokered")).toArray(new Address[0]));
+        AddressUtils.waitForDestinationsReady(AddressUtils.getAddresses(resourcesManager.getAddressSpace(infraNamespace, "brokered")).toArray(new Address[0]));
 
-        createAddressCMD(kubernetes.getInfraNamespace(), "standard-queue-xlarge", "standard-queue-xlarge", "standard", "queue", "standard-xlarge-queue", getApiVersion(version));
-        createAddressCMD(kubernetes.getInfraNamespace(), "standard-queue-small", "standard-queue-small", "standard", "queue", "standard-small-queue", getApiVersion(version));
-        createAddressCMD(kubernetes.getInfraNamespace(), "standard-topic", "standard-topic", "standard", "topic", "standard-small-topic", getApiVersion(version));
-        createAddressCMD(kubernetes.getInfraNamespace(), "standard-anycast", "standard-anycast", "standard", "anycast", "standard-small-anycast", getApiVersion(version));
-        createAddressCMD(kubernetes.getInfraNamespace(), "standard-multicast", "standard-multicast", "standard", "multicast", "standard-small-multicast", getApiVersion(version));
+        createAddressCMD(infraNamespace, "standard-queue-xlarge", "standard-queue-xlarge", "standard", "queue", "standard-xlarge-queue", getApiVersion(version));
+        createAddressCMD(infraNamespace, "standard-queue-small", "standard-queue-small", "standard", "queue", "standard-small-queue", getApiVersion(version));
+        createAddressCMD(infraNamespace, "standard-topic", "standard-topic", "standard", "topic", "standard-small-topic", getApiVersion(version));
+        createAddressCMD(infraNamespace, "standard-anycast", "standard-anycast", "standard", "anycast", "standard-small-anycast", getApiVersion(version));
+        createAddressCMD(infraNamespace, "standard-multicast", "standard-multicast", "standard", "multicast", "standard-small-multicast", getApiVersion(version));
         Thread.sleep(30_000);
-        AddressUtils.waitForDestinationsReady(AddressUtils.getAddresses(resourcesManager.getAddressSpace("standard")).toArray(new Address[0]));
+        AddressUtils.waitForDestinationsReady(AddressUtils.getAddresses(resourcesManager.getAddressSpace(infraNamespace, "standard")).toArray(new Address[0]));
 
         // Workaround - addresses may report ready before the broker pod backing the address report ready=true.  This happens because broker liveness/readiness is judged on a
         // Jolokia based probe. As jolokia becomes available after AMQP management, address can be ready when the broker is not. See https://github.com/EnMasseProject/enmasse/issues/2979
-        kubernetes.awaitPodsReady(new TimeoutBudget(5, TimeUnit.MINUTES));
+        kubernetes.awaitPodsReady(infraNamespace, new TimeoutBudget(5, TimeUnit.MINUTES));
 
         assertTrue(sendMessage("brokered", new RheaClientSender(), new UserCredentials("test-brokered", "test"), "brokered-queue", "pepa", MESSAGE_COUNT, true));
         assertTrue(sendMessage("standard", new RheaClientSender(), new UserCredentials("test-standard", "test"), "standard-queue-small", "pepa", MESSAGE_COUNT, true));
@@ -146,13 +179,15 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
 
         if (this.type.equals(EnmasseInstallType.ANSIBLE)) {
             installEnmasseAnsible(Paths.get(Environment.getInstance().getUpgradeTemplates()), true);
+        } else if(this.type.equals(EnmasseInstallType.OLM)) {
+            upgradeEnmasseOLM(Paths.get(Environment.getInstance().getUpgradeTemplates()), version);
         } else {
             upgradeEnmasseBundle(Paths.get(Environment.getInstance().getUpgradeTemplates()));
         }
 
-        AddressSpace brokered = resourcesManager.getAddressSpace("brokered");
+        AddressSpace brokered = resourcesManager.getAddressSpace(infraNamespace, "brokered");
         assertNotNull(brokered);
-        AddressSpace standard = resourcesManager.getAddressSpace("standard");
+        AddressSpace standard = resourcesManager.getAddressSpace(infraNamespace, "standard");
         assertNotNull(standard);
         Arrays.asList(brokered, standard).forEach(a -> {
             try {
@@ -165,7 +200,7 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
         AddressUtils.waitForDestinationsReady(AddressUtils.getAddresses(brokered).toArray(new Address[0]));
         AddressUtils.waitForDestinationsReady(AddressUtils.getAddresses(standard).toArray(new Address[0]));
 
-        List<User> items = kubernetes.getUserClient().list().getItems();
+        List<User> items = kubernetes.getUserClient(infraNamespace).list().getItems();
         log.info("After upgrade {} user(s)", items.size());
         items.forEach(u -> log.info("User {}", u.getSpec().getUsername()));
 
@@ -175,11 +210,11 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
             assertTrue(receiveMessages("standard", new RheaClientReceiver(), new UserCredentials("test-standard", "test"), "standard-queue-small", MESSAGE_COUNT, true));
             assertTrue(receiveMessages("standard", new RheaClientReceiver(), new UserCredentials("test-standard", "test"), "standard-queue-xlarge", MESSAGE_COUNT, true));
         } else {
-            if (!KubeCMDClient.getUser(kubernetes.getInfraNamespace(), "brokered", "test-brokered").getRetCode()) {
-                createUserCMD(kubernetes.getInfraNamespace(), "test-brokered", "test", "brokered", "v1alpha1");
+            if (!KubeCMDClient.getUser(infraNamespace, "brokered", "test-brokered").getRetCode()) {
+                createUserCMD(infraNamespace, "test-brokered", "test", "brokered", "v1alpha1");
             }
-            if (!KubeCMDClient.getUser(kubernetes.getInfraNamespace(), "standard", "test-standard").getRetCode()) {
-                createUserCMD(kubernetes.getInfraNamespace(), "test-standard", "test", "standard", "v1alpha1");
+            if (!KubeCMDClient.getUser(infraNamespace, "standard", "test-standard").getRetCode()) {
+                createUserCMD(infraNamespace, "test-standard", "test", "standard", "v1alpha1");
             }
             Thread.sleep(30_000);
 
@@ -216,21 +251,21 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
 
     private void installEnmasseBundle(Path templateDir, String version) throws Exception {
         log.info("Application will be deployed using bundle version {}", version);
-        KubeCMDClient.createNamespace(kubernetes.getInfraNamespace());
-        KubeCMDClient.switchProject(kubernetes.getInfraNamespace());
+        KubeCMDClient.createNamespace(infraNamespace);
+        KubeCMDClient.switchProject(infraNamespace);
         if (version.startsWith("0.26") || version.equals("1.0")) {
-            KubeCMDClient.applyFromFile(kubernetes.getInfraNamespace(), Paths.get(templateDir.toString(), "install", "bundles", productName.equals("enmasse") ? "enmasse-with-standard-authservice" : productName));
+            KubeCMDClient.applyFromFile(infraNamespace, Paths.get(templateDir.toString(), "install", "bundles", productName.equals("enmasse") ? "enmasse-with-standard-authservice" : productName));
         } else {
-            KubeCMDClient.applyFromFile(kubernetes.getInfraNamespace(), Paths.get(templateDir.toString(), "install", "bundles", productName));
-            KubeCMDClient.applyFromFile(kubernetes.getInfraNamespace(), Paths.get(templateDir.toString(), "install", "components", "example-plans"));
-            KubeCMDClient.applyFromFile(kubernetes.getInfraNamespace(), Paths.get(templateDir.toString(), "install", "components", "example-authservices", "standard-authservice.yaml"));
+            KubeCMDClient.applyFromFile(infraNamespace, Paths.get(templateDir.toString(), "install", "bundles", productName));
+            KubeCMDClient.applyFromFile(infraNamespace, Paths.get(templateDir.toString(), "install", "components", "example-plans"));
+            KubeCMDClient.applyFromFile(infraNamespace, Paths.get(templateDir.toString(), "install", "components", "example-authservices", "standard-authservice.yaml"));
         }
         Thread.sleep(60_000);
-        TestUtils.waitUntilDeployed(kubernetes.getInfraNamespace());
+        TestUtils.waitUntilDeployed(infraNamespace);
     }
 
     private void upgradeEnmasseBundle(Path templateDir) throws Exception {
-        KubeCMDClient.applyFromFile(kubernetes.getInfraNamespace(), Paths.get(templateDir.toString(), "install", "bundles", productName));
+        KubeCMDClient.applyFromFile(infraNamespace, Paths.get(templateDir.toString(), "install", "bundles", productName));
         Thread.sleep(600_000);
         checkImagesUpdated(getVersionFromTemplateDir(templateDir));
     }
@@ -244,7 +279,7 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
         Path inventoryFile = Paths.get(System.getProperty("user.dir"), "ansible", "inventory", kubernetes.getOcpVersion() == OpenShiftVersion.OCP3 ? "systemtests.inventory" : "systemtests.ocp4.inventory");
         Path ansiblePlaybook = Paths.get(templatePaths.toString(), "ansible", "playbooks", "openshift", "deploy_all.yml");
         List<String> cmd = Arrays.asList("ansible-playbook", ansiblePlaybook.toString(), "-i", inventoryFile.toString(),
-                "--extra-vars", String.format("namespace=%s authentication_services=[\"standard\"]", kubernetes.getInfraNamespace()));
+                "--extra-vars", String.format("namespace=%s authentication_services=[\"standard\"]", infraNamespace));
 
         assertTrue(Exec.execute(cmd, 300_000, true).getRetCode(), "Deployment of new version of enmasse failed");
         log.info("Sleep after {}", upgrade ? "upgrade" : "install");
@@ -254,7 +289,7 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
             Thread.sleep(600_000);
             checkImagesUpdated(getVersionFromTemplateDir(templatePaths));
         } else {
-            TestUtils.waitUntilDeployed(kubernetes.getInfraNamespace());
+            TestUtils.waitUntilDeployed(infraNamespace);
         }
     }
 
@@ -268,7 +303,7 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
         TestUtils.waitUntilCondition("Images are updated", (phase) -> {
             AtomicBoolean ready = new AtomicBoolean(true);
             log.info("=======================================================");
-            kubernetes.listPods().forEach(pod -> {
+            kubernetes.listPods(infraNamespace).forEach(pod -> {
                 pod.getSpec().getContainers().forEach(container -> {
                     log.info("Pod {}, current container {}", pod.getMetadata().getName(), container.getImage());
                     String replaced = container.getImage()
@@ -277,7 +312,7 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
                         .replace("console-httpd", "console-server");
 
                     log.info("Comparing: {}", replaced);
-                    if (!images.contains(replaced) && !container.getImage().contains("postgresql")) {
+                    if (!images.contains(replaced) && !container.getImage().contains("postgresql") && !container.getImage().contains("systemtests-operator-registry")) {
                         log.warn("Container is not upgraded");
                         ready.set(false);
                     } else {
@@ -298,7 +333,7 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
             });
             return ready.get();
         }, new TimeoutBudget(10, TimeUnit.MINUTES));
-        TestUtils.waitUntilDeployed(kubernetes.getInfraNamespace());
+        TestUtils.waitUntilDeployed(infraNamespace);
     }
 
     protected boolean sendMessage(String addressSpace, AbstractClient client, UserCredentials
@@ -308,7 +343,7 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
         arguments.put(ClientArgument.PASSWORD, credentials.getPassword());
         arguments.put(ClientArgument.CONN_SSL, "true");
         arguments.put(ClientArgument.MSG_CONTENT, content);
-        arguments.put(ClientArgument.BROKER, KubeCMDClient.getMessagingEndpoint(kubernetes.getInfraNamespace(), addressSpace) + ":443");
+        arguments.put(ClientArgument.BROKER, KubeCMDClient.getMessagingEndpoint(infraNamespace, addressSpace) + ":443");
         arguments.put(ClientArgument.ADDRESS, address);
         arguments.put(ClientArgument.COUNT, Integer.toString(count));
         arguments.put(ClientArgument.MSG_DURABLE, "true");
@@ -324,7 +359,7 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
         arguments.put(ClientArgument.USERNAME, credentials.getUsername());
         arguments.put(ClientArgument.PASSWORD, credentials.getPassword());
         arguments.put(ClientArgument.CONN_SSL, "true");
-        arguments.put(ClientArgument.BROKER, KubeCMDClient.getMessagingEndpoint(kubernetes.getInfraNamespace(), addressSpace) + ":443");
+        arguments.put(ClientArgument.BROKER, KubeCMDClient.getMessagingEndpoint(infraNamespace, addressSpace) + ":443");
         arguments.put(ClientArgument.ADDRESS, address);
         arguments.put(ClientArgument.COUNT, Integer.toString(count));
         arguments.put(ClientArgument.LOG_MESSAGES, "json");
@@ -334,7 +369,7 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
     }
 
     private void ensurePersistentAuthService(String authServiceName) throws Exception {
-        AuthenticationService authService = kubernetes.getAuthenticationServiceClient().withName(authServiceName).get();
+        AuthenticationService authService = kubernetes.getAuthenticationServiceClient(infraNamespace).withName(authServiceName).get();
 
         if (authService.getSpec() != null && authService.getSpec().getStandard() != null) {
 
@@ -344,17 +379,147 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
                 resourcesManager.removeAuthService(authService);
 
                 AuthenticationService replacement = AuthServiceUtils.createStandardAuthServiceObject(authServiceName, true);
-                kubernetes.getAuthenticationServiceClient().create(replacement);
+                kubernetes.getAuthenticationServiceClient(infraNamespace).create(replacement);
 
                 log.info("Replacement auth service : {}", replacement);
 
                 Thread.sleep(30_000);
-                TestUtils.waitUntilDeployed(kubernetes.getInfraNamespace());
+                TestUtils.waitUntilDeployed(infraNamespace);
             }
         }
     }
 
     private static Stream<Arguments> provideVersions() {
         return Arrays.stream(environment.getStartTemplates().split(",")).map(templates -> Arguments.of(getVersionFromTemplateDir(Paths.get(templates)), templates));
+    }
+
+    private void installEnmasseOLM(Path templateDir, String version) throws Exception {
+
+//        String installationNamespace = OperatorManager.getInstance().getNamespaceByOlmInstallationType(olmType);
+
+        if (olmType == OLMInstallationType.SPECIFIC) {
+            kubernetes.createNamespace(infraNamespace, Collections.singletonMap("allowed", "true"));
+        }
+
+        String catalogSourceName;
+        String catalogNamespace;
+        if (version.startsWith("0.30")) {
+            catalogSourceName = "community-operators";
+            catalogNamespace = "openshift-marketplace";
+        } else {
+            catalogSourceName = "enmasse-source";
+            catalogNamespace = infraNamespace;
+
+            String customRegistryImageToUse = buildPushCustomOperatorRegistry(catalogNamespace, templateDir, version);
+
+            deployCatalogSource(catalogSourceName, catalogNamespace, customRegistryImageToUse);
+        }
+
+        if (olmType == OLMInstallationType.SPECIFIC) {
+            Path operatorGroupFile = Files.createTempFile("operatorgroup", ".yaml");
+            String operatorGroup = Files.readString(Paths.get("custom-operator-registry", "operator-group.yaml"));
+            Files.writeString(operatorGroupFile, operatorGroup.replaceAll("\\$\\{OPERATOR_NAMESPACE}", infraNamespace));
+            KubeCMDClient.applyFromFile(infraNamespace, operatorGroupFile);
+        }
+
+        String csvName = getCsvName(templateDir, version);
+
+        applySubscription(infraNamespace, catalogSourceName, catalogNamespace, csvName);
+
+        TestUtils.waitForPodReady("enmasse-operator", infraNamespace);
+
+        KubeCMDClient.applyFromFile(infraNamespace, Paths.get(templateDir.toString(), "install", "components", "example-plans"));
+        KubeCMDClient.applyFromFile(infraNamespace, Paths.get(templateDir.toString(), "install", "components", "example-authservices", "standard-authservice.yaml"));
+
+        Thread.sleep(60_000);
+        OperatorManager.getInstance().waitUntilOperatorReadyOlm(olmType);
+        Thread.sleep(30_000);
+    }
+
+    private void applySubscription(String installationNamespace, String catalogSourceName, String catalogNamespace, String csvName) throws IOException {
+        Path subscriptionFile = Files.createTempFile("subscription", ".yaml");
+        String subscription = Files.readString(Paths.get("custom-operator-registry", "subscription.yaml"));
+        Files.writeString(subscriptionFile,
+                subscription
+                    .replaceAll("\\$\\{OPERATOR_NAMESPACE}", installationNamespace)
+                    .replaceAll("\\$\\{CATALOG_SOURCE_NAME}", catalogSourceName)
+                    .replaceAll("\\$\\{CATALOG_NAMESPACE}", catalogNamespace)
+                    .replaceAll("\\$\\{CSV}", csvName));
+        KubeCMDClient.applyFromFile(installationNamespace, subscriptionFile);
+    }
+
+    private void deployCatalogSource(String catalogSourceName, String catalogNamespace, String customRegistryImageToUse) throws IOException {
+        Path catalogSourceFile = Files.createTempFile("catalogsource", ".yaml");
+        String catalogSource = Files.readString(Paths.get("custom-operator-registry", "catalog-source.yaml"));
+        Files.writeString(catalogSourceFile,
+                catalogSource
+                    .replaceAll("\\$\\{CATALOG_SOURCE_NAME}", catalogSourceName)
+                    .replaceAll("\\$\\{OPERATOR_NAMESPACE}", catalogNamespace)
+                    .replaceAll("\\$\\{REGISTRY_IMAGE}", customRegistryImageToUse));
+        KubeCMDClient.applyFromFile(catalogNamespace, catalogSourceFile);
+    }
+
+    private void upgradeEnmasseOLM(Path upgradeTemplates, String previousVersion) throws Exception {
+        String customRegistryImageToUse = buildPushCustomOperatorRegistry(infraNamespace, upgradeTemplates, getVersionFromTemplateDir(upgradeTemplates));
+
+        String catalogSourceName = "enmasse-source";
+        String catalogNamespace = infraNamespace;
+        if (previousVersion.startsWith("0.30")) {
+            deployCatalogSource(catalogSourceName, catalogNamespace, customRegistryImageToUse);
+        } else {
+            kubernetes.deletePod(infraNamespace, Map.of("olm.catalogSource", "enmasse-source"));
+        }
+
+        String version = getVersionFromTemplateDir(upgradeTemplates);
+        String csvName = getCsvName(upgradeTemplates, version);
+
+        //update subscription to point to new catalog and to use latest csv
+        applySubscription(infraNamespace, catalogSourceName, catalogNamespace, csvName);
+
+        //should update
+        Thread.sleep(300_000);
+        checkImagesUpdated(getVersionFromTemplateDir(upgradeTemplates));
+    }
+
+    private String buildPushCustomOperatorRegistry(String namespace, Path templateDir, String version) throws Exception {
+        String manifestsRegistryReplacement = ""; //TODO fill this from env var
+
+        String customRegistryImageToPush = environment.getClusterExternalImageRegistry()+"/"+namespace+"/systemtests-operator-registry:latest";
+        String customRegistryImageToUse = environment.getClusterInternalImageRegistry()+"/"+namespace+"/systemtests-operator-registry:latest";
+
+        String olmManifestsImage;
+        if (version.equals("1.3")) {
+            String exampleCatalogSource = Files.readString(Paths.get(templateDir.toString(), "install", "components", "enmasse-operator", "050-Deployment-enmasse-operator.yaml"));
+            log.info(exampleCatalogSource);
+
+            log.info("Enmasse operator deployment found : {}", exampleCatalogSource!=null && !exampleCatalogSource.isEmpty());
+            var yaml = new YAMLMapper().readTree(exampleCatalogSource);
+            var spec = yaml.get("spec").get("template").get("spec");
+            log.info("Spec fields");
+            spec.fieldNames().forEachRemaining(log::info);
+            olmManifestsImage = spec.get("containers").get(0).get("image").asText();
+        } else {
+            String exampleCatalogSource = Files.readString(Paths.get(templateDir.toString(), "install", "components", "example-olm", "catalog-source.yaml"));
+            var tree = new YAMLMapper().readTree(exampleCatalogSource);
+            olmManifestsImage = tree.get("spec").get("image").asText();
+        }
+
+        var results = Exec.execute(Arrays.asList("make", "-C", "custom-operator-registry", "FROM="+olmManifestsImage, "TAG="+customRegistryImageToPush, "REGISTRY="+manifestsRegistryReplacement), true);
+
+        assertTrue(results.getRetCode(), "custom operator registry image build failed ");
+
+        return customRegistryImageToUse;
+    }
+
+    private String getCsvName(Path templateDir, String version) throws Exception {
+        if (version.equals("1.3") || version.startsWith("0.30")) {
+            String enmasseCSV = Files.readString(Paths.get(templateDir.toString(), "install", "olm", productName, "enmasse.clusterserviceversion.yaml"));
+            var yaml = new YAMLMapper().readTree(enmasseCSV);
+            return yaml.get("metadata").get("name").asText();
+        } else {
+            String enmasseCSV = Files.readString(Paths.get(templateDir.toString(), "install", "components", "example-olm", "subscription.yaml"));
+            var yaml = new YAMLMapper().readTree(enmasseCSV);
+            return yaml.get("spec").get("startingCSV").asText();
+        }
     }
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/upgrade/UpgradeTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/upgrade/UpgradeTest.java
@@ -538,13 +538,14 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
 
         olmManifestsImage = olmManifestsImage.replace(environment.getClusterInternalImageRegistry(), environment.getClusterExternalImageRegistry());
 
-        int retries = 2;
+        int retries = 5;
         ExecutionResultData results = null;
         while (retries > 0) {
             results = Exec.execute(Arrays.asList("make", "-C", "custom-operator-registry", "FROM="+olmManifestsImage, "TAG="+customRegistryImageToPush), true);
             if(results.getRetCode()) {
                 return customRegistryImageToUse;
             }
+            Thread.sleep(1000);
             retries--;
         }
         assertTrue(results != null && results.getRetCode(), "custom operator registry image build failed ");

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/upgrade/UpgradeTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/upgrade/UpgradeTest.java
@@ -87,6 +87,7 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
         } else {
             OperatorManager.getInstance().deleteEnmasseAnsible();
         }
+        TestUtils.waitForNamespaceDeleted(kubernetes, infraNamespace);
     }
 
     @ParameterizedTest(name = "testUpgradeBundle-{0}")

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/upgrade/UpgradeTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/upgrade/UpgradeTest.java
@@ -83,7 +83,9 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
         if (this.type.equals(EnmasseInstallType.BUNDLE)) {
             assertTrue(OperatorManager.getInstance().clean());
         } else if (this.type.equals(EnmasseInstallType.OLM)) {
-            assertTrue(OperatorManager.getInstance().removeOlm());
+            if (OperatorManager.getInstance().isEnmasseOlmDeployed()) {
+                assertTrue(OperatorManager.getInstance().removeOlm());
+            }
         } else {
             OperatorManager.getInstance().deleteEnmasseAnsible();
         }


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Systemtest

### Description

Includes two new test for olm upgrade process, adds the files for our custom-operator-registry used for the tests(which could be used in future to replace the olm-manifests image). Adds two new env variables, used in the process of build and deploy the custom operator registry.

This PR also includes two commits from the 0.31.0 release branch which are missing in master branch and are important in order for this new tests to run properly

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [x] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
