### PR TITLE
Remove examples for CRs that are created by default

### DIFF
--- a/olm-manifest/src/main/resources/latest/enmasse.clusterserviceversion.yaml
+++ b/olm-manifest/src/main/resources/latest/enmasse.clusterserviceversion.yaml
@@ -156,14 +156,6 @@ metadata:
           }
         },
         {
-          "apiVersion": "admin.enmasse.io/v1beta1",
-          "kind": "ConsoleService",
-          "metadata": {
-            "name": "console"
-          },
-          "spec": {}
-        },
-        {
           "apiVersion": "iot.enmasse.io/v1alpha1",
           "kind": "IoTConfig",
           "metadata": {
@@ -187,14 +179,6 @@ metadata:
               }
             }
           }
-        },
-        {
-          "apiVersion": "enmasse.io/v1beta1",
-          "kind": "AddressSpaceSchema",
-          "metadata": {
-            "name": "undefined"
-          },
-          "spec": {}
         },
         {
           "apiVersion": "iot.enmasse.io/v1alpha1",


### PR DESCRIPTION
These are no longer needed to pass operator scorecard test.