### PR TITLE
Collect all events in cluster on error

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/logs/GlobalLogCollector.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/logs/GlobalLogCollector.java
@@ -282,7 +282,8 @@ public class GlobalLogCollector {
 
             Files.writeString(path.resolve("describe_pods.txt"), KubeCMDClient.describePods(kube.getInfraNamespace()).getStdOut());
             Files.writeString(path.resolve("describe_nodes.txt"), KubeCMDClient.describeNodes().getStdOut());
-            Files.writeString(path.resolve("events.txt"), KubeCMDClient.getEvents(kube.getInfraNamespace()).getStdOut());
+            Files.writeString(path.resolve(String.format("events.%s.txt", kube.getInfraNamespace())), KubeCMDClient.getEvents(kube.getInfraNamespace()).getStdOut());
+            Files.writeString(path.resolve("events.txt"), KubeCMDClient.getAllEvents().getStdOut());
             Files.writeString(path.resolve("configmaps.yaml"), KubeCMDClient.getConfigmaps(kube.getInfraNamespace()).getStdOut());
             Files.writeString(path.resolve("pvs.txt"), KubeCMDClient.runOnClusterWithoutLogger("describe", "pv").getStdOut());
             Files.writeString(path.resolve("pvcs.txt"), KubeCMDClient.runOnClusterWithoutLogger("describe", "pvc", "-n", Kubernetes.getInstance().getInfraNamespace()).getStdOut());

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/KubeCMDClient.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/KubeCMDClient.java
@@ -310,6 +310,15 @@ public class KubeCMDClient {
         return Exec.execute(command, ONE_MINUTE_TIMEOUT, false);
     }
 
+    public static ExecutionResultData getAllEvents() {
+        List<String> command = Arrays.asList(CMD, "get", "events",
+                "--all-namespaces=true",
+                "--output", "custom-columns=LAST SEEN:{lastTimestamp},FIRST SEEN:{firstTimestamp},COUNT:{count},NAME:{metadata.name},KIND:{involvedObject.kind},SUBOBJECT:{involvedObject.fieldPath},TYPE:{type},REASON:{reason},SOURCE:{source.component},MESSAGE:{message}",
+                "--sort-by={.lastTimestamp}");
+
+        return Exec.execute(command, ONE_MINUTE_TIMEOUT, false);
+    }
+
     public static ExecutionResultData getApiServices(String name) {
         List<String> command = Arrays.asList(CMD, "get", "apiservices", name,
                 "--output", "custom-columns=NAME:{.name}",


### PR DESCRIPTION
This makes it easier to debug issues where events in other namespaces
than the infra namespace could be relevant.