### PR TITLE
Restrict YAML parser to not create Java objects

### DIFF
--- a/iot/iot-jdbc-base/pom.xml
+++ b/iot/iot-jdbc-base/pom.xml
@@ -71,6 +71,11 @@
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
     </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/iot/iot-jdbc-base/src/main/java/io/enmasse/iot/jdbc/store/StatementConfiguration.java
+++ b/iot/iot-jdbc-base/src/main/java/io/enmasse/iot/jdbc/store/StatementConfiguration.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
 
 public class StatementConfiguration {
 
@@ -58,7 +59,7 @@ public class StatementConfiguration {
             }
         }
 
-        final Yaml yaml = new Yaml();
+        final Yaml yaml = createYamlParser();
         @SuppressWarnings("unchecked")
         final Map<String, Object> properties = yaml.loadAs(input, Map.class);
         if (properties == null) {
@@ -151,6 +152,19 @@ public class StatementConfiguration {
             logger.info("{}\n{}", key, this.statements.get(key));
         }
 
+    }
+
+    /**
+     * Create a YAML parser which reject creating arbitrary Java objects.
+     * @return A new YAML parser, never returns {@code null}.
+     */
+    static Yaml createYamlParser() {
+        return new Yaml(new Constructor() {
+            @Override
+            protected Class<?> getClassForName(String name) throws ClassNotFoundException {
+                throw new IllegalArgumentException("Class instantiation is disabled");
+            }
+        });
     }
 
 }

--- a/iot/iot-jdbc-base/src/test/java/io/enmasse/iot/jdbc/store/StatementTest.java
+++ b/iot/iot-jdbc-base/src/test/java/io/enmasse/iot/jdbc/store/StatementTest.java
@@ -5,9 +5,18 @@
 
 package io.enmasse.iot.jdbc.store;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.ConstructorException;
 
 public class StatementTest {
 
@@ -42,6 +51,47 @@ public class StatementTest {
                 "AND\n" +
                 "   device_id=?");
         statement.validateParameters("data", "device_id", "next_version", "tenant_id");
+    }
+
+    /**
+     * Test that we didn't break basic YAML loading.
+     */
+    @Test
+    public void testPlainYamlStillWorks() {
+        final Yaml parser = StatementConfiguration.createYamlParser();
+        parser.load("foo: bar");
+    }
+
+    /**
+     * Test that we create a YAML parser which reject class instantiation.
+     */
+    @Test
+    public void testObjectCreationRejected(@TempDir Path tempDir) {
+        final Path markerFile = tempDir.resolve("testObjectCreationRejected.marker");
+        final String yaml = "!!java.io.FileOutputStream [" + markerFile.toAbsolutePath().toString() + "]";
+
+        assertThrows(ConstructorException.class, () -> {
+            final Yaml parser = StatementConfiguration.createYamlParser();
+            parser.load(yaml);
+        });
+
+        assertFalse(Files.isRegularFile(markerFile), "Marker file must not exist");
+    }
+
+    /**
+     * Test that we actually make use of the parser, preventing class instantiation.
+     */
+    @Test
+    public void testObjectCreationRejectedFull(@TempDir Path tempDir) {
+        final Path markerFile = tempDir.resolve("testObjectCreationRejectedFull.marker");
+        final String yaml = "!!java.io.FileOutputStream [" + markerFile.toAbsolutePath().toString() + "]";
+
+        assertThrows(ConstructorException.class, () -> {
+            var cfg = StatementConfiguration.empty();
+            cfg.overrideWith(new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)), false);
+        });
+
+        assertFalse(Files.isRegularFile(markerFile), "Marker file must not exist");
     }
 
 }


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [x] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
