### PR TITLE
Reference api-proxy image by tag

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/apps/SystemtestsKubernetesApps.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/apps/SystemtestsKubernetesApps.java
@@ -980,7 +980,7 @@ public class SystemtestsKubernetesApps {
                 .withNewSpec()
                 .addNewContainer()
                 .withName(API_PROXY)
-                .withImage("quay.io/enmasse/api-proxy:latest")
+                .withImage("quay.io/enmasse/api-proxy:0.1.0")
                 .withSecurityContext(new SecurityContextBuilder().withRunAsUser(0L).build())
                 .withPorts(new ContainerPortBuilder().withContainerPort(443).withName("https").withProtocol("TCP").build())
                 .withVolumeMounts(new VolumeMountBuilder().withMountPath("/etc/tls/private").withName("api-proxy-tls").withReadOnly(true).build())


### PR DESCRIPTION
A change needs to be made to api-proxy to resolve a downstream problem (SCC related - see #4218), this changes lets me update the image without breaking the tests.

This change makes no functional change.
