### PR TITLE
Apply defaults before performing impure operations

### DIFF
--- a/pkg/controller/authenticationservice/authenticationservice_controller.go
+++ b/pkg/controller/authenticationservice/authenticationservice_controller.go
@@ -131,7 +131,7 @@ func (r *ReconcileAuthenticationService) Reconcile(request reconcile.Request) (r
 
 func (r *ReconcileAuthenticationService) reconcileNoneAuthService(ctx context.Context, authservice *adminv1beta1.AuthenticationService) (reconcile.Result, error) {
 	currentStatus := authservice.Status
-	applyNoneAuthServiceDefaults(ctx, r.client, r.scheme, authservice)
+	applyNoneAuthServiceDefaults(authservice)
 
 	rc := &recon.ReconcileContext{}
 	rc.ProcessSimple(func() error {
@@ -174,7 +174,7 @@ func (r *ReconcileAuthenticationService) reconcileStandardAuthService(ctx contex
 
 	currentStatus := authservice.Status
 	rc := &recon.ReconcileContext{}
-	applyStandardAuthServiceDefaults(ctx, r.client, r.scheme, authservice)
+	applyStandardAuthServiceDefaults(authservice)
 
 	rc.ProcessSimple(func() error {
 		return r.reconcileStandardCredentials(ctx, authservice)

--- a/pkg/controller/authenticationservice/authenticationservice_controller.go
+++ b/pkg/controller/authenticationservice/authenticationservice_controller.go
@@ -131,9 +131,11 @@ func (r *ReconcileAuthenticationService) Reconcile(request reconcile.Request) (r
 
 func (r *ReconcileAuthenticationService) reconcileNoneAuthService(ctx context.Context, authservice *adminv1beta1.AuthenticationService) (reconcile.Result, error) {
 	currentStatus := authservice.Status
+	applyNoneAuthServiceDefaults(ctx, r.client, r.scheme, authservice)
+
 	rc := &recon.ReconcileContext{}
 	rc.ProcessSimple(func() error {
-		return applyNoneAuthServiceDefaults(ctx, r.client, r.scheme, authservice)
+		return r.reconcileCertificate(ctx, authservice, authservice.Spec.None.CertificateSecret.Name, applyNoneAuthServiceCert)
 	})
 
 	rc.Process(func() (reconcile.Result, error) {
@@ -172,8 +174,14 @@ func (r *ReconcileAuthenticationService) reconcileStandardAuthService(ctx contex
 
 	currentStatus := authservice.Status
 	rc := &recon.ReconcileContext{}
+	applyStandardAuthServiceDefaults(ctx, r.client, r.scheme, authservice)
+
 	rc.ProcessSimple(func() error {
-		return applyStandardAuthServiceDefaults(ctx, r.client, r.scheme, authservice)
+		return r.reconcileStandardCredentials(ctx, authservice)
+	})
+
+	rc.ProcessSimple(func() error {
+		return r.reconcileCertificate(ctx, authservice, authservice.Spec.Standard.CertificateSecret.Name, applyStandardAuthServiceCert)
 	})
 
 	rc.Process(func() (reconcile.Result, error) {
@@ -259,6 +267,18 @@ func (r *ReconcileAuthenticationService) updateStatus(ctx context.Context, auths
 	return reconcile.Result{}, nil
 }
 
+type ApplyCertificateFn func(authservice *adminv1beta1.AuthenticationService, existingSecret *corev1.Secret) error
+
+func (r *ReconcileAuthenticationService) reconcileCertificate(ctx context.Context, authservice *adminv1beta1.AuthenticationService, name string, applyFn ApplyCertificateFn) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: authservice.Namespace, Name: name},
+	}
+	_, err := controllerutil.CreateOrUpdate(ctx, r.client, secret, func() error {
+		return applyFn(authservice, secret)
+	})
+	return err
+}
+
 type ApplyDeploymentFn func(authservice *adminv1beta1.AuthenticationService, existingDeployment *appsv1.Deployment) error
 
 func (r *ReconcileAuthenticationService) reconcileDeployment(ctx context.Context, authservice *adminv1beta1.AuthenticationService, name string, fn ApplyDeploymentFn) (reconcile.Result, error) {
@@ -330,6 +350,16 @@ func (r *ReconcileAuthenticationService) reconcileStandardVolume(ctx context.Con
 		}
 	}
 	return reconcile.Result{}, nil
+}
+
+func (r *ReconcileAuthenticationService) reconcileStandardCredentials(ctx context.Context, authservice *adminv1beta1.AuthenticationService) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: authservice.Namespace, Name: authservice.Spec.Standard.CredentialsSecret.Name},
+	}
+	_, err := controllerutil.CreateOrUpdate(ctx, r.client, secret, func() error {
+		return applyStandardAuthServiceCredentials(authservice, secret)
+	})
+	return err
 }
 
 func (r *ReconcileAuthenticationService) reconcileStandardRoute(ctx context.Context, name string, authservice *adminv1beta1.AuthenticationService) (reconcile.Result, error) {

--- a/pkg/controller/authenticationservice/none.go
+++ b/pkg/controller/authenticationservice/none.go
@@ -5,19 +5,15 @@
 package authenticationservice
 
 import (
-	"context"
-
 	adminv1beta1 "github.com/enmasseproject/enmasse/pkg/apis/admin/v1beta1"
 	"github.com/enmasseproject/enmasse/pkg/util"
 	"github.com/enmasseproject/enmasse/pkg/util/install"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func applyNoneAuthServiceDefaults(ctx context.Context, client client.Client, scheme *runtime.Scheme, authservice *adminv1beta1.AuthenticationService) {
+func applyNoneAuthServiceDefaults(authservice *adminv1beta1.AuthenticationService) {
 	if authservice.Spec.None == nil {
 		authservice.Spec.None = &adminv1beta1.AuthenticationServiceSpecNone{}
 	}

--- a/pkg/controller/authenticationservice/standard.go
+++ b/pkg/controller/authenticationservice/standard.go
@@ -5,7 +5,6 @@
 package authenticationservice
 
 import (
-	"context"
 	"fmt"
 
 	adminv1beta1 "github.com/enmasseproject/enmasse/pkg/apis/admin/v1beta1"
@@ -16,12 +15,10 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	resource "k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/runtime"
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func applyStandardAuthServiceDefaults(ctx context.Context, client client.Client, scheme *runtime.Scheme, authservice *adminv1beta1.AuthenticationService) {
+func applyStandardAuthServiceDefaults(authservice *adminv1beta1.AuthenticationService) {
 	if authservice.Spec.Standard == nil {
 		authservice.Spec.Standard = &adminv1beta1.AuthenticationServiceSpecStandard{}
 	}


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Ensure that all defaults are applied before performing any potentially
failing operations. This prevents an issue where other reconcile loops
were making assumptions defaults were set, whereas they were not set
due to a failing operation.

Fixes #4184

### Checklist

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
