### PR TITLE
Removed hardcoded namespace from console rule

### DIFF
--- a/pkg/controller/consoleservice/consoleservice_controller.go
+++ b/pkg/controller/consoleservice/consoleservice_controller.go
@@ -485,7 +485,7 @@ func (r *ReconcileConsoleService) reconcilePrometheusRule(ctx context.Context, c
 					Rules: []monitoringv1.Rule{
 						{
 							Record: "enmasse_component_health",
-							Expr:   intstr.FromString("up{job='console',namespace='enmasse-infra'} or on(namespace) (1- absent(up{job='console',namespace='enmasse-infra'}))"),
+							Expr:   intstr.FromString("up{job='console',namespace='" + util.GetEnvOrDefault("NAMESPACE", "enmasse-infra") + "'} or on(namespace) (1- absent(up{job='console',namespace='" + util.GetEnvOrDefault("NAMESPACE", "enmasse-infra") + "'}))"),
 						},
 					},
 				},


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Hard-coded namespace in Prometheus rules was causing alert to fire when EnMasse is installed to non-default namespace. Changed to use the infra namespace environment variable

### Checklist

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
