### PR TITLE
Fix brokered - testAddressSpaceKubernetesApiServerRestart

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/CommonTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/CommonTest.java
@@ -369,10 +369,14 @@ class CommonTest extends TestBase implements ITestBaseIsolated {
                     .build();
             isolatedResourcesManager.createAddressSpaceList(standard);
 
-            // configure admin pod to use api proxy
+            // configure admin/agent pod to use api proxy
             Map<String, String> adminLabels = new HashMap<>();
             adminLabels.put(LabelKeys.INFRA_UUID, AddressSpaceUtils.getAddressSpaceInfraUuid(standard));
-            adminLabels.put(LabelKeys.NAME, "admin");
+            if ("brokered".equals(type)) {
+                adminLabels.put(LabelKeys.ROLE, "agent");
+            } else {
+                adminLabels.put(LabelKeys.NAME, "admin");
+            }
             adminLabels.put(LabelKeys.APP, "enmasse");
 
             kubernetes.listDeployments(adminLabels).forEach(d -> {


### PR DESCRIPTION

### Type of change

- Bugfix

### Description

The test was using the wrong labels - so the agent pod was not updated to use the proxy.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
