### PR TITLE
Add support for disabling cert provosioning for external endpoints

### DIFF
--- a/address-space-controller/src/main/java/io/enmasse/controller/AddressSpaceController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/AddressSpaceController.java
@@ -109,7 +109,7 @@ public class AddressSpaceController {
 
         CertManager certManager = OpenSSLCertManager.create(controllerClient);
         CertProviderFactory certProviderFactory = createCertProviderFactory(options, certManager);
-        AuthController authController = new AuthController(certManager, eventLogger, certProviderFactory);
+        AuthController authController = new AuthController(certManager, eventLogger, certProviderFactory, options.isDisableExternalCertProvisioning());
         AuthenticationServiceRegistry authenticationServiceRegistry = new SchemaAuthenticationServiceRegistry(schemaProvider);
         AuthenticationServiceResolver authenticationServiceResolver = new AuthenticationServiceResolver(authenticationServiceRegistry);
 

--- a/address-space-controller/src/main/java/io/enmasse/controller/AddressSpaceControllerOptions.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/AddressSpaceControllerOptions.java
@@ -22,6 +22,7 @@ public final class AddressSpaceControllerOptions {
     private String environment;
 
     private String wildcardCertSecret;
+    private boolean disableExternalCertProvisioning;
 
     private Duration resyncInterval;
     private Duration recheckInterval;
@@ -90,6 +91,8 @@ public final class AddressSpaceControllerOptions {
         options.setInstallDefaultResources(getEnv(env, "INSTALL_DEFAULT_RESOURCES").map(Boolean::parseBoolean).orElse(true));
 
         options.setWildcardCertSecret(getEnv(env, "WILDCARD_ENDPOINT_CERT_SECRET").orElse(null));
+
+        options.setDisableExternalCertProvisioning(getEnv(env, "DISABLE_EXTERNAL_CERT_PROVISIONING").map(Boolean::parseBoolean).orElse(false));
 
         options.setResyncInterval(getEnv(env, "RESYNC_INTERVAL")
                 .map(i -> Duration.ofSeconds(Long.parseLong(i)))
@@ -200,6 +203,7 @@ public final class AddressSpaceControllerOptions {
                 ", kubernetesApiConnectTimeout='" + kubernetesApiConnectTimeout + '\'' +
                 ", kubernetesApiReadTimeout='" + kubernetesApiReadTimeout + '\'' +
                 ", kubernetesApiWriteTimeout='" + kubernetesApiWriteTimeout + '\'' +
+                ", disableCertProvisioning='" + disableExternalCertProvisioning + '\'' +
                 '}';
     }
 
@@ -257,5 +261,13 @@ public final class AddressSpaceControllerOptions {
 
     public void setRouterStatusCheckInterval(Duration routerStatusCheckInterval) {
         this.routerStatusCheckInterval = routerStatusCheckInterval;
+    }
+
+    public boolean isDisableExternalCertProvisioning() {
+        return disableExternalCertProvisioning;
+    }
+
+    public void setDisableExternalCertProvisioning(boolean disableExternalCertProvisioning) {
+        this.disableExternalCertProvisioning = disableExternalCertProvisioning;
     }
 }

--- a/address-space-controller/src/main/java/io/enmasse/controller/auth/AuthController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/auth/AuthController.java
@@ -32,13 +32,15 @@ public class AuthController implements Controller {
     private final CertManager certManager;
     private final EventLogger eventLogger;
     private final CertProviderFactory certProviderFactory;
+    private final boolean disableExternalCertProvisioning;
 
     public AuthController(CertManager certManager,
                           EventLogger eventLogger,
-                          CertProviderFactory certProviderFactory) {
+                          CertProviderFactory certProviderFactory, boolean disableExternalCertProvisioning) {
         this.certManager = certManager;
         this.eventLogger = eventLogger;
         this.certProviderFactory = certProviderFactory;
+        this.disableExternalCertProvisioning = disableExternalCertProvisioning;
     }
 
     public void issueExternalCertificates(AddressSpace addressSpace) {
@@ -136,7 +138,10 @@ public class AuthController implements Controller {
         if (addressSpaceCa != null) {
             issueComponentCertificates(addressSpace, addressSpaceCa);
         }
-        issueExternalCertificates(addressSpace);
+
+        if (!disableExternalCertProvisioning) {
+            issueExternalCertificates(addressSpace);
+        }
         return addressSpace;
     }
 

--- a/pkg/controller/address_space_controller/controller.go
+++ b/pkg/controller/address_space_controller/controller.go
@@ -194,6 +194,7 @@ func ApplyDeployment(deployment *appsv1.Deployment) error {
 		install.ApplyEnvConfigMap(container, "RECHECK_INTERVAL", "recheckInterval", "address-space-controller-config", &t)
 		install.ApplyEnvConfigMap(container, "ROUTER_STATUS_CHECK_INTERVAL", "routerStatusCheckInterval", "address-space-controller-config", &t)
 		install.ApplyEnvConfigMap(container, "EXPOSE_ENDPOINTS_BY_DEFAULT", "exposeEndpointsByDefault", "address-space-controller-config", &t)
+		install.ApplyEnvConfigMap(container, "DISABLE_EXTERNAL_CERT_PROVISIONING", "disableExternalCertProvisioning", "address-space-controller-config", &t)
 
 		install.ApplyEnvSimple(container, "IMAGE_PULL_POLICY", string(images.PullPolicyFromImageName(container.Image)))
 		applyImageEnv(container, "ROUTER_IMAGE", "router")


### PR DESCRIPTION

### Type of change

<!--

_Select the type of your PR_

-->

- Enhancement / new feature

### Description

This allows for manging certificates for messaging endpoints using an
external infrastructure. The external infrastructure would use this
feature by reading the address space resource to find the name of the
secret that should be populated with the certificate.


### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
