### PR TITLE
Add watch permission to iot projects to protocol adapter roles

### DIFF
--- a/templates/iot/common/020-ClusterRole-qdr-configurator.yaml
+++ b/templates/iot/common/020-ClusterRole-qdr-configurator.yaml
@@ -12,9 +12,9 @@ rules:
     resources:
     - iotprojects
     verbs:
-    - create
     - get
     - list
+    - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
### Type of change


- Bugfix

### Description

Without this permission, protocol adapters are failing to watch iot projects.

### Checklist


- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
