### PR TITLE
Allow deletion of api-server deployment and service to fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * #4224: oauth2_proxy is now hosted by a new organisation (https://oauth2-proxy.github.io/oauth2-proxy/)
 
 
+## 0.31.1
+* #4241: Fix a race in upgrader logic that prevented upgrade from continuing
+
 ## 0.31.0
 *  Adding example partitioned/sharded queue example plans
 *  #3686: Add metrics endpoint to controller-managerxs


### PR DESCRIPTION

### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

If these resources don't exist, the upgrade can still proceed as they
are not needed for upgrade process to run.

Fixes #4241


### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
