### PR TITLE
Change standard auth service to use AMQP port probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * #4117: Add support for configuring console to use impersonation
 * #4172: [Kubernetes] Use headers for oauth-proxy to populate user information (for console/audit).
 * #4224: oauth2_proxy is now hosted by a new organisation (https://oauth2-proxy.github.io/oauth2-proxy/)
+* #4245 standard-auth - use AMQP port probe rather than keycloak HTTP endpoint
 
 
 ## 0.31.0

--- a/pkg/controller/authenticationservice/standard.go
+++ b/pkg/controller/authenticationservice/standard.go
@@ -165,22 +165,18 @@ func applyStandardAuthServiceDeployment(authservice *adminv1beta1.Authentication
 			Name:          "https",
 		}}
 		container.ReadinessProbe = &corev1.Probe{
-			InitialDelaySeconds: 60,
+			InitialDelaySeconds: 30,
 			Handler: corev1.Handler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Port:   intstr.FromString("https"),
-					Path:   "/auth",
-					Scheme: "HTTPS",
+				TCPSocket: &corev1.TCPSocketAction{
+					Port:   intstr.FromString("amqps"),
 				},
 			},
 		}
 		container.LivenessProbe = &corev1.Probe{
 			InitialDelaySeconds: 120,
 			Handler: corev1.Handler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Port:   intstr.FromString("https"),
-					Path:   "/auth",
-					Scheme: "HTTPS",
+				TCPSocket: &corev1.TCPSocketAction{
+					Port:   intstr.FromString("amqps"),
 				},
 			},
 		}


### PR DESCRIPTION
### Type of change


- Enhancement / new feature

### Description

Change standard auth service to use AMQP port probe rather than probing the Keycloak `auth` endpoint.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
