### PR TITLE
WIP - systemtests - cli clients wait for receivers to attach

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/listener/JunitCallbackListener.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/listener/JunitCallbackListener.java
@@ -6,7 +6,6 @@ package io.enmasse.systemtest.listener;
 
 import io.enmasse.systemtest.EnmasseInstallType;
 import io.enmasse.systemtest.Environment;
-import io.enmasse.systemtest.bases.ThrowableRunner;
 import io.enmasse.systemtest.info.TestInfo;
 import io.enmasse.systemtest.logs.CustomLogger;
 import io.enmasse.systemtest.logs.GlobalLogCollector;
@@ -18,6 +17,7 @@ import io.enmasse.systemtest.operator.OperatorManager;
 import io.enmasse.systemtest.platform.KubeCMDClient;
 import io.enmasse.systemtest.platform.Kubernetes;
 import io.enmasse.systemtest.utils.TestUtils;
+import io.enmasse.systemtest.utils.ThrowingRunner;
 
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -177,7 +177,7 @@ public class JunitCallbackListener implements TestExecutionExceptionHandler, Lif
         saveKubernetesState("Test after all", context, throwable);
     }
 
-    private void handleCallBackError(String description, ExtensionContext context, ThrowableRunner runnable) throws Exception {
+    private void handleCallBackError(String description, ExtensionContext context, ThrowingRunner runnable) throws Exception {
         try {
             runnable.run();
         } catch (Exception ex) {

--- a/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/ExternalMessagingClient.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/ExternalMessagingClient.java
@@ -13,6 +13,7 @@ import io.vertx.core.json.JsonArray;
 
 import java.util.Objects;
 import java.util.concurrent.Future;
+import java.util.concurrent.Flow.Subscriber;
 
 public class ExternalMessagingClient {
     private AbstractClient client;
@@ -85,6 +86,14 @@ public class ExternalMessagingClient {
         return this;
     }
 
+    public ExternalMessagingClient withStreamSubscriber(Subscriber<String> streamSubscriber) {
+        Objects.requireNonNull(this.client);
+        this.client.setStreamSubscriber(streamSubscriber);
+        withCount(1000);//just a big number so client can receive all possible test messages and real test messages
+        withTimeout(400);//also big timeout so there is no time restriction, test timeout will be managed in the provided subscriber
+        return this;
+    }
+
     //===================================================================
     //                          Content methods
     //===================================================================
@@ -141,5 +150,9 @@ public class ExternalMessagingClient {
 
     public void stop() {
         this.client.stop();
+    }
+
+    public void gatherResults() {
+        this.client.parseResults();
     }
 }

--- a/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/ExternalMessagingClientRun.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/ExternalMessagingClientRun.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.systemtest.messagingclients;
+
+import java.util.concurrent.Future;
+
+public class ExternalMessagingClientRun {
+
+    private Future<Boolean> result;
+    private ExternalMessagingClient client;
+    private ReceiverTester receiverTester;
+    private String descriptor;
+
+    public static ExternalMessagingClientRun of(ExternalMessagingClient client) {
+        return of(client, null);
+    }
+
+    public static ExternalMessagingClientRun of(ExternalMessagingClient client, ReceiverTester receiverTester) {
+        return of(client, receiverTester, null);
+    }
+
+    public static ExternalMessagingClientRun of(ExternalMessagingClient client, ReceiverTester receiverTester, String descriptor) {
+        ExternalMessagingClientRun run = new ExternalMessagingClientRun();
+        run.client = client;
+        run.receiverTester = receiverTester;
+        run.descriptor = descriptor;
+        return run;
+    }
+
+    public void runAsync() {
+        result = client.runAsync();
+    }
+
+    public Future<Boolean> getResult() {
+        return result;
+    }
+
+    public ExternalMessagingClient getClient() {
+        return client;
+    }
+
+    public ReceiverTester getReceiverTester() {
+        return receiverTester;
+    }
+
+    public String getDescriptor() {
+        return descriptor;
+    }
+
+}

--- a/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/ReceiverTester.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/ReceiverTester.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.systemtest.messagingclients;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.Flow.Subscriber;
+import java.util.concurrent.Flow.Subscription;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.slf4j.Logger;
+
+import io.enmasse.systemtest.logs.CustomLogger;
+import io.enmasse.systemtest.time.TimeoutBudget;
+import io.enmasse.systemtest.utils.ThrowingSupplier;
+
+public class ReceiverTester implements Subscriber<String> {
+
+    private Logger LOGGER = CustomLogger.getLogger();
+
+    private static final String TEST_MESSAGE_BODY = "test message";
+
+    private AtomicInteger testMessagesReceived = new AtomicInteger(0);
+    private AtomicInteger receivedMessages = new AtomicInteger(0);
+    private AtomicBoolean testStarted = new AtomicBoolean(false);
+
+    private CompletableFuture<Boolean> expectedMessagesResult;
+    private int expectedMessages;
+    private ThrowingSupplier<ExternalMessagingClient> testMessageSenderSupplier;
+
+
+    public ReceiverTester(int expectedMessages, ThrowingSupplier<ExternalMessagingClient> testMessageSenderSupplier) {
+        this.expectedMessages = expectedMessages;
+        this.testMessageSenderSupplier = testMessageSenderSupplier;
+
+        expectedMessagesResult = new CompletableFuture<Boolean>();
+    }
+
+    @Override
+    public void onSubscribe(Subscription subscription) {
+        LOGGER.info("ReceiverTester subscription started");
+    }
+
+    @Override
+    public void onNext(String item) {
+        LOGGER.info("DEBUG!!!!! message received");
+        if (item.contains(TEST_MESSAGE_BODY)) {
+            testMessagesReceived.getAndIncrement();
+            if (!testStarted.get()) {
+                LOGGER.info("First test message received, receiver is ready");
+                testStarted.set(true);
+            }
+        } else {
+            if (receivedMessages.incrementAndGet() == expectedMessages) {
+                expectedMessagesResult.complete(true);
+            }
+        }
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+        LOGGER.warn("Error in stream", throwable);
+        expectedMessagesResult.complete(false);
+    }
+
+    @Override
+    public void onComplete() {
+        LOGGER.info("ReceiverTester subscription completed");
+    }
+
+    public void waitForReceiverAttached() throws Exception {
+        var timeout = new TimeoutBudget(45, TimeUnit.SECONDS);
+        var testSender = testMessageSenderSupplier.get()
+                .withCount(1)
+                .withMessageBody(TEST_MESSAGE_BODY);
+
+        while (!testStarted.get() && !timeout.timeoutExpired()) {
+            try {
+                testSender.run();
+                Thread.sleep(1000);
+            } finally {
+                testSender.stop();
+            }
+        }
+        if (!testStarted.get()) {
+            //timeout expired, do one last check
+            Thread.sleep(15000);
+            if (!testStarted.get()) {
+                throw new IllegalStateException("Receiver not looking like it's attached");
+            }
+        }
+    }
+
+    public int getTestMessagesReceived() {
+        return testMessagesReceived.get();
+    }
+
+    public int getReceivedMessages() {
+        return receivedMessages.get();
+    }
+
+    public Future<Boolean> getExpectedMessagesResult() {
+        return expectedMessagesResult;
+    }
+}

--- a/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
@@ -355,9 +355,9 @@ public class TestUtils {
      * @param retries  Number of retries.
      * @param callable Code to execute.
      */
-    public static void runUntilPass(int retries, ThrowingCallable callable) throws InterruptedException {
+    public static void runUntilPass(int retries, ThrowingRunner callable) throws InterruptedException {
         runUntilPass(retries, () -> {
-            callable.call();
+            callable.run();
             return null;
         });
     }
@@ -693,12 +693,6 @@ public class TestUtils {
                     }
                     return inSync == routerPods.size();
                 }, new TimeoutBudget(10, TimeUnit.MINUTES));
-    }
-
-
-    @FunctionalInterface
-    public interface ThrowingCallable {
-        void call() throws Exception;
     }
 
     public static Path getFailedTestLogsPath(ExtensionContext extensionContext) {

--- a/systemtests/src/main/java/io/enmasse/systemtest/utils/ThrowingRunner.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/utils/ThrowingRunner.java
@@ -2,8 +2,11 @@
  * Copyright 2019, EnMasse authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.enmasse.systemtest.bases;
+package io.enmasse.systemtest.utils;
 
-public interface ThrowableRunner {
+@FunctionalInterface
+public interface ThrowingRunner {
+
     void run() throws Exception;
+
 }

--- a/systemtests/src/main/java/io/enmasse/systemtest/utils/ThrowingSupplier.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/utils/ThrowingSupplier.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.systemtest.utils;
+
+@FunctionalInterface
+public interface ThrowingSupplier<T> {
+
+    T get() throws Exception;
+
+}

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/soak/SoakTestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/soak/SoakTestBase.java
@@ -12,7 +12,6 @@ import io.enmasse.systemtest.SysytemTestsErrorCollector;
 import io.enmasse.systemtest.UserCredentials;
 import io.enmasse.systemtest.amqp.AmqpClient;
 import io.enmasse.systemtest.bases.TestBase;
-import io.enmasse.systemtest.bases.ThrowableRunner;
 import io.enmasse.systemtest.logs.CustomLogger;
 import io.enmasse.systemtest.model.address.AddressType;
 import io.enmasse.systemtest.model.addressspace.AddressSpaceType;
@@ -20,6 +19,8 @@ import io.enmasse.systemtest.shared.standard.QueueTest;
 import io.enmasse.systemtest.shared.standard.TopicTest;
 import io.enmasse.systemtest.utils.AddressUtils;
 import io.enmasse.systemtest.utils.TestUtils;
+import io.enmasse.systemtest.utils.ThrowingRunner;
+
 import org.apache.qpid.proton.message.Message;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -55,7 +56,7 @@ public abstract class SoakTestBase extends TestBase {
     // Runner tests methods
     //========================================================================================================
 
-    protected void runTestInLoop(int durationMinutes, ThrowableRunner test) throws Exception {
+    protected void runTestInLoop(int durationMinutes, ThrowingRunner test) throws Exception {
         log.info(String.format("Starting test running for %d minutes at %s",
                 durationMinutes, new Date().toString()));
         int fails = 0;

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/clients/artemis/MsgPatternsTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/clients/artemis/MsgPatternsTest.java
@@ -6,12 +6,23 @@ package io.enmasse.systemtest.shared.brokered.clients.artemis;
 
 import io.enmasse.systemtest.bases.clients.ClientTestBase;
 import io.enmasse.systemtest.bases.shared.ITestSharedBrokered;
+import io.enmasse.systemtest.messagingclients.AbstractClient;
 import io.enmasse.systemtest.messagingclients.artemis.ArtemisJMSClientReceiver;
 import io.enmasse.systemtest.messagingclients.artemis.ArtemisJMSClientSender;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class MsgPatternsTest extends ClientTestBase implements ITestSharedBrokered {
+
+    @Override
+    protected AbstractClient senderFactory() throws Exception {
+        return new ArtemisJMSClientSender();
+    }
+
+    @Override
+    protected AbstractClient receiverFactory() throws Exception {
+        return new ArtemisJMSClientReceiver();
+    }
 
     @Test
     void testBasicMessage() throws Exception {
@@ -21,13 +32,13 @@ class MsgPatternsTest extends ClientTestBase implements ITestSharedBrokered {
     @Test
     @DisplayName("testRoundRobinReceiver")
     void testRoundRobinReceiver() throws Exception {
-        doRoundRobinReceiverTest(new ArtemisJMSClientSender(), new ArtemisJMSClientReceiver(), new ArtemisJMSClientReceiver());
+        doRoundRobinReceiverTest();
     }
 
     @Test
     @DisplayName("testTopicSubscribe")
     void testTopicSubscribe() throws Exception {
-        doTopicSubscribeTest(new ArtemisJMSClientSender(), new ArtemisJMSClientReceiver(), new ArtemisJMSClientReceiver());
+        doTopicSubscribeTest();
     }
 
     @Test
@@ -48,7 +59,7 @@ class MsgPatternsTest extends ClientTestBase implements ITestSharedBrokered {
     @Test
     @DisplayName("testMessageSelectorTopic")
     void testMessageSelectorTopic() throws Exception {
-        doMessageSelectorTopicTest(new ArtemisJMSClientSender(), new ArtemisJMSClientSender(),
-                new ArtemisJMSClientReceiver(), new ArtemisJMSClientReceiver());
+        doMessageSelectorTopicTest();
     }
+
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/clients/openwire/MsgPatternsTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/clients/openwire/MsgPatternsTest.java
@@ -6,12 +6,23 @@ package io.enmasse.systemtest.shared.brokered.clients.openwire;
 
 import io.enmasse.systemtest.bases.clients.ClientTestBase;
 import io.enmasse.systemtest.bases.shared.ITestSharedBrokered;
+import io.enmasse.systemtest.messagingclients.AbstractClient;
 import io.enmasse.systemtest.messagingclients.openwire.OpenwireJMSClientReceiver;
 import io.enmasse.systemtest.messagingclients.openwire.OpenwireJMSClientSender;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class MsgPatternsTest extends ClientTestBase implements ITestSharedBrokered {
+
+    @Override
+    protected AbstractClient senderFactory() throws Exception {
+        return new OpenwireJMSClientSender();
+    }
+
+    @Override
+    protected AbstractClient receiverFactory() throws Exception {
+        return new OpenwireJMSClientReceiver();
+    }
 
     @Test
     void testBasicMessage() throws Exception {
@@ -21,13 +32,13 @@ class MsgPatternsTest extends ClientTestBase implements ITestSharedBrokered {
     @Test
     @DisplayName("testRoundRobinReceiver")
     void testRoundRobinReceiver() throws Exception {
-        doRoundRobinReceiverTest(new OpenwireJMSClientSender(), new OpenwireJMSClientReceiver(), new OpenwireJMSClientReceiver());
+        doRoundRobinReceiverTest();
     }
 
     @Test
     @DisplayName("testTopicSubscribe")
     void testTopicSubscribe() throws Exception {
-        doTopicSubscribeTest(new OpenwireJMSClientSender(), new OpenwireJMSClientReceiver(), new OpenwireJMSClientReceiver());
+        doTopicSubscribeTest();
     }
 
     @Test
@@ -48,7 +59,7 @@ class MsgPatternsTest extends ClientTestBase implements ITestSharedBrokered {
     @Test
     @DisplayName("testMessageSelectorTopic")
     void testMessageSelectorTopic() throws Exception {
-        doMessageSelectorTopicTest(new OpenwireJMSClientSender(), new OpenwireJMSClientSender(),
-                new OpenwireJMSClientReceiver(), new OpenwireJMSClientReceiver());
+        doMessageSelectorTopicTest();
     }
+
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/clients/proton/java/MsgPatternsTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/clients/proton/java/MsgPatternsTest.java
@@ -6,6 +6,7 @@ package io.enmasse.systemtest.shared.brokered.clients.proton.java;
 
 import io.enmasse.systemtest.bases.clients.ClientTestBase;
 import io.enmasse.systemtest.bases.shared.ITestSharedBrokered;
+import io.enmasse.systemtest.messagingclients.AbstractClient;
 import io.enmasse.systemtest.messagingclients.proton.java.ProtonJMSClientReceiver;
 import io.enmasse.systemtest.messagingclients.proton.java.ProtonJMSClientSender;
 import org.junit.jupiter.api.DisplayName;
@@ -17,6 +18,16 @@ import static io.enmasse.systemtest.TestTag.ACCEPTANCE;
 @Tag(ACCEPTANCE)
 class MsgPatternsTest extends ClientTestBase implements ITestSharedBrokered {
 
+    @Override
+    protected AbstractClient senderFactory() throws Exception {
+        return new ProtonJMSClientSender(logPath);
+    }
+
+    @Override
+    protected AbstractClient receiverFactory() throws Exception {
+        return new ProtonJMSClientReceiver(logPath);
+    }
+
     @Test
     void testBasicMessage() throws Exception {
         doBasicMessageTest(new ProtonJMSClientSender(logPath), new ProtonJMSClientReceiver(logPath));
@@ -25,13 +36,13 @@ class MsgPatternsTest extends ClientTestBase implements ITestSharedBrokered {
     @Test
     @DisplayName("testRoundRobinReceiver")
     void testRoundRobinReceiver() throws Exception {
-        doRoundRobinReceiverTest(new ProtonJMSClientSender(logPath), new ProtonJMSClientReceiver(logPath), new ProtonJMSClientReceiver(logPath));
+        doRoundRobinReceiverTest();
     }
 
     @Test
     @DisplayName("testTopicSubscribe")
     void testTopicSubscribe() throws Exception {
-        doTopicSubscribeTest(new ProtonJMSClientSender(logPath), new ProtonJMSClientReceiver(logPath), new ProtonJMSClientReceiver(logPath));
+        doTopicSubscribeTest();
     }
 
     @Test
@@ -52,7 +63,7 @@ class MsgPatternsTest extends ClientTestBase implements ITestSharedBrokered {
     @Test
     @DisplayName("testMessageSelectorTopic")
     void testMessageSelectorTopic() throws Exception {
-        doMessageSelectorTopicTest(new ProtonJMSClientSender(logPath), new ProtonJMSClientSender(logPath),
-                new ProtonJMSClientReceiver(logPath), new ProtonJMSClientReceiver(logPath));
+        doMessageSelectorTopicTest();
     }
+
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/clients/proton/python/MsgPatternsTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/clients/proton/python/MsgPatternsTest.java
@@ -6,12 +6,23 @@ package io.enmasse.systemtest.shared.brokered.clients.proton.python;
 
 import io.enmasse.systemtest.bases.clients.ClientTestBase;
 import io.enmasse.systemtest.bases.shared.ITestSharedBrokered;
+import io.enmasse.systemtest.messagingclients.AbstractClient;
 import io.enmasse.systemtest.messagingclients.proton.python.PythonClientReceiver;
 import io.enmasse.systemtest.messagingclients.proton.python.PythonClientSender;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class MsgPatternsTest extends ClientTestBase implements ITestSharedBrokered {
+
+    @Override
+    protected AbstractClient senderFactory() throws Exception {
+        return new PythonClientSender(logPath);
+    }
+
+    @Override
+    protected AbstractClient receiverFactory() throws Exception {
+        return new PythonClientReceiver(logPath);
+    }
 
     @Test
     void testBasicMessage() throws Exception {
@@ -21,13 +32,13 @@ class MsgPatternsTest extends ClientTestBase implements ITestSharedBrokered {
     @Test
     @DisplayName("testRoundRobinReceiver")
     void testRoundRobinReceiver() throws Exception {
-        doRoundRobinReceiverTest(new PythonClientSender(logPath), new PythonClientReceiver(logPath), new PythonClientReceiver(logPath));
+        doRoundRobinReceiverTest();
     }
 
     @Test
     @DisplayName("testTopicSubscribe")
     void testTopicSubscribe() throws Exception {
-        doTopicSubscribeTest(new PythonClientSender(logPath), new PythonClientReceiver(logPath), new PythonClientReceiver(logPath));
+        doTopicSubscribeTest();
     }
 
     @Test
@@ -48,7 +59,7 @@ class MsgPatternsTest extends ClientTestBase implements ITestSharedBrokered {
     @Test
     @DisplayName("testMessageSelectorTopic")
     void testMessageSelectorTopic() throws Exception {
-        doMessageSelectorTopicTest(new PythonClientSender(logPath), new PythonClientSender(logPath),
-                new PythonClientReceiver(logPath), new PythonClientReceiver(logPath));
+        doMessageSelectorTopicTest();
     }
+
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/clients/rhea/MsgPatternsTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/clients/rhea/MsgPatternsTest.java
@@ -6,6 +6,7 @@ package io.enmasse.systemtest.shared.brokered.clients.rhea;
 
 import io.enmasse.systemtest.bases.clients.ClientTestBase;
 import io.enmasse.systemtest.bases.shared.ITestSharedBrokered;
+import io.enmasse.systemtest.messagingclients.AbstractClient;
 import io.enmasse.systemtest.messagingclients.rhea.RheaClientReceiver;
 import io.enmasse.systemtest.messagingclients.rhea.RheaClientSender;
 import org.junit.jupiter.api.DisplayName;
@@ -16,6 +17,16 @@ import static io.enmasse.systemtest.TestTag.ACCEPTANCE;
 
 @Tag(ACCEPTANCE)
 class MsgPatternsTest extends ClientTestBase implements ITestSharedBrokered {
+
+    @Override
+    protected AbstractClient senderFactory() throws Exception {
+        return new RheaClientSender(logPath);
+    }
+
+    @Override
+    protected AbstractClient receiverFactory() throws Exception {
+        return new RheaClientReceiver(logPath);
+    }
 
     @Test
     void testBasicMessage() throws Exception {
@@ -30,13 +41,13 @@ class MsgPatternsTest extends ClientTestBase implements ITestSharedBrokered {
     @Test
     @DisplayName("testRoundRobinReceiver")
     void testRoundRobinReceiver() throws Exception {
-        doRoundRobinReceiverTest(new RheaClientSender(logPath), new RheaClientReceiver(logPath), new RheaClientReceiver(logPath));
+        doRoundRobinReceiverTest();
     }
 
     @Test
     @DisplayName("testTopicSubscribe")
     void testTopicSubscribe() throws Exception {
-        doTopicSubscribeTest(new RheaClientSender(logPath), new RheaClientReceiver(logPath), new RheaClientReceiver(logPath));
+        doTopicSubscribeTest();
     }
 
     @Test
@@ -57,7 +68,7 @@ class MsgPatternsTest extends ClientTestBase implements ITestSharedBrokered {
     @Test
     @DisplayName("testMessageSelectorTopic")
     void testMessageSelectorTopic() throws Exception {
-        doMessageSelectorTopicTest(new RheaClientSender(logPath), new RheaClientSender(logPath),
-                new RheaClientReceiver(logPath), new RheaClientReceiver(logPath));
+        doMessageSelectorTopicTest();
     }
+
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/clients/stomp/MsgPatternsTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/clients/stomp/MsgPatternsTest.java
@@ -6,12 +6,23 @@ package io.enmasse.systemtest.shared.brokered.clients.stomp;
 
 import io.enmasse.systemtest.bases.clients.ClientTestBase;
 import io.enmasse.systemtest.bases.shared.ITestSharedBrokered;
+import io.enmasse.systemtest.messagingclients.AbstractClient;
 import io.enmasse.systemtest.messagingclients.stomp.StompClientReceiver;
 import io.enmasse.systemtest.messagingclients.stomp.StompClientSender;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class MsgPatternsTest extends ClientTestBase implements ITestSharedBrokered {
+
+    @Override
+    protected AbstractClient senderFactory() throws Exception {
+        return new StompClientSender(logPath);
+    }
+
+    @Override
+    protected AbstractClient receiverFactory() throws Exception {
+        return new StompClientReceiver(logPath);
+    }
 
     @Test
     void testBasicMessage() throws Exception {
@@ -21,11 +32,12 @@ class MsgPatternsTest extends ClientTestBase implements ITestSharedBrokered {
     @Test
     @DisplayName("testTopicSubscribe")
     void testTopicSubscribe() throws Exception {
-        doTopicSubscribeTest(new StompClientSender(logPath), new StompClientReceiver(logPath), new StompClientReceiver(logPath));
+        doTopicSubscribeTest();
     }
 
     @Test
     void testStompUserPermissions() throws Exception {
         doTestUserPermissions(new StompClientSender(logPath), new StompClientReceiver(logPath));
     }
+
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/clients/proton/java/MsgPatternsTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/clients/proton/java/MsgPatternsTest.java
@@ -6,6 +6,7 @@ package io.enmasse.systemtest.shared.standard.clients.proton.java;
 
 import io.enmasse.systemtest.bases.clients.ClientTestBase;
 import io.enmasse.systemtest.bases.shared.ITestSharedStandard;
+import io.enmasse.systemtest.messagingclients.AbstractClient;
 import io.enmasse.systemtest.messagingclients.proton.java.ProtonJMSClientReceiver;
 import io.enmasse.systemtest.messagingclients.proton.java.ProtonJMSClientSender;
 import org.junit.jupiter.api.Disabled;
@@ -18,6 +19,16 @@ import static io.enmasse.systemtest.TestTag.ACCEPTANCE;
 @Tag(ACCEPTANCE)
 class MsgPatternsTest extends ClientTestBase implements ITestSharedStandard {
 
+    @Override
+    protected AbstractClient senderFactory() throws Exception {
+        return new ProtonJMSClientSender(logPath);
+    }
+
+    @Override
+    protected AbstractClient receiverFactory() throws Exception {
+        return new ProtonJMSClientReceiver(logPath);
+    }
+
     @Test
     void testBasicMessage() throws Exception {
         doBasicMessageTest(new ProtonJMSClientSender(logPath), new ProtonJMSClientReceiver(logPath));
@@ -26,7 +37,7 @@ class MsgPatternsTest extends ClientTestBase implements ITestSharedStandard {
     @Test
     @DisplayName("testTopicSubscribe")
     void testTopicSubscribe() throws Exception {
-        doTopicSubscribeTest(new ProtonJMSClientSender(logPath), new ProtonJMSClientReceiver(logPath), new ProtonJMSClientReceiver(logPath));
+        doTopicSubscribeTest();
     }
 
     @Test
@@ -38,7 +49,7 @@ class MsgPatternsTest extends ClientTestBase implements ITestSharedStandard {
     @Test
     @DisplayName("testMessageSelectorTopic")
     void testMessageSelectorTopic() throws Exception {
-        doMessageSelectorTopicTest(new ProtonJMSClientSender(logPath), new ProtonJMSClientSender(logPath),
-                new ProtonJMSClientReceiver(logPath), new ProtonJMSClientReceiver(logPath));
+        doMessageSelectorTopicTest();
     }
+
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/clients/proton/python/MsgPatternsTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/clients/proton/python/MsgPatternsTest.java
@@ -6,6 +6,7 @@ package io.enmasse.systemtest.shared.standard.clients.proton.python;
 
 import io.enmasse.systemtest.bases.clients.ClientTestBase;
 import io.enmasse.systemtest.bases.shared.ITestSharedStandard;
+import io.enmasse.systemtest.messagingclients.AbstractClient;
 import io.enmasse.systemtest.messagingclients.proton.python.PythonClientReceiver;
 import io.enmasse.systemtest.messagingclients.proton.python.PythonClientSender;
 import org.junit.jupiter.api.Disabled;
@@ -13,6 +14,16 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class MsgPatternsTest extends ClientTestBase implements ITestSharedStandard {
+
+    @Override
+    protected AbstractClient senderFactory() throws Exception {
+        return new PythonClientSender(logPath);
+    }
+
+    @Override
+    protected AbstractClient receiverFactory() throws Exception {
+        return new PythonClientReceiver(logPath);
+    }
 
     @Test
     void testBasicMessage() throws Exception {
@@ -22,7 +33,7 @@ class MsgPatternsTest extends ClientTestBase implements ITestSharedStandard {
     @Test
     @DisplayName("testTopicSubscribe")
     void testTopicSubscribe() throws Exception {
-        doTopicSubscribeTest(new PythonClientSender(logPath), new PythonClientReceiver(logPath), new PythonClientReceiver(logPath));
+        doTopicSubscribeTest();
     }
 
     @Test
@@ -34,7 +45,7 @@ class MsgPatternsTest extends ClientTestBase implements ITestSharedStandard {
     @Test
     @DisplayName("testMessageSelectorTopic")
     void testMessageSelectorTopic() throws Exception {
-        doMessageSelectorTopicTest(new PythonClientSender(logPath), new PythonClientSender(logPath),
-                new PythonClientReceiver(logPath), new PythonClientReceiver(logPath));
+        doMessageSelectorTopicTest();
     }
+
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/clients/rhea/MsgPatternsTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/clients/rhea/MsgPatternsTest.java
@@ -6,6 +6,7 @@ package io.enmasse.systemtest.shared.standard.clients.rhea;
 
 import io.enmasse.systemtest.bases.clients.ClientTestBase;
 import io.enmasse.systemtest.bases.shared.ITestSharedStandard;
+import io.enmasse.systemtest.messagingclients.AbstractClient;
 import io.enmasse.systemtest.messagingclients.rhea.RheaClientReceiver;
 import io.enmasse.systemtest.messagingclients.rhea.RheaClientSender;
 import org.junit.jupiter.api.Disabled;
@@ -17,6 +18,16 @@ import static io.enmasse.systemtest.TestTag.ACCEPTANCE;
 
 @Tag(ACCEPTANCE)
 class MsgPatternsTest extends ClientTestBase implements ITestSharedStandard {
+
+    @Override
+    protected AbstractClient senderFactory() throws Exception {
+        return new RheaClientSender(logPath);
+    }
+
+    @Override
+    protected AbstractClient receiverFactory() throws Exception {
+        return new RheaClientReceiver(logPath);
+    }
 
     @Test
     void testBasicMessage() throws Exception {
@@ -31,7 +42,7 @@ class MsgPatternsTest extends ClientTestBase implements ITestSharedStandard {
     @Test
     @DisplayName("testTopicSubscribe")
     void testTopicSubscribe() throws Exception {
-        doTopicSubscribeTest(new RheaClientSender(logPath), new RheaClientReceiver(logPath), new RheaClientReceiver(logPath));
+        doTopicSubscribeTest();
     }
 
     @Test
@@ -43,7 +54,7 @@ class MsgPatternsTest extends ClientTestBase implements ITestSharedStandard {
     @Test
     @DisplayName("testMessageSelectorTopic")
     void testMessageSelectorTopic() throws Exception {
-        doMessageSelectorTopicTest(new RheaClientSender(logPath), new RheaClientSender(logPath),
-                new RheaClientReceiver(logPath), new RheaClientReceiver(logPath));
+        doMessageSelectorTopicTest();
     }
+
 }


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

This PR tries to make messaging client tests more stable, currently there a sleep in some tests where receivers are started before senders, the changes in this PR add an active wait sending test messages to ensure the receivers are attached before running senders and start with the actual process of the test.
This is still WIP because proton.python tests are having some issues where the new functionalities implemented doesn't work...
<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [x] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
