### PR TITLE
Fix overlapping source directories

### DIFF
--- a/api-model/pom.xml
+++ b/api-model/pom.xml
@@ -110,7 +110,6 @@
           <includeJsr303Annotations>false</includeJsr303Annotations>
           <includeToString>false</includeToString>
           <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
-          <outputDirectory>${project.build.directory}/generated-sources</outputDirectory>
           <customAnnotator>io.enmasse.api.annotator.KubernetesTypeAnnotator</customAnnotator>
           <annotationStyle>none</annotationStyle>
         </configuration>


### PR DESCRIPTION
Sources got generated into:
 * target/generated-sources/
 * target/generated-sources/annotations

Which creates an overlap in the project source hierarchy.

The default of "jsonschema2pojo" already declared a sane default,
which got overridden by the enmasse build. This commit falls back
to the default.
