### PR TITLE
Add broker.globalMaxSize to the infraconfig CRDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ## 0.31.1
 * #4241: Fix a race in upgrader logic that prevented upgrade from continuing
+* #4266: Add broker.globalMaxSize to the infraconfig CRDs 
 * #4269: bump Netty dependency from netty-4.1.45.Final to netty-4.1.48.Final
 
 ## 0.31.0

--- a/templates/crds/brokeredinfraconfigs.crd.yaml
+++ b/templates/crds/brokeredinfraconfigs.crd.yaml
@@ -115,6 +115,10 @@ spec:
                   - BLOCK
                   - FAIL
                   - DROP
+                globalMaxSize:
+                  pattern: "^(?i)\\d+\\s*[kmg]?b?$"
+                  type: string
+                  description: Sets a global limit to the amount of memory the broker can use before it applies the rules determined by addressFullPolicy. Value in bytes or use a byte suffix ("B", "K", "MB", "GB")
                 storageClassName:
                   type: string
                 updatePersistentVolumeClaim:

--- a/templates/crds/standardinfraconfigs.crd.yaml
+++ b/templates/crds/standardinfraconfigs.crd.yaml
@@ -123,6 +123,10 @@ spec:
                   - BLOCK
                   - FAIL
                   - DROP
+                globalMaxSize:
+                  pattern: "^(?i)\\d+\\s*[kmg]?b?$"
+                  type: string
+                  description: Sets a global limit to the amount of memory the broker can use before it applies the rules determined by addressFullPolicy. Value in bytes or use a byte suffix ("B", "K", "MB", "GB")
                 storageClassName:
                   type: string
                 updatePersistentVolumeClaim:


### PR DESCRIPTION
### Type of change

- Improvement

### Description

Field broker.globalMaxSize is missing from the standardinfraconfig and brokeredinfraconfig CRDs.
Applies regex that has same effect of that of ARTEMIS-873.

### Checklist


- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
