### PR TITLE
systemtests - cli clients tests - wait for receivers to attach

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/AbstractClient.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/AbstractClient.java
@@ -23,7 +23,11 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.Flow.Subscriber;
+import java.util.concurrent.Flow.Subscription;
 import java.util.concurrent.Future;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 /**
  * Class represent abstract client which keeps common features of client
@@ -42,20 +46,21 @@ public abstract class AbstractClient {
     private List<String> executable;
     private String podName;
     private String podNamespace;
+    private CompletableFuture<Void> clientAttached;
     /**
      * Important: this is not any container_id nor nothing related with amqp, this is just an identifier for logging in our tests
      */
     private String id;
 
-    public AbstractClient(ClientType clientType) throws Exception {
+    protected AbstractClient(ClientType clientType) throws Exception {
         this(clientType, null, SystemtestsKubernetesApps.MESSAGING_PROJECT);
     }
 
-    public AbstractClient(ClientType clientType, String podNamespace) throws Exception {
+    protected AbstractClient(ClientType clientType, String podNamespace) throws Exception {
         this(clientType, null, podNamespace);
     }
 
-    public AbstractClient(ClientType clientType, Path logPath) throws Exception {
+    protected AbstractClient(ClientType clientType, Path logPath) throws Exception {
         this(clientType, logPath, SystemtestsKubernetesApps.MESSAGING_PROJECT);
     }
 
@@ -70,6 +75,9 @@ public abstract class AbstractClient {
         this.podName = SystemtestsKubernetesApps.getMessagingAppPodName(this.podNamespace);
         this.fillAllowedArgs();
         this.executable = transformExecutableCommand(ClientType.getCommand(clientType));
+        if (clientAttachedProbeFactory() != null) {
+            this.clientAttached = new CompletableFuture<Void>();
+        }
     }
 
     public String getId() {
@@ -155,6 +163,10 @@ public abstract class AbstractClient {
         return executor.getStdErr();
     }
 
+    public Future<Void> getClientAttached() {
+        return clientAttached;
+    }
+
     /**
      * Validates that client support this arg
      *
@@ -197,6 +209,9 @@ public abstract class AbstractClient {
         messages.clear();
         try {
             executor = new Exec(logPath);
+            if (clientAttachedProbeFactory() != null) {
+                setClientAttachedProbe();
+            }
             int ret = executor.exec(prepareCommand(), timeout);
             synchronized (lock) {
                 log.info("{} {} Return code - {}", this.getClass().getName(), clientType, ret);
@@ -216,6 +231,37 @@ public abstract class AbstractClient {
             ex.printStackTrace();
             return false;
         }
+    }
+
+    private void setClientAttachedProbe() {
+        var clientAttachedProbe = clientAttachedProbeFactory().get();
+        executor.setStdErrProcessor(new Subscriber<String>() {
+
+            @Override
+            public void onSubscribe(Subscription subscription) {
+                //empty
+            }
+
+            @Override
+            public void onNext(String item) {
+                if (!clientAttached.isDone()) {
+                    if (clientAttachedProbe.test(item)) {
+                        log.info("Client is attached!!");
+                        clientAttached.complete(null);
+                    }
+                }
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                clientAttached.completeExceptionally(throwable);
+            }
+
+            @Override
+            public void onComplete() {
+                clientAttached.complete(null);
+            }
+        });
     }
 
     /**
@@ -417,4 +463,9 @@ public abstract class AbstractClient {
 
         return args;
     }
+
+    protected Supplier<Predicate<String>> clientAttachedProbeFactory() {
+        return null;
+    }
+
 }

--- a/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/ExternalMessagingClient.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/ExternalMessagingClient.java
@@ -109,6 +109,11 @@ public class ExternalMessagingClient {
         return client.getId();
     }
 
+    public Future<Void> getClientAttachedProbe() {
+        Objects.requireNonNull(this.client);
+        return client.getClientAttached();
+    }
+
     //===================================================================
     //                          Run methods
     //===================================================================

--- a/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/ExternalMessagingClient.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/ExternalMessagingClient.java
@@ -8,13 +8,20 @@ package io.enmasse.systemtest.messagingclients;
 import io.enmasse.address.model.Address;
 import io.enmasse.systemtest.Endpoint;
 import io.enmasse.systemtest.UserCredentials;
+import io.enmasse.systemtest.logs.CustomLogger;
 import io.enmasse.systemtest.utils.AddressUtils;
 import io.vertx.core.json.JsonArray;
 
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
+import org.slf4j.Logger;
+
 public class ExternalMessagingClient {
+
+    private static Logger LOGGER = CustomLogger.getLogger();
+
     private AbstractClient client;
     private ClientArgumentMap arguments;
 
@@ -109,9 +116,22 @@ public class ExternalMessagingClient {
         return client.getId();
     }
 
-    public Future<Void> getClientAttachedProbe() {
+    public Future<Void> getLinkAttachedProbe() {
         Objects.requireNonNull(this.client);
-        return client.getClientAttached();
+        if (client.getLinkAttached() != null) {
+            return client.getLinkAttached();
+        } else {
+            CompletableFuture<Void> defaultWait = new CompletableFuture<Void>();
+            defaultWait.completeAsync(() -> {
+                try {
+                    Thread.sleep(14000);
+                } catch(Exception e) {
+                    LOGGER.error("Error in default wait for link attached", e);
+                }
+                return null;
+            }, r -> new Thread(r).start());
+            return defaultWait;
+        }
     }
 
     //===================================================================

--- a/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/artemis/ArtemisJMSClientReceiver.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/artemis/ArtemisJMSClientReceiver.java
@@ -5,6 +5,8 @@
 package io.enmasse.systemtest.messagingclients.artemis;
 
 import java.nio.file.Path;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import io.enmasse.systemtest.messagingclients.ClientArgumentMap;
 import io.enmasse.systemtest.messagingclients.ClientType;
@@ -26,4 +28,10 @@ public class ArtemisJMSClientReceiver extends ProtonJMSClientReceiver {
         args = modifySelectorArg(args);
         return args;
     }
+
+    @Override
+    public Supplier<Predicate<String>> linkAttachedProbeFactory() {
+        return null;
+    }
+
 }

--- a/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/artemis/ArtemisJMSClientReceiver.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/artemis/ArtemisJMSClientReceiver.java
@@ -4,13 +4,20 @@
  */
 package io.enmasse.systemtest.messagingclients.artemis;
 
+import java.nio.file.Path;
+
 import io.enmasse.systemtest.messagingclients.ClientArgumentMap;
 import io.enmasse.systemtest.messagingclients.ClientType;
 import io.enmasse.systemtest.messagingclients.proton.java.ProtonJMSClientReceiver;
 
 public class ArtemisJMSClientReceiver extends ProtonJMSClientReceiver {
+
+    public ArtemisJMSClientReceiver(Path logsPath) throws Exception {
+        super(ClientType.CLI_JAVA_ARTEMIS_JMS_RECEIVER, logsPath);
+    }
+
     public ArtemisJMSClientReceiver() throws Exception {
-        this.setClientType(ClientType.CLI_JAVA_ARTEMIS_JMS_RECEIVER);
+        super(ClientType.CLI_JAVA_ARTEMIS_JMS_RECEIVER, null);
     }
 
     @Override

--- a/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/artemis/ArtemisJMSClientSender.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/artemis/ArtemisJMSClientSender.java
@@ -4,14 +4,21 @@
  */
 package io.enmasse.systemtest.messagingclients.artemis;
 
+import java.nio.file.Path;
+
 import io.enmasse.systemtest.messagingclients.ClientArgumentMap;
 import io.enmasse.systemtest.messagingclients.ClientType;
 import io.enmasse.systemtest.messagingclients.proton.java.ProtonJMSClientSender;
 
 
 public class ArtemisJMSClientSender extends ProtonJMSClientSender {
+
+    public ArtemisJMSClientSender(Path logPath) throws Exception {
+        super(ClientType.CLI_JAVA_ARTEMIS_JMS_SENDER, logPath);
+    }
+
     public ArtemisJMSClientSender() throws Exception {
-        this.setClientType(ClientType.CLI_JAVA_ARTEMIS_JMS_SENDER);
+        super(ClientType.CLI_JAVA_ARTEMIS_JMS_SENDER, null);
     }
 
     @Override

--- a/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/openwire/OpenwireJMSClientReceiver.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/openwire/OpenwireJMSClientReceiver.java
@@ -5,6 +5,8 @@
 package io.enmasse.systemtest.messagingclients.openwire;
 
 import java.nio.file.Path;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import io.enmasse.systemtest.messagingclients.ClientArgumentMap;
 import io.enmasse.systemtest.messagingclients.ClientType;
@@ -26,4 +28,10 @@ public class OpenwireJMSClientReceiver extends ProtonJMSClientReceiver {
         args = modifySelectorArg(args);
         return args;
     }
+
+    @Override
+    public Supplier<Predicate<String>> linkAttachedProbeFactory() {
+        return null;
+    }
+
 }

--- a/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/openwire/OpenwireJMSClientReceiver.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/openwire/OpenwireJMSClientReceiver.java
@@ -4,13 +4,20 @@
  */
 package io.enmasse.systemtest.messagingclients.openwire;
 
+import java.nio.file.Path;
+
 import io.enmasse.systemtest.messagingclients.ClientArgumentMap;
 import io.enmasse.systemtest.messagingclients.ClientType;
 import io.enmasse.systemtest.messagingclients.proton.java.ProtonJMSClientReceiver;
 
 public class OpenwireJMSClientReceiver extends ProtonJMSClientReceiver {
+
+    public OpenwireJMSClientReceiver(Path logPath) throws Exception {
+        super(ClientType.CLI_JAVA_OPENWIRE_JMS_RECEIVER, logPath);
+    }
+
     public OpenwireJMSClientReceiver() throws Exception {
-        this.setClientType(ClientType.CLI_JAVA_OPENWIRE_JMS_RECEIVER);
+        super(ClientType.CLI_JAVA_OPENWIRE_JMS_RECEIVER, null);
     }
 
     @Override

--- a/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/openwire/OpenwireJMSClientSender.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/openwire/OpenwireJMSClientSender.java
@@ -4,14 +4,21 @@
  */
 package io.enmasse.systemtest.messagingclients.openwire;
 
+import java.nio.file.Path;
+
 import io.enmasse.systemtest.messagingclients.ClientArgumentMap;
 import io.enmasse.systemtest.messagingclients.ClientType;
 import io.enmasse.systemtest.messagingclients.proton.java.ProtonJMSClientSender;
 
 
 public class OpenwireJMSClientSender extends ProtonJMSClientSender {
+
+    public OpenwireJMSClientSender(Path logPath) throws Exception {
+        super(ClientType.CLI_JAVA_OPENWIRE_JMS_SENDER, logPath);
+    }
+
     public OpenwireJMSClientSender() throws Exception {
-        this.setClientType(ClientType.CLI_JAVA_OPENWIRE_JMS_SENDER);
+        super(ClientType.CLI_JAVA_OPENWIRE_JMS_SENDER, null);
     }
 
     @Override

--- a/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/proton/java/ProtonJMSClientReceiver.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/proton/java/ProtonJMSClientReceiver.java
@@ -12,14 +12,20 @@ import io.enmasse.systemtest.messagingclients.ClientType;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 public class ProtonJMSClientReceiver extends AbstractClient {
     public ProtonJMSClientReceiver() throws Exception {
-        super(ClientType.CLI_JAVA_PROTON_JMS_RECEIVER);
+        this(ClientType.CLI_JAVA_PROTON_JMS_RECEIVER, null);
     }
 
     public ProtonJMSClientReceiver(Path logPath) throws Exception {
-        super(ClientType.CLI_JAVA_PROTON_JMS_RECEIVER, logPath);
+        this(ClientType.CLI_JAVA_PROTON_JMS_RECEIVER, logPath);
+    }
+
+    protected ProtonJMSClientReceiver(ClientType type, Path logPath) throws Exception {
+        super(type, logPath);
     }
 
     @Override
@@ -95,4 +101,17 @@ public class ProtonJMSClientReceiver extends AbstractClient {
     protected List<String> transformExecutableCommand(String executableCommand) {
         return Arrays.asList("java", "-jar", executableCommand, "receiver");
     }
+
+    @Override
+    public Supplier<Predicate<String>> clientAttachedProbeFactory() {
+        return () -> {
+            return new Predicate<String>() {
+                @Override
+                public boolean test(String line) {
+                    return line.contains("New Proton Event: LINK_REMOTE_OPEN");
+                }
+            };
+        };
+    }
+
 }

--- a/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/proton/java/ProtonJMSClientReceiver.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/proton/java/ProtonJMSClientReceiver.java
@@ -103,7 +103,7 @@ public class ProtonJMSClientReceiver extends AbstractClient {
     }
 
     @Override
-    public Supplier<Predicate<String>> clientAttachedProbeFactory() {
+    public Supplier<Predicate<String>> linkAttachedProbeFactory() {
         return () -> {
             return new Predicate<String>() {
                 @Override

--- a/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/proton/java/ProtonJMSClientSender.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/proton/java/ProtonJMSClientSender.java
@@ -15,12 +15,17 @@ import java.util.List;
 
 
 public class ProtonJMSClientSender extends AbstractClient {
+
     public ProtonJMSClientSender() throws Exception {
-        super(ClientType.CLI_JAVA_PROTON_JMS_SENDER);
+        this(ClientType.CLI_JAVA_PROTON_JMS_SENDER, null);
     }
 
     public ProtonJMSClientSender(Path logPath) throws Exception {
-        super(ClientType.CLI_JAVA_PROTON_JMS_SENDER, logPath);
+        this(ClientType.CLI_JAVA_PROTON_JMS_SENDER, logPath);
+    }
+
+    protected ProtonJMSClientSender(ClientType type, Path logPath) throws Exception {
+        super(type, logPath);
     }
 
     @Override

--- a/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/proton/python/PythonClientReceiver.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/proton/python/PythonClientReceiver.java
@@ -12,6 +12,8 @@ import io.enmasse.systemtest.messagingclients.ClientType;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 public class PythonClientReceiver extends AbstractClient {
     public PythonClientReceiver() throws Exception {
@@ -76,4 +78,21 @@ public class PythonClientReceiver extends AbstractClient {
     protected List<String> transformExecutableCommand(String executableCommand) {
         return Arrays.asList(executableCommand);
     }
+
+    @Override
+    public Supplier<Predicate<String>> clientAttachedProbeFactory() {
+        return () -> {
+            return new Predicate<String>() {
+                int attachMsgCount = 0;
+                @Override
+                public boolean test(String line) {
+                    if (line.contains("@attach(18)")) {
+                        attachMsgCount++;
+                    }
+                    return attachMsgCount == 2;
+                }
+            };
+        };
+    }
+
 }

--- a/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/proton/python/PythonClientReceiver.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/proton/python/PythonClientReceiver.java
@@ -80,7 +80,7 @@ public class PythonClientReceiver extends AbstractClient {
     }
 
     @Override
-    public Supplier<Predicate<String>> clientAttachedProbeFactory() {
+    public Supplier<Predicate<String>> linkAttachedProbeFactory() {
         return () -> {
             return new Predicate<String>() {
                 int attachMsgCount = 0;

--- a/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/rhea/RheaClientReceiver.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/rhea/RheaClientReceiver.java
@@ -12,6 +12,8 @@ import io.enmasse.systemtest.messagingclients.ClientType;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 public class RheaClientReceiver extends AbstractClient {
     public RheaClientReceiver() throws Exception {
@@ -81,4 +83,21 @@ public class RheaClientReceiver extends AbstractClient {
     protected List<String> transformExecutableCommand(String executableCommand) {
         return Arrays.asList(executableCommand);
     }
+
+    @Override
+    public Supplier<Predicate<String>> clientAttachedProbeFactory() {
+        return () -> {
+            return new Predicate<String>() {
+                int attachMsgCount = 0;
+                @Override
+                public boolean test(String line) {
+                    if (line.contains("attach#12")) {
+                        attachMsgCount++;
+                    }
+                    return attachMsgCount == 2;
+                }
+            };
+        };
+    }
+
 }

--- a/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/rhea/RheaClientReceiver.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/rhea/RheaClientReceiver.java
@@ -85,7 +85,7 @@ public class RheaClientReceiver extends AbstractClient {
     }
 
     @Override
-    public Supplier<Predicate<String>> clientAttachedProbeFactory() {
+    public Supplier<Predicate<String>> linkAttachedProbeFactory() {
         return () -> {
             return new Predicate<String>() {
                 int attachMsgCount = 0;

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/apps/SystemtestsKubernetesApps.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/apps/SystemtestsKubernetesApps.java
@@ -74,7 +74,6 @@ import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.api.model.SecretVolumeSourceBuilder;
-import io.fabric8.kubernetes.api.model.SecurityContextBuilder;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import io.fabric8.kubernetes.api.model.ServicePort;
@@ -919,6 +918,7 @@ public class SystemtestsKubernetesApps {
                 .withImage("quay.io/enmasse/systemtests-clients:latest")
                 .withCommand("sleep")
                 .withArgs("infinity")
+                .withEnv(new EnvVarBuilder().withName("PN_TRACE_FRM").withValue("true").build())
                 .endContainer()
                 .endSpec()
                 .endTemplate()

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/clients/ClientTestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/clients/ClientTestBase.java
@@ -171,19 +171,8 @@ public abstract class ClientTestBase extends TestBase implements ITestBaseShared
         Future<Boolean> recResult = receiverClient1.runAsync();
         Future<Boolean> rec2Result = receiverClient2.runAsync();
 
-        Thread.sleep(2);
-
-        if (receiverClient1.getClientAttachedProbe() != null) {
-            receiverClient1.getClientAttachedProbe().get(15000, TimeUnit.MILLISECONDS);
-        } else {
-            Thread.sleep(15000);
-        }
-
-        if (receiverClient2.getClientAttachedProbe() != null) {
-            receiverClient2.getClientAttachedProbe().get(15000, TimeUnit.MILLISECONDS);
-        } else {
-            Thread.sleep(15000);
-        }
+        receiverClient1.getLinkAttachedProbe().get(15000, TimeUnit.MILLISECONDS);
+        receiverClient2.getLinkAttachedProbe().get(15000, TimeUnit.MILLISECONDS);
 
         assertTrue(senderClient.run(), "Sender failed, expected return code 0");
         assertTrue(recResult.get(), "Receiver failed, expected return code 0");
@@ -247,19 +236,8 @@ public abstract class ClientTestBase extends TestBase implements ITestBaseShared
         Future<Boolean> recResult = receiverClient1.runAsync();
         Future<Boolean> recResult2 = receiverClient2.runAsync();
 
-        Thread.sleep(2);
-
-        if (receiverClient1.getClientAttachedProbe() != null) {
-            receiverClient1.getClientAttachedProbe().get(15000, TimeUnit.MILLISECONDS);
-        } else {
-            Thread.sleep(15000);
-        }
-
-        if (receiverClient2.getClientAttachedProbe() != null) {
-            receiverClient2.getClientAttachedProbe().get(15000, TimeUnit.MILLISECONDS);
-        } else {
-            Thread.sleep(15000);
-        }
+        receiverClient1.getLinkAttachedProbe().get(15000, TimeUnit.MILLISECONDS);
+        receiverClient2.getLinkAttachedProbe().get(15000, TimeUnit.MILLISECONDS);
 
         assertAll(
                 () -> assertTrue(senderClient.run(), "Producer failed, expected return code 0"),
@@ -511,19 +489,8 @@ public abstract class ClientTestBase extends TestBase implements ITestBaseShared
         Future<Boolean> result1 = receiverClient1.runAsync();
         Future<Boolean> result2 = receiverClient2.runAsync();
 
-        Thread.sleep(2);
-
-        if (receiverClient1.getClientAttachedProbe() != null) {
-            receiverClient1.getClientAttachedProbe().get(15000, TimeUnit.MILLISECONDS);
-        } else {
-            Thread.sleep(15000);
-        }
-
-        if (receiverClient2.getClientAttachedProbe() != null) {
-            receiverClient2.getClientAttachedProbe().get(15000, TimeUnit.MILLISECONDS);
-        } else {
-            Thread.sleep(15000);
-        }
+        receiverClient1.getLinkAttachedProbe().get(15000, TimeUnit.MILLISECONDS);
+        receiverClient2.getLinkAttachedProbe().get(15000, TimeUnit.MILLISECONDS);
 
         assertTrue(senderClient1.run(), "Sender failed, expected return code 0");
         assertTrue(senderClient2.run(), "Sender2 failed, expected return code 0");

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/clients/ClientTestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/clients/ClientTestBase.java
@@ -36,6 +36,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -170,7 +171,19 @@ public abstract class ClientTestBase extends TestBase implements ITestBaseShared
         Future<Boolean> recResult = receiverClient1.runAsync();
         Future<Boolean> rec2Result = receiverClient2.runAsync();
 
-        Thread.sleep(15000);
+        Thread.sleep(2);
+
+        if (receiverClient1.getClientAttachedProbe() != null) {
+            receiverClient1.getClientAttachedProbe().get(15000, TimeUnit.MILLISECONDS);
+        } else {
+            Thread.sleep(15000);
+        }
+
+        if (receiverClient2.getClientAttachedProbe() != null) {
+            receiverClient2.getClientAttachedProbe().get(15000, TimeUnit.MILLISECONDS);
+        } else {
+            Thread.sleep(15000);
+        }
 
         assertTrue(senderClient.run(), "Sender failed, expected return code 0");
         assertTrue(recResult.get(), "Receiver failed, expected return code 0");
@@ -234,7 +247,19 @@ public abstract class ClientTestBase extends TestBase implements ITestBaseShared
         Future<Boolean> recResult = receiverClient1.runAsync();
         Future<Boolean> recResult2 = receiverClient2.runAsync();
 
-        Thread.sleep(15000);
+        Thread.sleep(2);
+
+        if (receiverClient1.getClientAttachedProbe() != null) {
+            receiverClient1.getClientAttachedProbe().get(15000, TimeUnit.MILLISECONDS);
+        } else {
+            Thread.sleep(15000);
+        }
+
+        if (receiverClient2.getClientAttachedProbe() != null) {
+            receiverClient2.getClientAttachedProbe().get(15000, TimeUnit.MILLISECONDS);
+        } else {
+            Thread.sleep(15000);
+        }
 
         assertAll(
                 () -> assertTrue(senderClient.run(), "Producer failed, expected return code 0"),
@@ -486,7 +511,19 @@ public abstract class ClientTestBase extends TestBase implements ITestBaseShared
         Future<Boolean> result1 = receiverClient1.runAsync();
         Future<Boolean> result2 = receiverClient2.runAsync();
 
-        Thread.sleep(15000);
+        Thread.sleep(2);
+
+        if (receiverClient1.getClientAttachedProbe() != null) {
+            receiverClient1.getClientAttachedProbe().get(15000, TimeUnit.MILLISECONDS);
+        } else {
+            Thread.sleep(15000);
+        }
+
+        if (receiverClient2.getClientAttachedProbe() != null) {
+            receiverClient2.getClientAttachedProbe().get(15000, TimeUnit.MILLISECONDS);
+        } else {
+            Thread.sleep(15000);
+        }
 
         assertTrue(senderClient1.run(), "Sender failed, expected return code 0");
         assertTrue(senderClient2.run(), "Sender2 failed, expected return code 0");

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/clients/artemis/MsgPatternsTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/clients/artemis/MsgPatternsTest.java
@@ -27,7 +27,7 @@ class MsgPatternsTest extends ClientTestBase implements ITestSharedBrokered {
     @Test
     @DisplayName("testTopicSubscribe")
     void testTopicSubscribe() throws Exception {
-        doTopicSubscribeTest(new ArtemisJMSClientSender(), new ArtemisJMSClientReceiver(), new ArtemisJMSClientReceiver());
+        doTopicSubscribeTest(new ArtemisJMSClientSender(logPath), new ArtemisJMSClientReceiver(logPath), new ArtemisJMSClientReceiver(logPath));
     }
 
     @Test

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/clients/openwire/MsgPatternsTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/clients/openwire/MsgPatternsTest.java
@@ -27,7 +27,7 @@ class MsgPatternsTest extends ClientTestBase implements ITestSharedBrokered {
     @Test
     @DisplayName("testTopicSubscribe")
     void testTopicSubscribe() throws Exception {
-        doTopicSubscribeTest(new OpenwireJMSClientSender(), new OpenwireJMSClientReceiver(), new OpenwireJMSClientReceiver());
+        doTopicSubscribeTest(new OpenwireJMSClientSender(logPath), new OpenwireJMSClientReceiver(logPath), new OpenwireJMSClientReceiver(logPath));
     }
 
     @Test


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

This PR tries to make messaging client tests more stable, currently there are tests where receivers are started before senders and this is a source of failures in some environments...
To address that systemtests now detects when the receivers are attached reading the trace log from the clients, note some clients we use do not support any kind of trace log that we can use for this purpose.

a sleep in some tests where receivers are started before senders, 
<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [x] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
