### PR TITLE
Bump Netty to netty-4.1.48.Final

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ## 0.31.1
 * #4241: Fix a race in upgrader logic that prevented upgrade from continuing
+* #4269: bump Netty dependency from netty-4.1.45.Final to netty-4.1.48.Final
 
 ## 0.31.0
 *  Adding example partitioned/sharded queue example plans

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <artemis.version>2.11.0</artemis.version>
         <ngwebdriver.version>1.1.4</ngwebdriver.version>
         <paho.version>1.2.1</paho.version>
-        <netty.version>4.1.45.Final</netty.version>
+        <netty.version>4.1.48.Final</netty.version>
         <keycloak.version>4.8.3.Final</keycloak.version>
         <jboss.logging.version>3.3.0.Final</jboss.logging.version>
         <jboss.logging.processor.version>2.1.0.Final</jboss.logging.processor.version>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Bump Netty dependency from netty-4.1.45.Final to netty-4.1.48.Final

### Checklist


- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
