### PR TITLE
fix JDBC service url

### DIFF
--- a/templates/iot/examples/iot-config.yaml
+++ b/templates/iot/examples/iot-config.yaml
@@ -10,7 +10,7 @@ spec:
           external:
             username: registry
             password: user12
-            url: jdbc:postgresql://postgresql/device-registry
+            url: jdbc:postgresql://postgresql.device-registry-storage.svc/device-registry
     deviceRegistry:
       jdbc:
         server:
@@ -20,7 +20,7 @@ spec:
               connection:
                 username: registry
                 password: user12
-                url: jdbc:postgresql://postgresql/device-registry
+                url: jdbc:postgresql://postgresql.device-registry-storage.svc/device-registry
   adapters:
     mqtt:
       enabled: true


### PR DESCRIPTION
Fix a small issue introduced by Jens refactoring. 
The default deployment of the postgresql is in another namespace. 