### PR TITLE
Broker support access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ## 0.31.1
 * #4046: add network-only as fetch policy for all queries 
+* #4090: Provide per-address space support credentials facilitating support access to the broker(s) (#4276)
 * #4184: Sometimes controller crashes when reconciling authentication service 
 * #4241: Fix a race in upgrader logic that prevented upgrade from continuing
 * #4242: #4246: Delegate authentication vrtx worker thread pool making authentication multi threaded.  Improve error handling.
@@ -27,6 +28,7 @@
 * #4317: Addresses with different casing is not becoming ready 
 * #4331: Issues installing monitoring resources (#4200) (#4222)
 * #4332: Unable to drain kube node when broker pod is deployed there
+
 
 ## 0.31.0
 *  Adding example partitioned/sharded queue example plans

--- a/address-space-controller/src/main/java/io/enmasse/controller/common/TemplateParameter.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/common/TemplateParameter.java
@@ -44,4 +44,7 @@ public interface TemplateParameter {
     String MQTT_LWT_IMAGE = "MQTT_LWT_IMAGE";
 
     String FS_GROUP_FALLBACK_MAP = "FS_GROUP_FALLBACK_MAP";
+    String BROKER_SUPPORT_USER = "BROKER_SUPPORT_USER";
+    String BROKER_SUPPORT_PWD = "BROKER_SUPPORT_PWD";
+
 }

--- a/address-space-controller/src/main/resources/templates/brokered-space-infra.yaml
+++ b/address-space-controller/src/main/resources/templates/brokered-space-infra.yaml
@@ -16,6 +16,21 @@ objects:
       infraUuid: ${INFRA_UUID}
       infraType: brokered
 - apiVersion: v1
+  kind: Secret
+  metadata:
+    name: broker-support-${INFRA_UUID}
+    annotations:
+      addressSpace: ${ADDRESS_SPACE}
+    labels:
+      app: enmasse
+      infraType: standard
+      infraUuid: ${INFRA_UUID}
+      role: support-credentials
+  type: Opaque
+  data:
+    username: ${BROKER_SUPPORT_USER}
+    password: ${BROKER_SUPPORT_PWD}
+- apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     annotations:
@@ -136,6 +151,9 @@ objects:
           - mountPath: /opt/apache-artemis/custom
             name: broker-custom
             readOnly: false
+          - mountPath: /opt/apache-artemis/support
+            name: broker-support
+            readOnly: true
         initContainers:
         - env:
           - name: INFRA_UUID
@@ -193,6 +211,9 @@ objects:
         - name: external-cert
           secret:
             secretName: ${MESSAGING_SECRET}
+        - name: broker-support
+          secret:
+            secretName: broker-support-${INFRA_UUID}
 - apiVersion: v1
   kind: Service
   metadata:
@@ -463,3 +484,7 @@ parameters:
 - description: Interval (in seconds) to use between controller resync
   name: CONTROLLER_RESYNC_INTERVAL
   value: '600'
+- description: Username for broker support access
+  name: BROKER_SUPPORT_USER
+- description: Password for broker support access
+  name: BROKER_SUPPORT_PWD

--- a/address-space-controller/src/main/resources/templates/standard-space-infra.yaml
+++ b/address-space-controller/src/main/resources/templates/standard-space-infra.yaml
@@ -197,6 +197,21 @@ objects:
       app: enmasse
       infraType: standard
       infraUuid: ${INFRA_UUID}
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: broker-support-${INFRA_UUID}
+    annotations:
+      addressSpace: ${ADDRESS_SPACE}
+    labels:
+      app: enmasse
+      infraType: standard
+      infraUuid: ${INFRA_UUID}
+      role: support-credentials
+  type: Opaque
+  data:
+    username: ${BROKER_SUPPORT_USER}
+    password: ${BROKER_SUPPORT_PWD}
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -583,3 +598,7 @@ parameters:
   value: ${env.TOPIC_FORWARDER_IMAGE}
 - description:
   name: FS_GROUP_FALLBACK_MAP
+- description: Username for broker support access
+  name: BROKER_SUPPORT_USER
+- description: Password for broker support access
+  name: BROKER_SUPPORT_PWD

--- a/broker-plugin/plugin/src/main/resources/brokered/broker.xml
+++ b/broker-plugin/plugin/src/main/resources/brokered/broker.xml
@@ -71,7 +71,10 @@ under the License.
 
       <metrics-plugin class-name="org.apache.activemq.artemis.core.server.metrics.plugins.ArtemisPrometheusMetricsPlugin" />
 
+      <jmx-management-enabled>true</jmx-management-enabled>
+
       <acceptors>
+         <acceptor name="artemis">tcp://127.0.0.1:61616?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=CORE</acceptor>
          <acceptor name="amqp">tcp://0.0.0.0:5672?protocols=AMQP,CORE,OPENWIRE,STOMP,MQTT;saslMechanisms=PLAIN</acceptor>
          <acceptor name="amqps">tcp://0.0.0.0:5671?protocols=AMQP,CORE,OPENWIRE,STOMP,MQTT;sslEnabled=true;saslMechanisms=PLAIN;keyStorePath=${EXTERNAL_KEYSTORE_PATH};keyStorePassword=enmasse;enabledProtocols=TLSv1.2,TLSv1.3</acceptor>
          <!-- SASL Mechanism should be EXTERNAL not anonymous... but Artemis doesn't support EXTERNAL -->

--- a/broker-plugin/plugin/src/main/resources/brokered/login.config
+++ b/broker-plugin/plugin/src/main/resources/brokered/login.config
@@ -24,5 +24,7 @@ activemq {
        valid_cert_users="agent.${INFRA_UUID}:admin"
        default_roles_authenticated="all"
        default_roles_unauthenticated="admin"
-       security_settings="enmasse";
+       security_settings="enmasse"
+       support_user_path="/opt/apache-artemis/support/username"
+       support_password_path="/opt/apache-artemis/support/password";
 };

--- a/broker-plugin/plugin/src/main/resources/management.xml
+++ b/broker-plugin/plugin/src/main/resources/management.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  ~ Copyright 2020, EnMasse authors.
+  ~ License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+  ~
+  -->
+
+<management-context xmlns="http://activemq.org/schema">
+    <!--<connector connector-port="1099"/>-->
+    <authorisation>
+        <whitelist>
+            <entry domain="hawtio"/>
+        </whitelist>
+        <default-access>
+            <access method="list*" roles="${HAWTIO_ROLE}"/>
+            <access method="get*" roles="${HAWTIO_ROLE}"/>
+            <access method="is*" roles="${HAWTIO_ROLE}"/>
+            <access method="set*" roles="${HAWTIO_ROLE}"/>
+            <access method="*" roles="${HAWTIO_ROLE}"/>
+        </default-access>
+        <role-access>
+            <match domain="org.apache.activemq.artemis">
+                <access method="list*" roles="${HAWTIO_ROLE}"/>
+                <access method="get*" roles="${HAWTIO_ROLE}"/>
+                <access method="is*" roles="${HAWTIO_ROLE}"/>
+                <access method="set*" roles="${HAWTIO_ROLE}"/>
+                <access method="*" roles="${HAWTIO_ROLE}"/>
+            </match>
+        </role-access>
+    </authorisation>
+</management-context>

--- a/broker-plugin/plugin/src/main/resources/shared/broker.xml
+++ b/broker-plugin/plugin/src/main/resources/shared/broker.xml
@@ -69,6 +69,8 @@ under the License.
 
       <metrics-plugin class-name="org.apache.activemq.artemis.core.server.metrics.plugins.ArtemisPrometheusMetricsPlugin" />
 
+      <jmx-management-enabled>true</jmx-management-enabled>
+
       <acceptors>
          <acceptor name="artemis">tcp://127.0.0.1:61616?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=CORE</acceptor>
          <acceptor name="amqps">tcp://0.0.0.0:5671?protocols=AMQP;saslMechanisms=EXTERNAL;sslEnabled=true;keyStorePath=${KEYSTORE_PATH};keyStorePassword=enmasse;trustStorePath=${TRUSTSTORE_PATH};trustStorePassword=enmasse;verifyHost=false;needClientAuth=true</acceptor>

--- a/broker-plugin/plugin/src/main/resources/standard/colocated/broker.xml
+++ b/broker-plugin/plugin/src/main/resources/standard/colocated/broker.xml
@@ -69,8 +69,10 @@ under the License.
 
       <metrics-plugin class-name="org.apache.activemq.artemis.core.server.metrics.plugins.ArtemisPrometheusMetricsPlugin" />
 
+      <jmx-management-enabled>true</jmx-management-enabled>
+
       <acceptors>
-         <acceptor name="artemis">tcp://0.0.0.0:61616?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=CORE</acceptor>
+         <acceptor name="artemis">tcp://127.0.0.1:61616?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=CORE</acceptor>
          <acceptor name="amqp">tcp://0.0.0.0:5673?protocols=AMQP;sslEnabled=true;keyStorePath=${KEYSTORE_PATH};keyStorePassword=enmasse;trustStorePath=${TRUSTSTORE_PATH};trustStorePassword=enmasse;verifyHost=false;needClientAuth=true</acceptor>
       </acceptors>
 

--- a/broker-plugin/plugin/src/main/resources/standard/login.config
+++ b/broker-plugin/plugin/src/main/resources/standard/login.config
@@ -24,5 +24,7 @@ activemq {
        valid_cert_users="admin.${INFRA_UUID}:admin;router.${INFRA_UUID}:admin;broker.${INFRA_UUID}:admin;subserv.${INFRA_UUID}:admin"
        default_roles_authenticated="all"
        default_roles_unauthenticated="admin"
-       security_settings="enmasse";
+       security_settings="enmasse"
+       support_user_path="/opt/apache-artemis/support/username"
+       support_password_path="/opt/apache-artemis/support/password";
 };

--- a/broker-plugin/plugin/src/main/resources/standard/sharded-queue/broker.xml
+++ b/broker-plugin/plugin/src/main/resources/standard/sharded-queue/broker.xml
@@ -57,6 +57,7 @@ broker which is the case after 0.26.x.
 
       <journal-buffer-timeout>2212000</journal-buffer-timeout>
 
+      <jmx-management-enabled>true</jmx-management-enabled>
 
       <!-- how often we are looking for how many bytes are being used on the disk in ms -->
       <disk-scan-period>5000</disk-scan-period>
@@ -79,7 +80,7 @@ broker which is the case after 0.26.x.
       <metrics-plugin class-name="org.apache.activemq.artemis.core.server.metrics.plugins.ArtemisPrometheusMetricsPlugin" />
 
       <acceptors>
-         <acceptor name="artemis">tcp://0.0.0.0:61616?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=CORE</acceptor>
+         <acceptor name="artemis">tcp://127.0.0.1:61616?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=CORE</acceptor>
          <acceptor name="amqp">tcp://0.0.0.0:5673?protocols=AMQP;sslEnabled=true;keyStorePath=${KEYSTORE_PATH};keyStorePassword=enmasse;trustStorePath=${TRUSTSTORE_PATH};trustStorePassword=enmasse;verifyHost=false;needClientAuth=true</acceptor>
       </acceptors>
 

--- a/broker-plugin/plugin/src/main/resources/standard/sharded-topic/broker.xml
+++ b/broker-plugin/plugin/src/main/resources/standard/sharded-topic/broker.xml
@@ -72,8 +72,10 @@ under the License.
 
       <metrics-plugin class-name="org.apache.activemq.artemis.core.server.metrics.plugins.ArtemisPrometheusMetricsPlugin" />
 
+      <jmx-management-enabled>true</jmx-management-enabled>
+
       <acceptors>
-         <acceptor name="artemis">tcp://0.0.0.0:61616?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=CORE</acceptor>
+         <acceptor name="artemis">tcp://127.0.0.1:61616?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=CORE</acceptor>
          <acceptor name="amqp">tcp://0.0.0.0:5673?protocols=AMQP;sslEnabled=true;keyStorePath=${KEYSTORE_PATH};keyStorePassword=enmasse;trustStorePath=${TRUSTSTORE_PATH};trustStorePassword=enmasse;verifyHost=false;needClientAuth=true</acceptor>
       </acceptors>
 

--- a/broker-plugin/plugin/src/main/sh/init-broker.sh
+++ b/broker-plugin/plugin/src/main/sh/init-broker.sh
@@ -111,6 +111,7 @@ function pre_configuration() {
     export ARTEMIS_INSTANCE_ETC_URI=file:${instanceDir}/etc/
     
     envsubst < $CONFIG_TEMPLATES/artemis.profile > $BROKER_CONF_DIR/artemis.profile
+    envsubst < $CONFIG_TEMPLATES/management.xml > $BROKER_CONF_DIR/management.xml
 
     cp $CONFIG_TEMPLATES/logging.properties $BROKER_CONF_DIR/logging.properties
 }

--- a/broker-plugin/sasl-delegation/src/main/java/io/enmasse/artemis/sasl_delegation/SaslDelegatingLogin.java
+++ b/broker-plugin/sasl-delegation/src/main/java/io/enmasse/artemis/sasl_delegation/SaslDelegatingLogin.java
@@ -203,11 +203,11 @@ public class SaslDelegatingLogin implements LoginModule {
             }
 
             if (this.supportPassword.isPresent() && this.supportUserName.isPresent()) {
-                LOG.info("Support access configured");
+                LOG.debug("Support access configured");
             }
 
         } else {
-            LOG.info("Support access not configured");
+            LOG.debug("Support access not configured");
             this.supportUserName = Optional.empty();
             this.supportPassword = Optional.empty();
         }

--- a/broker-plugin/sasl-delegation/src/main/java/io/enmasse/artemis/sasl_delegation/SaslDelegatingLogin.java
+++ b/broker-plugin/sasl-delegation/src/main/java/io/enmasse/artemis/sasl_delegation/SaslDelegatingLogin.java
@@ -26,6 +26,8 @@ import java.io.OutputStream;
 import java.lang.reflect.Field;
 import java.net.Socket;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.NoSuchAlgorithmException;
@@ -41,6 +43,7 @@ import javax.security.auth.Subject;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
 import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.login.LoginException;
 import javax.security.auth.spi.LoginModule;
@@ -63,6 +66,8 @@ public class SaslDelegatingLogin implements LoginModule {
     public static final String GROUPS = "groups";
     public static final String PROP_ADDRESS_AUTHZ = "address-authz";
     public static final Symbol CAPABILITY_ADDRESS_AUTHZ = Symbol.valueOf("ADDRESS-AUTHZ");
+    public static final String SUPPORT_USER_PATH = "support_user_path";
+    public static final String SUPPORT_PASSWORD_PATH = "support_password_path";
 
     private final Set<Principal> principals = new HashSet<>();
     private final Set<String> roles = new HashSet<>();
@@ -102,6 +107,9 @@ public class SaslDelegatingLogin implements LoginModule {
 
         }
     }
+
+    private Optional<String> supportUserName;
+    private Optional<String> supportPassword;
 
     @Override
     public void initialize(Subject subject,
@@ -177,6 +185,33 @@ public class SaslDelegatingLogin implements LoginModule {
             }
         }
 
+        if(options.containsKey(SUPPORT_USER_PATH) && options.containsKey(SUPPORT_PASSWORD_PATH)) {
+            String supportUserPath = String.valueOf(options.get(SUPPORT_USER_PATH));
+            String supportPasswordPath = String.valueOf(options.get(SUPPORT_PASSWORD_PATH));
+
+            try {
+                this.supportUserName = Files.readAllLines(Paths.get(supportUserPath)).stream().findFirst();
+            } catch (IOException e) {
+                LOG.warnf(e,"Failed to load support username from file : %s", supportUserPath);
+                this.supportUserName = Optional.empty();
+            }
+            try {
+                this.supportPassword = Files.readAllLines(Paths.get(supportPasswordPath)).stream().findFirst();
+            } catch (IOException e) {
+                LOG.warnf(e,"Failed to load support password from file : %s", supportPasswordPath);
+                this.supportPassword = Optional.empty();
+            }
+
+            if (this.supportPassword.isPresent() && this.supportUserName.isPresent()) {
+                LOG.info("Support access configured");
+            }
+
+        } else {
+            LOG.info("Support access not configured");
+            this.supportUserName = Optional.empty();
+            this.supportPassword = Optional.empty();
+        }
+
         this.options = options;
         loginSucceeded = false;
         saslFactories = new SaslMechanismFactory[] { new PlainSaslMechanismFactory() };
@@ -201,10 +236,33 @@ public class SaslDelegatingLogin implements LoginModule {
             if (!success) {
                 List<X509Certificate> certs = new ArrayList<>();
 
-                if (isAuthenticatedUsingCerts(certs)) {
-                    success = populateUserAndRolesFromCert(certs.get(0));
-                } else {
+                NameCallback nameCallback = new NameCallback("user:");
+                PasswordCallback passwordCallback = new PasswordCallback("password:", false);
+                CertificateCallback certificateCallback = new CertificateCallback();
+                callbackHandler.handle(new Callback[] { nameCallback, certificateCallback, passwordCallback});
+                X509Certificate[] certArray = certificateCallback.getCertificates();
 
+                if(certArray != null) {
+                    certs.addAll(Arrays.asList(certArray));
+                }
+
+                if (nameCallback.getName() == null && !certs.isEmpty()) {
+                    success = populateUserAndRolesFromCert(certs.get(0));
+                } else if (this.supportPassword.isPresent()
+                        && this.supportUserName.isPresent()
+                        && this.supportUserName.get().equals(nameCallback.getName())) {
+                    boolean passwordMatched = this.supportPassword.get().equals(new String(passwordCallback.getPassword()));
+                    if (passwordMatched) {
+                        String hawtioRole = System.getProperty("hawtio.role", "amq");
+                        user = nameCallback.getName();
+                        roles.addAll(defaultRolesAuthenticated);
+                        roles.add("admin");
+                        roles.add(hawtioRole);
+                        success = true;
+                    } else {
+                        LOG.debugf("Login failed for user : %s", nameCallback.getName());
+                    }
+                } else {
                     Transport transport = Proton.transport();
                     Connection connection = Proton.connection();
                     transport.bind(connection);
@@ -327,16 +385,6 @@ public class SaslDelegatingLogin implements LoginModule {
         }
     }
 
-    private boolean isAuthenticatedUsingCerts(List<X509Certificate> certs) throws IOException, UnsupportedCallbackException {
-        NameCallback nameHandler = new NameCallback("user:");
-        CertificateCallback certificateCallback = new CertificateCallback();
-        callbackHandler.handle(new Callback[] { nameHandler, certificateCallback });
-        X509Certificate[] certArray = certificateCallback.getCertificates();
-        if(certArray != null) {
-            certs.addAll(Arrays.asList(certArray));
-        }
-        return nameHandler.getName() == null && !certs.isEmpty();
-    }
 
     private void getUserAndRolesFromConnection(Connection connection) {
         final Map<Symbol, Object> remoteProperties = connection.getRemoteProperties();

--- a/standard-controller/src/main/resources/templates/queue-persisted.yaml
+++ b/standard-controller/src/main/resources/templates/queue-persisted.yaml
@@ -165,6 +165,9 @@ objects:
           - mountPath: /opt/apache-artemis/custom
             name: broker-custom
             readOnly: false
+          - mountPath: /opt/apache-artemis/support
+            name: broker-support
+            readOnly: true
         initContainers:
         - env:
           - name: MESSAGING_SERVICE_HOST
@@ -231,6 +234,9 @@ objects:
         - name: broker-internal-cert
           secret:
             secretName: broker-internal-cert.${INFRA_UUID}
+        - name: broker-support
+          secret:
+            secretName: broker-support-${INFRA_UUID}
     volumeClaimTemplates:
     - apiVersion: v1
       kind: PersistentVolumeClaim

--- a/standard-controller/src/main/resources/templates/topic-persisted.yaml
+++ b/standard-controller/src/main/resources/templates/topic-persisted.yaml
@@ -155,6 +155,9 @@ objects:
           - mountPath: /opt/apache-artemis/custom
             name: broker-custom
             readOnly: false
+          - mountPath: /opt/apache-artemis/support
+            name: broker-support
+            readOnly: true
         - env:
           - name: INFRA_UUID
             value: ${INFRA_UUID}
@@ -250,6 +253,9 @@ objects:
         - name: broker-internal-cert
           secret:
             secretName: broker-internal-cert.${INFRA_UUID}
+        - name: broker-support
+          secret:
+            secretName: broker-support-${INFRA_UUID}
     volumeClaimTemplates:
     - apiVersion: v1
       kind: PersistentVolumeClaim

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/support/SupportToolingTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/support/SupportToolingTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2018-2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.systemtest.isolated.support;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.enmasse.address.model.Address;
+import io.enmasse.address.model.AddressBuilder;
+import io.enmasse.address.model.AddressSpace;
+import io.enmasse.address.model.AddressSpaceBuilder;
+import io.enmasse.config.LabelKeys;
+import io.enmasse.systemtest.UserCredentials;
+import io.enmasse.systemtest.bases.TestBase;
+import io.enmasse.systemtest.bases.isolated.ITestBaseIsolated;
+import io.enmasse.systemtest.clients.ClientUtils;
+import io.enmasse.systemtest.executor.ExecutionResultData;
+import io.enmasse.systemtest.logs.CustomLogger;
+import io.enmasse.systemtest.model.addressplan.DestinationPlan;
+import io.enmasse.systemtest.model.addressspace.AddressSpacePlans;
+import io.enmasse.systemtest.model.addressspace.AddressSpaceType;
+import io.enmasse.systemtest.platform.KubeCMDClient;
+import io.enmasse.systemtest.time.TimeoutBudget;
+import io.enmasse.systemtest.utils.AddressSpaceUtils;
+import io.enmasse.systemtest.utils.AddressUtils;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Secret;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.Logger;
+
+import javax.security.sasl.AuthenticationException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import static io.enmasse.systemtest.TestTag.ISOLATED;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@Tag(ISOLATED)
+class SupportToolingTest extends TestBase implements ITestBaseIsolated {
+    private static Logger log = CustomLogger.getLogger();
+
+    @ParameterizedTest(name = "testBrokerSupportTooling-{0}-space")
+    @ValueSource(strings = {"standard", "brokered"})
+    void testBrokerSupportTooling(String type) throws Exception {
+
+        AddressSpace space = new AddressSpaceBuilder()
+                .withNewMetadata()
+                .withName("support-tooling-" + type)
+                .withNamespace(kubernetes.getInfraNamespace())
+                .endMetadata()
+                .withNewSpec()
+                .withType(type)
+                .withPlan(AddressSpaceType.STANDARD.toString().equals(type) ? AddressSpacePlans.STANDARD_SMALL : AddressSpacePlans.BROKERED)
+                .withNewAuthenticationService()
+                .withName("standard-authservice")
+                .endAuthenticationService()
+                .endSpec()
+                .build();
+
+        Address addr = new AddressBuilder()
+                .withNewMetadata()
+                .withNamespace(space.getMetadata().getNamespace())
+                .withName(AddressUtils.generateAddressMetadataName(space, "myqueue"))
+                .endMetadata()
+                .withNewSpec()
+                .withType("queue")
+                .withAddress("myqueue")
+                .withPlan(AddressSpaceType.STANDARD.toString().equals(type) ? DestinationPlan.STANDARD_SMALL_QUEUE : DestinationPlan.BROKERED_QUEUE)
+                .endSpec()
+                .build();
+
+        isolatedResourcesManager.createAddressSpaceList(space);
+        resourcesManager.setAddresses(addr);
+
+        Map<String, String> brokerLabels = new HashMap<>();
+        brokerLabels.put(LabelKeys.INFRA_UUID, AddressSpaceUtils.getAddressSpaceInfraUuid(space));
+        brokerLabels.put(LabelKeys.ROLE, "broker");
+
+        Map<String, String> secretLabels = new HashMap<>();
+        secretLabels.put(LabelKeys.INFRA_UUID, AddressSpaceUtils.getAddressSpaceInfraUuid(space));
+        secretLabels.put(LabelKeys.ROLE, "support-credentials");
+
+        Secret supportSecret = kubernetes.listSecrets(secretLabels).get(0);
+        Map<String, String> data = supportSecret.getData();
+        String supportUser = new String(Base64.getDecoder().decode(data.get("username")), StandardCharsets.UTF_8);
+        String supportPassword = new String(Base64.getDecoder().decode(data.get("password")), StandardCharsets.UTF_8);
+
+        // Workaround - addresses may report ready before the broker pod backing the address report ready=true.  This happens because broker liveness/readiness is judged on a
+        // Jolokia based probe. As jolokia becomes available after AMQP management, address can be ready when the broker is not. See https://github.com/EnMasseProject/enmasse/issues/2979
+        kubernetes.awaitPodsReady(kubernetes.getInfraNamespace(), new TimeoutBudget(5, TimeUnit.MINUTES));
+
+        List<Pod> brokerPods = kubernetes.listPods(brokerLabels);
+        assertThat(brokerPods.size(), is(1));
+
+        brokerPods.forEach(bp -> {
+            String podName = bp.getMetadata().getName();
+            ExecutionResultData jmxResponse = KubeCMDClient.runOnPod(kubernetes.getInfraNamespace(), podName, Optional.of("broker"),
+                    "curl",
+                    "--silent", "--insecure",
+                    "--user", String.format("%s:%s", supportUser, supportPassword),
+                    String.format("https://localhost:8161/console/jolokia/read/org.apache.activemq.artemis:broker=\"%s\"/AddressMemoryUsage", podName)
+            );
+
+            assertThat(jmxResponse.getRetCode(), is(true));
+            Map<String, Object> readValue = jsonResponseToMap(jmxResponse.getStdOut());
+            assertThat(readValue.get("status"), is(200));
+
+            ExecutionResultData artemisCmdResponse = KubeCMDClient.runOnPod(kubernetes.getInfraNamespace(), podName, Optional.of("broker"),
+                    "bash",
+                    "-c",
+                    "cd ${ARTEMIS_HOME:-${AMQ_HOME}}; ${0} ${@}", /* Handles upstream/downstream locations */
+                    "./bin/artemis",
+                    "address",
+                    "show",
+                    "--user", supportUser,
+                    "--password", supportPassword
+            );
+            assertThat(artemisCmdResponse.getRetCode(), is(true));
+            List<String> addresses = Arrays.asList(artemisCmdResponse.getStdOut().split("\n"));
+            assertThat(addresses, hasItem(addr.getSpec().getAddress()));
+
+            if (AddressSpaceType.STANDARD.toString().equals(type)) {
+                // FIXME: can't protect the brokered address space owing to #4295
+                Assertions.assertThrows(AuthenticationException.class,
+                        () -> new ClientUtils().connectAddressSpace(resourcesManager, space, new UserCredentials(supportUser, supportPassword)),
+                        "Must not be able to connect to the address space for messaging using support credentials");
+            }
+        });
+    }
+
+    private Map<String, Object> jsonResponseToMap(String json) {
+        try {
+            return new ObjectMapper().readValue(json, new TypeReference<>() {});
+        } catch (JsonProcessingException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}


### PR DESCRIPTION
### Type of change


- Enhancement / new feature

### Description

For the support use case, a support user should be able to connect to the broker(s) of an address space and run standard artemis support commands ` address show` and query JMX via Jolokia.
### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [x] Write tests and make sure they pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
