### PR TITLE
Fix - Creating an address fails with message "address space plan '' not found"

### DIFF
--- a/console/console-init/ui/src/pages/CreateAddress/CreateAddressPage.tsx
+++ b/console/console-init/ui/src/pages/CreateAddress/CreateAddressPage.tsx
@@ -7,7 +7,6 @@ import * as React from "react";
 import { Wizard } from "@patternfly/react-core";
 import { AddressDefinition } from "pages/CreateAddress/CreateAddressDefinition";
 import { PreviewAddress } from "./PreviewAddress";
-import { useApolloClient } from "@apollo/react-hooks";
 import { CREATE_ADDRESS } from "queries";
 import { IDropdownOption } from "components/common/FilterDropdown";
 import { messagingAddressNameRegexp } from "types/Configs";
@@ -17,8 +16,8 @@ interface ICreateAddressProps {
   name: string;
   namespace: string;
   addressSpace: string;
-  addressSpacePlan: string;
-  addressSpaceType: string;
+  addressSpacePlan: string | null;
+  addressSpaceType?: string;
   isCreateWizardOpen: boolean;
   setIsCreateWizardOpen: (value: boolean) => void;
   setOnCreationRefetch?: (value: boolean) => void;
@@ -37,7 +36,6 @@ export const CreateAddressPage: React.FunctionComponent<ICreateAddressProps> = (
   const [addressType, setAddressType] = React.useState(" ");
   const [plan, setPlan] = React.useState(" ");
   const [topic, setTopic] = React.useState(" ");
-  const client = useApolloClient();
   const [addressTypes, setAddressTypes] = React.useState<IDropdownOption[]>([]);
   const [addressPlans, setAddressPlans] = React.useState<IDropdownOption[]>([]);
   const [topicsForSubscription, setTopicForSubscription] = React.useState<

--- a/console/console-init/ui/src/queries/Address.ts
+++ b/console/console-init/ui/src/queries/Address.ts
@@ -484,7 +484,7 @@ const RETURN_ADDRESS_LINKS = (
 };
 
 const RETURN_ADDRESS_PLANS = (
-  addressSpacePlan: string,
+  addressSpacePlan: string | null,
   addressType: string
 ) => {
   const ADDRESS_PLANS = gql`


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

- Handled null check for fetching queries to get address types and plans in create Address configuration view.
- Fix - #4279 
### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
