### PR TITLE
Escape forbidden characters from filters

### DIFF
--- a/console/console-init/ui/src/components/AddressSpaceList/AddressSpaceListFilter.tsx
+++ b/console/console-init/ui/src/components/AddressSpaceList/AddressSpaceListFilter.tsx
@@ -41,7 +41,11 @@ import {
   TYPEAHEAD_REQUIRED_LENGTH,
   FetchPolicy
 } from "constants/constants";
-import { ISelectOption, getSelectOptionList } from "utils";
+import {
+  ISelectOption,
+  getSelectOptionList,
+  removeForbiddenChars
+} from "utils";
 
 interface IAddressSpaceListFilterProps {
   filterValue?: string;
@@ -246,8 +250,9 @@ export const AddressSpaceListFilter: React.FunctionComponent<IAddressSpaceListFi
   };
 
   const onNameSelectFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setNameInput(e.target.value);
-    onChangeNameData(e.target.value);
+    let name = removeForbiddenChars(e.target.value);
+    setNameInput(name);
+    onChangeNameData(name);
     const options: React.ReactElement[] = nameOptions
       ? nameOptions.map((option, index) => (
           <SelectOption key={index} value={option} />
@@ -295,8 +300,9 @@ export const AddressSpaceListFilter: React.FunctionComponent<IAddressSpaceListFi
   const onNamespaceSelectFilterChange = (
     e: React.ChangeEvent<HTMLInputElement>
   ) => {
-    setNameSpaceInput(e.target.value);
-    onChangeNamespaceData(e.target.value);
+    let namespace = removeForbiddenChars(e.target.value);
+    setNameSpaceInput(namespace);
+    onChangeNamespaceData(namespace);
     const options: React.ReactElement[] = namespaceOptions
       ? namespaceOptions.map((option, index) => (
           <SelectOption key={index} value={option} />

--- a/console/console-init/ui/src/pages/AddressDetail/AddressLinksFilter.tsx
+++ b/console/console-init/ui/src/pages/AddressDetail/AddressLinksFilter.tsx
@@ -46,7 +46,11 @@ import {
   NUMBER_OF_RECORDS_TO_DISPLAY_IF_SERVER_HAS_MORE_DATA,
   FetchPolicy
 } from "constants/constants";
-import { getSelectOptionList, ISelectOption } from "utils";
+import {
+  getSelectOptionList,
+  ISelectOption,
+  removeForbiddenChars
+} from "utils";
 
 interface IAddressLinksFilterProps {
   filterValue: string;
@@ -218,8 +222,9 @@ export const AddressLinksFilter: React.FunctionComponent<IAddressLinksFilterProp
     }
   };
   const onNameSelectFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setNameInput(e.target.value);
-    onChangeNameData(e.target.value);
+    let name = removeForbiddenChars(e.target.value);
+    setNameInput(name);
+    onChangeNameData(name);
     const options: React.ReactElement[] = nameOptions
       ? nameOptions.map((option, index) => (
           <SelectOption key={index} value={option} />
@@ -270,8 +275,9 @@ export const AddressLinksFilter: React.FunctionComponent<IAddressLinksFilterProp
   const onContainerSelectFilterChange = (
     e: React.ChangeEvent<HTMLInputElement>
   ) => {
-    setContainerInput(e.target.value);
-    onChangeContainerData(e.target.value);
+    let container = removeForbiddenChars(e.target.value);
+    setContainerInput(container);
+    onChangeContainerData(container);
     const options: React.ReactElement[] = containerOptions
       ? containerOptions.map((option, index) => (
           <SelectOption key={index} value={option} />

--- a/console/console-init/ui/src/pages/AddressSpaceDetail/AddressList/AddressListFilter.tsx
+++ b/console/console-init/ui/src/pages/AddressSpaceDetail/AddressList/AddressListFilter.tsx
@@ -41,7 +41,11 @@ import {
   NUMBER_OF_RECORDS_TO_DISPLAY_IF_SERVER_HAS_MORE_DATA,
   FetchPolicy
 } from "constants/constants";
-import { getSelectOptionList, ISelectOption } from "utils";
+import {
+  getSelectOptionList,
+  ISelectOption,
+  removeForbiddenChars
+} from "utils";
 
 interface IAddressListFilterProps {
   filterValue: string | null;
@@ -183,8 +187,9 @@ export const AddressListFilter: React.FunctionComponent<IAddressListFilterProps>
   };
 
   const onNameSelectFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setNameInput(e.target.value);
-    onChangeNameData(e.target.value);
+    let name = removeForbiddenChars(e.target.value);
+    setNameInput(name);
+    onChangeNameData(name);
     const options: React.ReactElement[] = nameOptions
       ? nameOptions.map((option, index) => (
           <SelectOption key={index} value={option} />

--- a/console/console-init/ui/src/pages/AddressSpaceDetail/ConnectionList/ConnectionListFilter.tsx
+++ b/console/console-init/ui/src/pages/AddressSpaceDetail/ConnectionList/ConnectionListFilter.tsx
@@ -40,7 +40,11 @@ import {
   NUMBER_OF_RECORDS_TO_DISPLAY_IF_SERVER_HAS_MORE_DATA,
   FetchPolicy
 } from "constants/constants";
-import { getSelectOptionList, ISelectOption } from "utils";
+import {
+  getSelectOptionList,
+  ISelectOption,
+  removeForbiddenChars
+} from "utils";
 
 interface IConnectionListFilterProps {
   filterValue?: string | null;
@@ -216,8 +220,9 @@ export const ConnectionListFilter: React.FunctionComponent<IConnectionListFilter
   const onHostnameSelectFilterChange = (
     e: React.ChangeEvent<HTMLInputElement>
   ) => {
-    setHostNameInput(e.target.value);
-    onChangeHostnameData(e.target.value);
+    let hostName = removeForbiddenChars(e.target.value);
+    setHostNameInput(hostName);
+    onChangeHostnameData(hostName);
     const options: React.ReactElement[] = hostnameOptions
       ? hostnameOptions.map((option, index) => (
           <SelectOption key={index} value={option} />
@@ -264,8 +269,9 @@ export const ConnectionListFilter: React.FunctionComponent<IConnectionListFilter
   const onContainerSelectFilterChange = (
     e: React.ChangeEvent<HTMLInputElement>
   ) => {
-    setContainerInput(e.target.value);
-    onChangeContainerData(e.target.value);
+    let container = removeForbiddenChars(e.target.value);
+    setContainerInput(container);
+    onChangeContainerData(container);
     const options: React.ReactElement[] = containerOptions
       ? containerOptions.map((option, index) => (
           <SelectOption key={index} value={option} />

--- a/console/console-init/ui/src/pages/ConnectionDetail/ConnectionLinksFilter.tsx
+++ b/console/console-init/ui/src/pages/ConnectionDetail/ConnectionLinksFilter.tsx
@@ -46,7 +46,11 @@ import {
   NUMBER_OF_RECORDS_TO_DISPLAY_IF_SERVER_HAS_MORE_DATA,
   FetchPolicy
 } from "constants/constants";
-import { getSelectOptionList, ISelectOption } from "utils";
+import {
+  getSelectOptionList,
+  ISelectOption,
+  removeForbiddenChars
+} from "utils";
 
 interface IConnectionLinksFilterProps {
   filterValue: string;
@@ -226,8 +230,9 @@ export const ConnectionLinksFilter: React.FunctionComponent<IConnectionLinksFilt
   };
 
   const onNameSelectFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setNameInput(e.target.value);
-    onChangeNameData(e.target.value);
+    let name = removeForbiddenChars(e.target.value);
+    setNameInput(name);
+    onChangeNameData(name);
     const options: React.ReactElement[] = nameOptions
       ? nameOptions.map((option, index) => (
           <SelectOption key={index} value={option} />
@@ -276,8 +281,9 @@ export const ConnectionLinksFilter: React.FunctionComponent<IConnectionLinksFilt
   const onAddressSelectFilterChange = (
     e: React.ChangeEvent<HTMLInputElement>
   ) => {
-    setAddressInput(e.target.value);
-    onChangeAddressData(e.target.value);
+    let address = removeForbiddenChars(e.target.value);
+    setAddressInput(address);
+    onChangeAddressData(address);
     const options: React.ReactElement[] = addressOptions
       ? addressOptions.map((option, index) => (
           <SelectOption key={index} value={option} />

--- a/console/console-init/ui/src/pages/EditAddressSpace.tsx
+++ b/console/console-init/ui/src/pages/EditAddressSpace.tsx
@@ -88,9 +88,6 @@ export const EditAddressSpace: React.FunctionComponent<IEditAddressSpaceProps> =
 
   return (
     <Form>
-      <TextContent>
-        <Text component={TextVariants.h2}>Choose a new plan.</Text>
-      </TextContent>
       <FormGroup label="Namespace" fieldId="name-space" isRequired={true}>
         <FormSelect
           id="edit-namespace"

--- a/console/console-init/ui/src/types/Configs.tsx
+++ b/console/console-init/ui/src/types/Configs.tsx
@@ -2,3 +2,6 @@ export const dnsSubDomainRfc1123NameRegexp = new RegExp(
   "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
 );
 export const messagingAddressNameRegexp = new RegExp("^[^#*\\s]+$");
+export const forbiddenBackslashRegexp = new RegExp(/\\/g);
+export const forbiddenSingleQuoteRegexp = new RegExp(/'/g);
+export const forbiddenDoubleQuoteRegexp = new RegExp(/"/g);

--- a/console/console-init/ui/src/utils/utils.ts
+++ b/console/console-init/ui/src/utils/utils.ts
@@ -3,6 +3,11 @@ import {
   TypeAheadMessage,
   NUMBER_OF_RECORDS_TO_DISPLAY_IF_SERVER_HAS_MORE_DATA
 } from "constants/constants";
+import {
+  forbiddenBackslashRegexp,
+  forbiddenSingleQuoteRegexp,
+  forbiddenDoubleQuoteRegexp
+} from "types/Configs";
 
 export interface ISelectOption {
   value: string;
@@ -48,4 +53,12 @@ const getSelectOptionList = (list: string[], totalRecords: number) => {
   return records;
 };
 
-export { getSelectOptionList };
+const removeForbiddenChars = (input: string) => {
+  let modifiedInput = input.replace(forbiddenBackslashRegexp, "\\\\");
+  modifiedInput = modifiedInput.replace(forbiddenSingleQuoteRegexp, "''");
+  modifiedInput = modifiedInput.replace(forbiddenDoubleQuoteRegexp, '\\"');
+  console.log("modified input", modifiedInput);
+  return modifiedInput;
+};
+
+export { getSelectOptionList, removeForbiddenChars };


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Add checks to not allow forbidden chars in filter and remove title from Edit Address Space dialog.
Fix: #4280 #4275 
### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
