### PR TITLE
Update broker image used in tests

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/apps/SystemtestsKubernetesApps.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/apps/SystemtestsKubernetesApps.java
@@ -1238,7 +1238,7 @@ public class SystemtestsKubernetesApps {
                 .withNewSpec()
                 .addToInitContainers(new ContainerBuilder()
                         .withName("artemis-init")
-                        .withImage("quay.io/enmasse/artemis-base:2.10.0")
+                        .withImage("quay.io/enmasse/artemis-base:2.11.0")
                         .withCommand("/bin/sh")
                         .withArgs("-c",
                                 "/opt/apache-artemis/bin/artemis create /var/run/artemis --allow-anonymous --force --user " + user + " --password " + password + " --role admin")
@@ -1253,7 +1253,7 @@ public class SystemtestsKubernetesApps {
                         .build(),
                         new ContainerBuilder()
                                 .withName("replace-broker-xml")
-                                .withImage("quay.io/enmasse/artemis-base:2.10.0")
+                                .withImage("quay.io/enmasse/artemis-base:2.11.0")
                                 .withCommand("/bin/sh")
                                 .withArgs("-c", "cp /etc/amq-secret-volume/broker.xml /var/run/artemis/etc/broker.xml")
                                 .withVolumeMounts(new VolumeMountBuilder()
@@ -1267,7 +1267,7 @@ public class SystemtestsKubernetesApps {
                                 .build())
                 .addNewContainer()
                 .withName(name)
-                .withImage("quay.io/enmasse/artemis-base:2.10.0")
+                .withImage("quay.io/enmasse/artemis-base:2.11.0")
                 .withImagePullPolicy("IfNotPresent")
                 .withCommand("/bin/sh")
                 .withArgs("-c", "/var/run/artemis/bin/artemis run")


### PR DESCRIPTION
ConnectorsTest have been failing several times failing to connect to the remote broker. Hoping a new broker will improve that, and maybe we should also consider to use an on-cluster client and turn of TLS.