### PR TITLE
revert skip_provider_button change

### DIFF
--- a/console/console-init/oauth-proxy/cfg/oauth-proxy-kubernetes.cfg
+++ b/console/console-init/oauth-proxy/cfg/oauth-proxy-kubernetes.cfg
@@ -32,6 +32,7 @@ scope = "${OAUTH2_SCOPE}"
 cookie_secret = "${SSO_COOKIE_SECRET}"
 cookie_domain = "${SSO_COOKIE_DOMAIN}"
 
-skip_provider_button = true
+# Turning off provider button prevents routing to the originally desired page, post login: see issue #4300
+skip_provider_button = false
 
 pass_user_headers = true

--- a/console/console-init/oauth-proxy/cfg/oauth-proxy-openshift.cfg
+++ b/console/console-init/oauth-proxy/cfg/oauth-proxy-openshift.cfg
@@ -35,4 +35,5 @@ validate_url = "${OPENSHIFT_VALIDATE_ENDPOINT}"
 cookie_secret = "${SSO_COOKIE_SECRET}"
 cookie_domain = "${SSO_COOKIE_DOMAIN}"
 
-skip_provider_button = true
+# Turning off provider button prevents routing to the originally desired page, post login: see issue #4300
+skip_provider_button = false


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Revert the skip_provider_button change in order that OAuthProxy is able to retain the originally requested url (including the fragment) and redirect to it after successful authentication.

### Checklist


- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
