### PR TITLE
Inject OpenShift custom ca bundle into console pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * #4241: Fix a race in upgrader logic that prevented upgrade from continuing
 * #4266: Add broker.globalMaxSize to the infraconfig CRDs 
 * #4269: bump Netty dependency from netty-4.1.45.Final to netty-4.1.48.Final
+* #4305: Inject OpenShift generated custom CA trust bundle into console pod so that console authentication works when a custom CA is in use.
 
 ## 0.31.0
 *  Adding example partitioned/sharded queue example plans

--- a/console/console-init/oauth-proxy/bin/init.sh
+++ b/console/console-init/oauth-proxy/bin/init.sh
@@ -14,6 +14,7 @@ get_endpoint() {
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 TARGET_DIR=${1-/apps}
+OAUTH2_CA_TRUST_FILE=${OAUTH2_CA_TRUST_FILE:-${TARGET_DIR}/ca-trust/certs.crt}
 
 SSO_COOKIE_SECRET=$(python3 -c \
 'import os,base64; \
@@ -51,6 +52,18 @@ do
       -e "s,\${OAUTH2_SCOPE},${OAUTH2_SCOPE},g" \
       -i ${c}
 done
+
+
+echo Aggregating OAuth/OIDC provider trust into "${OAUTH2_CA_TRUST_FILE}"
+mkdir -p "$(dirname "${OAUTH2_CA_TRUST_FILE}")"
+touch "${OAUTH2_CA_TRUST_FILE}"
+while IFS=: read -r -d: dir; do
+  if [[ "${dir}" && -d "${dir}" ]];
+  then
+    echo Aggregating trust from: "${dir}"
+    find "${dir}" -type f -name "*.crt" -exec cat {} \; >> "${OAUTH2_CA_TRUST_FILE}"
+  fi
+done <<< "${OAUTH2_CA_TRUST_PATH}:"
 
 echo "window.env = {" > ${TARGET_DIR}/www/env.js
 echo "  OPENSHIFT_AVAILABLE:${OPENSHIFT_AVAILABLE}," >> ${TARGET_DIR}/www/env.js

--- a/console/console-init/oauth-proxy/cfg/oauth-proxy-openshift.cfg
+++ b/console/console-init/oauth-proxy/cfg/oauth-proxy-openshift.cfg
@@ -21,6 +21,8 @@ upstream_ca = [
     "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
     ]
 
+# openshift_ca not supported in the config file.
+
 request_logging = true
 
 pass_access_token = true

--- a/systemtests/src/main/java/io/enmasse/systemtest/certs/openssl/CertPair.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/certs/openssl/CertPair.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.enmasse.systemtest.certs.openssl;
+
+import java.io.Closeable;
+import java.io.File;
+
+public class CertPair implements Closeable {
+    private final File key;
+    private final File cert;
+    private String subject;
+
+    public CertPair(File key, File cert, String subject) {
+        this.key = key;
+        this.cert = cert;
+        this.subject = subject;
+    }
+
+    public File getKey() {
+        return key;
+    }
+
+    public File getCert() {
+        return cert;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    @Override
+    public void close() {
+        if (key != null) {
+            key.delete();
+        }
+        if (cert != null) {
+            cert.delete();
+        }
+    }
+}

--- a/systemtests/src/main/java/io/enmasse/systemtest/certs/openssl/CertSigningRequest.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/certs/openssl/CertSigningRequest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2018, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.systemtest.certs.openssl;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+
+public class CertSigningRequest implements Closeable {
+    private final File csrFile;
+    private final File keyFile;
+
+    CertSigningRequest(File csrFile, File keyFile) {
+        this.csrFile = csrFile;
+        this.keyFile = keyFile;
+    }
+
+    public File getCsrFile() {
+        return csrFile;
+    }
+
+    public File getKeyFile() {
+        return keyFile;
+    }
+
+    @Override
+    public void close() throws IOException {
+        csrFile.delete();
+        keyFile.delete();
+    }
+}

--- a/systemtests/src/main/java/io/enmasse/systemtest/certs/openssl/OpenSSLUtil.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/certs/openssl/OpenSSLUtil.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.enmasse.systemtest.certs.openssl;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+public class OpenSSLUtil {
+    private static final Logger log = LoggerFactory.getLogger(OpenSSLUtil.class);
+
+    public static CertPair createSelfSignedCert(String subject) {
+        File key = null;
+        File cert = null;
+        boolean success = false;
+        try {
+            key = File.createTempFile("tls", ".key");
+            cert = File.createTempFile("tls", ".crt");
+            List<String> cmd = Arrays.asList("openssl", "req", "-new", "-days", "11000", "-x509", "-batch", "-nodes",
+                    "-out", cert.getAbsolutePath(),
+                    "-keyout", key.getAbsolutePath(),
+                    "-subj",
+                    subject);
+
+            runCommand(cmd.toArray(new String[] {}));
+
+            success = true;
+            return new CertPair(key, cert, subject);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } finally {
+            if (!success) {
+
+                if (key != null) {
+                    key.delete();
+                }
+                if (cert != null) {
+                    cert.delete();
+                }
+            }
+        }
+    }
+    public static CertSigningRequest createCsr(CertPair target) {
+        File csr = null;
+        boolean success = false;
+        try {
+            csr = File.createTempFile("server", ".csr");
+            runCommand("openssl", "req", "-new", "-batch", "-nodes", "-keyout", target.getKey().getAbsolutePath(), "-subj", target.getSubject(), "-out", csr.getAbsolutePath());
+            success = true;
+            return new CertSigningRequest(csr,target.getKey());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } finally {
+            if (!success) {
+                if (csr != null) {
+                    csr.delete();
+                }
+            }
+        }
+
+    }
+
+    public static CertPair signCrs(CertSigningRequest request, Collection<String> sans, CertPair ca) {
+        File crt = null;
+        boolean success = false;
+        try {
+            crt = File.createTempFile("server", ".crt");
+            if (sans.size() > 0) {
+                String sansString = "subjectAltName=DNS:" + sans.stream().collect(Collectors.joining(",DNS:"));
+                runCommand("bash",
+                        "-c",
+                        "openssl x509 -req -extfile <(printf \"" + sansString + "\") -days 11000 -in " + request.getCsrFile().getAbsolutePath() +
+                                " -CA " + ca.getCert().getAbsolutePath() +
+                                " -CAkey " + ca.getKey().getAbsolutePath() +
+                                " -CAcreateserial -out " + crt.getAbsolutePath());
+            } else {
+                runCommand("openssl",
+                        "x509",
+                        "-req",
+                        "-days",
+                        "11000",
+                        "-in",
+                        request.getCsrFile().getAbsolutePath(),
+                        "-CA",
+                        ca.getCert().getAbsolutePath(),
+                        "-CAkey",
+                        ca.getKey().getAbsolutePath(),
+                        "-CAcreateserial",
+                        "-out",
+                        crt.getAbsolutePath());
+            }
+            success = true;
+            return new CertPair(request.getKeyFile(), crt, null);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } finally {
+            if (!success) {
+                if (crt != null) {
+                    crt.delete();
+                }
+            }
+        }
+    }
+
+    public static CertPair downloadCert(String host, int port) {
+        File cert = null;
+        boolean success = false;
+        try {
+            cert = File.createTempFile(String.format("host_%s:%d", host, port), ".crt");
+            List<String> cmd = Arrays.asList("openssl", "s_client", "-crlf", "-showcerts", "-servername", host, "-connect", String.format("%s:%d", host, port));
+            String pems = runCommandWithInput("GET / HTTP/1.1\n", cmd.toArray(new String[] {}));
+            Files.writeString(cert.toPath(), pems);
+            success = true;
+            return new CertPair(null, cert, null);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } finally {
+            if (!success) {
+                if (cert != null) {
+                    cert.delete();
+                }
+            }
+        }
+    }
+
+    private static String runCommand(String... cmd) {
+        return runCommandWithInput(null, cmd);
+    }
+
+    private static String runCommandWithInput(String stdin, String... cmd) {
+        ProcessBuilder keyGenBuilder = new ProcessBuilder(cmd).redirectInput(ProcessBuilder.Redirect.PIPE).redirectErrorStream(true);
+
+        log.info("Running command '{}'", keyGenBuilder.command());
+        String outBuf = null;
+        boolean success = false;
+        try {
+            Process process = keyGenBuilder.start();
+            try (Writer writer = new OutputStreamWriter(process.getOutputStream());
+                 BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                if (stdin != null) {
+                    writer.write(stdin);
+                }
+                writer.close();
+
+                outBuf = reader.lines().collect(Collectors.joining("\n"));
+            }
+            if (!process.waitFor(1, TimeUnit.MINUTES)) {
+                throw new RuntimeException(String.format("Command '%s' timed out", keyGenBuilder.command()));
+            }
+
+            final int exitValue = process.waitFor();
+            success = exitValue == 0;
+            String msg = String.format("Command '%s' completed with exit value %d", keyGenBuilder.command(), exitValue);
+            if (success) {
+                log.info(msg);
+            } else {
+                log.error(msg);
+                throw new RuntimeException(String.format("Command '%s' failed with exit value %d", keyGenBuilder.command(), exitValue));
+            }
+        } catch (InterruptedException ignored) {
+            Thread.currentThread().interrupt();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } finally {
+            if (!success && outBuf != null) {
+                log.error("Command output: {}", outBuf);
+            }
+        }
+        return outBuf.toString();
+    }
+}

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/KubeCMDClient.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/KubeCMDClient.java
@@ -18,6 +18,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import io.enmasse.systemtest.bases.ITestBase;
+import io.enmasse.systemtest.time.TimeoutBudget;
+import io.enmasse.systemtest.utils.TestUtils;
 import org.slf4j.Logger;
 
 import io.enmasse.systemtest.Environment;
@@ -217,7 +220,10 @@ public class KubeCMDClient {
 
     public static String loginUser(String username, String password) {
         List<String> cmd = Arrays.asList(CMD, "login", "-u", username, "-p", password);
-        Exec.execute(cmd, DEFAULT_SYNC_TIMEOUT, true);
+        ExecutionResultData execute = Exec.execute(cmd, DEFAULT_SYNC_TIMEOUT, true);
+        if (!execute.getRetCode()) {
+            throw new IllegalStateException(String.format("Failed to login user : %s : %s", username, execute.getStdErr()));
+        }
         cmd = Arrays.asList(CMD, "whoami", "-t");
         return Exec.execute(cmd, DEFAULT_SYNC_TIMEOUT, true)
                 .getStdOut().replace(System.getProperty("line.separator"), "");
@@ -414,5 +420,14 @@ public class KubeCMDClient {
         command.add(CMD);
         command.addAll(Arrays.asList(args));
         return Exec.execute(command, ONE_MINUTE_TIMEOUT, false);
+    }
+
+    public static void awaitRollout(TimeoutBudget budget, String namespace, String deploymentName) {
+        TestUtils.waitUntilCondition(String.format("Wait for deployment %s in namespace %s rollout to complete", deploymentName, namespace), waitPhase -> {
+            ExecutionResultData rollout = Exec.execute(Arrays.asList(ITestBase.kubernetes.getCluster().getKubeCmd(), "rollout",
+                    "status", "deployment", deploymentName,
+                    "--namespace", namespace), true);
+            return rollout.getRetCode();
+        }, budget);
     }
 }

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/Kubernetes.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/Kubernetes.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import io.fabric8.openshift.api.model.Route;
 import org.apache.commons.io.output.CloseShieldOutputStream;
 import org.slf4j.Logger;
 
@@ -972,7 +973,7 @@ public abstract class Kubernetes {
         } while (!unready.isEmpty() && budget.timeLeft() > 0);
 
         if (!unready.isEmpty()) {
-            fail(String.format(" %d pod(s) still unready", unready.size()));
+            fail(String.format(" %d pod(s) still unready in namespace : %s", unready.size(), namespace));
         }
     }
 
@@ -1072,4 +1073,9 @@ public abstract class Kubernetes {
         log.info("Output: {}", stdoutString);
         return stdoutString;
     }
+
+    public List<Route> listRoutes(String namespace, Map<String, String> labels) {
+        throw new UnsupportedOperationException();
+    }
+
 }

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/Minikube.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/Minikube.java
@@ -15,16 +15,12 @@ import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.utils.HttpClientUtils;
-import io.fabric8.openshift.api.model.Route;
-import io.fabric8.openshift.client.OpenShiftClient;
 import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
 import org.slf4j.Logger;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 
 public class Minikube extends Kubernetes {
     private static Logger log = CustomLogger.getLogger();

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/Minikube.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/Minikube.java
@@ -15,12 +15,16 @@ import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.utils.HttpClientUtils;
+import io.fabric8.openshift.api.model.Route;
+import io.fabric8.openshift.client.OpenShiftClient;
 import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
 import org.slf4j.Logger;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 public class Minikube extends Kubernetes {
     private static Logger log = CustomLogger.getLogger();

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/OpenShift.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/OpenShift.java
@@ -5,6 +5,8 @@
 package io.enmasse.systemtest.platform;
 
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import org.slf4j.Logger;
 
@@ -154,5 +156,10 @@ public class OpenShift extends Kubernetes {
     @Override
     public String getOlmNamespace() {
         return OLM_NAMESPACE;
+    }
+
+    @Override
+    public List<Route> listRoutes(String namespace, Map<String, String> labels) {
+        return client.adapt(OpenShiftClient.class).routes().inNamespace(namespace).withLabels(labels).list().getItems();
     }
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/web/ConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/web/ConsoleTest.java
@@ -1447,10 +1447,12 @@ public abstract class ConsoleTest extends TestBase {
 
         String customCaCnName = "custom-ca";
         String customIngressSecretName = "custom-ingress";
+        String wildcardSan = String.format("*.%s", environment.kubernetesDomain());
+        log.info("Wildcard SAN for custom cert: {}", wildcardSan);
         try (CertPair ca = OpenSSLUtil.createSelfSignedCert("/O=io.enmasse/CN=MyCA");
              CertPair unsignedCluster = OpenSSLUtil.createSelfSignedCert("/O=io.enmasse//CN=MyCluster");
              CertSigningRequest csr = OpenSSLUtil.createCsr(unsignedCluster);
-             CertPair cluster = OpenSSLUtil.signCrs(csr, Collections.singletonList("*.apps-crc.testing"), ca)
+             CertPair cluster = OpenSSLUtil.signCrs(csr, Collections.singletonList(wildcardSan), ca)
         ) {
             // Steps from https://docs.openshift.com/container-platform/4.3/authentication/certificates/replacing-default-ingress-certificate.html#replacing-default-ingress_replacing-default-ingress
 

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/web/ConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/web/ConsoleTest.java
@@ -19,8 +19,13 @@ import io.enmasse.admin.model.v1.ResourceRequest;
 import io.enmasse.systemtest.UserCredentials;
 import io.enmasse.systemtest.amqp.AmqpClient;
 import io.enmasse.systemtest.bases.TestBase;
+import io.enmasse.systemtest.certs.openssl.CertPair;
+import io.enmasse.systemtest.certs.openssl.CertSigningRequest;
+import io.enmasse.systemtest.certs.openssl.OpenSSLUtil;
 import io.enmasse.systemtest.clients.ClientUtils;
 import io.enmasse.systemtest.clients.ClientUtils.ClientAttacher;
+import io.enmasse.systemtest.executor.Exec;
+import io.enmasse.systemtest.executor.ExecutionResultData;
 import io.enmasse.systemtest.info.TestInfo;
 import io.enmasse.systemtest.isolated.Credentials;
 import io.enmasse.systemtest.logs.CustomLogger;
@@ -35,9 +40,7 @@ import io.enmasse.systemtest.model.addressspace.AddressSpacePlans;
 import io.enmasse.systemtest.model.addressspace.AddressSpaceType;
 import io.enmasse.systemtest.platform.KubeCMDClient;
 import io.enmasse.systemtest.platform.Kubernetes;
-import io.enmasse.systemtest.platform.OpenShift;
 import io.enmasse.systemtest.platform.apps.SystemtestsKubernetesApps;
-import io.enmasse.systemtest.platform.cluster.OpenShiftCluster;
 import io.enmasse.systemtest.selenium.SeleniumProvider;
 import io.enmasse.systemtest.selenium.page.ConsoleWebPage;
 import io.enmasse.systemtest.selenium.resources.AddressWebItem;
@@ -52,6 +55,8 @@ import io.enmasse.systemtest.utils.Count;
 import io.enmasse.systemtest.utils.PlanUtils;
 import io.enmasse.systemtest.utils.TestUtils;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.openshift.api.model.Route;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.util.Strings;
 import org.junit.jupiter.api.AfterEach;
@@ -67,6 +72,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -77,8 +83,7 @@ import java.util.stream.IntStream;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.either;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -1417,6 +1422,134 @@ public abstract class ConsoleTest extends TestBase {
         consolePage.waitForErrorDialogToBePresent();
         assertThat("Error dialog is not present after error situation!", consolePage.getErrorDialog(), notNullValue());
 
+    }
+
+    protected void doTestOpenShiftWithCustomCert() throws Exception {
+        String openshiftConfigNamespace = "openshift-config";
+        String openshiftIngressNamespace = "openshift-ingress";
+        String openshiftIngressOperatorNamespace = "openshift-ingress-operator";
+        String openshiftAuthenticationNamespace = "openshift-authentication";
+
+        Map<String, String> oauthDeploymentLabels = Map.of(LabelKeys.APP, "oauth-openshift");
+        Map<String, String> oauthRouteLabels = Map.of(LabelKeys.APP, "oauth-openshift");
+        Map<String, String> consoleDeploymentLabels = Map.of(LabelKeys.APP, "enmasse", LabelKeys.NAME, "console");
+
+        Optional<Deployment> oauth = kubernetes.listDeployments(openshiftAuthenticationNamespace, oauthDeploymentLabels).stream().findFirst();
+        assertThat(oauth.isPresent(), is(true));
+
+        Optional<Route> oauthRoute = kubernetes.listRoutes(openshiftAuthenticationNamespace, oauthRouteLabels).stream().findFirst();
+        assertThat(oauthRoute.isPresent(), is(true));
+
+        Optional<Deployment> console = kubernetes.listDeployments(consoleDeploymentLabels).stream().findFirst();
+        assertThat(console.isPresent(), is(true));
+
+        CertPair originalOauthCert = OpenSSLUtil.downloadCert(oauthRoute.get().getSpec().getHost(), 443);
+
+        String customCaCnName = "custom-ca";
+        String customIngressSecretName = "custom-ingress";
+        try (CertPair ca = OpenSSLUtil.createSelfSignedCert("/O=io.enmasse/CN=MyCA");
+             CertPair unsignedCluster = OpenSSLUtil.createSelfSignedCert("/O=io.enmasse//CN=MyCluster");
+             CertSigningRequest csr = OpenSSLUtil.createCsr(unsignedCluster);
+             CertPair cluster = OpenSSLUtil.signCrs(csr, Collections.singletonList("*.apps-crc.testing"), ca)
+        ) {
+            // Steps from https://docs.openshift.com/container-platform/4.3/authentication/certificates/replacing-default-ingress-certificate.html#replacing-default-ingress_replacing-default-ingress
+
+            assertThat(cluster.getCert().canRead(), is(true));
+            assertThat(cluster.getKey().canRead(), is(true));
+
+            ExecutionResultData ingressSecret = Exec.execute(Arrays.asList(kubernetes.getCluster().getKubeCmd(), "create", "secret", "tls", customIngressSecretName,
+                    "--namespace", openshiftIngressNamespace,
+                    String.format("--cert=%s", cluster.getCert()),
+                    String.format("--key=%s", cluster.getKey())), true);
+            assertThat("failed to create ingress secret", ingressSecret.getRetCode(), is(true));
+
+            ExecutionResultData cmCustomCa = Exec.execute(Arrays.asList(kubernetes.getCluster().getKubeCmd(), "create", "configmap", customCaCnName,
+                    "--namespace", openshiftConfigNamespace,
+                    String.format("--from-file=ca-bundle.crt=%s", ca.getCert().getAbsolutePath())), true);
+            assertThat("failed to create custom-ca configmap", cmCustomCa.getRetCode(), is(true));
+
+            ExecutionResultData patchProxy = Exec.execute(Arrays.asList(kubernetes.getCluster().getKubeCmd(), "patch", "proxy/cluster",
+                    "--type=merge",
+                    String.format("--patch={\"spec\":{\"trustedCA\":{\"name\":\"%s\"}}}", customCaCnName)), true);
+            assertThat("failed to patch proxy/cluster", patchProxy.getRetCode(), is(true));
+
+            ExecutionResultData patchIngress = Exec.execute(Arrays.asList(kubernetes.getCluster().getKubeCmd(), "patch", "ingresscontroller.operator/default",
+                    "--type=merge",
+                    "--namespace", openshiftIngressOperatorNamespace,
+                    String.format("--patch={\"spec\":{\"defaultCertificate\": {\"name\": \"%s\"}}}", customIngressSecretName)), true);
+            assertThat("failed to patch ingress", patchIngress.getRetCode(), is(true));
+
+
+            awaitCertChange(ca, oauth.get(), console.get(), oauthRoute.get());
+
+            System.out.println(cluster.getCert());
+            System.out.println(cluster.getKey());
+
+            doTestCanOpenConsolePage(resourcesManager.getSharedAddressSpace(), clusterUser, true);
+
+        } finally {
+
+            Exec.execute(Arrays.asList(kubernetes.getCluster().getKubeCmd(), "patch", "proxy/cluster",
+                    "--type=merge",
+                    "--patch={\"spec\":{\"trustedCA\": null}}"), false);
+            Exec.execute(Arrays.asList(kubernetes.getCluster().getKubeCmd(), "patch", "ingresscontroller.operator/default",
+                    "--type=merge",
+                    "--namespace", openshiftIngressOperatorNamespace,
+                    "--patch={\"spec\":{\"defaultCertificate\": null}}"), false);
+            Exec.execute(Arrays.asList(kubernetes.getCluster().getKubeCmd(), "delete", "configmap", customCaCnName,
+                    "--namespace", openshiftConfigNamespace), false);
+            Exec.execute(Arrays.asList(kubernetes.getCluster().getKubeCmd(), "delete", "secret", customIngressSecretName,
+                    "--namespace", openshiftIngressNamespace), false);
+
+
+            awaitCertChange(originalOauthCert, oauth.get(), console.get(), oauthRoute.get());
+
+        }
+    }
+
+    private void awaitCertChange(CertPair expectedCa, Deployment oauthDeployment, Deployment consoleDeployment, Route oauthRoute) {
+        TestUtils.waitUntilCondition("Awaiting cert change", waitPhase -> {
+            try {
+                KubeCMDClient.loginUser(clusterUser.getUsername(), clusterUser.getUsername());
+                verifyCertChange(expectedCa, oauthDeployment, consoleDeployment, oauthRoute);
+                return true;
+            } catch (Exception e) {
+                return false;
+            }
+        }, new TimeoutBudget(5, TimeUnit.MINUTES));
+    }
+
+    private void verifyCertChange(CertPair ca, Deployment oauthDeployment, Deployment consoleDeployment, Route oauthRoute) throws Exception {
+        log.info("Awaiting openshift oauth to be ready again");
+        TestUtils.waitForChangedResourceVersion(new TimeoutBudget(1, TimeUnit.MINUTES), oauthDeployment.getMetadata().getResourceVersion(),
+                () -> {
+                    Optional<Deployment> upd = kubernetes.listDeployments(oauthDeployment.getMetadata().getNamespace(), oauthDeployment.getMetadata().getLabels()).stream().findFirst();
+                    assertThat(upd.isPresent(), is(true));
+                    return upd.get().getMetadata().getResourceVersion();
+                });
+
+        KubeCMDClient.awaitRollout(new TimeoutBudget(3, TimeUnit.MINUTES), oauthDeployment.getMetadata().getNamespace(), oauthDeployment.getMetadata().getName());
+
+        // await for oauth and verify it uses the correct certificate
+        if (ca != null) {
+            String oauthHost = oauthRoute.getSpec().getHost();
+            TestUtils.waitUntilCondition(String.format("Await for oauth http endpoint to become ready: %s", oauthHost), waitPhase -> {
+                List<String> curl = Arrays.asList("curl",
+                        "--cacert", ca.getCert().getAbsolutePath(),
+                        "--verbose", String.format("https://%s", oauthHost));
+                ExecutionResultData consolePing = Exec.execute(curl, true);
+                return consolePing.getRetCode();
+            }, new TimeoutBudget(3, TimeUnit.MINUTES));
+        }
+
+        log.info("Awaiting EnMasse console to be ready again");
+        TestUtils.waitForChangedResourceVersion(new TimeoutBudget(1, TimeUnit.MINUTES), consoleDeployment.getMetadata().getResourceVersion(),
+                () -> {
+                    Optional<Deployment> upd = kubernetes.listDeployments(consoleDeployment.getMetadata().getLabels()).stream().findFirst();
+                    assertThat(upd.isPresent(), is(true));
+                    return upd.get().getMetadata().getResourceVersion();
+                });
+        KubeCMDClient.awaitRollout(new TimeoutBudget(3, TimeUnit.MINUTES), kubernetes.getInfraNamespace(), consoleDeployment.getMetadata().getName());
     }
 
     //============================================================================================

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/web/FirefoxConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/web/FirefoxConsoleTest.java
@@ -8,6 +8,8 @@ import io.enmasse.address.model.AddressBuilder;
 import io.enmasse.systemtest.UserCredentials;
 import io.enmasse.systemtest.bases.shared.ITestSharedBrokered;
 import io.enmasse.systemtest.bases.web.ConsoleTest;
+import io.enmasse.systemtest.condition.OpenShift;
+import io.enmasse.systemtest.condition.OpenShiftVersion;
 import io.enmasse.systemtest.messagingclients.ExternalClients;
 import io.enmasse.systemtest.model.address.AddressType;
 import io.enmasse.systemtest.model.addressplan.DestinationPlan;
@@ -165,4 +167,12 @@ class FirefoxConsoleTest extends ConsoleTest implements ITestSharedBrokered {
     void testAddressLinks() throws Exception {
         doTestAddressLinks(getSharedAddressSpace(), DestinationPlan.BROKERED_QUEUE);
     }
+
+    @Test
+    @OpenShift(version = OpenShiftVersion.OCP4)
+    void testOpenShiftWithCustomCert() throws Exception {
+        doTestOpenShiftWithCustomCert();
+    }
+
+
 }


### PR DESCRIPTION
### Type of change


- Bugfix

### Description

Inject custom CA bundle into Console pod so that Console authentication functions even when the OpenShift cluster uses a custom CA.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [x] Write tests and make sure they pass
- [ ] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
