### PR TITLE
Remove "Enter more characters option" if rows are less than 10 in typeahead dropdown

### DIFF
--- a/console/console-init/ui/src/utils/utils.ts
+++ b/console/console-init/ui/src/utils/utils.ts
@@ -38,10 +38,12 @@ const getSelectOptionList = (list: string[], totalRecords: number) => {
       0,
       NUMBER_OF_RECORDS_TO_DISPLAY_IF_SERVER_HAS_MORE_DATA
     );
-    records.push({
-      value: TypeAheadMessage.MORE_CHAR_REQUIRED,
-      isDisabled: true
-    });
+    if (top_10_records.length >= 10) {
+      records.push({
+        value: TypeAheadMessage.MORE_CHAR_REQUIRED,
+        isDisabled: true
+      });
+    }
     top_10_records.map((data: string) =>
       records.push(createSelectOptionObject(data, false))
     );


### PR DESCRIPTION
### Type of change

- Bugfix
### Description
- Remove "Enter more characters" option from the dropdown if there are less than 10 records in the dropdown because of duplicates data received from the server.
