### PR TITLE
fix-column1 for name/namespace column in mobile view

### DIFF
--- a/console/console-init/ui/src/modules/address-space/containers/AddressSpaceListContainer/AddressSpaceListContainer.tsx
+++ b/console/console-init/ui/src/modules/address-space/containers/AddressSpaceListContainer/AddressSpaceListContainer.tsx
@@ -33,7 +33,6 @@ import {
   IAddressSpace,
   EmptyAddressSpace
 } from "modules/address-space/components";
-import { useWindowDimensions } from "components";
 
 export interface IAddressSpaceListContainerProps {
   page: number;
@@ -71,7 +70,6 @@ export const AddressSpaceListContainer: React.FC<IAddressSpaceListContainerProps
   const { dispatch } = useStoreContext();
   const [sortBy, setSortBy] = useState<ISortBy>();
   const refetchQueries: string[] = ["all_address_spaces"];
-  const { width } = useWindowDimensions();
   const [setDeleteAddressSpaceQueryVariables] = useMutationQuery(
     DELETE_ADDRESS_SPACE,
     refetchQueries

--- a/console/console-init/ui/src/modules/address-space/containers/AddressSpaceListContainer/AddressSpaceListContainer.tsx
+++ b/console/console-init/ui/src/modules/address-space/containers/AddressSpaceListContainer/AddressSpaceListContainer.tsx
@@ -33,6 +33,7 @@ import {
   IAddressSpace,
   EmptyAddressSpace
 } from "modules/address-space/components";
+import { useWindowDimensions } from "components";
 
 export interface IAddressSpaceListContainerProps {
   page: number;
@@ -70,6 +71,7 @@ export const AddressSpaceListContainer: React.FC<IAddressSpaceListContainerProps
   const { dispatch } = useStoreContext();
   const [sortBy, setSortBy] = useState<ISortBy>();
   const refetchQueries: string[] = ["all_address_spaces"];
+  const { width } = useWindowDimensions();
   const [setDeleteAddressSpaceQueryVariables] = useMutationQuery(
     DELETE_ADDRESS_SPACE,
     refetchQueries

--- a/console/console-init/ui/src/modules/address-space/utils/AddressSpaceFormatter.tsx
+++ b/console/console-init/ui/src/modules/address-space/utils/AddressSpaceFormatter.tsx
@@ -47,12 +47,12 @@ const statusToDisplay = (phase: string) => {
       icon = <ExclamationCircleIcon color="red" />;
       break;
     case "":
-      icon = <InProgressIcon />;
+      icon = <ExclamationCircleIcon color="red" />;
       break;
   }
   return (
     <span>
-      {icon}&nbsp;{phase.trim() !== "" ? phase : "Configuring"}
+      {icon}&nbsp;{phase.trim() !== "" ? phase : "Pending"}
     </span>
   );
 };

--- a/console/console-init/ui/src/modules/address-space/utils/TableFormatter.tsx
+++ b/console/console-init/ui/src/modules/address-space/utils/TableFormatter.tsx
@@ -18,7 +18,7 @@ const getTableCells = (row: IAddressSpace) => {
       {
         header: "name",
         title: (
-          <>
+          <span>
             <Link
               to={`address-spaces/${row.nameSpace}/${row.name}/${row.type}/addresses`}
             >
@@ -26,16 +26,16 @@ const getTableCells = (row: IAddressSpace) => {
             </Link>
             <br />
             {row.nameSpace}
-          </>
+          </span>
         )
       },
       {
         header: "type",
         title: (
-          <>
+          <span>
             <AddressSpaceIcon />
             {getType(row.type)}
-          </>
+          </span>
         )
       },
       {
@@ -102,6 +102,7 @@ const getTableColumns = [
         </div>
       </span>
     ),
+    dataLabel: "Name / Namespace",
     transforms: [sortable]
   },
   "Type",

--- a/console/console-init/ui/src/modules/connection/components/ConnectionList/ConnectionList.tsx
+++ b/console/console-init/ui/src/modules/connection/components/ConnectionList/ConnectionList.tsx
@@ -85,7 +85,7 @@ export const ConnectionList: React.FunctionComponent<IConnectionListProps> = ({
   const tableRows = rows && rows.map(toTableCells);
 
   const tableColumns = [
-    { title: "Hostname", dataLabel: "host", transforms: [sortable] },
+    { title: "Hostname", transforms: [sortable] },
     { title: "Container ID", transforms: [sortable] },
     { title: "Protocol", transforms: [sortable] },
     { title: "Time created", transforms: [sortable] },

--- a/console/console-init/ui/src/utils/Formatter.tsx
+++ b/console/console-init/ui/src/utils/Formatter.tsx
@@ -24,9 +24,9 @@ const ConnectionProtocolFormat: React.FunctionComponent<ProtocolIcon> = ({
   encrypted
 }) => {
   return (
-    <>
+    <span>
       {protocol && protocol.toUpperCase()} {protocolIconToDisplay(encrypted)}
-    </>
+    </span>
   );
 };
 const getFilteredValue = (object: IMetrics[], value: string) => {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description
- FIx - The column Name\Namespace is displayed as column-1 in mobile view of Address Space List.
- Replace Configuring status with Pending status when the address and address space is not picked up by controller in the server side. As configuring status misleads the user.