### PR TITLE
Fixed connectionLinks filter issue for address and delete address route isssue

### DIFF
--- a/console/console-init/ui/src/graphql-module/queries/Connection.ts
+++ b/console/console-init/ui/src/graphql-module/queries/Connection.ts
@@ -349,7 +349,7 @@ const CONNECTION_LINKS_FILTER = (
         filterForLink += "`$.spec.address` = '" + filterAddresseValue + "'";
       else
         filterForLink +=
-          "`$.spec.Address` LIKE '" + filterAddresseValue + "%' ";
+          "`$.spec.address` LIKE '" + filterAddresseValue + "%' ";
     }
     if (filterRole && filterRole.trim() !== "") {
       filterForLink += " AND ";

--- a/console/console-init/ui/src/modules/address-detail/AddressDetailPage.tsx
+++ b/console/console-init/ui/src/modules/address-detail/AddressDetailPage.tsx
@@ -71,7 +71,7 @@ export default function AddressDetailPage() {
   }
 
   const resetDeleteFormState = (data: any) => {
-    const deleteAddress = data && data.data && data.data.deleteAddress;
+    const deleteAddress = data && data.deleteAddress;
     if (deleteAddress) {
       history.push(`/address-spaces/${namespace}/${name}/${type}/addresses`);
     }
@@ -140,7 +140,7 @@ export default function AddressDetailPage() {
 
   const address = getAddress();
 
-  const onDelete = () => {
+  const onDelete = async () => {
     const data = addressDetail.metadata;
     const variables = {
       a: {
@@ -148,7 +148,7 @@ export default function AddressDetailPage() {
         namespace: data.namespace
       }
     };
-    setDeleteAddressQueryVariables(variables);
+    await setDeleteAddressQueryVariables(variables);
   };
 
   const purgeAddress = (data: any) => {


### PR DESCRIPTION


### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

1. ConnectionLinks:  Filter not working as expected for address category (for like operator)
2. Address Detail: After delete route didn't change

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
