### PR TITLE
Compare addresses by their name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * #4241: Fix a race in upgrader logic that prevented upgrade from continuing
 * #4266: Add broker.globalMaxSize to the infraconfig CRDs 
 * #4269: bump Netty dependency from netty-4.1.45.Final to netty-4.1.48.Final
+* #4317: Addresses with different casing is not becoming ready
 
 ## 0.31.0
 *  Adding example partitioned/sharded queue example plans

--- a/agent/lib/internal_address_source.js
+++ b/agent/lib/internal_address_source.js
@@ -103,7 +103,7 @@ function same_address_definition_and_status(a, b) {
 }
 
 function address_compare(a, b) {
-    return myutils.string_compare(a.address, b.address);
+    return myutils.string_compare(a.name, b.name);
 }
 
 function by_address(a) {

--- a/agent/test/internal_address_source.js
+++ b/agent/test/internal_address_source.js
@@ -376,4 +376,31 @@ describe('configmap backed address source', function() {
             });
         });
     });
+
+    function equal_properties (a, b) {
+        for (let k in a) {
+            if (a[k] !== b[k]) return false;
+        }
+        for (let k in b) {
+            if (b[k] !== a[k]) return false;
+        }
+        return true;
+    }
+
+    it('compares the name of the address', function(done) {
+        let source = new AddressSource({});
+        source.last = {};
+
+        // Populate the initial
+        source.get_changes('foo', [{name:'ab',address:'AB'}], equal_properties)
+
+        // Add the 'aa' address
+        let c = source.get_changes('foo', [{name:'aa',address:'aa'},{name:'ab',address:'AB'}], equal_properties)
+        assert(c !== undefined);
+        assert.equal(c.added.length, 1);
+        assert.equal(c.added[0].name, 'aa');
+        assert.equal(c.removed.length, 0);
+        assert.equal(c.modified.length, 0);
+        done();
+    });
 });

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/QueueTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/QueueTest.java
@@ -61,10 +61,10 @@ class QueueTest extends TestBase implements ITestSharedBrokered {
     }
 
 
-    // Test reproducing #4317
+    // Test reproducing GitHub issue #4317
     @Test
     @Tag(NON_PR)
-    void testAddressOrderingIssue4317() throws Exception {
+    void testAddressOrdering() throws Exception {
         Address ab = new AddressBuilder()
                 .withNewMetadata()
                 .withNamespace(getSharedAddressSpace().getMetadata().getNamespace())


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

Comparing addresses using their address can cause the expected
ordered input to changes function to be broken, as the addresses
retrieved from kubernetes are sorted by their name.

Fixes #4317


### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [x] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
