### PR TITLE
Use address name, for matching links, fixes issue when resource name suffix does not match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * #4241: Fix a race in upgrader logic that prevented upgrade from continuing
 * #4266: Add broker.globalMaxSize to the infraconfig CRDs 
 * #4269: bump Netty dependency from netty-4.1.45.Final to netty-4.1.48.Final
+* #4287: Address links not displayed if address resource name suffix does not match address name
 * #4305: Inject OpenShift generated custom CA trust bundle into console pod so that console authentication works when a custom CA is in use.
 * #4317: Addresses with different casing is not becoming ready
 

--- a/pkg/consolegraphql/resolvers/resolver_address.go
+++ b/pkg/consolegraphql/resolvers/resolver_address.go
@@ -37,7 +37,7 @@ const infraUuidAnnotation = "enmasse.io/infra-uuid"
 
 func (ar addressK8sResolver) Links(ctx context.Context, obj *consolegraphql.AddressHolder, first *int, offset *int, filter *string, orderBy *string) (*LinkQueryResultConsoleapiEnmasseIoV1beta1, error) {
 	if obj != nil {
-		fltrfunc, keyElements, e := BuildFilter(filter, "$.metadata.name")
+		fltrfunc, keyElements, e := BuildFilter(filter, "$.spec.address")
 		if e != nil {
 			return nil, e
 		}
@@ -52,7 +52,7 @@ func (ar addressK8sResolver) Links(ctx context.Context, obj *consolegraphql.Addr
 			return nil, e
 		}
 		// N.B. address name not prefixed in the link index
-		links, e := ar.Cache.Get(cache.AddressLinkObjectIndex, fmt.Sprintf("Link/%s/%s/%s/%s", obj.ObjectMeta.Namespace, addrtoks[0], addrtoks[1], keyElements), fltrfunc)
+		links, e := ar.Cache.Get(cache.AddressLinkObjectIndex, fmt.Sprintf("Link/%s/%s/%s/%s", obj.ObjectMeta.Namespace, addrtoks[0], obj.Spec.Address, keyElements), fltrfunc)
 		if e != nil {
 			return nil, e
 		}

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/web/ChromeConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/web/ChromeConsoleTest.java
@@ -184,6 +184,12 @@ public class ChromeConsoleTest extends ConsoleTest implements ITestSharedStandar
     }
 
     @Test
+    @ExternalClients
+    void testAddressLinksWithMismatchedAddressResourceNameAndSuffix() throws Exception {
+        doTestAddressLinksWithMismatchedAddressResourceNameAndSuffix(getSharedAddressSpace(), DestinationPlan.STANDARD_SMALL_QUEUE);
+    }
+
+    @Test
     void testMessagesStoredMetrics() throws Exception {
         doTestMessagesStoredMetrics(getSharedAddressSpace());
     }

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/web/FirefoxConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/web/FirefoxConsoleTest.java
@@ -262,6 +262,12 @@ public class FirefoxConsoleTest extends ConsoleTest implements ITestSharedStanda
 
     @Test
     @ExternalClients
+    void testAddressLinksWithMismatchedAddressResourceNameAndSuffix() throws Exception {
+        doTestAddressLinksWithMismatchedAddressResourceNameAndSuffix(getSharedAddressSpace(), DestinationPlan.STANDARD_SMALL_QUEUE);
+    }
+
+    @Test
+    @ExternalClients
     void testFilterConnectionsByContainerId() throws Exception {
         doTestFilterConnectionsByContainerId(getSharedAddressSpace());
     }


### PR DESCRIPTION
Fix: Address links not displayed if address resource name suffix does not match address name

### Type of change

- Bugfix

### Description

Fixes #4287 
Use address name, for matching links, fixes issue when resource name suffix does not match.

### Checklist

- [ ] Update/write design documentation in `./documentation/design`
- [x] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
