### PR TITLE
Remove min broker availability in examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * #4269: bump Netty dependency from netty-4.1.45.Final to netty-4.1.48.Final
 * #4305: Inject OpenShift generated custom CA trust bundle into console pod so that console authentication works when a custom CA is in use.
 * #4317: Addresses with different casing is not becoming ready
+* #4332: Unable to drain kube node when broker pod is deployed there
 
 ## 0.31.0
 *  Adding example partitioned/sharded queue example plans

--- a/templates/example-plans/020-StandardInfraConfig-default-with-mqtt.yaml
+++ b/templates/example-plans/020-StandardInfraConfig-default-with-mqtt.yaml
@@ -15,7 +15,6 @@ spec:
       memory: 512Mi
       storage: 2Gi
     addressFullPolicy: FAIL
-    maxUnavailable: 1
   router:
     minReplicas: 2
     resources:

--- a/templates/example-plans/020-StandardInfraConfig-default.yaml
+++ b/templates/example-plans/020-StandardInfraConfig-default.yaml
@@ -13,7 +13,6 @@ spec:
       memory: 512Mi
       storage: 2Gi
     addressFullPolicy: FAIL
-    maxUnavailable: 1
   router:
     minReplicas: 2
     resources:


### PR DESCRIPTION
# Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

Setting minAvailable/maxUnavailable for brokers is only applicable
when using partitioned queues, and should be a concious choice.

Fixes #4332

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
