### PR TITLE
Ensure that a failed broker sync retries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ## 0.31.2
 * #4305: Inject OpenShift generated custom CA trust bundle into console pod so that console authentication works when a custom CA is in use.
+* #4342: address stuck unready - failed to retrieve addresses: null (##4345)
 
 ## 0.31.1
 * #4046: add network-only as fetch policy for all queries 

--- a/agent/lib/qdr.js
+++ b/agent/lib/qdr.js
@@ -157,7 +157,7 @@ Router.prototype._abort_requests = function (error) {
 }
 
 Router.prototype.on_sender_error = function (context) {
-    log.info('[%s] sender error %s', this.get_id(), error);
+    log.info('[%s] sender error %s', this.get_id(), context.sender.error);
 };
 
 Router.prototype.disconnected = function (context) {

--- a/agent/lib/router.js
+++ b/agent/lib/router.js
@@ -228,6 +228,7 @@ ConnectedRouter.prototype._realise_address_definitions = function () {
     }).catch(function (error) {
         console.error('[%s] error while synchronizing addresses: %s', self.container_id, error);
         log.error('[%s] error while synchronizing addresses: %s', self.container_id, error);
+        throw error;
     });
 };
 


### PR DESCRIPTION
# Type of change


- Bugfix

### Description

Ensure that a failed broker sync retries.

* change serialize to retry the target function if it fails.
* fixed _sync_broker_addresses/_sync_broker_forwarders to rethrow on error.
* fixed an sender_error event handler that referenced an missing variable.
* reformatted _sync_broker_forwarders to correct indentation (no functional change).


### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
