### PR TITLE
Expand address space connector docs to include idleTimeout, maxFrameSize, role

### DIFF
--- a/documentation/modules/ref-address-space-example-connectors.adoc
+++ b/documentation/modules/ref-address-space-example-connectors.adoc
@@ -52,7 +52,7 @@ spec:
 <1> (Required) Specifies the name of the connector. All remote addresses are prefixed with the connector name and a forward slash, `/`.
 <2> (Required) Specifies a list of endpoints for this connector. This list must contain at least one entry, and any additional entries are used for failover. If not otherwise specified, the `port` field value is set to the registered IANA port for AMQP (or AMQPS if TLS is enabled).
 <3> (Optional) Idle timeout of the AMQP connection (seconds). 0 disables the idle timeout.
-<4> (Optional) Max frame size of AMQP connection.
+<4> (Optional) Max frame size of the AMQP connection.
 <5> (Optional) Enable TLS. The connector trusts global root CAs by default. To use a custom CA, specify a value for the `caCert` field.
 <6> (Optional) Specifies the username and password credentials to use for this connector. The values can be specified inline or by referencing a secret along with an optional key specifying the location within the secret. The secret must be readable by the `system:serviceaccounts:_{ProductNamespace}_` group.
 <7> (Optional) Role of connector. Can be "normal", "route-container", "edge". Defaults to 'route-container'.

--- a/documentation/modules/ref-address-space-example-connectors.adoc
+++ b/documentation/modules/ref-address-space-example-connectors.adoc
@@ -32,15 +32,18 @@ spec:
     - host: messaging.example.com
       port: 5672
     - host: messaging2.example.com
-    tls: {} <3>
-    credentials: <4>
+    idleTimeout: <3>
+    maxFrameSize: <4>
+    tls: {} <5>
+    credentials: <6>
       username:
         value: test
       password:
         valueFromSecret:
           name: password-secret
           key: password.txt
-    addresses: <5>
+    role: <7>
+    addresses: <8>
     - name: p1
       pattern: "prices/*"
     - name: p2
@@ -48,9 +51,12 @@ spec:
 ----
 <1> (Required) Specifies the name of the connector. All remote addresses are prefixed with the connector name and a forward slash, `/`.
 <2> (Required) Specifies a list of endpoints for this connector. This list must contain at least one entry, and any additional entries are used for failover. If not otherwise specified, the `port` field value is set to the registered IANA port for AMQP (or AMQPS if TLS is enabled).
-<3> (Optional) Enable TLS. The connector trusts global root CAs by default. To use a custom CA, specify a value for the `caCert` field.
-<4> (Optional) Specifies the username and password credentials to use for this connector. The values can be specified inline or by referencing a secret along with an optional key specifying the location within the secret. The secret must be readable by the `system:serviceaccounts:_{ProductNamespace}_` group.
-<5> (Required) Specifies a list of patterns matching addresses to be exposed on the remote endpoint. The pattern consists of one or more tokens separated by a forward slash, `/`. A token can be one of the following: a * character, a # character, or a sequence of characters that do not include /, *, or #. The * token matches any single token. The # token matches zero or more tokens. * has higher precedence than #, and exact match has the highest precedence.
+<3> (Optional) Idle timeout of AMQP connection (seconds). 0 disables the idle timeout.
+<4> (Optional) Max frame size of AMQP connection.
+<5> (Optional) Enable TLS. The connector trusts global root CAs by default. To use a custom CA, specify a value for the `caCert` field.
+<6> (Optional) Specifies the username and password credentials to use for this connector. The values can be specified inline or by referencing a secret along with an optional key specifying the location within the secret. The secret must be readable by the `system:serviceaccounts:_{ProductNamespace}_` group.
+<7> (Optional) Role of connector. Can be "normal", "route-container", "edge". Defaults to 'route-container'.
+<8> (Required) Specifies a list of patterns matching addresses to be exposed on the remote endpoint. The pattern consists of one or more tokens separated by a forward slash, `/`. A token can be one of the following: a * character, a # character, or a sequence of characters that do not include /, *, or #. The * token matches any single token. The # token matches zero or more tokens. * has higher precedence than #, and exact match has the highest precedence.
 
 == Address space connector using mutual TLS
 

--- a/documentation/modules/ref-address-space-example-connectors.adoc
+++ b/documentation/modules/ref-address-space-example-connectors.adoc
@@ -51,7 +51,7 @@ spec:
 ----
 <1> (Required) Specifies the name of the connector. All remote addresses are prefixed with the connector name and a forward slash, `/`.
 <2> (Required) Specifies a list of endpoints for this connector. This list must contain at least one entry, and any additional entries are used for failover. If not otherwise specified, the `port` field value is set to the registered IANA port for AMQP (or AMQPS if TLS is enabled).
-<3> (Optional) Idle timeout of AMQP connection (seconds). 0 disables the idle timeout.
+<3> (Optional) Idle timeout of the AMQP connection (seconds). 0 disables the idle timeout.
 <4> (Optional) Max frame size of AMQP connection.
 <5> (Optional) Enable TLS. The connector trusts global root CAs by default. To use a custom CA, specify a value for the `caCert` field.
 <6> (Optional) Specifies the username and password credentials to use for this connector. The values can be specified inline or by referencing a secret along with an optional key specifying the location within the secret. The secret must be readable by the `system:serviceaccounts:_{ProductNamespace}_` group.

--- a/documentation/modules/ref-address-space-example-connectors.adoc
+++ b/documentation/modules/ref-address-space-example-connectors.adoc
@@ -55,7 +55,7 @@ spec:
 <4> (Optional) Max frame size of the AMQP connection.
 <5> (Optional) Enable TLS. The connector trusts global root CAs by default. To use a custom CA, specify a value for the `caCert` field.
 <6> (Optional) Specifies the username and password credentials to use for this connector. The values can be specified inline or by referencing a secret along with an optional key specifying the location within the secret. The secret must be readable by the `system:serviceaccounts:_{ProductNamespace}_` group.
-<7> (Optional) Role of connector. Can be "normal", "route-container", "edge". Defaults to 'route-container'.
+<7> (Optional) Role of the connector. Valid values are "normal", "edge", and "route-container" (default value).
 <8> (Required) Specifies a list of patterns matching addresses to be exposed on the remote endpoint. The pattern consists of one or more tokens separated by a forward slash, `/`. A token can be one of the following: a * character, a # character, or a sequence of characters that do not include /, *, or #. The * token matches any single token. The # token matches zero or more tokens. * has higher precedence than #, and exact match has the highest precedence.
 
 == Address space connector using mutual TLS


### PR DESCRIPTION

### Type of change

- Documentation

### Description

Expand address space connector docs to include idleTimeout, maxFrameSize, role

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
