### PR TITLE
Fix broker support access documentation for newer version of jolokia.

### DIFF
--- a/documentation/modules/proc-examine-broker-state.adoc
+++ b/documentation/modules/proc-examine-broker-state.adoc
@@ -71,7 +71,7 @@ To execute an {BrokerName} CLI command, use a command similar to the following:
 +
 [options="nowrap",subs="+quotes,attributes"]
 ----
-{cmdcli} oc exec _broker pod name_ -- curl --silent --insecure --user _username_:_password_ 'https://localhost:8161/console/jolokia/read/org.apache.activemq.artemis:broker="_broker pod name_"/AddressMemoryUsage'
+{cmdcli} oc exec _broker pod name_ -- curl --silent --insecure --user _username_:_password_ -H "Origin: https://localhost:8161" 'https://localhost:8161/console/jolokia/read/org.apache.activemq.artemis:broker="_broker pod name_"/AddressMemoryUsage'
 ----
 +
 IMPORTANT: The double quotes around the broker pod name within the URL are required. Make sure you protect them from your

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/support/SupportToolingTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/support/SupportToolingTest.java
@@ -107,8 +107,9 @@ class SupportToolingTest extends TestBase implements ITestBaseIsolated {
                     "curl",
                     "--silent", "--insecure",
                     "--user", String.format("%s:%s", supportUser, supportPassword),
-                    String.format("https://localhost:8161/console/jolokia/read/org.apache.activemq.artemis:broker=\"%s\"/AddressMemoryUsage", podName)
-            );
+                    "-H", "Origin: https://localhost:8161",
+                    String.format("https://localhost:8161/console/jolokia/read/org.apache.activemq.artemis:broker=\"%s\"/AddressMemoryUsage", podName));
+
 
             assertThat(jmxResponse.getRetCode(), is(true));
             Map<String, Object> readValue = jsonResponseToMap(jmxResponse.getStdOut());


### PR DESCRIPTION

### Type of change

- Documentation

### Description

Newer versions of jolokia require "Origin: or Referer:" added to the header, as per:
https://jolokia.org/reference/html/security.html

The change was made in jolokia-core 1.5.  Therefore the header wasn't needed in 1.3.7, but will be needed in 1.6.1

### Checklist

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
