### PR TITLE
build OLM operator registry in systemtests

### DIFF
--- a/olm-manifest/Dockerfile
+++ b/olm-manifest/Dockerfile
@@ -3,7 +3,7 @@
 # License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
 #
 
-FROM quay.io/openshift/origin-operator-registry:latest
+FROM quay.io/enmasse/fedora-minimal:31
 
 ARG version
 ARG commit
@@ -11,10 +11,4 @@ ARG maven_version
 ENV VERSION=${version} MAVEN_VERSION=${maven_version} COMMIT=${commit}
 
 ADD target/olm-manifest-${maven_version}-dist.tar.gz /
-USER root
 RUN /bin/replace-images.sh
-USER 1001
-
-RUN /usr/bin/initializer -m /manifests -o bundles.db
-ENTRYPOINT ["/usr/bin/registry-server"]
-CMD ["-d", "bundles.db", "-t", "termination.log"]

--- a/systemtests/src/main/java/io/enmasse/systemtest/operator/EnmasseOperatorManager.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/operator/EnmasseOperatorManager.java
@@ -37,9 +37,11 @@ public class EnmasseOperatorManager {
     private Kubernetes kube = Kubernetes.getInstance();
     private String productName;
     private static EnmasseOperatorManager instance;
+    private OLMOperatorManager olm;
 
     private EnmasseOperatorManager() {
         productName = Environment.getInstance().getProductName();
+        olm = OLMOperatorManager.getInstance();
     }
 
     public static synchronized EnmasseOperatorManager getInstance() {
@@ -47,6 +49,10 @@ public class EnmasseOperatorManager {
             instance = new EnmasseOperatorManager();
         }
         return instance;
+    }
+
+    public OLMOperatorManager olm() {
+        return olm;
     }
 
     public void installEnmasseBundle() throws Exception {
@@ -109,7 +115,9 @@ public class EnmasseOperatorManager {
         LOGGER.info("***********************************************************");
         LOGGER.info("                  Enmasse OLM install");
         LOGGER.info("***********************************************************");
-        installOlm(installation);
+        LOGGER.info("Installing enmasse operators from: {}", Environment.getInstance().getTemplatesPath());
+        generateTemplates();
+        olm.install(installation);
         waitUntilOperatorReadyOlm(installation);
         LOGGER.info("***********************************************************");
     }
@@ -127,33 +135,6 @@ public class EnmasseOperatorManager {
         generateTemplates();
         kube.createNamespace(kube.getInfraNamespace(), Collections.singletonMap("allowed", "true"));
         KubeCMDClient.applyFromFile(kube.getInfraNamespace(), Paths.get(Environment.getInstance().getTemplatesPath(), "install", "bundles", productName));
-    }
-
-    private void installOlm(OLMInstallationType installation) throws Exception {
-        String namespace = getNamespaceByOlmInstallationType(installation);
-
-        if (installation == OLMInstallationType.SPECIFIC) {
-            kube.createNamespace(namespace, Collections.singletonMap("allowed", "true"));
-        }
-
-        Path catalogSourceFile = Files.createTempFile("catalogsource", ".yaml");
-        String catalogSource = Files.readString(Paths.get(Environment.getInstance().getTemplatesPath(), "install", "components", "example-olm", "catalog-source.yaml"));
-        Files.writeString(catalogSourceFile, catalogSource.replaceAll("\\$\\{OPERATOR_NAMESPACE}", namespace));
-        KubeCMDClient.applyFromFile(namespace, catalogSourceFile);
-
-        if (installation == OLMInstallationType.SPECIFIC) {
-            Path operatorGroupFile = Files.createTempFile("operatorgroup", ".yaml");
-            String operatorGroup = Files.readString(Paths.get(Environment.getInstance().getTemplatesPath(), "install", "components", "example-olm", "operator-group.yaml"));
-            Files.writeString(operatorGroupFile, operatorGroup.replaceAll("\\$\\{OPERATOR_NAMESPACE}", namespace));
-            KubeCMDClient.applyFromFile(namespace, operatorGroupFile);
-        }
-
-        Path subscriptionFile = Files.createTempFile("subscription", ".yaml");
-        String subscription = Files.readString(Paths.get(Environment.getInstance().getTemplatesPath(), "install", "components", "example-olm", "subscription.yaml"));
-        Files.writeString(subscriptionFile, subscription.replaceAll("\\$\\{OPERATOR_NAMESPACE}", namespace));
-        KubeCMDClient.applyFromFile(namespace, subscriptionFile);
-
-        TestUtils.waitForPodReady("enmasse-operator", namespace);
     }
 
     public void installExamplePlans(String namespace) {
@@ -187,7 +168,6 @@ public class EnmasseOperatorManager {
         LOGGER.info("Installing enmasse IoT operator from: {}", Environment.getInstance().getTemplatesPath());
         KubeCMDClient.applyFromFile(kube.getInfraNamespace(), Paths.get(Environment.getInstance().getTemplatesPath(), "install", "preview-bundles", "iot"));
         LOGGER.info("***********************************************************");
-
     }
 
     public void removeOperators() {
@@ -356,6 +336,6 @@ public class EnmasseOperatorManager {
     }
 
     public String getNamespaceByOlmInstallationType(OLMInstallationType installation) {
-        return installation == OLMInstallationType.DEFAULT ? kube.getOlmNamespace() : kube.getInfraNamespace();
+        return olm.getNamespaceByOlmInstallationType(installation);
     }
 }

--- a/systemtests/src/main/java/io/enmasse/systemtest/operator/OLMOperatorManager.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/operator/OLMOperatorManager.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.systemtest.operator;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import org.slf4j.Logger;
+
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+
+import io.enmasse.systemtest.Environment;
+import io.enmasse.systemtest.OLMInstallationType;
+import io.enmasse.systemtest.executor.Exec;
+import io.enmasse.systemtest.executor.ExecutionResultData;
+import io.enmasse.systemtest.logs.CustomLogger;
+import io.enmasse.systemtest.platform.KubeCMDClient;
+import io.enmasse.systemtest.platform.Kubernetes;
+import io.enmasse.systemtest.utils.TestUtils;
+
+public class OLMOperatorManager {
+
+    private static final String DEFAULT_NAME_ENMASSE_SOURCE = "enmasse-source";
+    private static final Logger log = CustomLogger.getLogger();
+    private Kubernetes kube = Kubernetes.getInstance();
+    private String clusterExternalImageRegistry;
+    private String clusterInternalImageRegistry;
+    private static OLMOperatorManager instance;
+
+    private OLMOperatorManager() {
+        clusterExternalImageRegistry = Environment.getInstance().getClusterExternalImageRegistry();
+        clusterInternalImageRegistry = Environment.getInstance().getClusterInternalImageRegistry();
+    }
+
+    public static synchronized OLMOperatorManager getInstance() {
+        if (instance == null) {
+            instance = new OLMOperatorManager();
+        }
+        return instance;
+    }
+
+    public void install(OLMInstallationType installation) throws Exception {
+        install(installation, getLatestManifestsImage(), getLatestStartingCsv());
+    }
+
+    public void install(OLMInstallationType installation, String manifestsImage, String csvName) throws Exception {
+        String namespace = getNamespaceByOlmInstallationType(installation);
+
+        if (installation == OLMInstallationType.SPECIFIC) {
+            kube.createNamespace(namespace, Collections.singletonMap("allowed", "true"));
+        }
+
+        String catalogSourceName = DEFAULT_NAME_ENMASSE_SOURCE;
+        String catalogNamespace = namespace;
+
+        buildPushCustomOperatorRegistry(catalogNamespace, manifestsImage);
+        String customRegistryImageToUse = getCustomOperatorRegistryInternalImage(catalogNamespace);
+        deployCatalogSource(catalogSourceName, catalogNamespace, customRegistryImageToUse);
+
+        if (installation == OLMInstallationType.SPECIFIC) {
+            Path operatorGroupFile = Files.createTempFile("operatorgroup", ".yaml");
+            String operatorGroup = Files.readString(Paths.get("custom-operator-registry", "operator-group.yaml"));
+            Files.writeString(operatorGroupFile, operatorGroup.replaceAll("\\$\\{OPERATOR_NAMESPACE}", namespace));
+            KubeCMDClient.applyFromFile(namespace, operatorGroupFile);
+        }
+
+        applySubscription(namespace, catalogSourceName, catalogNamespace, csvName);
+
+        TestUtils.waitForPodReady("enmasse-operator", namespace);
+
+    }
+
+    public void applySubscription(String installationNamespace, String catalogSourceName, String catalogNamespace, String csvName) throws IOException {
+        Path subscriptionFile = Files.createTempFile("subscription", ".yaml");
+        String subscription = Files.readString(Paths.get("custom-operator-registry", "subscription.yaml"));
+        Files.writeString(subscriptionFile,
+                subscription
+                    .replaceAll("\\$\\{OPERATOR_NAMESPACE}", installationNamespace)
+                    .replaceAll("\\$\\{CATALOG_SOURCE_NAME}", catalogSourceName)
+                    .replaceAll("\\$\\{CATALOG_NAMESPACE}", catalogNamespace)
+                    .replaceAll("\\$\\{CSV}", csvName));
+        KubeCMDClient.applyFromFile(installationNamespace, subscriptionFile);
+    }
+
+    public void deployCatalogSource(String catalogSourceName, String catalogNamespace, String customRegistryImageToUse) throws IOException {
+        Path catalogSourceFile = Files.createTempFile("catalogsource", ".yaml");
+        String catalogSource = Files.readString(Paths.get("custom-operator-registry", "catalog-source.yaml"));
+        Files.writeString(catalogSourceFile,
+                catalogSource
+                    .replaceAll("\\$\\{CATALOG_SOURCE_NAME}", catalogSourceName)
+                    .replaceAll("\\$\\{OPERATOR_NAMESPACE}", catalogNamespace)
+                    .replaceAll("\\$\\{REGISTRY_IMAGE}", customRegistryImageToUse));
+        KubeCMDClient.applyFromFile(catalogNamespace, catalogSourceFile);
+    }
+
+    public void buildPushCustomOperatorRegistry(String namespace, String manifestsImage) throws Exception {
+        String customRegistryImageToPush = clusterExternalImageRegistry+"/"+namespace+"/systemtests-operator-registry:latest";
+
+        String olmManifestsImage = manifestsImage.replace(clusterInternalImageRegistry, clusterExternalImageRegistry);
+
+        int retries = 5;
+        ExecutionResultData results = null;
+        while (retries > 0) {
+            results = Exec.execute(Arrays.asList("make", "-C", "custom-operator-registry", "FROM="+olmManifestsImage, "TAG="+customRegistryImageToPush), true);
+            if(results.getRetCode()) {
+                return;
+            }
+            Thread.sleep(1000);
+            retries--;
+        }
+        assertTrue(results != null && results.getRetCode(), "custom operator registry image build failed ");
+    }
+
+    public String getCustomOperatorRegistryInternalImage(String namespace) {
+        return clusterInternalImageRegistry+"/"+namespace+"/systemtests-operator-registry:latest";
+    }
+
+    public String getLatestStartingCsv() throws Exception {
+        String enmasseCSV = Files.readString(Paths.get(Environment.getInstance().getTemplatesPath().toString(), "install", "components", "example-olm", "subscription.yaml"));
+        var yaml = new YAMLMapper().readTree(enmasseCSV);
+        return yaml.get("spec").get("startingCSV").asText();
+    }
+
+    public String getLatestManifestsImage() throws Exception {
+        String exampleCatalogSource = Files.readString(Paths.get(Environment.getInstance().getTemplatesPath().toString(), "install", "components", "example-olm", "catalog-source.yaml"));
+        var tree = new YAMLMapper().readTree(exampleCatalogSource);
+        return tree.get("spec").get("image").asText();
+    }
+
+    public String getNamespaceByOlmInstallationType(OLMInstallationType installation) {
+        return installation == OLMInstallationType.DEFAULT ? kube.getOlmNamespace() : kube.getInfraNamespace();
+    }
+
+}

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/upgrade/UpgradeTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/upgrade/UpgradeTest.java
@@ -19,7 +19,6 @@ import io.enmasse.systemtest.bases.isolated.ITestIsolatedStandard;
 import io.enmasse.systemtest.condition.OpenShift;
 import io.enmasse.systemtest.condition.OpenShiftVersion;
 import io.enmasse.systemtest.executor.Exec;
-import io.enmasse.systemtest.executor.ExecutionResultData;
 import io.enmasse.systemtest.logs.CustomLogger;
 import io.enmasse.systemtest.logs.GlobalLogCollector;
 import io.enmasse.systemtest.messagingclients.AbstractClient;
@@ -44,6 +43,8 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 
 import java.io.IOException;
@@ -51,7 +52,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -77,6 +77,7 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
     private String infraNamespace;
     private EnmasseInstallType type;
     private OLMInstallationType olmType;
+    private EnmasseOperatorManager operatorManager = EnmasseOperatorManager.getInstance();
 
     @BeforeAll
     void prepareUpgradeEnv() throws Exception {
@@ -92,7 +93,7 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
         }
         boolean waitForNamespace = true;
         if (this.type.equals(EnmasseInstallType.BUNDLE)) {
-            assertTrue(EnmasseOperatorManager.getInstance().clean());
+            assertTrue(operatorManager.clean());
         } else if (this.type.equals(EnmasseInstallType.OLM)) {
             if (EnmasseOperatorManager.getInstance().isEnmasseOlmDeployed()) {
                 for (var addrSpace : kubernetes.getAddressSpaceClient(infraNamespace).list().getItems()) {
@@ -105,12 +106,12 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
                     }
                 }
             }
-            assertTrue(EnmasseOperatorManager.getInstance().removeOlm());
+            assertTrue(operatorManager.removeOlm());
             if (olmType != null && olmType == OLMInstallationType.DEFAULT) {
                 waitForNamespace = false;
             }
         } else {
-            EnmasseOperatorManager.getInstance().deleteEnmasseAnsible();
+            operatorManager.deleteEnmasseAnsible();
         }
         if (waitForNamespace) {
             TestUtils.waitForNamespaceDeleted(kubernetes, infraNamespace);
@@ -140,7 +141,7 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
     void testUpgradeOLMSpecific(String version, String templates) throws Exception {
         this.type = EnmasseInstallType.OLM;
         this.olmType = OLMInstallationType.SPECIFIC;
-        this.infraNamespace = EnmasseOperatorManager.getInstance().getNamespaceByOlmInstallationType(olmType);
+        this.infraNamespace = operatorManager.getNamespaceByOlmInstallationType(olmType);
         doTestUpgrade(templates, version);
     }
 
@@ -150,7 +151,7 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
     void testUpgradeOLMDefault(String version, String templates) throws Exception {
         this.type = EnmasseInstallType.OLM;
         this.olmType = OLMInstallationType.DEFAULT;
-        this.infraNamespace = EnmasseOperatorManager.getInstance().getNamespaceByOlmInstallationType(olmType);
+        this.infraNamespace = operatorManager.getNamespaceByOlmInstallationType(olmType);
         doTestUpgrade(templates, version);
     }
 
@@ -433,37 +434,9 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
     }
 
     private void installEnmasseOLM(Path templateDir, String version) throws Exception {
-
-        if (olmType == OLMInstallationType.SPECIFIC) {
-            kubernetes.createNamespace(infraNamespace, Collections.singletonMap("allowed", "true"));
-        }
-
-        String catalogSourceName;
-        String catalogNamespace;
-        if (version.startsWith("0.30")) {
-            catalogSourceName = "community-operators";
-            catalogNamespace = "openshift-marketplace";
-        } else {
-            catalogSourceName = "enmasse-source";
-            catalogNamespace = infraNamespace;
-
-            String customRegistryImageToUse = buildPushCustomOperatorRegistry(catalogNamespace, templateDir, version);
-
-            deployCatalogSource(catalogSourceName, catalogNamespace, customRegistryImageToUse);
-        }
-
-        if (olmType == OLMInstallationType.SPECIFIC) {
-            Path operatorGroupFile = Files.createTempFile("operatorgroup", ".yaml");
-            String operatorGroup = Files.readString(Paths.get("custom-operator-registry", "operator-group.yaml"));
-            Files.writeString(operatorGroupFile, operatorGroup.replaceAll("\\$\\{OPERATOR_NAMESPACE}", infraNamespace));
-            KubeCMDClient.applyFromFile(infraNamespace, operatorGroupFile);
-        }
-
+        String manifestsImage = getManifestsImage(templateDir, version);
         String csvName = getCsvName(templateDir, version);
-
-        applySubscription(infraNamespace, catalogSourceName, catalogNamespace, csvName);
-
-        TestUtils.waitForPodReady("enmasse-operator", infraNamespace);
+        operatorManager.olm().install(olmType, manifestsImage, csvName);
 
         Thread.sleep(30_000);
 
@@ -471,91 +444,43 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
         KubeCMDClient.applyFromFile(infraNamespace, Paths.get(templateDir.toString(), "install", "components", "example-authservices", "standard-authservice.yaml"));
 
         Thread.sleep(60_000);
-        EnmasseOperatorManager.getInstance().waitUntilOperatorReadyOlm(olmType);
+        operatorManager.waitUntilOperatorReadyOlm(olmType);
         Thread.sleep(30_000);
-    }
-
-    private void applySubscription(String installationNamespace, String catalogSourceName, String catalogNamespace, String csvName) throws IOException {
-        Path subscriptionFile = Files.createTempFile("subscription", ".yaml");
-        String subscription = Files.readString(Paths.get("custom-operator-registry", "subscription.yaml"));
-        Files.writeString(subscriptionFile,
-                subscription
-                    .replaceAll("\\$\\{OPERATOR_NAMESPACE}", installationNamespace)
-                    .replaceAll("\\$\\{CATALOG_SOURCE_NAME}", catalogSourceName)
-                    .replaceAll("\\$\\{CATALOG_NAMESPACE}", catalogNamespace)
-                    .replaceAll("\\$\\{CSV}", csvName));
-        KubeCMDClient.applyFromFile(installationNamespace, subscriptionFile);
-    }
-
-    private void deployCatalogSource(String catalogSourceName, String catalogNamespace, String customRegistryImageToUse) throws IOException {
-        Path catalogSourceFile = Files.createTempFile("catalogsource", ".yaml");
-        String catalogSource = Files.readString(Paths.get("custom-operator-registry", "catalog-source.yaml"));
-        Files.writeString(catalogSourceFile,
-                catalogSource
-                    .replaceAll("\\$\\{CATALOG_SOURCE_NAME}", catalogSourceName)
-                    .replaceAll("\\$\\{OPERATOR_NAMESPACE}", catalogNamespace)
-                    .replaceAll("\\$\\{REGISTRY_IMAGE}", customRegistryImageToUse));
-        KubeCMDClient.applyFromFile(catalogNamespace, catalogSourceFile);
     }
 
     private void upgradeEnmasseOLM(Path upgradeTemplates, String previousVersion) throws Exception {
         String newVersion = getVersionFromTemplateDir(upgradeTemplates);
-        String customRegistryImageToUse = buildPushCustomOperatorRegistry(infraNamespace, upgradeTemplates, newVersion);
+        String manifestsImage = getManifestsImage(upgradeTemplates, newVersion);
+        //update manifests image
+        operatorManager.olm().buildPushCustomOperatorRegistry(infraNamespace, manifestsImage);
 
-        String catalogSourceName = "enmasse-source";
-        String catalogNamespace = infraNamespace;
-        if (previousVersion.startsWith("0.30")) {
-            deployCatalogSource(catalogSourceName, catalogNamespace, customRegistryImageToUse);
-        } else {
-            kubernetes.deletePod(infraNamespace, Map.of("olm.catalogSource", "enmasse-source"));
-        }
+        //delete catalog pod to force update
+        kubernetes.deletePod(infraNamespace, Map.of("olm.catalogSource", "enmasse-source"));
 
         String csvName = getCsvName(upgradeTemplates, newVersion);
-
+        String catalogSourceName = "enmasse-source";
+        String catalogNamespace = infraNamespace;
         //update subscription to point to new catalog and to use latest csv
-        applySubscription(infraNamespace, catalogSourceName, catalogNamespace, csvName);
+        operatorManager.olm().applySubscription(infraNamespace, catalogSourceName, catalogNamespace, csvName);
 
         //should update
         Thread.sleep(300_000);
         checkImagesUpdated(getVersionFromTemplateDir(upgradeTemplates));
     }
 
-    private String buildPushCustomOperatorRegistry(String namespace, Path templateDir, String version) throws Exception {
-        String customRegistryImageToPush = environment.getClusterExternalImageRegistry()+"/"+namespace+"/systemtests-operator-registry:latest";
-        String customRegistryImageToUse = environment.getClusterInternalImageRegistry()+"/"+namespace+"/systemtests-operator-registry:latest";
-
-        String olmManifestsImage;
+    private String getManifestsImage(Path templateDir, String version) throws IOException, JsonProcessingException, JsonMappingException {
+        String manifestsImage;
         if (version.equals("1.3")) {
             String exampleCatalogSource = Files.readString(Paths.get(templateDir.toString(), "install", "components", "enmasse-operator", "050-Deployment-enmasse-operator.yaml"));
-            log.info(exampleCatalogSource);
-
-            log.info("Enmasse operator deployment found : {}", exampleCatalogSource!=null && !exampleCatalogSource.isEmpty());
             var yaml = new YAMLMapper().readTree(exampleCatalogSource);
             var spec = yaml.get("spec").get("template").get("spec");
-            log.info("Spec fields");
-            spec.fieldNames().forEachRemaining(log::info);
-            olmManifestsImage = spec.get("containers").get(0).get("image").asText();
+            manifestsImage = spec.get("containers").get(0).get("image").asText();
         } else {
             String exampleCatalogSource = Files.readString(Paths.get(templateDir.toString(), "install", "components", "example-olm", "catalog-source.yaml"));
             var tree = new YAMLMapper().readTree(exampleCatalogSource);
-            olmManifestsImage = tree.get("spec").get("image").asText();
+            manifestsImage = tree.get("spec").get("image").asText();
         }
-
-        olmManifestsImage = olmManifestsImage.replace(environment.getClusterInternalImageRegistry(), environment.getClusterExternalImageRegistry());
-
-        int retries = 5;
-        ExecutionResultData results = null;
-        while (retries > 0) {
-            results = Exec.execute(Arrays.asList("make", "-C", "custom-operator-registry", "FROM="+olmManifestsImage, "TAG="+customRegistryImageToPush), true);
-            if(results.getRetCode()) {
-                return customRegistryImageToUse;
-            }
-            Thread.sleep(1000);
-            retries--;
-        }
-        assertTrue(results != null && results.getRetCode(), "custom operator registry image build failed ");
-
-        return customRegistryImageToUse;
+        return manifestsImage;
     }
 
     private String getCsvName(Path templateDir, String version) throws Exception {


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Enhancement

### Description
This PR changes the Dockerfile for olm-manifests and modifies systemtests to build a operator registry from the olm-manifests
<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [x] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
