### PR TITLE
broker init.sh - stops execution of a script if a command has an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ## 0.31.2
 * #4305: Inject OpenShift generated custom CA trust bundle into console pod so that console authentication works when a custom CA is in use.
+* #4358: broker init.sh stop script execution of a script if a command has an error (#4359)
 
 ## 0.31.1
 * #4046: add network-only as fetch policy for all queries 

--- a/broker-plugin/plugin/src/main/sh/init-broker.sh
+++ b/broker-plugin/plugin/src/main/sh/init-broker.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 #ENV_VARS
 BROKER_DIR=$ARTEMIS_HOME
 BROKER_PLUGIN_DIR=/opt/broker-plugin
@@ -38,7 +40,7 @@ function configure_shared() {
 function configure_standard() {
     if [ -n "$TOPIC_NAME" ]; then
         cp $CONFIG_TEMPLATES/standard/sharded-topic/broker.xml /tmp/broker.xml
-    elif [ -n $QUEUE_NAME ] && [ "$QUEUE_NAME" != "" ]; then
+    elif [ -n "$QUEUE_NAME" ] && [ "$QUEUE_NAME" != "" ]; then
         cp $CONFIG_TEMPLATES/standard/sharded-queue/broker.xml /tmp/broker.xml
     else
         cp $CONFIG_TEMPLATES/standard/colocated/broker.xml /tmp/broker.xml


### PR DESCRIPTION
### Type of change


- Bugfix

### Description

Broker's init.sh should stop execution and return a non-zero return code to the execution environment if an initialisation command ends in error.

### Checklist


- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
