### PR TITLE
Documentation - fix get log anchors

### DIFF
--- a/documentation/modules/proc-get-logs-broker.adoc
+++ b/documentation/modules/proc-get-logs-broker.adoc
@@ -3,7 +3,7 @@
 // assembly-monitoring-oc.adoc
 // assembly-monitoring-kube.adoc
 
-[id='get-logs-router-{context}']
+[id='get-logs-broker-{context}']
 = Viewing broker logs
 
 For the `brokered` or `standard` address space type, you can view the broker logs to troubleshoot issues with clients not connecting or issues with sending and receiving messages.

--- a/documentation/modules/proc-get-logs-router.adoc
+++ b/documentation/modules/proc-get-logs-router.adoc
@@ -3,7 +3,7 @@
 // assembly-monitoring-oc.adoc
 // assembly-monitoring-kube.adoc
 
-[id='get-logs-broker-{context}']
+[id='get-logs-router-{context}']
 = Viewing router logs
 
 For the `standard` address space type, you can view the router logs to troubleshoot issues with clients not connecting or issues with sending and receiving messages.


### PR DESCRIPTION
### Type of change


- Documentation

### Description

The anchors to get broker logs and get router logs are switched around.

### Checklist


- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
