### PR TITLE
Make uninstall part less verbose

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/listener/JunitExecutionListener.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/listener/JunitExecutionListener.java
@@ -35,7 +35,8 @@ public class JunitExecutionListener implements TestExecutionListener {
 
     @Override
     public void testPlanExecutionFinished(TestPlan testPlan) {
-
+        LOGGER.info("================================================================");
+        LOGGER.info("Test plan finished");
         var tags = TestInfo.getInstance().getTestRunTags();
         if (tags != null && tags.size() == 1 && tags.get(0).equals(TestTag.FRAMEWORK)) {
             LOGGER.info("Running framework tests, no cleanup performed");

--- a/systemtests/src/main/java/io/enmasse/systemtest/operator/EnmasseOperatorManager.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/operator/EnmasseOperatorManager.java
@@ -242,7 +242,7 @@ public class EnmasseOperatorManager {
     public void removeIoT() {
         LOGGER.info("Delete enmasse IoT from: {}", Environment.getInstance().getTemplatesPath());
         KubeCMDClient.deleteFromFile(kube.getInfraNamespace(), Paths.get(Environment.getInstance().getTemplatesPath(), "install", "preview-bundles", "iot"));
-        KubeCMDClient.runOnCluster("delete", "iotconfigs", "-n", kube.getInfraNamespace());
+        KubeCMDClient.runOnClusterWithoutLogger("delete", "iotconfigs", "-n", kube.getInfraNamespace());
     }
 
     public void deleteEnmasseAnsible() {
@@ -259,14 +259,14 @@ public class EnmasseOperatorManager {
 
     public boolean clean() throws Exception {
         cleanCRDs();
-        KubeCMDClient.runOnCluster("delete", "clusterrolebindings", "-l", "app=enmasse");
-        KubeCMDClient.runOnCluster("delete", "clusterroles", "-l", "app=enmasse");
-        KubeCMDClient.runOnCluster("delete", "apiservices", "-l", "app=enmasse");
-        KubeCMDClient.runOnCluster("delete", "oauthclients", "-l", "app=enmasse");
+        KubeCMDClient.runOnClusterWithoutLogger("delete", "clusterrolebindings", "-l", "app=enmasse");
+        KubeCMDClient.runOnClusterWithoutLogger("delete", "clusterroles", "-l", "app=enmasse");
+        KubeCMDClient.runOnClusterWithoutLogger("delete", "apiservices", "-l", "app=enmasse");
+        KubeCMDClient.runOnClusterWithoutLogger("delete", "oauthclients", "-l", "app=enmasse");
         if (kube.getOcpVersion() == OpenShiftVersion.OCP4) {
-            KubeCMDClient.runOnCluster("delete", "consolelinks", "-l", "app=enmasse");
+            KubeCMDClient.runOnClusterWithoutLogger("delete", "consolelinks", "-l", "app=enmasse");
         }
-        KubeCMDClient.runOnCluster("delete", "clusterservicebrokers", "-l", "app=enmasse");
+        KubeCMDClient.runOnClusterWithoutLogger("delete", "clusterservicebrokers", "-l", "app=enmasse");
         if (!kube.getInfraNamespace().equals(kube.getOlmNamespace())) {
             kube.deleteNamespace(kube.getInfraNamespace(), Duration.ofMinutes(kube.getOcpVersion() == OpenShiftVersion.OCP4 ? 10 : 5));
         }
@@ -274,8 +274,8 @@ public class EnmasseOperatorManager {
     }
 
     private void cleanCRDs() {
-        KubeCMDClient.runOnCluster("delete", "crd", "-l", "app=enmasse,enmasse-component=iot");
-        KubeCMDClient.runOnClusterWithTimeout(600_000, "delete", "crd", "-l", "app=enmasse", "--timeout=600s");
+        KubeCMDClient.runOnClusterWithoutLogger("delete", "crd", "-l", "app=enmasse,enmasse-component=iot");
+        KubeCMDClient.runOnClusterWithoutLogger("delete", "crd", "-l", "app=enmasse", "--timeout=300s");
     }
 
     public void waitUntilOperatorReadyOlm() throws Exception {

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/KubeCMDClient.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/KubeCMDClient.java
@@ -370,7 +370,7 @@ public class KubeCMDClient {
     public static ExecutionResultData deleteFromFile(String namespace, Path path) {
         Objects.requireNonNull(namespace);
         Objects.requireNonNull(path);
-        return runOnClusterWithoutLogger(CMD, "-n", namespace, "delete", "-f", path.toString());
+        return runOnClusterWithoutLogger("-n", namespace, "delete", "-f", path.toString());
     }
 
     public static String getMessagingEndpoint(String namespace, String addressspace) {

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/KubeCMDClient.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/KubeCMDClient.java
@@ -370,7 +370,7 @@ public class KubeCMDClient {
     public static ExecutionResultData deleteFromFile(String namespace, Path path) {
         Objects.requireNonNull(namespace);
         Objects.requireNonNull(path);
-        return Exec.execute(Arrays.asList(CMD, "-n", namespace, "delete", "-f", path.toString()), ONE_MINUTE_TIMEOUT, true);
+        return runOnClusterWithoutLogger(CMD, "-n", namespace, "delete", "-f", path.toString());
     }
 
     public static String getMessagingEndpoint(String namespace, String addressspace) {
@@ -426,7 +426,7 @@ public class KubeCMDClient {
         List<String> command = new LinkedList<>();
         command.add(CMD);
         command.addAll(Arrays.asList(args));
-        return Exec.execute(command, ONE_MINUTE_TIMEOUT, false);
+        return Exec.execute(command, FIVE_MINUTES_TIMEOUT, false);
     }
 
     public static void awaitRollout(TimeoutBudget budget, String namespace, String deploymentName) {


### PR DESCRIPTION
When I read transcript log of systemtests I'm totally lost in all output of command when uninstall is running. So this pr make uninstall part less verbose for better readability.