### PR TITLE
Fix up the wiring when using the split registry deployment models

### DIFF
--- a/iot/iot-device-registry-base/src/main/java/io/enmasse/iot/registry/server/DeviceRegistryAmqpServer.java
+++ b/iot/iot-device-registry-base/src/main/java/io/enmasse/iot/registry/server/DeviceRegistryAmqpServer.java
@@ -1,16 +1,19 @@
 /*
- * Copyright 2019, EnMasse authors.
+ * Copyright 2019-2020, EnMasse authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 
 package io.enmasse.iot.registry.server;
 
 import org.eclipse.hono.config.ServiceConfigProperties;
+import org.eclipse.hono.service.amqp.AmqpEndpoint;
 import org.eclipse.hono.service.amqp.AmqpServiceBase;
 import org.eclipse.hono.util.Constants;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.stereotype.Component;
 
 @Component
+@ConditionalOnBean(AmqpEndpoint.class)
 public final class DeviceRegistryAmqpServer extends AmqpServiceBase<ServiceConfigProperties> {
 
     @Override

--- a/iot/iot-device-registry-base/src/main/java/io/enmasse/iot/registry/server/DeviceRegistryRestServer.java
+++ b/iot/iot-device-registry-base/src/main/java/io/enmasse/iot/registry/server/DeviceRegistryRestServer.java
@@ -1,14 +1,17 @@
 /*
- * Copyright 2019, EnMasse authors.
+ * Copyright 2019-2020, EnMasse authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 
 package io.enmasse.iot.registry.server;
 
 import org.eclipse.hono.config.ServiceConfigProperties;
+import org.eclipse.hono.service.http.HttpEndpoint;
 import org.eclipse.hono.service.http.HttpServiceBase;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.stereotype.Component;
 
 @Component
+@ConditionalOnBean(HttpEndpoint.class)
 public class DeviceRegistryRestServer extends HttpServiceBase<ServiceConfigProperties> {
 }

--- a/pkg/controller/iotconfig/adapter.go
+++ b/pkg/controller/iotconfig/adapter.go
@@ -242,21 +242,16 @@ func AppendHonoAdapterEnvs(config *iotv1alpha1.IoTConfig, container *corev1.Cont
 	username := adapter.Name + "-adapter@HONO"
 	password := config.Status.Adapters[adapter.Name].InterServicePassword
 
-	registryServiceName, err := getRegistryAdapterServiceName(config)
-	if err != nil {
-		return err
-	}
-
 	container.Env = append(container.Env, []corev1.EnvVar{
 		{Name: "HONO_MESSAGING_HOST", Value: "localhost"},
 		{Name: "HONO_MESSAGING_PORT", Value: "5672"},
 		{Name: "HONO_COMMAND_HOST", Value: "localhost"},
 		{Name: "HONO_COMMAND_PORT", Value: "5672"},
 
-		{Name: "HONO_REGISTRATION_HOST", Value: FullHostNameForEnvVar(registryServiceName)},
+		{Name: "HONO_REGISTRATION_HOST", Value: FullHostNameForEnvVar(nameDeviceRegistry)},
 		{Name: "HONO_REGISTRATION_USERNAME", Value: username},
 		{Name: "HONO_REGISTRATION_PASSWORD", Value: password},
-		{Name: "HONO_CREDENTIALS_HOST", Value: FullHostNameForEnvVar(registryServiceName)},
+		{Name: "HONO_CREDENTIALS_HOST", Value: FullHostNameForEnvVar(nameDeviceRegistry)},
 		{Name: "HONO_CREDENTIALS_USERNAME", Value: username},
 		{Name: "HONO_CREDENTIALS_PASSWORD", Value: password},
 		{Name: "HONO_DEVICE_CONNECTION_HOST", Value: FullHostNameForEnvVar("iot-device-connection")},
@@ -499,5 +494,5 @@ func mergeAdapterOptions(first, second *iotv1alpha1.AdapterOptions) iotv1alpha1.
 
 func applyDefaultAdapterDeploymentSpec(deployment *appsv1.Deployment) {
 	deployment.Spec.Template.Spec.ServiceAccountName = "iot-protocol-adapter"
-	deployment.Annotations[util.ConnectsTo] = "iot-auth-service,iot-device-registry,iot-tenant-service"
+	deployment.Annotations[util.ConnectsTo] = "iot-auth-service,iot-device-connection,iot-device-registry,iot-tenant-service"
 }

--- a/pkg/controller/iotconfig/infinispan_device_registry.go
+++ b/pkg/controller/iotconfig/infinispan_device_registry.go
@@ -43,9 +43,6 @@ func (r *ReconcileIoTConfig) reconcileInfinispanDeviceRegistryDeployment(config 
 	deployment.Spec.Template.Spec.ServiceAccountName = "iot-device-registry"
 	deployment.Spec.Template.Annotations[RegistryTypeAnnotation] = "infinispan"
 
-	deployment.Spec.Template.Labels[RegistryAdapterFeatureLabel] = "true"
-	deployment.Spec.Template.Labels[RegistryManagementFeatureLabel] = "true"
-
 	service := config.Spec.ServicesConfig.DeviceRegistry
 	applyDefaultDeploymentConfig(deployment, service.Infinispan.ServiceConfig, nil)
 

--- a/pkg/controller/iotconfig/iotconfig_controller.go
+++ b/pkg/controller/iotconfig/iotconfig_controller.go
@@ -55,9 +55,6 @@ const DeviceConnectionTypeAnnotation = iotPrefix + "/deviceConnection.type"
 const RegistryTypeAnnotation = iotPrefix + "/registry.type"
 const RegistryJdbcModeAnnotation = iotPrefix + "/registry.jdbc.mode"
 
-const RegistryAdapterFeatureLabel = iotPrefix + "/registry-adapter"
-const RegistryManagementFeatureLabel = iotPrefix + "/registry-management"
-
 var log = logf.Log.WithName("controller_iotconfig")
 
 // Gets called by parent "init", adding as to the manager

--- a/pkg/controller/iotconfig/monitoring.go
+++ b/pkg/controller/iotconfig/monitoring.go
@@ -54,7 +54,7 @@ func allTargets(config *iotv1alpha1.IoTConfig) []MonitoringTarget {
 		// we can ignore the error here, as it will be handled by the reconcile loop anyway
 		if split {
 			targets = append(targets, []MonitoringTarget{
-				{nameDeviceRegistryAdapter},
+				{nameDeviceRegistry},
 				{nameDeviceRegistryManagement},
 			}...)
 		} else {

--- a/pkg/controller/iotconfig/secret_handler.go
+++ b/pkg/controller/iotconfig/secret_handler.go
@@ -96,7 +96,6 @@ func (s secretHandler) allSecrets(meta v1.Object) []string {
 				nameAuthService+"-tls",
 				nameDeviceConnection+"-tls",
 				nameDeviceRegistry+"-tls",
-				nameDeviceRegistryAdapter+"-tls",
 				nameDeviceRegistryManagement+"-tls",
 				nameTenantService+"-tls",
 				nameServiceMeshInter+"-tls",

--- a/pkg/controller/iotconfig/utils.go
+++ b/pkg/controller/iotconfig/utils.go
@@ -221,7 +221,7 @@ func (r *ReconcileIoTConfig) reconcileMetricsService(serviceName string) func(co
 
 // Configure a metrics service for hono standard components.
 // Hono exposes metrics on /prometheus on the health endpoint. We create a "<component>-metrics" service and map
-// the "prometheus" port form the service to the "health" port of the container. So we can define a "prometheus"
+// the "prometheus" port from the service to the "health" port of the container. So we can define a "prometheus"
 // port on the ServiceMonitor on EnMasse with a custom path of "/prometheus".
 func processReconcileMetricsService(_ *iotv1alpha1.IoTConfig, serviceName string, service *corev1.Service) error {
 

--- a/systemtests/src/main/java/io/enmasse/systemtest/utils/IoTUtils.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/utils/IoTUtils.java
@@ -67,7 +67,6 @@ public class IoTUtils {
     private static final String IOT_HTTP_ADAPTER = "iot-http-adapter";
     private static final String IOT_AUTH_SERVICE = "iot-auth-service";
     private static final String IOT_DEVICE_REGISTRY = "iot-device-registry";
-    private static final String IOT_DEVICE_REGISTRY_ADAPTER = "iot-device-registry-adapter";
     private static final String IOT_DEVICE_REGISTRY_MANAGEMENT = "iot-device-registry-management";
     private static final String IOT_DEVICE_CONNECTION = "iot-device-connection";
     private static final String IOT_TENANT_SERVICE = "iot-tenant-service";
@@ -157,6 +156,8 @@ public class IoTUtils {
 
         // device registry
 
+        expectedDeployments.add(IOT_DEVICE_REGISTRY);
+
         if (config.getSpec().getServices() != null &&
                 config.getSpec().getServices().getDeviceRegistry() != null &&
                 config.getSpec().getServices().getDeviceRegistry().getJdbc() != null &&
@@ -167,15 +168,8 @@ public class IoTUtils {
 
             var external = config.getSpec().getServices().getDeviceRegistry().getJdbc().getServer().getExternal();
             if ( external.getManagement() != null && external.getAdapter() != null ) {
-                expectedDeployments.add(IOT_DEVICE_REGISTRY_ADAPTER);
                 expectedDeployments.add(IOT_DEVICE_REGISTRY_MANAGEMENT);
-            } else if (external.getManagement() == null && external.getAdapter() != null ) {
-                expectedDeployments.add(IOT_DEVICE_REGISTRY_ADAPTER);
-            } else {
-                expectedDeployments.add(IOT_DEVICE_REGISTRY);
             }
-        } else {
-            expectedDeployments.add(IOT_DEVICE_REGISTRY);
         }
 
         // common services

--- a/systemtests/src/test/java/io/enmasse/systemtest/iot/isolated/SimpleK8sDeployTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/iot/isolated/SimpleK8sDeployTest.java
@@ -107,7 +107,7 @@ class SimpleK8sDeployTest extends TestBase implements ITestIoTIsolated {
                 .endTenant()
 
                 .withDeviceConnection(DefaultDeviceRegistry.newPostgresBasedConnection(jdbcEndpoint))
-                .withDeviceRegistry(DefaultDeviceRegistry.newPostgresBasedRegistry(jdbcEndpoint, Mode.JSON_TREE))
+                .withDeviceRegistry(DefaultDeviceRegistry.newPostgresBasedRegistry(jdbcEndpoint, Mode.JSON_TREE, false))
 
                 .editDeviceConnection()
                 .editJdbc()

--- a/systemtests/src/test/java/io/enmasse/systemtest/iot/isolated/registry/PostgresTableSplitDeviceRegistryTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/iot/isolated/registry/PostgresTableSplitDeviceRegistryTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019-2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.enmasse.systemtest.iot.isolated.registry;
+
+import static io.enmasse.systemtest.TestTag.ACCEPTANCE;
+import static io.enmasse.systemtest.iot.DefaultDeviceRegistry.newPostgresSplitTableBased;
+import static io.enmasse.systemtest.utils.IoTUtils.assertCorrectRegistryMode;
+import static io.enmasse.systemtest.utils.IoTUtils.assertCorrectRegistryType;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.enmasse.iot.model.v1.IoTConfigBuilder;
+import io.enmasse.iot.model.v1.Mode;
+import io.enmasse.systemtest.iot.IoTTestSession;
+
+/**
+ * Postgres table model, split adapter and management pods.
+ */
+class PostgresTableSplitDeviceRegistryTest extends DeviceRegistryTest {
+
+    @Override
+    protected IoTConfigBuilder provideIoTConfig() throws Exception {
+        return IoTTestSession
+                .createDefaultConfig()
+                .editOrNewSpec()
+                .withServices(newPostgresSplitTableBased())
+                .endSpec();
+    }
+
+    @Test
+    void testCorrectTypeDeployed () {
+        assertCorrectRegistryType("jdbc");
+        assertCorrectRegistryMode(Mode.TABLE);
+    }
+
+    @Test
+    @Tag(ACCEPTANCE)
+    void testRegisterDevice() throws Exception {
+        super.doTestRegisterDevice();
+    }
+
+    @Test
+    @Tag(ACCEPTANCE)
+    void testDisableDevice() throws Exception {
+        super.doTestDisableDevice();
+    }
+
+    @Test
+    void testDeviceCredentials() throws Exception {
+        super.doTestDeviceCredentials();
+    }
+
+    @Test
+    void testDeviceCredentialsPlainPassword() throws Exception {
+        super.doTestDeviceCredentialsPlainPassword();
+    }
+
+    @Test
+    @Disabled("Fixed in hono/pull/1565")
+    void testDeviceCredentialsDoesNotContainsPasswordDetails() throws Exception {
+        super.doTestDeviceCredentialsDoesNotContainsPasswordDetails();
+    }
+
+    @Test
+    @Disabled("Caches expire a bit unpredictably")
+    void testCacheExpiryForCredentials() throws Exception {
+        super.doTestCacheExpiryForCredentials();
+    }
+
+    @Test
+    void testSetExpiryForCredentials() throws Exception {
+        super.doTestSetExpiryForCredentials();
+    }
+
+    @Test
+    void testCreateForNonExistingTenantFails() throws Exception {
+        super.doTestCreateForNonExistingTenantFails();
+    }
+
+    @Test
+    void testCreateDuplicateDeviceFails() throws Exception {
+        super.doCreateDuplicateDeviceFails();
+    }
+
+    @Test
+    void testRegisterMultipleDevices() throws Exception {
+        super.doRegisterMultipleDevices();
+    }
+
+    @Test
+    void testTenantDeletionTriggersDevicesDeletion() throws Exception {
+        super.doTestTenantDeletionTriggersDevicesDeletion();
+    }
+}


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix
- Refactoring

### Description

**Note:** This is already based on @dejanb's PR, implementing the missing JDBC device registry bits.

There had been a few issues with the split deployment. The main reason for that was the fact
that we did not have a system test for it. That is added now.

Also did the services not properly select their backing pods. Fixed as well.

I reverted back from the completely split naming (iot-device-registry-adapter and iot-device-registry-management). The `iot-device-registry` service will now stay, and additionally a `iot-device-registry-management` service will be created/deleted.

The metrics service for the split mode was fixed as well.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
