### PR TITLE
[Docs] Fix CLI/Jolokia command descriptions

### DIFF
--- a/documentation/modules/proc-examine-broker-state.adoc
+++ b/documentation/modules/proc-examine-broker-state.adoc
@@ -60,14 +60,14 @@ In the standard address, there may be many brokers.  To identify the broker(s) h
 
 . Execute support commands on the broker's pod:
 +
-To execute an {BrokerName} Jolokia JMX command, use a command similar to the following:
+To execute an {BrokerName} CLI command, use a command similar to the following:
 +
 [options="nowrap",subs="+quotes,attributes"]
 ----
 {cmdcli} exec _broker pod name_ -- {BrokerCLI} address show --user _username_ --password _password_
 ----
 +
-To execute an {BrokerName} CLI command, use a command similar to the following:
+To execute an {BrokerName} Jolokia JMX command, use a command similar to the following:
 +
 [options="nowrap",subs="+quotes,attributes"]
 ----


### PR DESCRIPTION

### Type of change


- Documentation

### Description

Command descriptions associated with the commands lines were the wrong way about.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
