### PR TITLE
Add performance test of create and delete

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/messaginginfra/ResourceManager.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/messaginginfra/ResourceManager.java
@@ -185,8 +185,6 @@ public class ResourceManager {
     @SafeVarargs
     public final <T extends HasMetadata> void createResource(boolean waitReady, T... resources) {
 
-        LOGGER.info("Creating {} resources", resources.length);
-
         for (T resource : resources) {
             ResourceType<T> type = findResourceType(resource);
             if (type == null) {
@@ -199,7 +197,7 @@ public class ResourceManager {
                 createResource(waitReady, new NamespaceBuilder().editOrNewMetadata().withName(resource.getMetadata().getNamespace()).endMetadata().build());
             }
 
-            LOGGER.debug("Create/Update of {} {} in namespace {}",
+            LOGGER.info("Create/Update of {} {} in namespace {}",
                     resource.getKind(), resource.getMetadata().getName(), resource.getMetadata().getNamespace() == null ? "(not set)" : resource.getMetadata().getNamespace());
 
             type.create(resource);
@@ -208,9 +206,6 @@ public class ResourceManager {
         pointerResources.push(() -> {
             deleteResource(resources);
         });
-
-
-        LOGGER.info("Waiting for {} resources to be ready", resources.length);
 
         if (waitReady) {
             for (T resource : resources) {
@@ -236,14 +231,13 @@ public class ResourceManager {
 
     @SafeVarargs
     public final <T extends HasMetadata> void deleteResource(T... resources) throws Exception {
-        LOGGER.info("Deleting {} resources", resources.length);
         for (T resource : resources) {
             ResourceType<T> type = findResourceType(resource);
             if (type == null) {
                 LOGGER.warn("Can't find resource type, please create it manually");
                 continue;
             }
-            LOGGER.debug("Delete of {} {} in namespace {}",
+            LOGGER.info("Delete of {} {} in namespace {}",
                     resource.getKind(), resource.getMetadata().getName(), resource.getMetadata().getNamespace() == null ? "(not set)" : resource.getMetadata().getNamespace());
             type.delete(resource);
             cleanDefault(resource);

--- a/systemtests/src/main/java/io/enmasse/systemtest/scale/ResultWriter.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/scale/ResultWriter.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.systemtest.scale;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Map;
+
+public class ResultWriter {
+    private final Path rootDir;
+
+    public ResultWriter(Path rootDir) {
+        this.rootDir = rootDir;
+    }
+
+    public void write(Map<String, Object> result) throws Exception {
+        saveResultsFile("results.json", result);
+        savePlotCSV("plot.dat", result);
+    }
+
+    private void saveResultsFile(String filename, Map<String, Object> result) throws Exception {
+        var mapper = new ObjectMapper().writerWithDefaultPrettyPrinter();
+        Files.createDirectories(rootDir);
+        Files.write(rootDir.resolve(filename), mapper.writeValueAsBytes(result));
+    }
+
+    private void savePlotCSV(String fileName, Map<String, Object> data) throws IOException {
+        Files.createDirectories(rootDir);
+        Path file = rootDir.resolve(fileName);
+        try (BufferedWriter writer = Files.newBufferedWriter(file, StandardCharsets.UTF_8, StandardOpenOption.CREATE)) {
+            writer.write(String.join(",", data.keySet().toArray(new String[0])));
+            writer.newLine();
+            writer.write(String.join(",", data.values().stream().map(value -> value.toString().replaceAll("\\D+", "")).toArray(String[]::new)));
+            writer.newLine();
+        }
+    }
+}

--- a/systemtests/src/main/java/io/enmasse/systemtest/scale/ResultWriter.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/scale/ResultWriter.java
@@ -22,19 +22,19 @@ public class ResultWriter {
     }
 
     public void write(Map<String, Object> result) throws Exception {
-        saveResultsFile("results.json", result);
-        savePlotCSV("plot.dat", result);
+        Files.createDirectories(rootDir);
+        saveResultsFile(rootDir.resolve("results.json"), result);
+        Path plotDir = rootDir.resolve("plot-data");
+        Files.createDirectories(plotDir);
+        savePlotCSV(plotDir.resolve("plot.dat"),result);
     }
 
-    private void saveResultsFile(String filename, Map<String, Object> result) throws Exception {
+    private void saveResultsFile(Path file, Map<String, Object> result) throws Exception {
         var mapper = new ObjectMapper().writerWithDefaultPrettyPrinter();
-        Files.createDirectories(rootDir);
-        Files.write(rootDir.resolve(filename), mapper.writeValueAsBytes(result));
+        Files.write(file, mapper.writeValueAsBytes(result));
     }
 
-    private void savePlotCSV(String fileName, Map<String, Object> data) throws IOException {
-        Files.createDirectories(rootDir);
-        Path file = rootDir.resolve(fileName);
+    private void savePlotCSV(Path file, Map<String, Object> data) throws IOException {
         try (BufferedWriter writer = Files.newBufferedWriter(file, StandardCharsets.UTF_8, StandardOpenOption.CREATE)) {
             writer.write(String.join(",", data.keySet().toArray(new String[0])));
             writer.newLine();

--- a/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
@@ -706,6 +706,10 @@ public class TestUtils {
         return getLogsPath(extensionContext, "failed_test_logs");
     }
 
+    public static Path getPerformanceTestLogsPath(ExtensionContext extensionContext) {
+        return getLogsPath(extensionContext, "performance_test");
+    }
+
     public static Path getScaleTestLogsPath(ExtensionContext extensionContext) {
         return getLogsPath(extensionContext, "scale_test");
     }

--- a/systemtests/src/test/java/io/enmasse/systemtest/sharedinfra/MessagingAddressPerfTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/sharedinfra/MessagingAddressPerfTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.systemtest.sharedinfra;
+
+import io.enmasse.api.model.MessagingAddress;
+import io.enmasse.api.model.MessagingAddressBuilder;
+import io.enmasse.api.model.MessagingEndpoint;
+import io.enmasse.api.model.MessagingEndpointBuilder;
+import io.enmasse.api.model.MessagingTenant;
+import io.enmasse.systemtest.annotations.DefaultMessagingInfra;
+import io.enmasse.systemtest.annotations.DefaultMessagingTenant;
+import io.enmasse.systemtest.bases.TestBase;
+import io.enmasse.systemtest.bases.isolated.ITestIsolatedSharedInfra;
+import io.enmasse.systemtest.info.TestInfo;
+import io.enmasse.systemtest.messaginginfra.resources.MessagingAddressResourceType;
+import io.enmasse.systemtest.scale.ResultWriter;
+import io.enmasse.systemtest.utils.TestUtils;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public class MessagingAddressPerfTest extends TestBase implements ITestIsolatedSharedInfra {
+    /**
+     * Simple performance test to be able to track create and delete performance of addresses.
+     */
+    @Test
+    @DefaultMessagingInfra
+    @DefaultMessagingTenant
+    public void testCreateDelete() throws Exception {
+        MessagingTenant tenant = infraResourceManager.getDefaultMessagingTenant();
+        MessagingEndpoint endpoint = new MessagingEndpointBuilder()
+                .editOrNewMetadata()
+                .withNamespace(tenant.getMetadata().getNamespace())
+                .withName("app")
+                .endMetadata()
+                .editOrNewSpec()
+                .withHost(kubernetes.getHost())
+                .addToProtocols("AMQP")
+                .editOrNewNodePort()
+                .endNodePort()
+                .endSpec()
+                .build();
+        infraResourceManager.createResource(endpoint);
+
+        int numAnycast = 1000;
+        int numQueues = 300;
+        List<MessagingAddress> addresses = new ArrayList<>();
+
+        for (int i = 0; i < numAnycast; i++) {
+            addresses.add(new MessagingAddressBuilder()
+                    .editOrNewMetadata()
+                    .withNamespace(tenant.getMetadata().getNamespace())
+                    .withName(String.format("anycast%d", i))
+                    .endMetadata()
+                    .editOrNewSpec()
+                    .editOrNewAnycast()
+                    .endAnycast()
+                    .endSpec()
+                    .build());
+        }
+
+        for (int i = 0; i < numQueues; i++) {
+            addresses.add(new MessagingAddressBuilder()
+                    .editOrNewMetadata()
+                    .withNamespace(tenant.getMetadata().getNamespace())
+                    .withName(String.format("queue%d", i))
+                    .endMetadata()
+                    .editOrNewSpec()
+                    .editOrNewQueue()
+                    .endQueue()
+                    .endSpec()
+                    .build());
+        }
+
+        MessagingAddress[] toCreate = addresses.toArray(new MessagingAddress[0]);
+
+        long start = System.nanoTime();
+        infraResourceManager.createResource(true, toCreate);
+        long end = System.nanoTime();
+
+        long startDelete = System.nanoTime();
+        infraResourceManager.deleteResource(toCreate);
+        for (MessagingAddress next : addresses) {
+            while (MessagingAddressResourceType.getOperation().inNamespace(next.getMetadata().getNamespace()).withName(next.getMetadata().getName()).get() != null) {
+                Thread.sleep(1000);
+            }
+        }
+        long endDelete = System.nanoTime();
+
+        Map<String, Object> results = new HashMap<>();
+        results.put("create", TimeUnit.NANOSECONDS.toSeconds(end - start));
+        results.put("delete", TimeUnit.NANOSECONDS.toSeconds(endDelete - startDelete));
+        LOGGER.info("Result: {}", results);
+
+        ResultWriter resultWriter = new ResultWriter(TestUtils.getPerformanceTestLogsPath(TestInfo.getInstance().getActualTest()));
+        resultWriter.write(results);
+    }
+}


### PR DESCRIPTION
At present, the test needs to be run manually, but can be useful to
measure the impact of changes to the messaging address reconciling.

@kornys where would be the best place to put this kind of test that isn't too long-running but I'd like to run it nightly? Should we define a profile for messaginginfra tests? 

Also, what do I need beside creating the plot file? Does it need to have a specific name to get picked up by jenkins grapher?