### PR TITLE
Ops procedures - document enable protocol trace for router/broker

### DIFF
--- a/documentation/assemblies/assembly-ops-procedures.adoc
+++ b/documentation/assemblies/assembly-ops-procedures.adoc
@@ -14,6 +14,10 @@ include::../modules/proc-get-logs-router.adoc[leveloffset=+1]
 
 include::../modules/proc-get-logs-broker.adoc[leveloffset=+1]
 
+include::../modules/proc-enable-protocol-trace-router.adoc[leveloffset=+1]
+
+include::../modules/proc-enable-protocol-trace-broker.adoc[leveloffset=+1]
+
 include::../modules/proc-examine-broker-state.adoc[leveloffset=+1]
 
 :context: {parent-context}

--- a/documentation/modules/proc-enable-protocol-trace-broker.adoc
+++ b/documentation/modules/proc-enable-protocol-trace-broker.adoc
@@ -29,7 +29,7 @@ ifeval::["{cmdcli}" == "oc"]
 
 . Change to the project where {ProductName} is installed:
 +
-[subs="attributes",options="nowrap"]
+[subs="+quotes,attributes",options="nowrap"]
 ----
 {cmdcli} project _{ProductNamespace}_
 ----

--- a/documentation/modules/proc-enable-protocol-trace-broker.adoc
+++ b/documentation/modules/proc-enable-protocol-trace-broker.adoc
@@ -5,17 +5,17 @@
 [id='enable-protocol-trace-broker-{context}']
 = Enabling an AMQP protocol trace for the broker
 
-For diagnostic purposes, it is possible to enable an AMQP protocol trace for a broker.   This can be helpful to
-to troubleshoot problems sending or receiving messages.
+For diagnostic purposes, you can enable an AMQP protocol trace for a broker. This can be helpful
+to troubleshoot problems with sending or receiving messages.
 
-To enable the protocol trace, configuration is be applied to the  `standardinfaconfig` (for standard
+To enable the protocol trace, you apply configuration to the `standardinfraconfig` (for standard
 address spaces) or `brokeredinfraconfig` (for brokered address spaces) that enables the protocol trace for all
-brokers of all the address spaces that use that configuration.  Applying this configuration will cause the
+brokers of all the address spaces that use that configuration. Applying this configuration will cause the
 brokers to restart.
 
-WARNING: The protocol trace is verbose.  Enabling it increases the CPU overhead of the broker(s) and may decrease
+WARNING: Enabling the protocol trace increases the CPU overhead of the broker(s) and may decrease
 messaging performance. It may also increase the disk space requirements associated with any log retention system.
-Therefore it is recommended to enable the protocol trace for as shorter time as possible.
+Therefore, it is recommended that you enable the protocol trace for as short a time as possible.
 
 .Procedure
 
@@ -49,7 +49,7 @@ endif::[]
 {cmdcli} get addressspaceplan _addressspaceplan_ --output 'jsonpath={.spec.infraConfigRef}{"\n"}'
 ----
 
-. Enable the protocol trace for all the brokers of the all the address spaces using that use that `standardinfraconfig`
+. Enable the protocol trace for all the brokers of all the address spaces using that `standardinfraconfig`
 or `brokeredinfraconfig`:
 +
 [options="nowrap",subs="+quotes,attributes"]
@@ -57,7 +57,7 @@ or `brokeredinfraconfig`:
 {cmdcli} patch _infraconfigresource_ _infraconfigname_ --type=merge -p '{"spec":{"broker":{"podTemplate":{"spec":{"containers":[{"env":[{"name":"PN_TRACE_FRM","value":"true"}],"name":"broker"}]}}}}}'
 ----
 
-. Display the logs for the Pod which will include the protocol trace:
+. Display the logs for the Pod that will include the protocol trace:
 +
 [options="nowrap",subs="+quotes,attributes"]
 ----

--- a/documentation/modules/proc-enable-protocol-trace-broker.adoc
+++ b/documentation/modules/proc-enable-protocol-trace-broker.adoc
@@ -39,7 +39,7 @@ endif::[]
 +
 [subs="+quotes,attributes",options="nowrap"]
 ----
-{cmdcli} get addressspace -n _namespace_ _addressspace name_ --output 'jsonpath={.spec.plan}{"\n"}'
+{cmdcli} get addressspace -n _namespace_ _addressspacename_ --output 'jsonpath={.spec.plan}{"\n"}'
 ----
 
 . Determine the `standardinfraconfig` or `brokeredinfraconfig` name for the `addressspaceplan` name:

--- a/documentation/modules/proc-enable-protocol-trace-broker.adoc
+++ b/documentation/modules/proc-enable-protocol-trace-broker.adoc
@@ -1,0 +1,72 @@
+// Module included in the following assemblies:
+//
+// assembly-ops-procedures.adoc
+
+[id='enable-protocol-trace-broker-{context}']
+= Enabling an AMQP protocol trace for the broker
+
+For diagnostic purposes, it is possible to enable an AMQP protocol trace for a broker.   This can be helpful to
+to troubleshoot problems sending or receiving messages.
+
+To enable the protocol trace, configuration is be applied to the  `standardinfaconfig` (for standard
+address spaces) or `brokeredinfraconfig` (for brokered address spaces) that enables the protocol trace for all
+brokers of all the address spaces that use that configuration.  Applying this configuration will cause the
+brokers to restart.
+
+WARNING: The protocol trace is verbose.  Enabling it increases the CPU overhead of the broker(s) and may decrease
+messaging performance. It may also increase the disk space requirements associated with any log retention system.
+Therefore it is recommended to enable the protocol trace for as shorter time as possible.
+
+.Procedure
+
+ifeval::["{cmdcli}" == "oc"]
+. Log in as a service operator:
++
+[subs="attributes",options="nowrap"]
+----
+{cmdcli} login -u developer
+----
+
+. Change to the project where {ProductName} is installed:
++
+[subs="attributes",options="nowrap"]
+----
+{cmdcli} project _{ProductNamespace}_
+----
+endif::[]
+
+. Determine the `addresspaceplan` name for the address space concerned:
++
+[subs="+quotes,attributes",options="nowrap"]
+----
+{cmdcli} get addressspace -n _namespace_ _addressspace name_ --output 'jsonpath={.spec.plan}{"\n"}'
+----
+
+. Determine the `standardinfraconfig` or `brokeredinfraconfig` name for the `addressspaceplan` name:
++
+[subs="+quotes,attributes",options="nowrap"]
+----
+{cmdcli} get addressspaceplan _addressspaceplan_ --output 'jsonpath={.spec.infraConfigRef}{"\n"}'
+----
+
+. Enable the protocol trace for all the brokers of the all the address spaces using that use that `standardinfraconfig`
+or `brokeredinfraconfig`:
++
+[options="nowrap",subs="+quotes,attributes"]
+----
+{cmdcli} patch _infraconfigresource_ _infraconfigname_ --type=merge -p '{"spec":{"broker":{"podTemplate":{"spec":{"containers":[{"env":[{"name":"PN_TRACE_FRM","value":"true"}],"name":"broker"}]}}}}}'
+----
+
+. Display the logs for the Pod which will include the protocol trace:
++
+[options="nowrap",subs="+quotes,attributes"]
+----
+{cmdcli} logs _pod_
+----
+
+. Disable the protocol trace:
++
+[options="nowrap",subs="+quotes,attributes"]
+----
+{cmdcli} patch _infraconfigresource_ _infraconfigname_ --type=merge -p '{"spec":{"broker":{"podTemplate":{"spec":{"containers":[{"env":[{"name":"PN_TRACE_FRM"}],"name":"broker"}]}}}}}'
+----

--- a/documentation/modules/proc-enable-protocol-trace-router.adoc
+++ b/documentation/modules/proc-enable-protocol-trace-router.adoc
@@ -22,7 +22,8 @@ WARNING: The protocol trace is verbose.  Enabling it increases the CPU overhead 
 messaging performance. It may also increase the disk space requirements associated with any log retention system.
 Therefore it is recommended to enable the protocol trace for as shorter time as possible.
 
-.Procedure (dynamic)
+== Dynamic
+.Procedure
 
 ifeval::["{cmdcli}" == "oc"]
 . Log in as a service operator:
@@ -68,7 +69,9 @@ echo '{"enable":"trace+"}' | {cmdcli} exec qdrouterd-_podname_ --stdin=true --tt
 echo '{"enable":null}' | {cmdcli} exec qdrouterd-_podname_ --stdin=true --tty=false -- qdmanage update -b 127.0.0.1:7777 --type=log --name=log/SERVER --stdin
 ----
 
-.Procedure (environment variable)
+== `StandardInfraConfig` environment variable
+
+.Procedure
 
 ifeval::["{cmdcli}" == "oc"]
 . Log in as a service operator:

--- a/documentation/modules/proc-enable-protocol-trace-router.adoc
+++ b/documentation/modules/proc-enable-protocol-trace-router.adoc
@@ -9,7 +9,7 @@ For diagnostic purposes, it is possible to enable an AMQP protocol trace for a r
 to troubleshoot issues with clients not connecting or problems sending or receiving messages.  There are two
 ways this can be achieved.
 
-* It is possible to enable/disable the protocol trace, dynamically, for a single broker using a `qdmange` command. This
+* It is possible to enable/disable the protocol trace, dynamically, for a single router using a `qdmange` command. This
 method avoids the need to restart the router.  The setting will be lost next time the router restarts.
 
 * Alternatively, configuration can be applied to the  `standardinfaconfig` that enables the protocol trace for all

--- a/documentation/modules/proc-enable-protocol-trace-router.adoc
+++ b/documentation/modules/proc-enable-protocol-trace-router.adoc
@@ -13,7 +13,6 @@ ways this can be achieved.
 method avoids the need to restart the router.  The setting will be lost the next time the router restarts.
 
 * Alternatively, you can apply configuration to the `standardinfraconfig` that enables the protocol trace for all
-``
 routers of all the address spaces that use that `standardinfraconfig`.  This method will cause all the routers to
 restart.
 

--- a/documentation/modules/proc-enable-protocol-trace-router.adoc
+++ b/documentation/modules/proc-enable-protocol-trace-router.adoc
@@ -34,7 +34,7 @@ ifeval::["{cmdcli}" == "oc"]
 
 . Change to the project where {ProductName} is installed:
 +
-[subs="attributes",options="nowrap"]
+[subs="+quotes,attributes",options="nowrap"]
 ----
 {cmdcli} project _{ProductNamespace}_
 ----
@@ -80,7 +80,7 @@ ifeval::["{cmdcli}" == "oc"]
 
 . Change to the project where {ProductName} is installed:
 +
-[subs="attributes",options="nowrap"]
+[subs="+quotes,attributes",options="nowrap"]
 ----
 {cmdcli} project _{ProductNamespace}_
 ----

--- a/documentation/modules/proc-enable-protocol-trace-router.adoc
+++ b/documentation/modules/proc-enable-protocol-trace-router.adoc
@@ -93,7 +93,7 @@ endif::[]
 +
 [subs="+quotes,attributes",options="nowrap"]
 ----
-{cmdcli} get addressspace -n _namespace_ _addressspace name_ --output "jsonpath={.spec.plan}"
+{cmdcli} get addressspace -n _namespace_ _addressspacename_ --output 'jsonpath={.spec.plan}{"\n"}'
 ----
 
 . Determine the `standardinfraconfig` name for the `addressspaceplan` name:

--- a/documentation/modules/proc-enable-protocol-trace-router.adoc
+++ b/documentation/modules/proc-enable-protocol-trace-router.adoc
@@ -1,0 +1,122 @@
+// Module included in the following assemblies:
+//
+// assembly-ops-procedures.adoc
+
+[id='enable-protocol-trace-router-{context}']
+= Enabling an AMQP protocol trace for the router
+
+For diagnostic purposes, it is possible to enable an AMQP protocol trace for a router.   This can be helpful to
+to troubleshoot issues with clients not connecting or problems sending or receiving messages.  There are two
+ways this can be achieved.
+
+* It is possible to enable/disable the protocol trace, dynamically, for a single broker using a `qdmange` command. This
+method avoids the need to restart the router.  The setting will be lost next time the router restarts.
+
+* Alternatively, configuration can be applied to the  `standardinfaconfig` that enables the protocol trace for all
+routers of  all the address spaces that use that `standardinfaconfig`.  This method will cause all the routers to
+restart.
+
+Both procedures are described next.
+
+WARNING: The protocol trace is verbose.  Enabling it increases the CPU overhead of the router(s) and may decrease
+messaging performance. It may also increase the disk space requirements associated with any log retention system.
+Therefore it is recommended to enable the protocol trace for as shorter time as possible.
+
+.Procedure (dynamic)
+
+ifeval::["{cmdcli}" == "oc"]
+. Log in as a service operator:
++
+[subs="attributes",options="nowrap"]
+----
+{cmdcli} login -u developer
+----
+
+. Change to the project where {ProductName} is installed:
++
+[subs="attributes",options="nowrap"]
+----
+{cmdcli} project _{ProductNamespace}_
+----
+endif::[]
+
+. List all router Pods and choose the Pod for the relevant address space:
++
+[options="nowrap",subs="+quotes,attributes"]
+----
+{cmdcli} get pods -l name=qdrouterd -o go-template --template '{{range .items}}{{.metadata.name}}{{"\t"}}{{.metadata.annotations.addressSpace}}{{"\n"}}{{end}}'
+----
+
+. Enable the protocol trace for a single router:
++
+[options="nowrap",subs="+quotes,attributes"]
+----
+echo '{"enable":"trace+"}' | {cmdcli} exec qdrouterd-_podname_ --stdin=true --tty=false -- qdmanage update -b 127.0.0.1:7777 --type=log --name=log/SERVER --stdin
+----
+
+. Display the logs for the Pod which will include the protocol trace:
++
+[options="nowrap",subs="+quotes,attributes"]
+----
+{cmdcli} logs _pod_
+----
+
+. Disable the protocol trace:
++
+[options="nowrap",subs="+quotes,attributes"]
+----
+echo '{"enable":null}' | {cmdcli} exec qdrouterd-_podname_ --stdin=true --tty=false -- qdmanage update -b 127.0.0.1:7777 --type=log --name=log/SERVER --stdin
+----
+
+.Procedure (environment variable)
+
+ifeval::["{cmdcli}" == "oc"]
+. Log in as a service operator:
++
+[subs="attributes",options="nowrap"]
+----
+{cmdcli} login -u developer
+----
+
+. Change to the project where {ProductName} is installed:
++
+[subs="attributes",options="nowrap"]
+----
+{cmdcli} project _{ProductNamespace}_
+----
+endif::[]
+
+. Determine the `addresspaceplan` name for the address space concerned:
++
+[subs="+quotes,attributes",options="nowrap"]
+----
+{cmdcli} get addressspace -n _namespace_ _addressspace name_ --output "jsonpath={.spec.plan}"
+----
+
+. Determine the `standardinfraconfig` name for the `addressspaceplan` name:
++
+[subs="+quotes,attributes",options="nowrap"]
+----
+{cmdcli} get addressspaceplan _addressspaceplan_ --output 'jsonpath={.spec.infraConfigRef}{"\n"}'
+----
+
+. Enable the protocol trace for all the routers of the all the address spaces using that use that `standardinfaconfig`:
++
+[options="nowrap",subs="+quotes,attributes"]
+----
+{cmdcli} patch standardinfraconfig _standardinfraconfigname_ --type=merge -p '{"spec":{"router":{"podTemplate":{"spec":{"containers":[{"env":[{"name":"PN_TRACE_FRM","value":"true"}],"name":"router"}]}}}}}'
+----
+
+. Display the logs for the Pod which will include the protocol trace:
++
+[options="nowrap",subs="+quotes,attributes"]
+----
+{cmdcli} logs _pod_
+----
+
+. Disable the protocol trace:
++
+[options="nowrap",subs="+quotes,attributes"]
+----
+{cmdcli} patch standardinfraconfig _standardinfraconfig name_ --type=merge -p '{"spec":{"router":{"podTemplate":{"spec":{"containers":[{"env":[{"name":"PN_TRACE_FRM"}],"name":"router"}]}}}}}'
+----

--- a/documentation/modules/proc-enable-protocol-trace-router.adoc
+++ b/documentation/modules/proc-enable-protocol-trace-router.adoc
@@ -70,7 +70,7 @@ echo '{"enable":"trace+"}' | {cmdcli} exec qdrouterd-_podname_ --stdin=true --tt
 echo '{"enable":null}' | {cmdcli} exec qdrouterd-_podname_ --stdin=true --tty=false -- qdmanage update -b 127.0.0.1:7777 --type=log --name=log/SERVER --stdin
 ----
 
-== `StandardInfraConfig` environment variable
+== Enabling the protocol trace using the `StandardInfraConfig` environment variable
 
 .Procedure
 

--- a/documentation/modules/proc-enable-protocol-trace-router.adoc
+++ b/documentation/modules/proc-enable-protocol-trace-router.adoc
@@ -5,24 +5,25 @@
 [id='enable-protocol-trace-router-{context}']
 = Enabling an AMQP protocol trace for the router
 
-For diagnostic purposes, it is possible to enable an AMQP protocol trace for a router.   This can be helpful to
-to troubleshoot issues with clients not connecting or problems sending or receiving messages.  There are two
+For diagnostic purposes, you can enable an AMQP protocol trace for a router.   This can be helpful
+when troubleshooting issues related to client connectivity or with sending and receiving messages.  There are two
 ways this can be achieved.
 
-* It is possible to enable/disable the protocol trace, dynamically, for a single router using a `qdmange` command. This
-method avoids the need to restart the router.  The setting will be lost next time the router restarts.
+* You can dynamically enable/disable the protocol trace for a single router using a `qdmange` command. This
+method avoids the need to restart the router.  The setting will be lost the next time the router restarts.
 
-* Alternatively, configuration can be applied to the  `standardinfaconfig` that enables the protocol trace for all
-routers of  all the address spaces that use that `standardinfaconfig`.  This method will cause all the routers to
+* Alternatively, you can apply configuration to the `standardinfraconfig` that enables the protocol trace for all
+``
+routers of all the address spaces that use that `standardinfraconfig`.  This method will cause all the routers to
 restart.
 
 Both procedures are described next.
 
-WARNING: The protocol trace is verbose.  Enabling it increases the CPU overhead of the router(s) and may decrease
+WARNING: Enabling the protocol trace increases the CPU overhead of the router(s) and may decrease
 messaging performance. It may also increase the disk space requirements associated with any log retention system.
-Therefore it is recommended to enable the protocol trace for as shorter time as possible.
+Therefore, it is recommended that you enable the protocol trace for as short a time as possible.
 
-== Dynamic
+== Dynamically enabling the protocol trace for a single router
 .Procedure
 
 ifeval::["{cmdcli}" == "oc"]
@@ -55,7 +56,7 @@ endif::[]
 echo '{"enable":"trace+"}' | {cmdcli} exec qdrouterd-_podname_ --stdin=true --tty=false -- qdmanage update -b 127.0.0.1:7777 --type=log --name=log/SERVER --stdin
 ----
 
-. Display the logs for the Pod which will include the protocol trace:
+. Display the logs for the Pod that will include the protocol trace:
 +
 [options="nowrap",subs="+quotes,attributes"]
 ----
@@ -103,14 +104,14 @@ endif::[]
 {cmdcli} get addressspaceplan _addressspaceplan_ --output 'jsonpath={.spec.infraConfigRef}{"\n"}'
 ----
 
-. Enable the protocol trace for all the routers of the all the address spaces using that use that `standardinfaconfig`:
+. Enable the protocol trace for all the routers of the all the address spaces using that `standardinfraconfig`:
 +
 [options="nowrap",subs="+quotes,attributes"]
 ----
 {cmdcli} patch standardinfraconfig _standardinfraconfigname_ --type=merge -p '{"spec":{"router":{"podTemplate":{"spec":{"containers":[{"env":[{"name":"PN_TRACE_FRM","value":"true"}],"name":"router"}]}}}}}'
 ----
 
-. Display the logs for the Pod which will include the protocol trace:
+. Display the logs for the Pod that will include the protocol trace:
 +
 [options="nowrap",subs="+quotes,attributes"]
 ----

--- a/documentation/modules/proc-enable-protocol-trace-router.adoc
+++ b/documentation/modules/proc-enable-protocol-trace-router.adoc
@@ -52,7 +52,7 @@ endif::[]
 +
 [options="nowrap",subs="+quotes,attributes"]
 ----
-echo '{"enable":"trace+"}' | {cmdcli} exec qdrouterd-_podname_ --stdin=true --tty=false -- qdmanage update -b 127.0.0.1:7777 --type=log --name=log/SERVER --stdin
+echo '{"enable":"trace+"}' | {cmdcli} exec qdrouterd-_podname_ --stdin=true --tty=false -- qdmanage update -b 127.0.0.1:7777 --type=log --name=log/PROTOCOL --stdin
 ----
 
 . Display the logs for the Pod that will include the protocol trace:
@@ -66,7 +66,7 @@ echo '{"enable":"trace+"}' | {cmdcli} exec qdrouterd-_podname_ --stdin=true --tt
 +
 [options="nowrap",subs="+quotes,attributes"]
 ----
-echo '{"enable":null}' | {cmdcli} exec qdrouterd-_podname_ --stdin=true --tty=false -- qdmanage update -b 127.0.0.1:7777 --type=log --name=log/SERVER --stdin
+echo '{"enable":"info"}' | {cmdcli} exec qdrouterd-_podname_ --stdin=true --tty=false -- qdmanage update -b 127.0.0.1:7777 --type=log --name=log/PROTOCOL --stdin
 ----
 
 == Enabling the protocol trace using the `StandardInfraConfig` environment variable


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Ops procedures - document the enabling/disabling of AMQP protocol trace for router/broker

### Checklist


- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
