### PR TITLE
Refator router state to work with entities

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -9,7 +9,7 @@ To build EnMasse, you need
    * [Docker](https://www.docker.com/)
    * [GNU Make](https://www.gnu.org/software/make/)
    * [Asciidoctor](https://asciidoctor.org/) >= 1.5.7
-   * [Go](https://golang.org/) >= 1.12.0
+   * [Go](https://golang.org/) >= 1.13.0
    * [Go Yacc](golang.org/x/tools/cmd/goyacc)
    * [Ragel](http://www.colm.net/open-source/ragel/)
 

--- a/pkg/controller/messagingaddress/messagingaddress_controller.go
+++ b/pkg/controller/messagingaddress/messagingaddress_controller.go
@@ -252,6 +252,11 @@ func (r *ReconcileMessagingAddress) Reconcile(request reconcile.Request) (reconc
 			return processorResult{}, nil
 		}
 
+		// These addresses don't require scheduling
+		if address.Spec.Anycast != nil || address.Spec.Multicast != nil {
+			return processorResult{}, nil
+		}
+
 		// TODO: Make configurable and a better scheduler
 		scheduler := &DummyScheduler{}
 

--- a/pkg/state/infra_test.go
+++ b/pkg/state/infra_test.go
@@ -29,7 +29,7 @@ func TestSyncConnectors(t *testing.T) {
 		return &RouterState{
 			host:          host,
 			port:          port,
-			connectors:    make(map[string]*RouterConnector, 0),
+			entities:      make(map[RouterEntityType]map[string]RouterEntity, 0),
 			commandClient: rclient,
 		}
 	}, func(host string, port int32) *BrokerState {
@@ -63,7 +63,7 @@ func TestSyncConnectors(t *testing.T) {
 
 	statuses, err := i.SyncAll([]string{"r1.example.com", "r2.example.com"}, []string{"b1.example.com", "b2.example.com"})
 	assert.Nil(t, err)
-	assert.Equal(t, 2, len(i.routers["r1.example.com"].connectors))
-	assert.Equal(t, 2, len(i.routers["r2.example.com"].connectors))
+	assert.Equal(t, 2, len(i.routers["r1.example.com"].entities[RouterConnectorEntity]))
+	assert.Equal(t, 2, len(i.routers["r2.example.com"].entities[RouterConnectorEntity]))
 	assert.Equal(t, 4, len(statuses))
 }

--- a/pkg/state/router_test.go
+++ b/pkg/state/router_test.go
@@ -6,6 +6,7 @@
 package state
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -51,7 +52,7 @@ func TestInitialize(t *testing.T) {
 	assert.Equal(t, "example.com", state.entities[RouterConnectorEntity]["conn1"].(*RouterConnector).Host)
 
 	// Adding connector should not call any command client
-	err = state.EnsureEntities([]RouterEntity{&RouterConnector{
+	err = state.EnsureEntities(context.TODO(), []RouterEntity{&RouterConnector{
 		Name: "conn1",
 		Host: "example.com",
 		Port: "5672",
@@ -93,7 +94,7 @@ func TestEnsureConnector(t *testing.T) {
 	assert.Equal(t, 0, len(state.entities[RouterConnectorEntity]))
 
 	// Adding connector should not call any command client
-	err = state.EnsureEntities([]RouterEntity{&RouterConnector{
+	err = state.EnsureEntities(context.TODO(), []RouterEntity{&RouterConnector{
 		Name: "conn1",
 		Host: "example.com",
 		Port: "5672",
@@ -101,7 +102,7 @@ func TestEnsureConnector(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Adding again should be no problem as long as it is the same
-	err = state.EnsureEntities([]RouterEntity{&RouterConnector{
+	err = state.EnsureEntities(context.TODO(), []RouterEntity{&RouterConnector{
 		Name: "conn1",
 		Host: "example.com",
 		Port: "5672",
@@ -109,7 +110,7 @@ func TestEnsureConnector(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Adding again is not ok when attributes have changed (not supported by qpid dispatch router)
-	err = state.EnsureEntities([]RouterEntity{&RouterConnector{
+	err = state.EnsureEntities(context.TODO(), []RouterEntity{&RouterConnector{
 		Name: "conn1",
 		Host: "example.com",
 		Port: "5672",

--- a/pkg/state/router_types.go
+++ b/pkg/state/router_types.go
@@ -17,10 +17,27 @@ type RouterState struct {
 	initialized   bool
 	nextResync    time.Time
 	commandClient amqpcommand.Client
-	connectors    map[string]*RouterConnector
-	addresses     map[string]*RouterAddress
-	autoLinks     map[string]*RouterAutoLink
-	listeners     map[string]*RouterListener
+	entities      map[RouterEntityType]map[string]RouterEntity
+}
+
+type RouterEntityType string
+
+const (
+	RouterAddressEntity   RouterEntityType = "org.apache.qpid.dispatch.router.config.address"
+	RouterListenerEntity  RouterEntityType = "org.apache.qpid.dispatch.listener"
+	RouterConnectorEntity RouterEntityType = "org.apache.qpid.dispatch.connector"
+	RouterAutoLinkEntity  RouterEntityType = "org.apache.qpid.dispatch.router.config.autoLink"
+)
+
+type RouterEntity interface {
+	Type() RouterEntityType
+	GetName() string
+	Equals(RouterEntity) bool
+}
+
+type NamedEntity struct {
+	EntityType RouterEntityType
+	Name       string
 }
 
 type RouterConnector struct {
@@ -36,6 +53,8 @@ type RouterConnector struct {
 	IdleTimeoutSeconds int    `json:"idleTimeoutSeconds,omitempty"`
 	VerifyHostname     bool   `json:"verifyHostname,omitempty"`
 	PolicyVhost        string `json:"policyVhost,omitempty"`
+	ConnectionStatus   string `json:"connectionStatus,omitempty"`
+	ConnectionMsg      string `json:"connectionMsg,omitempty"`
 }
 
 type RouterListener struct {


### PR DESCRIPTION
This allows for batching requests for multiple entities in the same
per-router invocation as well as reduces per-type code required.