### PR TITLE
Address space connector should offer SASL ANONYMOUS if it cannot offer PLAIN or EXTERNAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * #4299: Bump vertx from 3.8.3 to 3.9.0
 * #4315: [IoT] Add the ability to configure TLS options
 * #4314: [IoT] Add alerts for infrastructure and projects
+* #4438: Address space connector - offer SASL ANONYMOUS if it cannot offer PLAIN or EXTERNAL.
 
 ## 0.31.2
 * #4305: Inject OpenShift generated custom CA trust bundle into console pod so that console authentication works when a custom CA is in use.

--- a/address-space-controller/src/main/java/io/enmasse/controller/RouterConfigController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/RouterConfigController.java
@@ -620,6 +620,10 @@ public class RouterConfigController implements Controller {
                 saslMechanisms.add("PLAIN");
             }
 
+            if (saslMechanisms.isEmpty()) {
+                saslMechanisms.add("ANONYMOUS");
+            }
+
             remoteConnector.setSaslMechanisms(String.join(" ", saslMechanisms));
 
             String prefix = String.format("%s/", connector.getName());


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Address space connector should offer SASL ANONYMOUS if it cannot offer PLAIN or EXTERNAL owing to the connector's configuration.

### Checklist


- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
