### PR TITLE
Fix the primary key on the credentials table

### DIFF
--- a/iot/iot-infinispan-base/src/main/java/io/enmasse/iot/infinispan/config/InfinispanProperties.java
+++ b/iot/iot-infinispan-base/src/main/java/io/enmasse/iot/infinispan/config/InfinispanProperties.java
@@ -12,7 +12,7 @@ public class InfinispanProperties {
 
     public static class CacheNames {
         private static final String DEFAULT_ADAPTER_CREDENTIALS_CACHE_NAME = "adapterCredentials";
-        private static final String DEFAULT_DEVICE_CONNECTIONS_CACHE_NAME = "deviceStates";
+        private static final String DEFAULT_DEVICE_CONNECTIONS_CACHE_NAME = "device-connection";
         private static final String DEFAULT_DEVICES_CACHE_NAME = "devices";
 
         private String adapterCredentials = DEFAULT_ADAPTER_CREDENTIALS_CACHE_NAME;

--- a/templates/iot/examples/h2/create.sql
+++ b/templates/iot/examples/h2/create.sql
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS device_credentials (
 
 	data json,
 
-	PRIMARY KEY (tenant_id, device_id),
+	PRIMARY KEY (tenant_id, type, auth_id),
 	FOREIGN KEY (tenant_id, device_id) REFERENCES device_registrations (tenant_id, device_id) ON DELETE CASCADE
 );
 
@@ -34,4 +34,5 @@ CREATE TABLE IF NOT EXISTS device_states (
 -- create index for tenant only lookups
 CREATE INDEX idx_device_registrations_tenant ON device_registrations (tenant_id);
 CREATE INDEX idx_device_credentials_tenant ON device_credentials (tenant_id);
+CREATE INDEX idx_device_credentials_tenant_and_device ON device_credentials (tenant_id, device_id);
 CREATE INDEX idx_device_states_tenant ON device_states (tenant_id);

--- a/templates/iot/examples/postgresql/create.sql
+++ b/templates/iot/examples/postgresql/create.sql
@@ -17,11 +17,11 @@ CREATE TABLE IF NOT EXISTS device_credentials (
 
 	data json,
 
-	PRIMARY KEY (tenant_id, device_id),
+	PRIMARY KEY (tenant_id, type, auth_id),
 	FOREIGN KEY (tenant_id, device_id) REFERENCES device_registrations (tenant_id, device_id) ON DELETE CASCADE
 );
 
 -- create index for tenant only lookups
 CREATE INDEX idx_device_registrations_tenant ON device_registrations (tenant_id);
 CREATE INDEX idx_device_credentials_tenant ON device_credentials (tenant_id);
-CREATE INDEX idx_device_credentials_tenant_auth_id ON device_credentials (tenant_id, auth_id);
+CREATE INDEX idx_device_credentials_tenant_and_device ON device_credentials (tenant_id, device_id);


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

There was a wrong primary key on the credentials table. It was (tenant, device) and should have been (tenant, type, auth id). This also makes the additional index unnecessary, as the lookup is always by (tenant, type, auth id).

Additionally we require a new index on (tenant, device id) for credential management operations, as they work "by device".

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
