### PR TITLE
Surefire remove workaround and try latest snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.1.1</maven-jar-plugin.version>
         <maven-shade-plugin.version>3.1.0</maven-shade-plugin.version>
-        <maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.0.0-SNAPSHOT</maven-surefire-plugin.version>
         <maven-site-plugin.version>3.5.1</maven-site-plugin.version>
         <maven-project-info-reports-plugin.version>2.9</maven-project-info-reports-plugin.version>
         <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/clients/ClientTestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/clients/ClientTestBase.java
@@ -49,11 +49,6 @@ public abstract class ClientTestBase extends TestBase implements ITestBaseShared
     protected Path logPath = null;
     private List<AbstractClient> clients;
 
-    @BeforeAll
-    public void removeme() throws Exception {
-        throw new Exception("pepa");
-    }
-
     @BeforeEach
     public void setUpClientBase(TestInfo info) {
         clients = new ArrayList<>();

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/clients/ClientTestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/clients/ClientTestBase.java
@@ -25,6 +25,7 @@ import io.enmasse.user.model.v1.Operation;
 import io.enmasse.user.model.v1.User;
 import io.enmasse.user.model.v1.UserAuthorizationBuilder;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.function.Executable;
@@ -47,6 +48,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public abstract class ClientTestBase extends TestBase implements ITestBaseShared {
     protected Path logPath = null;
     private List<AbstractClient> clients;
+
+    @BeforeAll
+    public void removeme() throws Exception {
+        throw new Exception("pepa");
+    }
 
     @BeforeEach
     public void setUpClientBase(TestInfo info) {


### PR DESCRIPTION
Seems surefire plugin M5 release is moved to unknown date with fix for handling exceptions in beforeAll/afterAll methods, so I tried to move surefire to snapshot release. My question is can we use snapshot release of maven surefire 3.0.0 or we should still use workaround. One issue with workaround is that we are not able to handle afterAll. 