### PR TITLE
Organise for the agent command delegate to await the delegate running

### DIFF
--- a/pkg/amqpcommand/test/fake_client.go
+++ b/pkg/amqpcommand/test/fake_client.go
@@ -19,6 +19,7 @@ type FakeClient struct {
 	Handler RequestHandler
 }
 
+
 var _ amqpcommand.Client = &FakeClient{}
 
 func NewFakeClient() *FakeClient {
@@ -26,6 +27,9 @@ func NewFakeClient() *FakeClient {
 }
 
 func (c *FakeClient) Start() {
+}
+
+func (c *FakeClient) AwaitRunning() {
 }
 
 func (c *FakeClient) Stop() {

--- a/pkg/consolegraphql/agent/agent.go
+++ b/pkg/consolegraphql/agent/agent.go
@@ -374,6 +374,7 @@ func (aad *amqpAgentDelegate) newAgentDelegate(token string, impersonateUser str
 	}
 
 	a.commandClient.Start()
+	a.commandClient.AwaitRunning()
 	return a
 }
 


### PR DESCRIPTION
Fixes regression that made purgeAddress tests fail

### Type of change


- Bugfix

### Description

Organise for the agent command delegate to await the delegate running.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
