### PR TITLE
investigating sporadic console login oauth authentication issue

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/logs/GlobalLogCollector.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/logs/GlobalLogCollector.java
@@ -5,6 +5,7 @@
 package io.enmasse.systemtest.logs;
 
 import io.enmasse.systemtest.bases.ThrowableRunner;
+import io.enmasse.systemtest.condition.OpenShiftVersion;
 import io.enmasse.systemtest.executor.ExecutionResultData;
 import io.enmasse.systemtest.info.TestInfo;
 import io.enmasse.systemtest.platform.KubeCMDClient;
@@ -282,6 +283,10 @@ public class GlobalLogCollector {
             List<String> nsList = new ArrayList<>();
             nsList.add(infraNamespace);
             nsList.addAll(Arrays.asList(SystemtestsKubernetesApps.ST_NAMESPACES));
+            // TMP: trying to understand sporadic problems with openshift 4 console authentication.
+            if (Kubernetes.isOpenShiftCompatible(OpenShiftVersion.OCP4)) {
+                nsList.add("openshift-authentication");
+            }
             for (String ns : nsList) {
                 if (kube.namespaceExists(ns)) {
                     List<Pod> pods = kube.listAllPods(ns);
@@ -335,6 +340,8 @@ public class GlobalLogCollector {
             Files.writeString(path.resolve("storageclass.yml"), KubeCMDClient.runOnClusterWithoutLogger("get", "storageclass", "-o", "yaml").getStdOut());
             if (Kubernetes.isOpenShiftCompatible()) {
                 Files.writeString(path.resolve("routes.yml"), KubeCMDClient.runOnClusterWithoutLogger("get", "-A", "routes", "-o", "yaml").getStdOut());
+                Files.writeString(path.resolve("routes.yml"), KubeCMDClient.runOnClusterWithoutLogger("get", "-A", "routes", "-o", "yaml").getStdOut());
+
             }
             Files.writeString(path.resolve("events.txt"), KubeCMDClient.getAllEvents().getStdOut());
             Files.writeString(path.resolve("describe_nodes.txt"), KubeCMDClient.describeNodes().getStdOut());


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Capture the OpenShift openshift-authentication (OAuth) logs when the tests fail.  Hoping to identity the root cause of the 500s we see in the oauth-proxy logs.

### Checklist


- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
