### PR TITLE
Remove connected and running variables

### DIFF
--- a/pkg/consolegraphql/agent/agent.go
+++ b/pkg/consolegraphql/agent/agent.go
@@ -11,13 +11,15 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"fmt"
-	"github.com/enmasseproject/enmasse/pkg/amqpcommand"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"log"
 	"net"
-	"pack.ag/amqp"
 	"sync"
 	"time"
+
+	"github.com/enmasseproject/enmasse/pkg/amqpcommand"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"pack.ag/amqp"
 )
 
 // The agent delegate is the facade to the address space's agent component.  It allows events broadcast by the
@@ -374,7 +376,6 @@ func (aad *amqpAgentDelegate) newAgentDelegate(token string, impersonateUser str
 	}
 
 	a.commandClient.Start()
-	a.commandClient.AwaitRunning()
 	return a
 }
 

--- a/pkg/controller/messaginginfra/messaginginfra_controller.go
+++ b/pkg/controller/messaginginfra/messaginginfra_controller.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
 	//"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -360,7 +361,7 @@ func (r *ReconcileMessagingInfra) Reconcile(request reconcile.Request) (reconcil
 	result, err = rc.Process(func(infra *v1beta2.MessagingInfra) (processorResult, error) {
 		statuses, err := r.clientManager.GetClient(infra).SyncAll(routerHosts, brokerHosts)
 		// Treat as transient error
-		if errors.Is(err, amqpcommand.NotConnectedError) {
+		if errors.Is(err, amqpcommand.RequestTimeoutError) {
 			logger.Info("Error syncing infra", "error", err.Error())
 			infra.Status.Message = err.Error()
 			synchronized.SetStatus(corev1.ConditionFalse, "", err.Error())


### PR DESCRIPTION
The code that previously required connection to be checked has been
made resilient to handle this error instead, and this should no longer
be needed, allowing the console and infra controller to work with the
old interface.

The lastErr variable is kept to handle the closing of requests that
occur during a reconnect.