### PR TITLE
[Docs] correct loadbalance spec indentation

### DIFF
--- a/documentation/modules/ref-address-space-example-exposing-endpoints.adoc
+++ b/documentation/modules/ref-address-space-example-exposing-endpoints.adoc
@@ -31,10 +31,10 @@ spec:
      loadBalancerPorts: <4>
      - amqp
      - amqps
-    annotations: <5>
-      mykey: myvalue
-    loadBalancerSourceRanges: <6>
-    - 10.0.0.0/8
+      annotations: <5>
+        mykey: myvalue
+      loadBalancerSourceRanges: <6>
+      - 10.0.0.0/8
 ----
 <1> (Required) The name of the endpoint. The name specified affects the name of the {KubePlatform} service to be created as well as the name of the endpoint in the status section of the `AddressSpace`.
 <2> (Required) The service configured for the endpoint. Valid values for `service` are `messaging` and `mqtt`. However, the `mqtt` service is supported for the `standard` address space type only.


### PR DESCRIPTION
Typo..

### Type of change


- Documentation

### Description

Correcting typo in documentation.

### Checklist


- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
