### PR TITLE
Fix - Console shows unexpected error when I click on address with error message

### DIFF
--- a/console/console-init/ui/src/graphql-module/queries/Address.ts
+++ b/console/console-init/ui/src/graphql-module/queries/Address.ts
@@ -225,6 +225,7 @@ const RETURN_ADDRESS_DETAIL = (
           }
           spec {
             address
+            type
             topic
             plan {
               spec {

--- a/console/console-init/ui/src/modules/address-detail/AddressDetailPage.tsx
+++ b/console/console-init/ui/src/modules/address-detail/AddressDetailPage.tsx
@@ -111,7 +111,7 @@ export default function AddressDetailPage() {
       name: addressDetail.metadata.name,
       displayName: addressDetail.spec.address,
       namespace: addressDetail.metadata.namespace,
-      type: addressDetail.spec.plan.spec.addressType,
+      type: addressDetail.spec.type || addressDetail.spec.plan.spec.addressType,
       planLabel:
         addressDetail.spec.plan.spec.displayName ||
         addressDetail.spec.plan.metadata.name,

--- a/console/console-init/ui/src/schema/ResponseTypes.ts
+++ b/console/console-init/ui/src/schema/ResponseTypes.ts
@@ -101,6 +101,7 @@ export interface IAddressDetailResponse {
       };
       spec: {
         address: string;
+        type: string;
         topic: string | null;
         plan: {
           spec: {


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description
Fix - Console shows unexpected error when I click on address with error message
For address with invalid address plan the addressType in response in an empty string. Handled to pick type from address.spec.type instead of address.spec.plan.spec.addressType

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

![image](https://user-images.githubusercontent.com/29524461/81809046-4d8fc480-953e-11ea-8116-42ffb972a679.png)
![image](https://user-images.githubusercontent.com/29524461/81809068-5c767700-953e-11ea-8680-49341ca9f0b8.png)

