### PR TITLE
[Docs] proc-deploying-standard-auth-service is defined twice

### DIFF
--- a/documentation/modules/proc-standard-auth-service-ha.adoc
+++ b/documentation/modules/proc-standard-auth-service-ha.adoc
@@ -2,7 +2,7 @@
 //
 // assembly-auth-services.adoc
 
-[id='proc-deploying-standard-auth-service-{context}']
+[id='proc-deploying-standard-auth-service-ha-{context}']
 = Deploying the `standard` authentication service for high availability (HA)
 
 For production deployment, the authentication services should be setup for high availability in order to reduce downtime during {KubePlatform} updates or in the event of a node failure. To implement the `standard` authentication service in HA mode, you deploy it using a PostgreSQL database as the backend.


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

AsciiDoc build was failing owing to `proc-deploying-standard-auth-service` being defined twice.

### Checklist


- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
