### PR TITLE
[Docs] correct OpenShift refs in kube docs for console

### DIFF
--- a/documentation/master-kubernetes.adoc
+++ b/documentation/master-kubernetes.adoc
@@ -8,6 +8,7 @@ include::common/attributes.adoc[]
 :imagesdir: ../kubernetes/images
 :cmdcli: kubectl
 :KubePlatform: Kubernetes
+:KubePlatformCredentials: OIDC
 :OperatorMarketplaceNamespace: marketplace
 
 = Documentation for {ProductName} on Kubernetes
@@ -51,4 +52,3 @@ include::common/restapi-reference.adoc[leveloffset=+2]
 
 // Revision information
 //include::common/revision-info.adoc[]
-

--- a/documentation/master-kubernetes.adoc
+++ b/documentation/master-kubernetes.adoc
@@ -11,6 +11,8 @@ include::common/attributes.adoc[]
 :KubePlatformCredentials: OIDC
 :OperatorMarketplaceNamespace: marketplace
 
+:KubePlatformRbacURL: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+
 = Documentation for {ProductName} on Kubernetes
 
 Welcome to the {ProductName} documentation, where you can find information to help you learn about

--- a/documentation/master-openshift.adoc
+++ b/documentation/master-openshift.adoc
@@ -8,6 +8,7 @@ include::common/attributes.adoc[]
 :imagesdir: ../openshift/images
 :cmdcli: oc
 :KubePlatform: OpenShift
+:KubePlatformCredentials: OpenShift
 :OperatorMarketplaceNamespace: openshift-marketplace
 
 = Documentation for {ProductName} on OpenShift
@@ -51,4 +52,3 @@ include::common/restapi-reference.adoc[leveloffset=+2]
 
 // Revision information
 //include::common/revision-info.adoc[]
-

--- a/documentation/master-openshift.adoc
+++ b/documentation/master-openshift.adoc
@@ -11,6 +11,9 @@ include::common/attributes.adoc[]
 :KubePlatformCredentials: OpenShift
 :OperatorMarketplaceNamespace: openshift-marketplace
 
+:KubePlatformRbacURL: https://access.redhat.com/documentation/en-us/openshift_container_platform/3.11/html-single/cluster_administration/index#admin-guide-manage-rbac
+
+
 = Documentation for {ProductName} on OpenShift
 
 Welcome to the {ProductName} documentation, where you can find information to help you learn about

--- a/documentation/modules/con-console.adoc
+++ b/documentation/modules/con-console.adoc
@@ -5,9 +5,9 @@
 [id='con-console-{context}']
 = {ConsoleName} user permissions
 
-{ConsoleName} uses the OpenShift RBAC permissions model. For more information about the OpenShift RBAC permissions model, see the link:https://access.redhat.com/documentation/en-us/openshift_container_platform/3.11/html-single/cluster_administration/index#admin-guide-manage-rbac[OpenShift 3.11 documentation^].
+{ConsoleName} uses the link:{KubePlatformRbacURL}[{KubePlatform} RBAC permissions model].
 
-To use {ConsoleName}, the OpenShift user requires a role that grants access to `addressspace` and `address` resources. For example, for edit access, `create`, `update` and `delete` permissions need be to given to the associated role object, and for view-only access, `list` permissions need to be granted.
+To use {ConsoleName}, the {KubePlatformCredentials} user requires a role that grants access to `addressspace` and `address` resources. For example, for edit access, `create`, `update` and `delete` permissions need be to given to the associated role object, and for view-only access, `list` permissions need to be granted.
 
 ifdef::SingleBookLink[]
 For more information about the {ProductName} example roles, see link:{BookUrlBase}{BaseProductVersion}{BookNameUrl}#ref-example-roles-messaging[{ProductName} example roles].

--- a/documentation/modules/proc-logging-in-console.adoc
+++ b/documentation/modules/proc-logging-in-console.adoc
@@ -29,7 +29,7 @@ endif::[]
 .Procedure
 . In a web browser, navigate to `https://_console-host-name_` where `_console-host-name_` is the {ConsoleName} host name.
 
-. Log in with your OpenShift user credentials. The {ConsoleName} opens.
+. Log in with your {KubePlatformCredentials} user credentials. The {ConsoleName} opens and lists all the address spaces that you can administer. For information on creating an address space, see link:{BookUrlBase}{BaseProductVersion}{BookNameUrl}#proc-create-address-space-console-messaging[Creating an address space using the {ConsoleName}].
 
 ifdef::Asciidoctor[]
 image::console-screenshot.png[{ConsoleName}]


### PR DESCRIPTION
### Type of change


- Bugfix
- Documentation

### Description

The RBAC refs were OpenShift specific.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
