### PR TITLE
Delivering management functionality for shared infra

### DIFF
--- a/documentation/design/proposals/management_tasks-for-shared.adoc
+++ b/documentation/design/proposals/management_tasks-for-shared.adoc
@@ -17,7 +17,7 @@ The current design has number of drawbacks:
    and HTTP proxies).  If the management request takes too long the response channel is lost meaning the user has no
    mechanism to monitor the request's completion.  Purging a deep queue or moving a significant number of messages
    is likely to breach timeouts. 
-1. The deisgn has no mechnaism to monitor the progress of a request
+1. The deisgn has no mechnaism to monitor the progress of a request or even know if it is still running.
 1. The deisgn has no mechnaism to cancel a management request.
 1. The Console UI uses modals UI elements to initiate the request and blocks awaiting the response. The user is unable
    to continue to interact with the app whilst the request is in progress.

--- a/documentation/design/proposals/management_tasks-for-shared.adoc
+++ b/documentation/design/proposals/management_tasks-for-shared.adoc
@@ -45,6 +45,9 @@ https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion
 The tenant admin would be able to CRUDWL `ManagementTask` from the CLI using `kubectl`/`oc` tooling (usual RBAC permissions
 apply), or later an EnMasse CLI tool might abstract away some details. 
 
+The operator would orchestrate the task.  The precise details of the orchestration would vary from task to task.   For some
+tasks we might delegate the work of the to a Kubernetes job in the infra namespace.
+
 From the Console. functions such as purge queue/subscription would, behind the button cause an instance of this object to
 be created.  There would be an area of the UI which lists running/recently finsihed tasks.  From this page, you'd be able
 to cancel running tasks too.

--- a/documentation/design/proposals/management_tasks-for-shared.adoc
+++ b/documentation/design/proposals/management_tasks-for-shared.adoc
@@ -38,15 +38,15 @@ https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion
 1. The EnMasse Operator periodically updates the task with progress of the task thus allowing the Tenant Admin to monitor
    the task for completion.  The availablility of progress information depends on the type of task.
 1. The Tenant Admin may delete a ManagementTask, this would be a signal to the Operator to cancel the task (if possible).
-1. The Operator would mark the ManagementTask as compete. A `ttlSecondsAfterFinished` parameter would allow the Operator to 
-   clean up the ManagementTasks automatically.
+1. The Operator would mark the ManagementTask as compete. A `ttlSecondsAfterFinished` parameter (defined at `MessagingInfra`
+   level) would allow the Operator to clean up the ManagementTasks automatically.
 
 The tenant admin would be able to CRUDWL `ManagementTask` from the CLI using `kubectl`/`oc` tooling (usual RBAC permissions
-apply), or later an EnMasse API.
+apply), or later an EnMasse CLI tool might abstract way some details.
 
 From the Console. functions such as purge queue/subscription would, behind the button cause an instance of this object to
 be created.  There would be an area of the UI which lists running/recently finsihed tasks.  From this page, you'd be able
-to cancel the task too.
+to cancel running tasks too.
 
 === CRD sketch
 

--- a/documentation/design/proposals/management_tasks-for-shared.adoc
+++ b/documentation/design/proposals/management_tasks-for-shared.adoc
@@ -85,4 +85,5 @@ Open Questions:
 
 * The ability of create a ManagementTask would be typically granted to an Tenant Admin.  This would give that user
   the permission to do any type of management functiion permitted by the task.  Would we need to be more discriminating?
+* View message?
 

--- a/documentation/design/proposals/management_tasks-for-shared.adoc
+++ b/documentation/design/proposals/management_tasks-for-shared.adoc
@@ -85,5 +85,5 @@ Open Questions:
 
 * The ability of create a ManagementTask would be typically granted to an Tenant Admin.  This would give that user
   the permission to do any type of management functiion permitted by the task.  Would we need to be more discriminating?
-* View message?
+* View message management function - how would that be delivered?  
 

--- a/documentation/design/proposals/management_tasks-for-shared.adoc
+++ b/documentation/design/proposals/management_tasks-for-shared.adoc
@@ -30,16 +30,16 @@ Introduce a new CRD `ManagementTask`.  A `ManagementTask` executes a management 
 tenant namespace within EnMasse.  It would be rather similar to
 https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/[Jobs] from Kubernetes.
 
-* The Tenant Admin would create an instance of the resource in order to cause the task to occur.  The contents of the
-  resource describe the jobs and its parameters.
-* The EnMasse Operator actions the tasks - initiating requests to Brokers or Routers as necessary.  This might invoke
+1. The Tenant Admin would create an instance of the resource in order to cause the task to occur.  The contents of the
+   resource describe the jobs and its parameters.
+1. The EnMasse Operator actions the tasks - initiating requests to Brokers or Routers as necessary.  This might invoke
   the invocation of Router/Broker management functions (close connection, clear queue etc), or might involve putting down
   router wiring to implement a move message task.
-* The EnMasse Operator periodically updates the task with progress of the task thus allowing the Tenant Admin to monitor
-  the task for completion.  The availablility of progress information depends on the type of task.
-* The Tenant Admin may delete a ManagementTask, this would be a signal to the Operator to cancel the task (if possible).
-* The Operator would mark the ManagementTask as compete. A `ttlSecondsAfterFinished` parameter would allow the Operator to 
-  clean up the ManagementTasks automatically.
+1. The EnMasse Operator periodically updates the task with progress of the task thus allowing the Tenant Admin to monitor
+   the task for completion.  The availablility of progress information depends on the type of task.
+1. The Tenant Admin may delete a ManagementTask, this would be a signal to the Operator to cancel the task (if possible).
+1. The Operator would mark the ManagementTask as compete. A `ttlSecondsAfterFinished` parameter would allow the Operator to 
+   clean up the ManagementTasks automatically.
 
 The tenant admin would be able to CRUDWL `ManagementTask` from the CLI using `kubectl`/`oc` tooling (usual RBAC permissions
 apply), or later an EnMasse API.

--- a/documentation/design/proposals/management_tasks-for-shared.adoc
+++ b/documentation/design/proposals/management_tasks-for-shared.adoc
@@ -31,8 +31,8 @@ Introduce a new CRD `ManagementTask`.  A `ManagementTask` executes a management 
 tenant namespace within EnMasse.  It would be rather similar to
 https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/[Jobs] from Kubernetes.
 
-1. The Tenant Admin would create an instance of the resource in order to cause the task to occur.  The contents of the
-   resource describe the jobs and its parameters.
+1. The Tenant Admin would create an instance of the resource in the tenant namespace in order to cause the task to occur.
+   The contents of the resource describe the jobs and its parameters.  The name of the resource is not significant.
 1. The EnMasse Operator actions the tasks - initiating requests to Brokers or Routers as necessary.  This might invoke
   the invocation of Router/Broker management functions (close connection, clear queue etc), or might involve putting down
   router wiring to implement a move message task.
@@ -43,7 +43,7 @@ https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion
    level) would allow the Operator to clean up the ManagementTasks automatically.
 
 The tenant admin would be able to CRUDWL `ManagementTask` from the CLI using `kubectl`/`oc` tooling (usual RBAC permissions
-apply), or later an EnMasse CLI tool might abstract away some details.
+apply), or later an EnMasse CLI tool might abstract away some details. 
 
 From the Console. functions such as purge queue/subscription would, behind the button cause an instance of this object to
 be created.  There would be an area of the UI which lists running/recently finsihed tasks.  From this page, you'd be able

--- a/documentation/design/proposals/management_tasks-for-shared.adoc
+++ b/documentation/design/proposals/management_tasks-for-shared.adoc
@@ -17,7 +17,8 @@ The current design has number of drawbacks:
    and HTTP proxies).  If the management request takes too long the response channel is lost meaning the user has no
    mechanism to monitor the request's completion.  Purging a deep queue or moving a significant number of messages
    is likely to breach timeouts. 
-1. The deisgn has no mechnaism to monitor the progress of a request or even know if it is still running.
+1. The deisgn has no mechnaism to monitor the progress of a request or even know if it is still running. If the Tenant
+   Admin role is shared amongst many people, the actions of one admin is hidden from another.
 1. The deisgn has no mechnaism to cancel a management request.
 1. The Console UI uses modals UI elements to initiate the request and blocks awaiting the response. The user is unable
    to continue to interact with the app whilst the request is in progress.
@@ -42,7 +43,7 @@ https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion
    level) would allow the Operator to clean up the ManagementTasks automatically.
 
 The tenant admin would be able to CRUDWL `ManagementTask` from the CLI using `kubectl`/`oc` tooling (usual RBAC permissions
-apply), or later an EnMasse CLI tool might abstract way some details.
+apply), or later an EnMasse CLI tool might abstract away some details.
 
 From the Console. functions such as purge queue/subscription would, behind the button cause an instance of this object to
 be created.  There would be an area of the UI which lists running/recently finsihed tasks.  From this page, you'd be able

--- a/documentation/design/proposals/management_tasks-for-shared.adoc
+++ b/documentation/design/proposals/management_tasks-for-shared.adoc
@@ -80,7 +80,8 @@ status:
   message: ..
   conditions:
     ...
-    
+```
+
 Open Questions:
 
 * The ability of create a ManagementTask would be typically granted to an Tenant Admin.  This would give that user

--- a/documentation/design/proposals/management_tasks-for-shared.adoc
+++ b/documentation/design/proposals/management_tasks-for-shared.adoc
@@ -1,0 +1,88 @@
+= Management Tasks for Shared
+
+EnMasse user stories defines a number of management functions that are available to the Tenant Admin.  These include
+purging a queue/subscription, closing a connection,  move/copy message(s) from one queue/subscription to a different address.
+
+Of those use-cases, the current solution implements only purge. The current implementation uses synchronous request/responses
+messages (HTTP and AMQP) to action the managemnet requests and relies on the existance of the `agent` component (something
+that will disappear with shared infrastructure.
+
+We need new design for this part of the system in order to deliver shared.
+
+== Current Design Flaws
+
+The current design has number of drawbacks:
+
+1. The design assumes that the management request can be completed within a HTTP request timeout (of both the use-agent
+   and HTTP proxies).  If the management request takes too long the response channel is lost meaning the user has no
+   mechanism to monitor the request's completion.  Purging a deep queue or moving a significant number of messages
+   is likely to breach timeouts. 
+1. The deisgn has no mechnaism to monitor the progress of a request
+1. The deisgn has no mechnaism to cancel a management request.
+1. The Console UI uses modals UI elements to initiate the request and blocks awaiting the response. The user is unable
+   to continue to interact with the app whilst the request is in progress.
+1. There is no provision for a command line interface.
+1. Poorly defined RBAC model.
+
+== High Level Proposal
+
+Introduce a new CRD `ManagementTask`.  A `ManagementTask` executes a management function (such as a purge) in a
+tenant namespace within EnMasse.  It would be rather similar to
+https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/[Jobs] from Kubernetes.
+
+* The Tenant Admin would create an instance of the resource in order to cause the task to occur.  The contents of the
+  resource describe the jobs and its parameters.
+* The EnMasse Operator actions the tasks - initiating requests to Brokers or Routers as necessary.  This might invoke
+  the invocation of Router/Broker management functions (close connection, clear queue etc), or might involve putting down
+  router wiring to implement a move message task.
+* The EnMasse Operator periodically updates the task with progress of the task thus allowing the Tenant Admin to monitor
+  the task for completion.  The availablility of progress information depends on the type of task.
+* The Tenant Admin may delete a ManagementTask, this would be a signal to the Operator to cancel the task (if possible).
+* The Operator would mark the ManagementTask as compete. A `ttlSecondsAfterFinished` parameter would allow the Operator to 
+  clean up the ManagementTasks automatically.
+
+The tenant admin would be able to CRUDWL `ManagementTask` from the CLI using `kubectl`/`oc` tooling (usual RBAC permissions
+apply), or later an EnMasse API.
+
+From the Console. functions such as purge queue/subscription would, behind the button cause an instance of this object to
+be created.  There would be an area of the UI which lists running/recently finsihed tasks.  From this page, you'd be able
+to cancel the task too.
+
+=== CRD sketch
+
+```
+apiVersion: enmasse.io/v1
+kind: ManagementTask
+metadata:
+  name: mytenantnamespace
+spec:
+  # oneOf
+  addressPurge:
+    addressSelector:
+      matchLabels:
+        foo: bar
+      matchNames:
+       - addr1
+       - addr1
+  connectionClose:  
+    connectionSelector:
+      matchNames:
+       - example.com:3456
+       - example.com:4567
+  moveMessage:
+     sourceAddress: addr1
+     filter:
+       type: amqp:sql-filter
+       expression: application-properties.color = 'blue'
+     targetAddress: add2
+status:
+  phase: New | Running | Failed | Completed
+  message: ..
+  conditions:
+    ...
+    
+Open Questions:
+
+* The ability of create a ManagementTask would be typically granted to an Tenant Admin.  This would give that user
+  the permission to do any type of management functiion permitted by the task.  Would we need to be more discriminating?
+


### PR DESCRIPTION
### Type of change

- Design sketch

I was thinking about how we'd deliver management functionality in the shared world.
I had some thoughts about a possible solution that I've captured as an embryonic proposal.

https://github.com/k-wall/enmasse/blob/man-tasks-for-shared/documentation/design/proposals/management_tasks-for-shared.adoc

All comments welcome.

### Description

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
