### PR TITLE
Handle multiple addresses for purge in a single query

### DIFF
--- a/console/console-init/ui/src/graphql-module/queries/Address.ts
+++ b/console/console-init/ui/src/graphql-module/queries/Address.ts
@@ -15,8 +15,8 @@ const DELETE_ADDRESS = gql`
 `;
 
 const PURGE_ADDRESS = gql`
-  mutation purge_addr($a: ObjectMeta_v1_Input!) {
-    purgeAddress(input: $a)
+  mutation purge_addresses($addrs: [ObjectMeta_v1_Input!]!) {
+    purgeAddresses(input: $addrs)
   }
 `;
 

--- a/console/console-init/ui/src/modules/address-detail/AddressDetailPage.tsx
+++ b/console/console-init/ui/src/modules/address-detail/AddressDetailPage.tsx
@@ -153,10 +153,12 @@ export default function AddressDetailPage() {
 
   const purgeAddress = (data: any) => {
     const variables = {
-      a: {
-        name: data.name,
-        namespace: data.namespace
-      }
+      addrs: [
+        {
+          name: data.name,
+          namespace: data.namespace
+        }
+      ]
     };
     setPurgeAddressQueryVariables(variables);
   };

--- a/console/console-init/ui/src/modules/address/containers/AddressListContainer/AddressListContainer.tsx
+++ b/console/console-init/ui/src/modules/address/containers/AddressListContainer/AddressListContainer.tsx
@@ -144,10 +144,12 @@ export const AddressListContainer: React.FunctionComponent<IAddressListPageProps
   const onPurge = async (address: IAddress) => {
     if (address) {
       const variables = {
-        a: {
-          name: address.name,
-          namespace: address.namespace
-        }
+        addrs: [
+          {
+            name: address.name,
+            namespace: address.namespace
+          }
+        ]
       };
       setPurgeAddressQueryVariables(variables);
     }


### PR DESCRIPTION

### Type of change

- Refactoring

### Description

Modify purge address mutation query and the usage to accept list of addresses.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
