### PR TITLE
Ignore .lock files generated by podman

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ scripts/swagger2markup.jar
 artifacts/
 
 imageenv.txt
+
+# Podman
+.lock


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

Since a recent update podman seems to create (and not remove) `.lock` files. In any case, we shouldn't add them to git.

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
