### PR TITLE
Correct Go-lang closure problem preventing the purging of >1 address

### DIFF
--- a/pkg/consolegraphql/resolvers/resolver_address.go
+++ b/pkg/consolegraphql/resolvers/resolver_address.go
@@ -267,8 +267,9 @@ func (r *mutationResolver) PurgeAddresses(ctx context.Context, inputs []*metav1.
 			return nil, e
 		}
 
+		copy := *input
 		purgeCommands = append(purgeCommands, func() error {
-			return commandDelegate.PurgeAddress(*input)
+			return commandDelegate.PurgeAddress(copy)
 		})
 	}
 

--- a/pkg/consolegraphql/resolvers/resolver_address_test.go
+++ b/pkg/consolegraphql/resolvers/resolver_address_test.go
@@ -445,7 +445,7 @@ func TestPurgeQueue(t *testing.T) {
 	delegate, err := collector.CommandDelegate(server.GetRequestStateFromContext(ctx).UserAccessToken, "")
 	assert.NoError(t, err)
 
-	assert.Equal(t, 1, delegate.(*mockCommandDelegate).purgeCount)
+	assert.ElementsMatch(t, []metav1.ObjectMeta{addr.ObjectMeta}, delegate.(*mockCommandDelegate).purged)
 }
 
 func TestPurgeQueues(t *testing.T) {
@@ -475,7 +475,7 @@ func TestPurgeQueues(t *testing.T) {
 	delegate, err := collector.CommandDelegate(server.GetRequestStateFromContext(ctx).UserAccessToken, "")
 	assert.NoError(t, err)
 
-	assert.Equal(t, 2, delegate.(*mockCommandDelegate).purgeCount)
+	assert.ElementsMatch(t, []metav1.ObjectMeta{addr1.ObjectMeta, addr2.ObjectMeta}, delegate.(*mockCommandDelegate).purged)
 }
 
 func TestPurgeUnsupportedAddressType(t *testing.T) {

--- a/pkg/consolegraphql/resolvers/resolver_connection_test.go
+++ b/pkg/consolegraphql/resolvers/resolver_connection_test.go
@@ -384,7 +384,7 @@ func TestCloseConnections(t *testing.T) {
 	delegate, err := collector.CommandDelegate(server.GetRequestStateFromContext(ctx).UserAccessToken, "")
 	assert.NoError(t, err)
 
-	assert.Equal(t, 2, delegate.(*mockCommandDelegate).closeCount)
+	assert.ElementsMatch(t, []metav1.ObjectMeta{con1.ObjectMeta, con2.ObjectMeta}, delegate.(*mockCommandDelegate).closed)
 }
 
 func TestCloseConnectionsOneConnectionNotFound(t *testing.T) {
@@ -412,7 +412,7 @@ func TestCloseConnectionsOneConnectionNotFound(t *testing.T) {
 	delegate, err := collector.CommandDelegate(server.GetRequestStateFromContext(ctx).UserAccessToken, "")
 	assert.NoError(t, err)
 
-	assert.Equal(t, 1, delegate.(*mockCommandDelegate).closeCount)
+	assert.ElementsMatch(t, []metav1.ObjectMeta{con.ObjectMeta}, delegate.(*mockCommandDelegate).closed)
 }
 
 func createConnectionLink(namespace string, addressspace string, con string, role string, metrics ...*consolegraphql.Metric) *consolegraphql.Link {

--- a/pkg/consolegraphql/resolvers/test_utils.go
+++ b/pkg/consolegraphql/resolvers/test_utils.go
@@ -132,17 +132,17 @@ type mockCollector struct {
 }
 
 type mockCommandDelegate struct {
-	purgeCount int
-	closeCount int
+	purged []metav1.ObjectMeta
+	closed []metav1.ObjectMeta
 }
 
-func (mcd *mockCommandDelegate) PurgeAddress(_ metav1.ObjectMeta) error {
-	mcd.purgeCount++
+func (mcd *mockCommandDelegate) PurgeAddress(a metav1.ObjectMeta) error {
+	mcd.purged = append(mcd.purged, a)
 	return nil
 }
 
-func (mcd *mockCommandDelegate) CloseConnection(_ metav1.ObjectMeta) error {
-	mcd.closeCount++
+func (mcd *mockCommandDelegate) CloseConnection(c metav1.ObjectMeta) error {
+	mcd.closed = append(mcd.closed, c)
 	return nil
 }
 


### PR DESCRIPTION
Strengthen unit tests.

- Bugfix

### Description

I'd made this mistake:

https://www.calhoun.io/gotchas-and-common-mistakes-with-closures-in-go/#variables-declared-in-for-loops-are-passed-by-reference

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
