### PR TITLE
Stability improvments for the addressspace/address/connection 'gone-away' page tests

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/selenium/page/ConsoleWebPage.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/selenium/page/ConsoleWebPage.java
@@ -40,6 +40,9 @@ import java.util.function.Supplier;
 public class ConsoleWebPage implements IWebPage {
 
     private static Logger log = CustomLogger.getLogger();
+    private static final By ADDRESS_LIST_XPATH = By.xpath("//table[@aria-label='Address List']");
+    private static final By CONNECTION_LIST_XPATH = By.xpath("//table[@aria-label='connection list']");
+    private static final By NOT_FOUND_STATE_XPATH = By.className("pf-c-empty-state");
 
     SeleniumProvider selenium;
     String ocRoute;
@@ -91,7 +94,7 @@ public class ConsoleWebPage implements IWebPage {
     }
 
     private WebElement getAddressTable() {
-        return selenium.getDriver().findElement(By.xpath("//table[@aria-label='Address List']"));
+        return selenium.getDriver().findElement(ADDRESS_LIST_XPATH);
     }
 
     private WebElement getTableAddressHeader() {
@@ -103,7 +106,7 @@ public class ConsoleWebPage implements IWebPage {
     }
 
     private WebElement getConnectionTable() {
-        return selenium.getDriver().findElement(By.xpath("//table[@aria-label='connection list']"));
+        return selenium.getDriver().findElement(CONNECTION_LIST_XPATH);
     }
 
     private WebElement getTableConnectionHeader() {
@@ -470,8 +473,9 @@ public class ConsoleWebPage implements IWebPage {
         return selenium.getDriver().findElement(By.id("adheader-name"));
     }
 
-    public WebElement getNotFoundPage() {
-        return selenium.getDriver().findElement(By.className("pf-c-empty-state"));
+    public void awaitGoneAwayPage() {
+        selenium.getDriverWait().withTimeout(Duration.ofSeconds(120)).until(ExpectedConditions.visibilityOfElementLocated(ConsoleWebPage.NOT_FOUND_STATE_XPATH));
+        selenium.takeScreenShot();
     }
 
     //==================================================================
@@ -686,10 +690,14 @@ public class ConsoleWebPage implements IWebPage {
 
     public void switchToAddressTab() {
         selenium.clickOnItem(getAddressTab(), "Addresses");
+        selenium.getDriverWait().withTimeout(Duration.ofSeconds(60)).until(ExpectedConditions.visibilityOfElementLocated(ADDRESS_LIST_XPATH));
+        selenium.takeScreenShot();
     }
 
     public void switchToConnectionTab() {
         selenium.clickOnItem(getConnectionTab(), "Connections");
+        selenium.getDriverWait().withTimeout(Duration.ofSeconds(60)).until(ExpectedConditions.visibilityOfElementLocated(CONNECTION_LIST_XPATH));
+        selenium.takeScreenShot();
     }
 
     public void addFilter(FilterType filterType, String filterValue) throws Exception {

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/web/ConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/web/ConsoleTest.java
@@ -133,7 +133,11 @@ public abstract class ConsoleTest extends TestBase {
         consolePage.createAddressSpace(addressSpace);
         consolePage.openAddressList(addressSpace);
         resourcesManager.deleteAddressSpaceWithoutWait(addressSpace);
-        consolePage.awaitGoneAwayPage();
+        try {
+            consolePage.awaitGoneAwayPage();
+        } finally {
+            resourcesManager.deleteAddressSpace(addressSpace);
+        }
     }
 
     protected void doTestGoneAwayPageAfterAddressDeletion() throws Exception {

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/web/ConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/web/ConsoleTest.java
@@ -64,7 +64,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.slf4j.Logger;
 
 import java.time.Duration;
@@ -127,19 +126,17 @@ public abstract class ConsoleTest extends TestBase {
         consolePage.deleteAddressSpace(addressSpace);
     }
 
-    protected void doTestBlankPageAfterAddressSpaceDeletion() throws Exception {
+    protected void doTestGoneAwayPageAfterAddressSpaceDeletion() throws Exception {
         AddressSpace addressSpace = generateAddressSpaceObject(AddressSpaceType.STANDARD);
         consolePage = new ConsoleWebPage(selenium, TestUtils.getGlobalConsoleRoute(), clusterUser);
         consolePage.openConsolePage();
         consolePage.createAddressSpace(addressSpace);
         consolePage.openAddressList(addressSpace);
         resourcesManager.deleteAddressSpaceWithoutWait(addressSpace);
-        selenium.getDriverWait().withTimeout(Duration.ofMinutes(22))
-                .until(ExpectedConditions.invisibilityOf(consolePage.getAddressSpaceTitle()));
-        assertNotNull(consolePage.getNotFoundPage());
+        consolePage.awaitGoneAwayPage();
     }
 
-    protected void doTestBlankPageAfterAddressDeletion() throws Exception {
+    protected void doTestGoneAwayPageAfterAddressDeletion() throws Exception {
         AddressSpace addressSpace = generateAddressSpaceObject(AddressSpaceType.STANDARD);
         consolePage = new ConsoleWebPage(selenium, TestUtils.getGlobalConsoleRoute(), clusterUser);
         consolePage.openConsolePage();
@@ -149,9 +146,7 @@ public abstract class ConsoleTest extends TestBase {
         consolePage.createAddress(address);
         consolePage.openClientsList(address);
         resourcesManager.deleteAddresses(address);
-        selenium.getDriverWait().withTimeout(Duration.ofSeconds(90))
-                .until(ExpectedConditions.invisibilityOf(consolePage.getAddressTitle()));
-        assertNotNull(consolePage.getNotFoundPage());
+        consolePage.awaitGoneAwayPage();
         resourcesManager.deleteAddressSpace(addressSpace);
     }
 
@@ -1155,7 +1150,7 @@ public abstract class ConsoleTest extends TestBase {
                 consolePage.getClientItems().size(), is(connectionCount * 2));
     }
 
-    protected void doTestEmptyLinkPage(AddressSpace addressSpace, ExtensionContext context) throws Exception {
+    protected void doTestGoneAwayPageAfterConnectionClose(AddressSpace addressSpace, ExtensionContext context) throws Exception {
         consolePage = new ConsoleWebPage(selenium, TestUtils.getGlobalConsoleRoute(), clusterUser);
         consolePage.openConsolePage();
         Address address = generateAddressObject(addressSpace, DestinationPlan.STANDARD_LARGE_QUEUE);
@@ -1171,11 +1166,7 @@ public abstract class ConsoleTest extends TestBase {
         kubernetes.deletePod(SystemtestsKubernetesApps.MESSAGING_CLIENTS, pod.getMetadata().getName());
         waitForPodsToTerminate(Collections.singletonList(pod.getMetadata().getUid()));
 
-        selenium.getDriverWait().withTimeout(Duration.ofSeconds(90))
-                .until(ExpectedConditions.invisibilityOf(consolePage.getLinkContainerId()));
-
-        assertNotNull(consolePage.getNotFoundPage());
-
+        consolePage.awaitGoneAwayPage();
     }
 
     protected void  doTestSortConnectionsByContainerId(AddressSpace addressSpace) throws Exception {

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/web/ChromeConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/web/ChromeConsoleTest.java
@@ -114,13 +114,13 @@ class ChromeConsoleTest extends ConsoleTest implements ITestIsolatedStandard {
     }
 
     @Test
-    void testBlankPageAfterAddressSpaceDeletion() throws Exception {
-        doTestBlankPageAfterAddressSpaceDeletion();
+    void testGoneAwayPageAfterAddressSpaceDeletion() throws Exception {
+        doTestGoneAwayPageAfterAddressSpaceDeletion();
     }
 
     @Test
-    void testBlankPageAfterAddressDeletion() throws Exception {
-        doTestBlankPageAfterAddressDeletion();
+    void testGoneAwayPageAfterAddressDeletion() throws Exception {
+        doTestGoneAwayPageAfterAddressDeletion();
     }
 }
 

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/web/FirefoxConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/web/FirefoxConsoleTest.java
@@ -126,13 +126,13 @@ class FirefoxConsoleTest extends ConsoleTest implements ITestIsolatedStandard {
     }
 
     @Test
-    void testBlankPageAfterAddressSpaceDeletion() throws Exception {
-        doTestBlankPageAfterAddressSpaceDeletion();
+    void testGoneAwayPageAfterAddressSpaceDeletion() throws Exception {
+        doTestGoneAwayPageAfterAddressSpaceDeletion();
     }
 
     @Test
-    void testBlankPageAfterAddressDeletion() throws Exception {
-        doTestBlankPageAfterAddressDeletion();
+    void testGoneAwayAfterAddressDeletion() throws Exception {
+        doTestGoneAwayPageAfterAddressDeletion();
     }
 
     @Test

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/web/ChromeConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/web/ChromeConsoleTest.java
@@ -207,8 +207,8 @@ public class ChromeConsoleTest extends ConsoleTest implements ITestSharedStandar
 
     @Test
     @ExternalClients
-    void testEmptyLinkPage() throws Exception {
-        doTestEmptyLinkPage(getSharedAddressSpace(), TestInfo.getInstance().getActualTest());
+    void testGoneAwayPageAfterConnectionClose() throws Exception {
+        doTestGoneAwayPageAfterConnectionClose(getSharedAddressSpace(), TestInfo.getInstance().getActualTest());
     }
 
     @Test()

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/web/FirefoxConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/web/FirefoxConsoleTest.java
@@ -318,8 +318,8 @@ public class FirefoxConsoleTest extends ConsoleTest implements ITestSharedStanda
 
     @Test
     @ExternalClients
-    void testEmptyLinkPage() throws Exception {
-        doTestEmptyLinkPage(getSharedAddressSpace(), TestInfo.getInstance().getActualTest());
+    void testGoneAwayPageAfterConnectionClose() throws Exception {
+        doTestGoneAwayPageAfterConnectionClose(getSharedAddressSpace(), TestInfo.getInstance().getActualTest());
     }
 
     @Test()


### PR DESCRIPTION
# Type of change


- Bugfix

### Description

Addresses two problems: test would fail spuriously after clicking connection tab and selenium observed the loading page rather than the connection list as it expected.  there was a similar issue after deleting/closing the addressspace/address/connection which again would lead to spurious failure.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
