### PR TITLE
Refactor GraphQL query in client side for deleteAddressSpace and deleteAddress to send many target objects 

### DIFF
--- a/console/console-init/ui/src/graphql-module/queries/Address.ts
+++ b/console/console-init/ui/src/graphql-module/queries/Address.ts
@@ -9,8 +9,8 @@ import { removeForbiddenChars } from "utils";
 import { generateFilterPattern } from "./query";
 
 const DELETE_ADDRESS = gql`
-  mutation delete_addr($a: ObjectMeta_v1_Input!) {
-    deleteAddress(input: $a)
+  mutation delete_addr($a: [ObjectMeta_v1_Input!]!) {
+    deleteAddresses(input: $a)
   }
 `;
 

--- a/console/console-init/ui/src/graphql-module/queries/AddressSpace.ts
+++ b/console/console-init/ui/src/graphql-module/queries/AddressSpace.ts
@@ -9,8 +9,8 @@ import { removeForbiddenChars } from "utils";
 import { generateFilterPattern } from "./query";
 
 const DELETE_ADDRESS_SPACE = gql`
-  mutation delete_as($a: ObjectMeta_v1_Input!) {
-    deleteAddressSpace(input: $a)
+  mutation delete_as($as: [ObjectMeta_v1_Input!]!) {
+    deleteAddressSpaces(input: $a)
   }
 `;
 

--- a/console/console-init/ui/src/graphql-module/queries/AddressSpace.ts
+++ b/console/console-init/ui/src/graphql-module/queries/AddressSpace.ts
@@ -10,7 +10,7 @@ import { generateFilterPattern } from "./query";
 
 const DELETE_ADDRESS_SPACE = gql`
   mutation delete_as($as: [ObjectMeta_v1_Input!]!) {
-    deleteAddressSpaces(input: $a)
+    deleteAddressSpaces(input: $as)
   }
 `;
 

--- a/console/console-init/ui/src/modules/address-detail/AddressDetailPage.tsx
+++ b/console/console-init/ui/src/modules/address-detail/AddressDetailPage.tsx
@@ -142,17 +142,19 @@ export default function AddressDetailPage() {
 
   const onDelete = async () => {
     const data = addressDetail.metadata;
-    const variables = {
-      a: {
-        name: data.name,
-        namespace: data.namespace
-      }
+    const queryVariables = {
+      a: [
+        {
+          name: data.name,
+          namespace: data.namespace
+        }
+      ]
     };
-    await setDeleteAddressQueryVariables(variables);
+    await setDeleteAddressQueryVariables(queryVariables);
   };
 
   const purgeAddress = (data: any) => {
-    const variables = {
+    const queryVariables = {
       addrs: [
         {
           name: data.name,
@@ -160,7 +162,7 @@ export default function AddressDetailPage() {
         }
       ]
     };
-    setPurgeAddressQueryVariables(variables);
+    setPurgeAddressQueryVariables(queryVariables);
   };
 
   const onChangeEdit = () => {

--- a/console/console-init/ui/src/modules/address-space/AddressSpaceDetailPage.tsx
+++ b/console/console-init/ui/src/modules/address-space/AddressSpaceDetailPage.tsx
@@ -154,10 +154,12 @@ export default function AddressSpaceDetailPage() {
 
   const onDelete = () => {
     const variables = {
-      a: {
-        name: addressSpaceDetails.name,
-        namespace: addressSpaceDetails.namespace
-      }
+      as: [
+        {
+          name: addressSpaceDetails.name,
+          namespace: addressSpaceDetails.namespace
+        }
+      ]
     };
     setDeleteAddressSpaceQueryVariables(variables);
   };

--- a/console/console-init/ui/src/modules/address-space/containers/AddressSpaceListContainer/AddressSpaceListContainer.tsx
+++ b/console/console-init/ui/src/modules/address-space/containers/AddressSpaceListContainer/AddressSpaceListContainer.tsx
@@ -113,13 +113,15 @@ export const AddressSpaceListContainer: React.FC<IAddressSpaceListContainerProps
 
   const onDeleteAddressSpace = (addressSpace: IAddressSpace) => {
     if (addressSpace) {
-      const variables = {
-        a: {
-          name: addressSpace.name,
-          namespace: addressSpace.nameSpace
-        }
+      const queryVariable = {
+        as: [
+          {
+            name: addressSpace.name,
+            namespace: addressSpace.nameSpace
+          }
+        ]
       };
-      setDeleteAddressSpaceQueryVariables(variables);
+      setDeleteAddressSpaceQueryVariables(queryVariable);
     }
   };
 

--- a/console/console-init/ui/src/modules/address/containers/AddressListContainer/AddressListContainer.tsx
+++ b/console/console-init/ui/src/modules/address/containers/AddressListContainer/AddressListContainer.tsx
@@ -182,13 +182,15 @@ export const AddressListContainer: React.FunctionComponent<IAddressListPageProps
 
   const onDelete = async (address: IAddress) => {
     if (address) {
-      const variables = {
-        a: {
-          name: address.name,
-          namespace: address.namespace
-        }
+      const queryVariables = {
+        a: [
+          {
+            name: address.name,
+            namespace: address.namespace
+          }
+        ]
       };
-      setDeleteAddressQueryVariablse(variables);
+      setDeleteAddressQueryVariablse(queryVariables);
     }
   };
 


### PR DESCRIPTION

### Type of change

- Refactoring

### Description

<!--

_Please describe your pull request_

-->
Refactor GraphQL client query for deleteAddressSpace and deleteAddress to pass variable as an array argument in console UI

### Checklist

- [ ] Update/write design documentation in ./documentation/design
 - [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ]  Check RBAC rights for Kubernetes / OpenShift roles
- [ ]  Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ]  Reference relevant issue(s) and close them after merging
- [ ]  Update CHANGELOG.md