### PR TITLE
[Console-UI] Add status as filter in toolbar for address space list 

### DIFF
--- a/console/console-init/ui/mock-console-server/mock-console-server.js
+++ b/console/console-init/ui/mock-console-server/mock-console-server.js
@@ -634,7 +634,10 @@ function createAddressSpace(as) {
         name: as.spec.authenticationService ? as.spec.authenticationService.name : null
       }
     },
-    status: null
+    status: {
+      phase:"",
+      messages:[]
+    }
   };
 
   addressSpaces.push(addressSpace);
@@ -1202,7 +1205,10 @@ function createAddress(addr, addressSpaceName) {
       type: addr.spec.type,
       topic: addr.spec.topic
     },
-    status: null,
+    status: {
+      phase:"",
+      messages:[]
+    },
   };
   scheduleSetAddressStatus(address, phase, messages, planStatus);
   addresses.push(address);

--- a/console/console-init/ui/src/graphql-module/queries/Address.ts
+++ b/console/console-init/ui/src/graphql-module/queries/Address.ts
@@ -63,19 +63,8 @@ const ALL_ADDRESS_FOR_ADDRESS_SPACE_FILTER = (
   if (typeValue && statusValue) {
     filter += " AND ";
   }
+
   //filter status
-  // if (statusValue) {
-  //   if (statusValue !== "Pending") {
-  //     filter += generateFilterPattern("status.phase", [
-  //       { value: statusValue, isExact: true }
-  //     ]);
-  //   } else {
-  //     filter += generateFilterPattern("status.phase", [
-  //       { value: statusValue, isExact: true },
-  //       { value: "", isExact: true }
-  //     ]);
-  //   }
-  // }
   if (statusValue) {
     if (statusValue !== "Pending") {
       filter += generateFilterPattern("status.phase", [

--- a/console/console-init/ui/src/graphql-module/queries/Address.ts
+++ b/console/console-init/ui/src/graphql-module/queries/Address.ts
@@ -63,11 +63,30 @@ const ALL_ADDRESS_FOR_ADDRESS_SPACE_FILTER = (
   if (typeValue && statusValue) {
     filter += " AND ";
   }
-
+  //filter status
+  // if (statusValue) {
+  //   if (statusValue !== "Pending") {
+  //     filter += generateFilterPattern("status.phase", [
+  //       { value: statusValue, isExact: true }
+  //     ]);
+  //   } else {
+  //     filter += generateFilterPattern("status.phase", [
+  //       { value: statusValue, isExact: true },
+  //       { value: "", isExact: true }
+  //     ]);
+  //   }
+  // }
   if (statusValue) {
-    filter += generateFilterPattern("status.phase", [
-      { value: statusValue, isExact: true }
-    ]);
+    if (statusValue !== "Pending") {
+      filter += generateFilterPattern("status.phase", [
+        { value: statusValue, isExact: true }
+      ]);
+    } else {
+      filter += generateFilterPattern("status.phase", [
+        { value: statusValue, isExact: true },
+        { value: "", isExact: true }
+      ]);
+    }
   }
   return filter;
 };

--- a/console/console-init/ui/src/graphql-module/queries/AddressSpace.ts
+++ b/console/console-init/ui/src/graphql-module/queries/AddressSpace.ts
@@ -17,7 +17,8 @@ const DELETE_ADDRESS_SPACE = gql`
 const ALL_ADDRESS_SPACES_FILTER = (
   filterNames?: any[],
   filterNameSpaces?: any[],
-  filterType?: string | null
+  filterType?: string | null,
+  filterStatus?: string | null
 ) => {
   let filter = "";
   let filterNamesLength = filterNames && filterNames.length;
@@ -51,6 +52,20 @@ const ALL_ADDRESS_SPACES_FILTER = (
       { value: filterType.toLowerCase(), isExact: true }
     ]);
   }
+
+  //filter tye
+  if (filterStatus) {
+    if (filterStatus !== "Pending") {
+      filter += generateFilterPattern("status.phase", [
+        { value: filterStatus, isExact: true }
+      ]);
+    } else {
+      filter += generateFilterPattern("status.phase", [
+        { value: filterStatus, isExact: true },
+        { value: "", isExact: true }
+      ]);
+    }
+  }
   return filter;
 };
 
@@ -83,12 +98,14 @@ const RETURN_ALL_ADDRESS_SPACES = (
   filterNames?: any[],
   filterNameSpaces?: any[],
   filterType?: string | null,
+  filterStatus?: string | null,
   sortBy?: ISortBy
 ) => {
   let filter = ALL_ADDRESS_SPACES_FILTER(
     filterNames,
     filterNameSpaces,
-    filterType
+    filterType,
+    filterStatus
   );
   let orderBy = ALL_ADDRESS_SPACES_SORT(sortBy);
 

--- a/console/console-init/ui/src/modules/address-space/AddressSpacePage.tsx
+++ b/console/console-init/ui/src/modules/address-space/AddressSpacePage.tsx
@@ -36,6 +36,7 @@ export default function AddressSpacePage() {
   const [filterNames, setFilterNames] = useState<string[]>([]);
   const [filterNamespaces, setFilterNamespaces] = useState<string[]>([]);
   const [filterType, setFilterType] = useState<string | null>(null);
+  const [filterStatus, setFilterStatus] = useState<string | null>(null);
   const [totalAddressSpaces, setTotalAddressSpaces] = useState<number>(0);
   const [sortDropDownValue, setSortDropdownValue] = useState<ISortBy>();
   const location = useLocation();
@@ -147,6 +148,8 @@ export default function AddressSpacePage() {
             setSelectedNamespaces={setFilterNamespaces}
             typeSelected={filterType}
             setTypeSelected={setFilterType}
+            statusSelected={filterStatus}
+            setStatusSelected={setFilterStatus}
             totalAddressSpaces={totalAddressSpaces}
             sortValue={sortDropDownValue}
             setSortValue={setSortDropdownValue}
@@ -164,6 +167,7 @@ export default function AddressSpacePage() {
         filterNames={filterNames}
         filterNamespaces={filterNamespaces}
         filterType={filterType}
+        filterStatus={filterStatus}
         sortValue={sortDropDownValue}
         setSortValue={setSortDropdownValue}
         selectedAddressSpaces={selectedAddressSpaces}

--- a/console/console-init/ui/src/modules/address-space/components/MessagingDatatoolbarToggleGroup/MessagingDataToolbarToggleGroup.tsx
+++ b/console/console-init/ui/src/modules/address-space/components/MessagingDatatoolbarToggleGroup/MessagingDataToolbarToggleGroup.tsx
@@ -21,7 +21,11 @@ import {
 } from "@patternfly/react-core";
 import { ISelectOption } from "utils";
 import { FilterIcon, SearchIcon } from "@patternfly/react-icons";
-import { DropdownWithToggle, TypeAheadSelect } from "components";
+import {
+  DropdownWithToggle,
+  TypeAheadSelect,
+  IDropdownOption
+} from "components";
 
 export interface IMessagingToolbarToggleGroupProps {
   totalRecords: number;
@@ -33,6 +37,7 @@ export interface IMessagingToolbarToggleGroupProps {
   nameOptions?: any[];
   namespaceOptions?: any[];
   typeSelected?: string | null;
+  statusSelected?: string | null;
   selectedNames: Array<{ value: string; isExact: boolean }>;
   selectedNamespaces: Array<{ value: string; isExact: boolean }>;
   onFilterSelect: (value: string) => void;
@@ -41,6 +46,7 @@ export interface IMessagingToolbarToggleGroupProps {
   onNamespaceSelect: (e: any, selection: SelectOptionObject) => void;
   onNamespaceClear: () => void;
   onTypeSelect: (selection: string) => void;
+  onStatusSelect: (selection: string) => void;
   onDeleteAll: () => void;
   onSearch: () => void;
   onDelete: (
@@ -60,6 +66,7 @@ const MessagingToolbarToggleGroup: React.FunctionComponent<IMessagingToolbarTogg
   namespaceSelected,
   namespaceInput,
   typeSelected,
+  statusSelected,
   selectedNames,
   selectedNamespaces,
   onFilterSelect,
@@ -68,6 +75,7 @@ const MessagingToolbarToggleGroup: React.FunctionComponent<IMessagingToolbarTogg
   onNamespaceSelect,
   onNamespaceClear,
   onTypeSelect,
+  onStatusSelect,
   onSearch,
   onDelete,
   onChangeNameInput,
@@ -78,18 +86,29 @@ const MessagingToolbarToggleGroup: React.FunctionComponent<IMessagingToolbarTogg
   const filterMenuItems = [
     { key: "name", value: "Name" },
     { key: "namespace", value: "Namespace" },
-    { key: "type", value: "Type" }
+    { key: "type", value: "Type" },
+    { key: "status", value: "Status" }
   ];
+
   const typeOptions: ISelectOption[] = [
     { key: "standard", value: "Standard", isDisabled: false },
     { key: "brokered", value: "Brokered", isDisabled: false }
+  ];
+
+  const statusOptions: IDropdownOption[] = [
+    { key: "active", value: "Active", label: "Active" },
+    { key: "configuring", value: "Configuring", label: "Configuring" },
+    { key: "pending", value: "Pending", label: "Pending" },
+    { key: "failed", value: "Failed", label: "Failed" },
+    { key: "terminating", value: "Terminating", label: "Terminating" }
   ];
 
   const checkIsFilterApplied = () => {
     if (
       (selectedNames && selectedNames.length > 0) ||
       (selectedNamespaces && selectedNamespaces.length > 0) ||
-      (typeSelected && typeSelected.trim() !== "")
+      (typeSelected && typeSelected.trim() !== "") ||
+      (statusSelected && statusSelected.trim() !== "")
     ) {
       return true;
     }
@@ -181,6 +200,26 @@ const MessagingToolbarToggleGroup: React.FunctionComponent<IMessagingToolbarTogg
               onSelectItem={onTypeSelect}
               dropdownItems={typeOptions}
               value={typeSelected || "Select Type"}
+            />
+          )}
+        </DataToolbarFilter>
+      </DataToolbarItem>
+      <DataToolbarItem
+        breakpointMods={[{ modifier: "spacer-none", breakpoint: "md" }]}
+      >
+        <DataToolbarFilter
+          chips={statusSelected ? [statusSelected] : []}
+          deleteChip={onDelete}
+          categoryName="Status"
+        >
+          {filterSelected && filterSelected.toLowerCase() === "status" && (
+            <DropdownWithToggle
+              id={"al-filter-dropdown-status"}
+              dropdownItemId={"al-filter-dropdown-item-status"}
+              position={DropdownPosition.left}
+              onSelectItem={onStatusSelect}
+              dropdownItems={statusOptions}
+              value={statusSelected || "Select Status"}
             />
           )}
         </DataToolbarFilter>

--- a/console/console-init/ui/src/modules/address-space/components/MessagingToolbar/MessagingToolbar.tsx
+++ b/console/console-init/ui/src/modules/address-space/components/MessagingToolbar/MessagingToolbar.tsx
@@ -38,6 +38,7 @@ const MessagingToolbar: React.FunctionComponent<IMessageToolbarProps &
   nameOptions,
   namespaceOptions,
   typeSelected,
+  statusSelected,
   selectedNames,
   selectedNamespaces,
   onFilterSelect,
@@ -46,6 +47,7 @@ const MessagingToolbar: React.FunctionComponent<IMessageToolbarProps &
   onNamespaceSelect,
   onNamespaceClear,
   onTypeSelect,
+  onStatusSelect,
   onDeleteAll,
   onSearch,
   onDelete,
@@ -77,6 +79,7 @@ const MessagingToolbar: React.FunctionComponent<IMessageToolbarProps &
         nameOptions={nameOptions}
         namespaceOptions={namespaceOptions}
         typeSelected={typeSelected}
+        statusSelected={statusSelected}
         selectedNames={selectedNames}
         selectedNamespaces={selectedNamespaces}
         onFilterSelect={onFilterSelect}
@@ -85,6 +88,7 @@ const MessagingToolbar: React.FunctionComponent<IMessageToolbarProps &
         onNamespaceSelect={onNamespaceSelect}
         onNamespaceClear={onNamespaceClear}
         onTypeSelect={onTypeSelect}
+        onStatusSelect={onStatusSelect}
         onDeleteAll={onDeleteAll}
         onSearch={onSearch}
         onDelete={onDelete}

--- a/console/console-init/ui/src/modules/address-space/containers/AddressSpaceListContainer/AddressSpaceListContainer.tsx
+++ b/console/console-init/ui/src/modules/address-space/containers/AddressSpaceListContainer/AddressSpaceListContainer.tsx
@@ -41,6 +41,7 @@ export interface IAddressSpaceListContainerProps {
   filterNames: string[];
   filterNamespaces: string[];
   filterType: string | null;
+  filterStatus: string | null;
   sortValue?: ISortBy;
   setSortValue: (value: ISortBy) => void;
   onSelectAddressSpace: (data: IAddressSpace, isSelected: boolean) => void;
@@ -58,6 +59,7 @@ export const AddressSpaceListContainer: React.FC<IAddressSpaceListContainerProps
   filterNames,
   filterNamespaces,
   filterType,
+  filterStatus,
   sortValue,
   setSortValue,
   onSelectAddressSpace,
@@ -82,6 +84,7 @@ export const AddressSpaceListContainer: React.FC<IAddressSpaceListContainerProps
       filterNames,
       filterNamespaces,
       filterType,
+      filterStatus,
       sortBy
     ),
     { pollInterval: POLL_INTERVAL, fetchPolicy: FetchPolicy.NETWORK_ONLY }

--- a/console/console-init/ui/src/modules/address-space/containers/MessagingToolbarContainer/MessagingToolbarContainer.tsx
+++ b/console/console-init/ui/src/modules/address-space/containers/MessagingToolbarContainer/MessagingToolbarContainer.tsx
@@ -25,6 +25,8 @@ export interface IMessagingToolbarContainerProps {
   setSelectedNamespaces: (value: Array<any>) => void;
   typeSelected?: string | null;
   setTypeSelected: (value: string | null) => void;
+  statusSelected?: string | null;
+  setStatusSelected: (value: string | null) => void;
   totalAddressSpaces: number;
   sortValue?: ISortBy;
   setSortValue: (value: ISortBy) => void;
@@ -39,6 +41,8 @@ export const MessagingToolbarContainer: React.FunctionComponent<IMessagingToolba
   setSelectedNamespaces,
   typeSelected,
   setTypeSelected,
+  statusSelected,
+  setStatusSelected,
   totalAddressSpaces,
   sortValue,
   setSortValue,
@@ -58,6 +62,7 @@ export const MessagingToolbarContainer: React.FunctionComponent<IMessagingToolba
     setSelectedNamespaces([]);
     setSelectedNames([]);
     setTypeSelected(null);
+    setStatusSelected(null);
   };
 
   const onCreateAddressSpace = () => {
@@ -77,7 +82,8 @@ export const MessagingToolbarContainer: React.FunctionComponent<IMessagingToolba
   const resettInitialState = () => {
     setNameInput("");
     setNamespaceInput("");
-    setTypeSelected("");
+    setTypeSelected(null);
+    setStatusSelected(null);
   };
 
   const onFilterSelect = (value: string) => {
@@ -156,6 +162,10 @@ export const MessagingToolbarContainer: React.FunctionComponent<IMessagingToolba
 
   const onTypeSelect = (selection: string) => {
     setTypeSelected(selection);
+  };
+
+  const onStatusSelect = (selection: string) => {
+    setStatusSelected(selection);
   };
 
   const onSearch = () => {
@@ -248,6 +258,9 @@ export const MessagingToolbarContainer: React.FunctionComponent<IMessagingToolba
       case "type":
         setTypeSelected(null);
         break;
+      case "status":
+        setStatusSelected(null);
+        break;
     }
   };
 
@@ -260,6 +273,7 @@ export const MessagingToolbarContainer: React.FunctionComponent<IMessagingToolba
       namespaceSelected={namespaceSelected}
       namespaceInput={namespaceInput}
       typeSelected={typeSelected}
+      statusSelected={statusSelected}
       selectedNames={selectedNames}
       selectedNamespaces={selectedNamespaces}
       onFilterSelect={onFilterSelect}
@@ -268,6 +282,7 @@ export const MessagingToolbarContainer: React.FunctionComponent<IMessagingToolba
       onNamespaceSelect={onNamespaceSelect}
       onNamespaceClear={onNamespaceClear}
       onTypeSelect={onTypeSelect}
+      onStatusSelect={onStatusSelect}
       onDeleteAll={onDeleteAll}
       onSearch={onSearch}
       onDelete={onDelete}

--- a/console/console-init/ui/src/modules/address-space/utils/AddressSpaceFormatter.tsx
+++ b/console/console-init/ui/src/modules/address-space/utils/AddressSpaceFormatter.tsx
@@ -51,6 +51,9 @@ const statusToDisplay = (phase: string) => {
     case "failed":
       icon = <ErrorCircleOIcon color="red" />;
       break;
+    case "terminating":
+      icon = <BanIcon color="red" />;
+      break;
     case "":
       icon = <ExclamationCircleIcon color="red" />;
       break;

--- a/console/console-init/ui/src/modules/address/components/AddressToggleGroup/AddressToggleGroup.tsx
+++ b/console/console-init/ui/src/modules/address/components/AddressToggleGroup/AddressToggleGroup.tsx
@@ -79,7 +79,8 @@ const AddressToggleGroup: React.FunctionComponent<IAddressToggleGroupProps> = ({
     { key: "active", value: "Active", isDisabled: false },
     { key: "configuring", value: "Configuring", isDisabled: false },
     { key: "pending", value: "Pending", isDisabled: false },
-    { key: "failed", value: "Failed", isDisabled: false }
+    { key: "failed", value: "Failed", isDisabled: false },
+    { key: "terminating", value: "Terminating", isDisabled: false }
   ];
 
   const checkIsFilterApplied = () => {


### PR DESCRIPTION


### Type of change

<!--

_Select the type of your PR_

-->

- Enhancement / new feature
- Refactoring

### Description

- Add functionality to support filter address space by status
- Include terminating status in status filter dropdown for address
![image](https://user-images.githubusercontent.com/29524461/82603860-00ac8d80-9bd1-11ea-9538-e3255e43de07.png)

![image](https://user-images.githubusercontent.com/29524461/82603834-f7232580-9bd0-11ea-84a6-112a2ede34dd.png)

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
