### PR TITLE
Fix double "enmasse_" prefix on metrics

### DIFF
--- a/pkg/custom-metrics/iot.go
+++ b/pkg/custom-metrics/iot.go
@@ -12,85 +12,85 @@ import (
 
 var (
 
-	//region IoTConfig
+	// region IoTConfig
 
 	IoTConfig = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name:        "enmasse_iot_configs",
+			Name:        "iot_configs",
 			Help:        "Number of IoT Configs",
 			ConstLabels: defaultLabels(),
 		},
 	)
 	IoTConfigActive = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name:        "enmasse_iot_configs_active",
+			Name:        "iot_configs_active",
 			Help:        "Number of IoT Configs with status 'active'",
 			ConstLabels: defaultLabels(),
 		},
 	)
 	IoTConfigConfiguring = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name:        "enmasse_iot_configs_configuring",
+			Name:        "iot_configs_configuring",
 			Help:        "Number of IoT Configs with status 'configuring'",
 			ConstLabels: defaultLabels(),
 		},
 	)
 	IoTConfigTerminating = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name:        "enmasse_iot_configs_terminating",
+			Name:        "iot_configs_terminating",
 			Help:        "Number of IoT Configs with status 'terminating'",
 			ConstLabels: defaultLabels(),
 		},
 	)
 	IoTConfigFailed = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name:        "enmasse_iot_configs_failed",
+			Name:        "iot_configs_failed",
 			Help:        "Number of IoT Configs with status 'failed'",
 			ConstLabels: defaultLabels(),
 		},
 	)
 
-	//endregion
+	// endregion
 
-	//region IoTProject
+	// region IoTProject
 
 	IoTProject = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name:        "enmasse_iot_projects",
+			Name:        "iot_projects",
 			Help:        "Number of IoT Projects",
 			ConstLabels: defaultLabels(),
 		},
 	)
 	IoTProjectActive = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name:        "enmasse_iot_projects_active",
+			Name:        "iot_projects_active",
 			Help:        "Number of IoT Projects with status 'active'",
 			ConstLabels: defaultLabels(),
 		},
 	)
 	IoTProjectConfiguring = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name:        "enmasse_iot_projects_configuring",
+			Name:        "iot_projects_configuring",
 			Help:        "Number of IoT Projects with status 'configuring'",
 			ConstLabels: defaultLabels(),
 		},
 	)
 	IoTProjectTerminating = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name:        "enmasse_iot_projects_terminating",
+			Name:        "iot_projects_terminating",
 			Help:        "Number of IoT Projects with status 'terminating'",
 			ConstLabels: defaultLabels(),
 		},
 	)
 	IoTProjectFailed = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name:        "enmasse_iot_projects_failed",
+			Name:        "iot_projects_failed",
 			Help:        "Number of IoT Projects with status 'failed'",
 			ConstLabels: defaultLabels(),
 		},
 	)
 
-	//endregion
+	// endregion
 
 )
 


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
