### PR TITLE
Enable admonition icons

### DIFF
--- a/documentation/common/attributes.adoc
+++ b/documentation/common/attributes.adoc
@@ -10,6 +10,7 @@
 :sectnums:
 :source-highlighter: highlightjs
 :linkattrs:
+:icons: font
 
 // Product attributes
 


### PR DESCRIPTION
This enables admonition icons, based on font awesome. Everything is handled be asciidoc, and it is purely optional.

## Before

![Screenshot_20200526_121308](https://user-images.githubusercontent.com/202474/82889580-3fcd3c80-9f4b-11ea-9851-cd2e4fd49f88.png)

## After

![Screenshot_20200526_121731](https://user-images.githubusercontent.com/202474/82889592-4491f080-9f4b-11ea-84c9-e757510997b8.png)
