### PR TITLE
Skip revision information

### DIFF
--- a/documentation/contributing/master.adoc
+++ b/documentation/contributing/master.adoc
@@ -24,6 +24,3 @@ include::git-tips.adoc[leveloffset=+1]
 
 [appendix]
 include::templates.adoc[leveloffset=+1]
-
-// Revision information
-include::common/revision-info.adoc[]


### PR DESCRIPTION
Skip revision information to avoid pushing docs on every build (updates date).