### PR TITLE
[Investigation] Add extra logging to understand websocket/AWS issue

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/clients/ClientTestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/clients/ClientTestBase.java
@@ -100,6 +100,7 @@ public abstract class ClientTestBase extends TestBase implements ITestBaseShared
                 .withCount(expectedMsgCount)
                 .withMessageBody("msg no. %d")
                 .withTimeout(30)
+                .withAdditionalArgument(ClientArgument.LOG_LIB, "ALL") // KWDEBUG investigating websocket failure.
                 .withAdditionalArgument(ClientArgument.CONN_WEB_SOCKET, websocket)
                 .withAdditionalArgument(ClientArgument.CONN_WEB_SOCKET_PROTOCOLS, getSharedAddressSpace().getSpec().getType().equals(AddressSpaceType.STANDARD.toString()) ? "binary" : "")
                 .withAdditionalArgument(ClientArgument.DEST_TYPE, "ANYCAST");


### PR DESCRIPTION
### Type of change

We see failures of MsgPatternsTest.testBasicMessageWebSocket on AWS environment. Adding extra trace to help understand the problem.

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
