### PR TITLE
Temporarily exclude websocket tests from OCP4

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/clients/rhea/MsgPatternsInternalTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/clients/rhea/MsgPatternsInternalTest.java
@@ -6,6 +6,8 @@ package io.enmasse.systemtest.shared.brokered.clients.rhea;
 
 import io.enmasse.systemtest.bases.clients.ClusterClientTestBase;
 import io.enmasse.systemtest.bases.shared.ITestSharedBrokered;
+import io.enmasse.systemtest.condition.OpenShift;
+import io.enmasse.systemtest.condition.OpenShiftVersion;
 import io.enmasse.systemtest.messagingclients.rhea.RheaClientReceiver;
 import io.enmasse.systemtest.messagingclients.rhea.RheaClientSender;
 import org.junit.jupiter.api.Test;
@@ -18,6 +20,7 @@ class MsgPatternsInternalTest extends ClusterClientTestBase implements ITestShar
     }
 
     @Test
+    @OpenShift(version = OpenShiftVersion.OCP3)
     void testBasicMessageWebSocket() throws Exception {
         doBasicMessageTest(new RheaClientSender(), new RheaClientReceiver(), true);
     }

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/clients/rhea/MsgPatternsTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/clients/rhea/MsgPatternsTest.java
@@ -6,6 +6,8 @@ package io.enmasse.systemtest.shared.brokered.clients.rhea;
 
 import io.enmasse.systemtest.bases.clients.ClientTestBase;
 import io.enmasse.systemtest.bases.shared.ITestSharedBrokered;
+import io.enmasse.systemtest.condition.OpenShift;
+import io.enmasse.systemtest.condition.OpenShiftVersion;
 import io.enmasse.systemtest.messagingclients.rhea.RheaClientReceiver;
 import io.enmasse.systemtest.messagingclients.rhea.RheaClientSender;
 import org.junit.jupiter.api.DisplayName;
@@ -23,6 +25,7 @@ class MsgPatternsTest extends ClientTestBase implements ITestSharedBrokered {
     }
 
     @Test
+    @OpenShift(version = OpenShiftVersion.OCP3)
     void testBasicMessageWebSocket() throws Exception {
         doBasicMessageTest(new RheaClientSender(logPath), new RheaClientReceiver(logPath), true);
     }

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/web/ChromeWebSocketBrowserTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/web/ChromeWebSocketBrowserTest.java
@@ -7,6 +7,8 @@ package io.enmasse.systemtest.shared.brokered.web;
 import io.enmasse.address.model.AddressBuilder;
 import io.enmasse.systemtest.bases.shared.ITestSharedBrokered;
 import io.enmasse.systemtest.bases.web.WebSocketBrowserTest;
+import io.enmasse.systemtest.condition.OpenShift;
+import io.enmasse.systemtest.condition.OpenShiftVersion;
 import io.enmasse.systemtest.model.address.AddressType;
 import io.enmasse.systemtest.annotations.SeleniumChrome;
 import io.enmasse.systemtest.utils.AddressUtils;
@@ -17,6 +19,7 @@ import static io.enmasse.systemtest.TestTag.NON_PR;
 
 @Tag(NON_PR)
 @SeleniumChrome
+@OpenShift(version = OpenShiftVersion.OCP3)
 class ChromeWebSocketBrowserTest extends WebSocketBrowserTest implements ITestSharedBrokered {
 
 

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/web/FirefoxWebSocketBrowserTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/web/FirefoxWebSocketBrowserTest.java
@@ -7,12 +7,15 @@ package io.enmasse.systemtest.shared.brokered.web;
 import io.enmasse.address.model.AddressBuilder;
 import io.enmasse.systemtest.bases.shared.ITestSharedBrokered;
 import io.enmasse.systemtest.bases.web.WebSocketBrowserTest;
+import io.enmasse.systemtest.condition.OpenShift;
+import io.enmasse.systemtest.condition.OpenShiftVersion;
 import io.enmasse.systemtest.model.address.AddressType;
 import io.enmasse.systemtest.annotations.SeleniumFirefox;
 import io.enmasse.systemtest.utils.AddressUtils;
 import org.junit.jupiter.api.Test;
 
 @SeleniumFirefox
+@OpenShift(version = OpenShiftVersion.OCP3)
 class FirefoxWebSocketBrowserTest extends WebSocketBrowserTest implements ITestSharedBrokered {
 
 

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/clients/rhea/MsgPatternsInternalTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/clients/rhea/MsgPatternsInternalTest.java
@@ -6,6 +6,8 @@ package io.enmasse.systemtest.shared.standard.clients.rhea;
 
 import io.enmasse.systemtest.bases.clients.ClusterClientTestBase;
 import io.enmasse.systemtest.bases.shared.ITestSharedStandard;
+import io.enmasse.systemtest.condition.OpenShift;
+import io.enmasse.systemtest.condition.OpenShiftVersion;
 import io.enmasse.systemtest.messagingclients.rhea.RheaClientReceiver;
 import io.enmasse.systemtest.messagingclients.rhea.RheaClientSender;
 import org.junit.jupiter.api.Test;
@@ -18,6 +20,7 @@ class MsgPatternsInternalTest extends ClusterClientTestBase implements ITestShar
     }
 
     @Test
+    @OpenShift(version = OpenShiftVersion.OCP3)
     void testBasicMessageWebSocket() throws Exception {
         doBasicMessageTest(new RheaClientSender(), new RheaClientReceiver(), true);
     }

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/clients/rhea/MsgPatternsTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/clients/rhea/MsgPatternsTest.java
@@ -6,6 +6,8 @@ package io.enmasse.systemtest.shared.standard.clients.rhea;
 
 import io.enmasse.systemtest.bases.clients.ClientTestBase;
 import io.enmasse.systemtest.bases.shared.ITestSharedStandard;
+import io.enmasse.systemtest.condition.OpenShift;
+import io.enmasse.systemtest.condition.OpenShiftVersion;
 import io.enmasse.systemtest.messagingclients.rhea.RheaClientReceiver;
 import io.enmasse.systemtest.messagingclients.rhea.RheaClientSender;
 import org.junit.jupiter.api.Disabled;
@@ -24,6 +26,7 @@ class MsgPatternsTest extends ClientTestBase implements ITestSharedStandard {
     }
 
     @Test
+    @OpenShift(version = OpenShiftVersion.OCP3)
     void testBasicMessageWebSocket() throws Exception {
         doBasicMessageTest(new RheaClientSender(logPath), new RheaClientReceiver(logPath), true);
     }

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/web/ChromeWebSocketBrowserTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/web/ChromeWebSocketBrowserTest.java
@@ -7,6 +7,8 @@ package io.enmasse.systemtest.shared.standard.web;
 import io.enmasse.address.model.AddressBuilder;
 import io.enmasse.systemtest.bases.shared.ITestSharedStandard;
 import io.enmasse.systemtest.bases.web.WebSocketBrowserTest;
+import io.enmasse.systemtest.condition.OpenShift;
+import io.enmasse.systemtest.condition.OpenShiftVersion;
 import io.enmasse.systemtest.model.address.AddressType;
 import io.enmasse.systemtest.annotations.SeleniumChrome;
 import io.enmasse.systemtest.utils.AddressUtils;
@@ -17,6 +19,7 @@ import static io.enmasse.systemtest.TestTag.NON_PR;
 
 @Tag(NON_PR)
 @SeleniumChrome
+@OpenShift(version = OpenShiftVersion.OCP3)
 class ChromeWebSocketBrowserTest extends WebSocketBrowserTest implements ITestSharedStandard {
 
     @Test

--- a/systemtests/src/test/java/io/enmasse/systemtest/sharedinfra/MessagingEndpointTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/sharedinfra/MessagingEndpointTest.java
@@ -391,7 +391,7 @@ public class MessagingEndpointTest extends TestBase implements ITestIsolatedShar
     }
 
     @Test
-    @OpenShift
+    @OpenShift(version = OpenShiftVersion.OCP3)
     public void testRouteEndpointWebsocketTlsReencrypt() throws Exception {
         MessagingTenant tenant = infraResourceManager.getDefaultMessagingTenant();
         MessagingEndpoint endpoint = new MessagingEndpointBuilder()


### PR DESCRIPTION
### Type of change

Temporary test exclusion on the OCP4 platform, relates to  #4641

### Description


### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
