### PR TITLE
Fix: failing UI build and unit tests

### DIFF
--- a/console/console-init/ui/src/modules/iot-certificates/components/CertificateForm/CertificateForm.tsx
+++ b/console/console-init/ui/src/modules/iot-certificates/components/CertificateForm/CertificateForm.tsx
@@ -71,7 +71,7 @@ export const CertificateForm: React.FunctionComponent<ICertificateFormProps> = (
     value: string | boolean,
     event: React.FormEvent<HTMLInputElement>
   ) => {
-    const cerftificateField = event?.target?.name;
+    const { name: cerftificateField } = event.currentTarget;
     const newCertificateData = { ...certificateFormData };
     (newCertificateData as any)[cerftificateField] = value;
     setCertificateFormData(newCertificateData);

--- a/console/console-init/ui/src/modules/iot-project-detail/components/GeneralInfo/GeneralInfo.test.tsx
+++ b/console/console-init/ui/src/modules/iot-project-detail/components/GeneralInfo/GeneralInfo.test.tsx
@@ -31,7 +31,7 @@ describe("<GeneralInfo />", () => {
     );
     getByText("General Info");
     getByText("Address space");
-    getByText("Event address name");
+    getByText("Events address name");
     getByText("Telemetry address name");
     getByText("Command address name");
     getByText("Max Connection");

--- a/console/console-init/ui/src/modules/project/components/MessagingConfigurationStep/MessagingConfigurationStep.tsx
+++ b/console/console-init/ui/src/modules/project/components/MessagingConfigurationStep/MessagingConfigurationStep.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import { isMessagingProjectValid } from "modules/project/dailogs";
+import { isMessagingProjectValid } from "modules/project/utils";
 import { dnsSubDomainRfc1123NameRegexp } from "utils";
 import { Configuration } from "modules/address-space";
 

--- a/console/console-init/ui/src/modules/project/dailogs/index.ts
+++ b/console/console-init/ui/src/modules/project/dailogs/index.ts
@@ -3,4 +3,4 @@
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 
-export * from "../utils";
+export * from "./CreateProjectContainer";


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes the issue arising due to re-defining of project utils and the failing build due to the FormCertificate. The re-definition has been removed. The tests that were earlier failing due to `isMessagingProjectValid` re-definition are passing now.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [x] Resolve all warnings
- [ ] Update license
- [ ] Write test cases for null checks in Unit Tests
- [ ] Reference relevant issue(s) and close them after merging

