### PR TITLE
correct capitalisation of v1beta2 enums in GraphQL schema

### DIFF
--- a/console/console-init/ui/mock-console-server/mock-console-server.js
+++ b/console/console-init/ui/mock-console-server/mock-console-server.js
@@ -788,9 +788,9 @@ function makeMessagingEndpoints() {
 
   function mapPorts(src, targetProtocols, targetPorts) {
     src.forEach(sp => {
-      var mappedProtocol = sp.name.replace("-", "_");
-      if (mappedProtocol === "https") {
-        mappedProtocol = "amqp_wss";
+      var mappedProtocol = sp.name.replace("-", "_").toUpperCase();
+      if (mappedProtocol === "HTTPS") {
+        mappedProtocol = "AMQP_WSS";
       }
       targetProtocols.push(mappedProtocol);
       targetPorts.push({
@@ -820,7 +820,7 @@ function makeMessagingEndpoints() {
           message: "",
           ports: [],
           internalPorts: [],
-          type: "cluster"
+          type: "Cluster"
         };
 
         var serviceName = `${as.metadata.name}.${ep.service}.cluster`;
@@ -843,7 +843,7 @@ function makeMessagingEndpoints() {
           message: "",
           ports: [],
           internalPorts: [],
-          type: ep.expose.type === "route" ? "route" : "loadBalancer"
+          type: ep.expose.type === "route" ? "Route" : "LoadBalancer"
         };
 
         var name = `${as.metadata.name}.${ep.name}`;
@@ -864,7 +864,7 @@ function makeMessagingEndpoints() {
 
               var ep = endpointStatus.externalPorts.find(ep => ep.name === lbp);
               if (ep) {
-                var mappedProtocol = ep.name.replace("-", "_");
+                var mappedProtocol = ep.name.replace("-", "_").toUpperCase();
                 status.ports.push({
                   name: ep.name,
                   protocol: mappedProtocol,

--- a/console/console-init/ui/mock-console-server/schema.js
+++ b/console/console-init/ui/mock-console-server/schema.js
@@ -77,24 +77,24 @@ const typeDefs = gql`
     }
 
     enum MessagingEndpointType_enmasse_io_v1beta2  {
-        cluster,
-        nodePort,
-        loadBalancer,
-        route,
-        ingress
+        Cluster,
+        NodePort,
+        LoadBalancer,
+        Route,
+        Ingress
     }
 
     enum MessagingEndpointProtocol_enmasse_io_v1beta2  {
-        amqp,
-        amqps,
-        amqp_ws,
-        amqp_wss,
+        AMQP,
+        AMQPS,
+        AMQP_WS,
+        AMQP_WSS,
     }
 
     enum MessagingEndpointPhase_enmasse_io_v1beta2  {
-        configuring,
-        active,
-        terminating,
+        Configuring,
+        Active,
+        Terminating,
     }
 
     type Metric_consoleapi_enmasse_io_v1beta1 {

--- a/console/console-init/ui/mock-console-server/test/mock.js
+++ b/console/console-init/ui/mock-console-server/test/mock.js
@@ -276,7 +276,7 @@ describe('mock', function () {
 
                 var endpoint = result.messagingEndpoints[0];
                 assert.strictEqual(endpoint.spec.protocols.length, 3);
-                assert.strictEqual(endpoint.status.type, "cluster");
+                assert.strictEqual(endpoint.status.type, "Cluster");
                 assert.strictEqual(endpoint.status.phase, "Active");
                 assert.strictEqual(endpoint.status.host, "messaging-mercury_as1.app1_ns.svc");
                 assert.strictEqual(endpoint.status.ports.length, 3);
@@ -311,14 +311,14 @@ describe('mock', function () {
                 assert.strictEqual(result.total, 2);
 
                 var clusterEndpoint = result.messagingEndpoints[0];
-                assert.strictEqual(clusterEndpoint.status.type, "cluster");
+                assert.strictEqual(clusterEndpoint.status.type, "Cluster");
 
                 var routeEndpoint = result.messagingEndpoints[1];
                 assert.strictEqual(routeEndpoint.spec.protocols.length, 1);
-                assert.strictEqual(routeEndpoint.spec.protocols[0], "amqps");
+                assert.strictEqual(routeEndpoint.spec.protocols[0], "AMQPS");
                 assert.strictEqual(routeEndpoint.spec.route.routeTlsTermination, "passthrough");
 
-                assert.strictEqual(routeEndpoint.status.type, "route");
+                assert.strictEqual(routeEndpoint.status.type, "Route");
                 assert.strictEqual(routeEndpoint.status.phase, "Active");
                 assert.strictEqual(routeEndpoint.status.host, "messaging-mercury_as2.app1_ns.apps-crc.testing");
                 assert.strictEqual(routeEndpoint.status.ports.length, 1);
@@ -353,18 +353,18 @@ describe('mock', function () {
                 assert.strictEqual(result.total, 2);
 
                 var clusterEndpoint = result.messagingEndpoints[0];
-                assert.strictEqual(clusterEndpoint.status.type, "cluster");
+                assert.strictEqual(clusterEndpoint.status.type, "Cluster");
 
                 var routeEndpoint = result.messagingEndpoints[1];
                 assert.strictEqual(routeEndpoint.spec.protocols.length, 1);
-                assert.strictEqual(routeEndpoint.spec.protocols[0], "amqp_wss");
+                assert.strictEqual(routeEndpoint.spec.protocols[0], "AMQP_WSS");
                 assert.strictEqual(routeEndpoint.spec.route.routeTlsTermination, "reencrypt");
 
-                assert.strictEqual(routeEndpoint.status.type, "route");
+                assert.strictEqual(routeEndpoint.status.type, "Route");
                 assert.strictEqual(routeEndpoint.status.phase, "Active");
                 assert.strictEqual(routeEndpoint.status.host, "messaging-wss-mercury_as3.app1_ns.apps-crc.testing");
                 assert.strictEqual(routeEndpoint.status.ports.length, 1);
-                assert.strictEqual(routeEndpoint.status.ports[0].protocol, "amqp_wss");
+                assert.strictEqual(routeEndpoint.status.ports[0].protocol, "AMQP_WSS");
             });
         });
         it('two_routes_and_cluster', function () {
@@ -431,7 +431,7 @@ describe('mock', function () {
 
             return mock.whenActive(m).then(() => {
                 var result = mock.resolvers.Query.messagingEndpoints(null,
-                    {filter: "`$.metadata.namespace` = 'app1_ns' AND `$.metadata.name` LIKE 'mercury_as5.%' AND `$.status.type` = 'route'"});
+                    {filter: "`$.metadata.namespace` = 'app1_ns' AND `$.metadata.name` LIKE 'mercury_as5.%' AND `$.status.type` = 'Route'"});
                 assert.strictEqual(result.total, 1);
 
                 var routeEndpoint = result.messagingEndpoints[0];
@@ -462,14 +462,14 @@ describe('mock', function () {
 
             return mock.whenActive(m).then(() => {
                 var result = mock.resolvers.Query.messagingEndpoints(null,
-                    {filter: "`$.metadata.namespace` = 'app1_ns' AND `$.metadata.name` LIKE 'mercury_as6.%' AND `$.status.type` = 'loadBalancer'"});
+                    {filter: "`$.metadata.namespace` = 'app1_ns' AND `$.metadata.name` LIKE 'mercury_as6.%' AND `$.status.type` = 'LoadBalancer'"});
                 assert.strictEqual(result.total, 1);
 
                 var loadbalancerEndpoint = result.messagingEndpoints[0];
-                assert.strictEqual(loadbalancerEndpoint.status.type, "loadBalancer");
+                assert.strictEqual(loadbalancerEndpoint.status.type, "LoadBalancer");
                 assert.strictEqual(loadbalancerEndpoint.status.phase, "Active");
                 assert.strictEqual(loadbalancerEndpoint.status.ports.length, 1);
-                assert.strictEqual(loadbalancerEndpoint.status.ports[0].protocol, "amqps");
+                assert.strictEqual(loadbalancerEndpoint.status.ports[0].protocol, "AMQPS");
             });
         });
 

--- a/console/console-server/src/main/resources/schema.graphql
+++ b/console/console-server/src/main/resources/schema.graphql
@@ -75,26 +75,25 @@ enum RouteTlsTermination_enmasse_io_v1beta1 {
   reencrypt
 }
 
-
 enum MessagingEndpointType_enmasse_io_v1beta2  {
-  cluster,
-  nodePort,
-  loadBalancer,
-  route,
-  ingress
+  Cluster,
+  NodePort,
+  LoadBalancer,
+  Route,
+  Ingress
 }
 
 enum MessagingEndpointProtocol_enmasse_io_v1beta2  {
-  amqp,
-  amqps,
-  amqp_ws,
-  amqp_wss,
+  AMQP,
+  AMQPS,
+  AMQP_WS,
+  AMQP_WSS,
 }
 
 enum MessagingEndpointPhase_enmasse_io_v1beta2  {
-  configuring,
-  active,
-  terminating,
+  Configuring,
+  Active,
+  Terminating,
 }
 
 type Metric_consoleapi_enmasse_io_v1beta1 {

--- a/pkg/consolegraphql/resolvers/generated.go
+++ b/pkg/consolegraphql/resolvers/generated.go
@@ -2197,24 +2197,24 @@ enum RouteTlsTermination_enmasse_io_v1beta1 {
 
 
 enum MessagingEndpointType_enmasse_io_v1beta2  {
-  cluster,
-  nodePort,
-  loadBalancer,
-  route,
-  ingress
+  Cluster,
+  NodePort,
+  LoadBalancer,
+  Route,
+  Ingress
 }
 
 enum MessagingEndpointProtocol_enmasse_io_v1beta2  {
-  amqp,
-  amqps,
-  amqp_ws,
-  amqp_wss,
+  AMQP,
+  AMQPS,
+  AMQP_WS,
+  AMQP_WSS,
 }
 
 enum MessagingEndpointPhase_enmasse_io_v1beta2  {
-  configuring,
-  active,
-  terminating,
+  Configuring,
+  Active,
+  Terminating,
 }
 
 type Metric_consoleapi_enmasse_io_v1beta1 {


### PR DESCRIPTION

### Type of change


- Refactoring

### Description

Capitalisation of the v1beta2 enums needs to match the Go enum values.


### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
