### PR TITLE
Install uncaught exception handler in address-space-controller and standard-controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * #4574: Set globalMaxSize to 1/4 of broker JVM heap
 * #4567: Refactor GraphQL deleteAddressSpace and deleteAddress to accept many target objects
 * #4610: Extend addressspaceschema to enumerate endpoint types etc (#4590)
+* #4650: Install uncaught exception handler in address-space-controller and standard-controller
 
 ## 0.31.2
 * #4098: Added alert for high broker address memory usage

--- a/address-space-controller/src/main/java/io/enmasse/controller/AddressSpaceController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/AddressSpaceController.java
@@ -267,6 +267,8 @@ public class AddressSpaceController {
     }
 
     public static void main(String args[]) {
+        setUncaughtExceptionHandler();
+
         AddressSpaceController controller = null;
         try {
             final AddressSpaceControllerOptions options = AddressSpaceControllerOptions.fromEnv(System.getenv());
@@ -285,4 +287,27 @@ public class AddressSpaceController {
             }
         }
     }
+
+    protected static void setUncaughtExceptionHandler() {
+        Thread.setDefaultUncaughtExceptionHandler((t, e) -> {
+            try {
+                System.err.println("########################################################################");
+                System.err.println("#");
+                System.err.print("# Uncaught Exception ");
+                System.err.print(e.toString());
+                System.err.print(" in Thread ");
+                System.err.println(t.getName());
+                System.err.println("#");
+                System.err.println("#");
+                System.err.println("########################################################################");
+                e.printStackTrace(System.err);
+
+                log.error("Fatal, uncaught exception", e);
+
+            } finally {
+                Runtime.getRuntime().halt(1);
+            }
+        });
+    }
+
 }

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/StandardController.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/StandardController.java
@@ -50,6 +50,7 @@ public class StandardController {
     }
 
     public static void main(String[] args) throws Exception {
+        setUncaughtExceptionHandler();
         StandardController standardController = null;
         try {
             Map<String, String> env = System.getenv();
@@ -166,5 +167,27 @@ public class StandardController {
                 log.info("StandardController stopped");
             }
         }
+    }
+
+    protected static void setUncaughtExceptionHandler() {
+        Thread.setDefaultUncaughtExceptionHandler((t, e) -> {
+            try {
+                System.err.println("########################################################################");
+                System.err.println("#");
+                System.err.print("# Uncaught Exception ");
+                System.err.print(e.toString());
+                System.err.print(" in Thread ");
+                System.err.println(t.getName());
+                System.err.println("#");
+                System.err.println("#");
+                System.err.println("########################################################################");
+                e.printStackTrace(System.err);
+
+                log.error("Fatal, uncaught exception", e);
+
+            } finally {
+                Runtime.getRuntime().halt(1);
+            }
+        });
     }
 }


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

Install uncaught exception handler in address-space-controller and standard-controller so that any uncaught exception, that kills a thread, will cause the JVM to terminate.  This will allow Kubernetes to restart the pod, thus restoring service.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
