### PR TITLE
Guard against an existing connector target secret without data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * #4574: Set globalMaxSize to 1/4 of broker JVM heap
 * #4567: Refactor GraphQL deleteAddressSpace and deleteAddress to accept many target objects
 * #4610: Extend addressspaceschema to enumerate endpoint types etc (#4590)
+* #4656: Defining a connector before its referenced secret exists results in NPE and permanently unready address space
 
 ## 0.31.2
 * #4098: Added alert for high broker address memory usage

--- a/address-space-controller/src/main/java/io/enmasse/controller/RouterConfigController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/RouterConfigController.java
@@ -229,6 +229,9 @@ public class RouterConfigController implements Controller {
         boolean needsUpdate = false;
         log.debug("Reconciling connector secret {} for connector {}", connectorSecret, connector);
         if (connector.getTls() != null) {
+            if (connectorSecret.getData() == null) {
+                connectorSecret.setData(new HashMap<>());
+            }
             if (connector.getTls().getCaCert() != null) {
                 String data = getSelectorValue(addressSpace.getMetadata().getNamespace(), connector.getTls().getCaCert(), "ca.crt").orElse(null);
                 if (data == null) {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Guard against an existing connector target secret without data causing a NPE exception and prevent address space reconciliation.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
