### PR TITLE
Add address canary check for routers and brokers

### DIFF
--- a/address-space-controller/src/main/java/io/enmasse/controller/RouterConfigController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/RouterConfigController.java
@@ -507,6 +507,12 @@ public class RouterConfigController implements Controller {
         dlqAddress.setWaypoint(true);
         addresses.add(dlqAddress);
 
+        Address routerHealthCheckAddress = new Address();
+        routerHealthCheckAddress.setName("!!HEALTH_CHECK_ROUTER");
+        routerHealthCheckAddress.setPrefix("!!HEALTH_CHECK_ROUTER");
+        mqttAddress.setDistribution(Distribution.balanced);
+        addresses.add(routerHealthCheckAddress);
+
         // Autolinks
         List<AutoLink> autoLinks = new ArrayList<>();
         AutoLink dlqAutoLink = new AutoLink();

--- a/address-space-controller/src/test/java/io/enmasse/controller/RouterConfigControllerTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/RouterConfigControllerTest.java
@@ -121,7 +121,7 @@ public class RouterConfigControllerTest {
         assertEquals(8, actual.getListeners().size());
         assertEquals(2, actual.getLinkRoutes().size());
         assertEquals(1, actual.getAutoLinks().size());
-        assertEquals(4, actual.getAddresses().size());
+        assertEquals(5, actual.getAddresses().size());
         assertEquals(1, actual.getConnectors().size());
         assertEquals(1, actual.getPolicies().size());
         assertEquals(2, actual.getVhosts().size());

--- a/agent/lib/broker_controller.js
+++ b/agent/lib/broker_controller.js
@@ -330,7 +330,7 @@ function exclude_subscriptions(type) {
 }
 
 function excluded_addresses(address) {
-    return address === '!!GLOBAL_DLQ' || address === 'DLQ' || address === 'ExpiryQueue' || address === 'activemq.notifications' || address === 'activemq.management';
+    return address === '!!GLOBAL_DLQ' || address === 'DLQ' || address === 'ExpiryQueue' || address === 'activemq.notifications' || address === 'activemq.management' || address.startsWith("!!HEALTH_CHECK_BROKER");
 }
 
 function is_temp_queue(a) {

--- a/agent/lib/ragent.js
+++ b/agent/lib/ragent.js
@@ -148,7 +148,7 @@ Ragent.prototype.addresses_updated = function () {
         this.sync_broker(this.connected_brokers[b]);
     }
     for (var r in this.connected_routers) {
-        this.sync_router_addresses(this.connected_routers[r]);
+        this.sync_router_addresses(this.connected_routers[r], Object.keys(this.connected_brokers));
     }
 }
 
@@ -163,8 +163,8 @@ Ragent.prototype.sync_addresses = function (updated) {
     this.addresses_updated();
 }
 
-Ragent.prototype.sync_router_addresses = function (router) {
-    router.sync_addresses(this.addresses);
+Ragent.prototype.sync_router_addresses = function (router, brokers) {
+    router.sync_addresses(this.addresses, brokers);
 }
 
 Ragent.prototype.verify_addresses = function (expected) {
@@ -346,7 +346,7 @@ Ragent.prototype.configure_handlers = function () {
                 router.retrieve_connectors();
                 router.on('synchronized', self.on_synchronized.bind(self));
                 if (self.addresses_initialised) {
-                    router.sync_addresses(self.addresses);
+                    router.sync_addresses(self.addresses, Object.keys(self.connected_brokers));
                 }
                 router.on('listeners_updated', self.connected_routers_updated.bind(self));//advertise only once have listeners
                 router.on('connectors_updated', self.check_router_connectors.bind(self));
@@ -358,6 +358,9 @@ Ragent.prototype.configure_handlers = function () {
             log.info('broker %s connected', broker.id);
             if (self.addresses_initialised) {
                 self.sync_broker(broker);
+                for (var r in self.connected_routers) {
+                    self.sync_router_addresses(self.connected_routers[r], Object.keys(self.connected_brokers));
+                }
             }
             broker.on('synchronized', self.on_synchronized.bind(self));
             context.connection.on('disconnected', self.on_broker_disconnect.bind(self));

--- a/agent/lib/router_config.js
+++ b/agent/lib/router_config.js
@@ -363,8 +363,14 @@ function apply_config(desired, router, count) {
     });
 }
 
-function desired_address_config(high_level_address_definitions) {
+function desired_address_config(high_level_address_definitions, brokers) {
     var config = new RouterConfig(ID_QUALIFIER);
+    // Addresses and autolinks for broker health checks
+    for (var i in brokers) {
+        var address = "!!HEALTH_CHECK_BROKER_" + brokers[i];
+        config.add_address({prefix:address, distribution:'balanced', waypoint:true});
+        config.add_autolink_pair({address:address, containerId: brokers[i]});
+    }
     for (var i in high_level_address_definitions) {
         var def = high_level_address_definitions[i];
         if (def.type === 'queue') {
@@ -463,8 +469,8 @@ function deduce_definition(actual_config) {
 }
 
 module.exports = {
-    realise_address_definitions: function (high_level_address_definitions, router) {
-        return apply_config(desired_address_config(high_level_address_definitions), router).then(function (actual) {
+    realise_address_definitions: function (high_level_address_definitions, router, brokers) {
+        return apply_config(desired_address_config(high_level_address_definitions, brokers), router).then(function (actual) {
             return deduce_definition(actual);
         });
     }

--- a/broker-plugin/plugin/src/main/resources/standard/colocated/broker.xml
+++ b/broker-plugin/plugin/src/main/resources/standard/colocated/broker.xml
@@ -99,7 +99,7 @@ under the License.
             <default-address-routing-type>ANYCAST</default-address-routing-type>
          </address-setting>
          <address-setting match="!!HEALTH_CHECK_BROKER_${CONTAINER_ID}">
-            <last-value-queue>true</last-value-queue>
+            <default-last-value-key>probe</default-last-value-key>
          </address-setting>
       </address-settings>
 

--- a/broker-plugin/plugin/src/main/resources/standard/colocated/broker.xml
+++ b/broker-plugin/plugin/src/main/resources/standard/colocated/broker.xml
@@ -98,6 +98,9 @@ under the License.
             <address-full-policy>${ADDRESS_FULL_POLICY}</address-full-policy>
             <default-address-routing-type>ANYCAST</default-address-routing-type>
          </address-setting>
+         <address-setting match="!!HEALTH_CHECK_BROKER_${CONTAINER_ID}">
+            <last-value-queue>true</last-value-queue>
+         </address-setting>
       </address-settings>
 
       <wildcard-addresses>
@@ -111,6 +114,11 @@ under the License.
         <address name="!!GLOBAL_DLQ">
           <anycast>
             <queue name="!!GLOBAL_DLQ" />
+          </anycast>
+        </address>
+        <address name="!!HEALTH_CHECK_BROKER_${CONTAINER_ID}">
+          <anycast>
+            <queue name="!!HEALTH_CHECK_BROKER_${CONTAINER_ID}" />
           </anycast>
         </address>
       </addresses>

--- a/broker-plugin/plugin/src/main/resources/standard/sharded-queue/broker.xml
+++ b/broker-plugin/plugin/src/main/resources/standard/sharded-queue/broker.xml
@@ -105,11 +105,19 @@ broker which is the case after 0.26.x.
             <message-counter-history-day-limit>10</message-counter-history-day-limit>
             <address-full-policy>${ADDRESS_FULL_POLICY}</address-full-policy>
          </address-setting>
+         <address-setting match="!!HEALTH_CHECK_BROKER_${CONTAINER_ID}">
+            <last-value-queue>true</last-value-queue>
+         </address-setting>
       </address-settings>
       <addresses>
          <address name="!!GLOBAL_DLQ">
            <anycast>
              <queue name="!!GLOBAL_DLQ" />
+           </anycast>
+         </address>
+         <address name="!!HEALTH_CHECK_BROKER_${CONTAINER_ID}">
+           <anycast>
+             <queue name="!!HEALTH_CHECK_BROKER_${CONTAINER_ID}" />
            </anycast>
          </address>
       </addresses>

--- a/broker-plugin/plugin/src/main/resources/standard/sharded-queue/broker.xml
+++ b/broker-plugin/plugin/src/main/resources/standard/sharded-queue/broker.xml
@@ -106,7 +106,7 @@ broker which is the case after 0.26.x.
             <address-full-policy>${ADDRESS_FULL_POLICY}</address-full-policy>
          </address-setting>
          <address-setting match="!!HEALTH_CHECK_BROKER_${CONTAINER_ID}">
-            <last-value-queue>true</last-value-queue>
+            <default-last-value-key>probe</default-last-value-key>
          </address-setting>
       </address-settings>
       <addresses>

--- a/broker-plugin/plugin/src/main/resources/standard/sharded-topic/broker.xml
+++ b/broker-plugin/plugin/src/main/resources/standard/sharded-topic/broker.xml
@@ -100,6 +100,9 @@ under the License.
             <message-counter-history-day-limit>10</message-counter-history-day-limit>
             <address-full-policy>${ADDRESS_FULL_POLICY}</address-full-policy>
          </address-setting>
+         <address-setting match="!!HEALTH_CHECK_BROKER_${CONTAINER_ID}">
+            <last-value-queue>true</last-value-queue>
+         </address-setting>
       </address-settings>
       <addresses>
          <address name="$TOPIC_NAME">
@@ -111,6 +114,11 @@ under the License.
          <address name="!!GLOBAL_DLQ">
            <anycast>
              <queue name="!!GLOBAL_DLQ" />
+           </anycast>
+         </address>
+         <address name="!!HEALTH_CHECK_BROKER_${CONTAINER_ID}">
+           <anycast>
+             <queue name="!!HEALTH_CHECK_BROKER_${CONTAINER_ID}" />
            </anycast>
          </address>
       </addresses>
@@ -129,13 +137,23 @@ under the License.
         </divert>
       </diverts>
       <connector-services>
-        <connector-service name="$${dummy}override-amqp-connector">
+        <!-- Needed for health probes and subscription -->
+        <connector-service name="$${dummy}override-amqp-connector-out">
           <factory-class>org.apache.activemq.artemis.integration.amqp.AMQPConnectorServiceFactory</factory-class>
           <param key="host" value="$MESSAGING_SERVICE_HOST" />
           <param key="port" value="$MESSAGING_SERVICE_PORT_AMQPS_BROKER" />
-          <param key="containerId" value="$CONTAINER_ID-out" /> <!-- currently only needed for subscriptions -->
+          <param key="containerId" value="$CONTAINER_ID-out" />
           <param key="clusterId" value="$CONTAINER_ID" />
         </connector-service>
+        <connector-service name="$${dummy}override-amqp-connector-in">
+          <factory-class>org.apache.activemq.artemis.integration.amqp.AMQPConnectorServiceFactory</factory-class>
+          <param key="host" value="$MESSAGING_SERVICE_HOST" />
+          <param key="port" value="$MESSAGING_SERVICE_PORT_AMQPS_BROKER" />
+          <param key="containerId" value="$CONTAINER_ID-in" />
+          <param key="clusterId" value="$CONTAINER_ID" />
+        </connector-service>
+
+        <!-- Needed for agent configuration -->
         <connector-service name="$${dummy}override-ragent-connector">
           <factory-class>org.apache.activemq.artemis.integration.amqp.AMQPConnectorServiceFactory</factory-class>
           <param key="host" value="$QUEUE_SCHEDULER_SERVICE_HOST" />
@@ -143,6 +161,8 @@ under the License.
           <param key="containerId" value="$CONTAINER_ID" />
           <param key="clusterId" value="sharded-topic" />
         </connector-service>
+
+        <!-- For the sharded address -->
         <connector-service name="$${dummy}override-address-connector-in">
           <factory-class>org.apache.activemq.artemis.integration.amqp.AMQPConnectorServiceFactory</factory-class>
           <param key="host" value="$MESSAGING_SERVICE_HOST" />
@@ -161,6 +181,8 @@ under the License.
           <param key="idleTimeoutMs" value="$CONNECTOR_OUT_IDLE_TIMEOUT_MS" />
           <param key="nettyThreads" value="$CONNECTOR_OUT_NETTY_THREADS" />
         </connector-service>
+
+        <!-- For the global DLQ -->
         <connector-service name="$${dummy}override-dlq-out">
           <factory-class>org.apache.activemq.artemis.integration.amqp.AMQPConnectorServiceFactory</factory-class>
           <param key="host" value="$MESSAGING_SERVICE_HOST" />

--- a/broker-plugin/plugin/src/main/resources/standard/sharded-topic/broker.xml
+++ b/broker-plugin/plugin/src/main/resources/standard/sharded-topic/broker.xml
@@ -101,7 +101,7 @@ under the License.
             <address-full-policy>${ADDRESS_FULL_POLICY}</address-full-policy>
          </address-setting>
          <address-setting match="!!HEALTH_CHECK_BROKER_${CONTAINER_ID}">
-            <last-value-queue>true</last-value-queue>
+            <default-last-value-key>probe</default-last-value-key>
          </address-setting>
       </address-settings>
       <addresses>

--- a/controller-manager/src/main/resources/templates/PrometheusRules-enmasse.yaml
+++ b/controller-manager/src/main/resources/templates/PrometheusRules-enmasse.yaml
@@ -55,6 +55,20 @@ spec:
         severity: warning
       expr: enmasse_addresses_not_ready_total > 0
       for: 300s
+    - alert: AddressCanaryCheckHealth
+      annotations:
+        description: Address(s) canary health check endpoints have failed for more than 5 minutes
+        value: "{{ "{{" }} $value {{ "}}" }}"
+        severity: warning
+      expr: increase(enmasse_address_canary_health_check_failures_total[5m]) > 0
+      for: 300s
+    - alert: AddressCanaryHealth
+      annotations:
+        description: Address(s) canary health have been failing for more than 5 minutes
+        value: "{{ "{{" }} $value {{ "}}" }}"
+        severity: warning
+      expr: enmasse_address_canary_health_failures_total > 0
+      for: 300s
     - alert: RouterMeshConnectivityHealth
       annotations:
         description: Router mesh(s) have not been fully connected for over 5 minutes

--- a/documentation/design/proposals/authentication.adoc
+++ b/documentation/design/proposals/authentication.adoc
@@ -213,39 +213,39 @@ System tests will need to be able to support creation / deletion of address spac
 ==== EnMasse Authentication Service
 
 * Validate successful authentication with enmasse authentication service and valid credentials
- . create an address space `A` which uses the enmasse authentication service
- . add a user `U` with password `P` to the Keycloak domain for `A` (using Keycloak API)
- . verify that AMQP & MQTT messaging clients can establish a connection to `A` using username `U` and password `P`
+ . create an address space `HealthChecker` which uses the enmasse authentication service
+ . add a user `U` with password `P` to the Keycloak domain for `HealthChecker` (using Keycloak API)
+ . verify that AMQP & MQTT messaging clients can establish a connection to `HealthChecker` using username `U` and password `P`
  . create an address space `B` which uses the enmasse authentication service
  . add a user `U` with password `X` to the Keycloak domain for `B`
- . verify that AMQP & MQTT messaging clients can still establish a connection to `A` using username `U` and password `P`
+ . verify that AMQP & MQTT messaging clients can still establish a connection to `HealthChecker` using username `U` and password `P`
 
 * Validate unsuccessful authentication with enmasse authentication service with no credentials
- . create an address space `A` which uses the enmasse authentication service
+ . create an address space `HealthChecker` which uses the enmasse authentication service
  . verify that AMQP & MQTT messaging clients cannot establish a connection without credentials
- . add a user `U` with password `P` to the Keycloak domain for `A`
+ . add a user `U` with password `P` to the Keycloak domain for `HealthChecker`
  . verify that AMQP & MQTT messaging clients still cannot establish a connection without credentials
 
 * Validate unsuccessful authentication with enmasse authentication service with incorrect credentials
- . create an address space `A` which uses the enmasse authentication service
- . verify that AMQP & MQTT messaging clients cannot establish a connection to `A` using username `U` and password `P`
- . add a user `U` with password `P` to the Keycloak domain for `A`
- . verify that AMQP & MQTT messaging clients cannot establish a connection to `A` using username `U` and password `X`
- . verify that AMQP & MQTT messaging clients cannot establish a connection to `A` using username `V` and password `P`
+ . create an address space `HealthChecker` which uses the enmasse authentication service
+ . verify that AMQP & MQTT messaging clients cannot establish a connection to `HealthChecker` using username `U` and password `P`
+ . add a user `U` with password `P` to the Keycloak domain for `HealthChecker`
+ . verify that AMQP & MQTT messaging clients cannot establish a connection to `HealthChecker` using username `U` and password `X`
+ . verify that AMQP & MQTT messaging clients cannot establish a connection to `HealthChecker` using username `V` and password `P`
  . create an address space `B` which uses the enmasse authentication service
  . add a user `U` with password `X` to the Keycloak domain for `B`
- . verify that AMQP & MQTT messaging clients cannot establish a connection to `A` using username `U` and password `X`
+ . verify that AMQP & MQTT messaging clients cannot establish a connection to `HealthChecker` using username `U` and password `X`
  . verify that AMQP & MQTT messaging clients cannot establish a connection to `B` using username `U` and password `P`
 
 ==== No Authentication
 
 * Validate successful authentication with no authentication
- . create an address space `A` which uses the enmasse authentication service
- . verify that AMQP & MQTT messaging clients can establish a connection to address space `A` without credentials
- . verify that AMQP & MQTT messaging clients can establish a connection to address space `A` using username `U` and password `P`
+ . create an address space `HealthChecker` which uses the enmasse authentication service
+ . verify that AMQP & MQTT messaging clients can establish a connection to address space `HealthChecker` without credentials
+ . verify that AMQP & MQTT messaging clients can establish a connection to address space `HealthChecker` using username `U` and password `P`
  . create an address space `B` which uses the enmasse authentication service
- . verify that AMQP & MQTT messaging clients can still establish a connection to address space `A` without credentials
- . verify that AMQP & MQTT messaging clients can still establish a connection to address space `A` using username `U` and password `P`
+ . verify that AMQP & MQTT messaging clients can still establish a connection to address space `HealthChecker` without credentials
+ . verify that AMQP & MQTT messaging clients can still establish a connection to address space `HealthChecker` using username `U` and password `P`
 
 === Testing Console Access
 

--- a/k8s-api/src/main/java/io/enmasse/k8s/api/ResourceChecker.java
+++ b/k8s-api/src/main/java/io/enmasse/k8s/api/ResourceChecker.java
@@ -52,6 +52,8 @@ public class ResourceChecker<T> implements CacheWatcher<T>, Runnable {
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
+                running = false;
+                log.warn("ResourceChecker interrupted, stopping.");
             } catch (Exception e) {
                 log.warn("Exception in checker task", e);
             }

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/AddressCanaryHealth.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/AddressCanaryHealth.java
@@ -126,6 +126,8 @@ public class AddressCanaryHealth implements Runnable {
                 checkHealth(kubernetes.listClusters());
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
+                running = false;
+                log.warn("AddressCanaryHealth interrupted, stopping.");
             } catch (Exception e) {
                 log.warn("Exception in collector task", e);
             }

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/AddressCanaryHealth.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/AddressCanaryHealth.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.controller.standard;
+
+import io.enmasse.metrics.api.MetricLabel;
+import io.enmasse.metrics.api.MetricType;
+import io.enmasse.metrics.api.MetricValue;
+import io.enmasse.metrics.api.Metrics;
+import io.enmasse.metrics.api.ScalarMetric;
+import io.fabric8.kubernetes.api.model.Pod;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+public class AddressCanaryHealth implements Runnable {
+    private static final Logger log = LoggerFactory.getLogger(AddressCanaryHealth.class);
+
+    private final Kubernetes kubernetes;
+    private final AddressProber runner;
+
+    private volatile boolean running = false;
+    private Thread thread;
+    private final Duration checkInterval;
+
+    private volatile List<AddressCanaryResult> latestResult = Collections.emptyList();
+    private final AtomicInteger healthCheckFailures = new AtomicInteger(0);
+
+    AddressCanaryHealth(Kubernetes kubernetes, Duration checkInterval, AddressProber runner, Metrics metrics)
+    {
+        this.kubernetes = kubernetes;
+        this.checkInterval = checkInterval;
+        this.runner = runner;
+        registerMetrics(metrics);
+    }
+
+    private void registerMetrics(Metrics metrics) {
+        metrics.registerMetric(new ScalarMetric(
+                "address_canary_health_failures_total",
+                "Total number of health check failures due to failure to send and receive messages to probe addresses.",
+                MetricType.gauge,
+                () -> latestResult.stream().flatMap(
+                        result -> {
+                            List<MetricValue> values = new ArrayList<>();
+                            values.add(new MetricValue(result.getFailed().size(), new MetricLabel("router", result.getRouterId())));
+                            for (String failed : result.getFailed()) {
+                                values.add(new MetricValue(1, new MetricLabel("router", result.getRouterId()), new MetricLabel("address", failed)));
+                            }
+
+                            for (String passed : result.getPassed()) {
+                                values.add(new MetricValue(0, new MetricLabel("router", result.getRouterId()), new MetricLabel("address", passed)));
+                            }
+                            return values.stream();
+                        }).collect(Collectors.toList())));
+
+        metrics.registerMetric(new ScalarMetric(
+                "address_canary_health_check_failures_total",
+                "Total number of attempted health check runs that failed due to controller errors.",
+                MetricType.counter,
+                () -> Collections.singletonList(new MetricValue(healthCheckFailures.get()))));
+    }
+
+    void checkHealth(List<BrokerCluster> brokerClusters) {
+        List<Pod> routers = new ArrayList<>(kubernetes.listRouters());
+
+        List<Pod> brokers = brokerClusters.stream()
+                .flatMap(cluster -> kubernetes.listBrokers(cluster.getClusterId()).stream())
+                .collect(Collectors.toList());
+
+        // Check if we can send/receive to all brokers through all routers
+        Set<String> addresses = new HashSet<>();
+        addresses.add("!!HEALTH_CHECK_ROUTER");
+        for (Pod broker : brokers) {
+            addresses.add(String.format("!!HEALTH_CHECK_BROKER_%s", broker.getMetadata().getName()));
+        }
+
+        List<AddressCanaryResult> addressCanaryResults = new ArrayList<>(routers.size());
+        for (Pod router : routers) {
+            try {
+                log.debug("[route {}] Running health check against {}:55671 for addresses {}", router.getMetadata().getName(), router.getStatus().getPodIP(), addresses);
+                Set<String> passed = runner.run(router.getStatus().getPodIP(), 55671, addresses);
+                Set<String> failed = new HashSet<>(addresses);
+                failed.removeAll(passed);
+                log.debug("[router {}] Passed: {}. Failed: {}", router.getMetadata().getName(), passed, failed);
+                addressCanaryResults.add(new AddressCanaryResult(router.getMetadata().getName(), passed, failed));
+            } catch (Exception e) {
+                log.warn("Error checking address health", e);
+                healthCheckFailures.incrementAndGet();
+            }
+        }
+        this.latestResult = addressCanaryResults;
+    }
+
+    public void start() {
+        running = true;
+        thread = new Thread(this);
+        thread.setName("router-status-collector");
+        thread.setDaemon(true);
+        thread.start();
+    }
+
+    public void stop() {
+        try {
+            running = false;
+            thread.interrupt();
+            thread.join();
+        } catch (InterruptedException ignored) {
+            log.warn("Interrupted while stopping", ignored);
+        }
+    }
+
+    @Override
+    public void run() {
+        while (running) {
+            try {
+                Thread.sleep(checkInterval.toMillis());
+                checkHealth(kubernetes.listClusters());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (Exception e) {
+                log.warn("Exception in collector task", e);
+            }
+        }
+    }
+}

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/AddressCanaryResult.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/AddressCanaryResult.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.controller.standard;
+
+import java.util.Set;
+
+public class AddressCanaryResult {
+    private final String routerId;
+    private final Set<String> passed;
+    private final Set<String> failed;
+
+    public AddressCanaryResult(String routerId, Set<String> passed, Set<String> failed) {
+        this.routerId = routerId;
+        this.passed = passed;
+        this.failed = failed;
+    }
+
+    public String getRouterId() {
+        return routerId;
+    }
+
+    public Set<String> getPassed() {
+        return passed;
+    }
+
+    public Set<String> getFailed() {
+        return failed;
+    }
+}

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/AddressProbeClient.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/AddressProbeClient.java
@@ -142,16 +142,20 @@ public class AddressProbeClient implements AutoCloseable {
         if (context != null) {
             CompletableFuture.allOf(
                     runOnContext(context, () -> {
-                        for (ProtonSender sender : senders) {
-                            if (sender != null) {
-                                sender.close();
+                        synchronized (senders) {
+                            for (ProtonSender sender : senders) {
+                                if (sender != null) {
+                                    sender.close();
+                                }
                             }
                         }
                     }),
                     runOnContext(context, () -> {
-                        for (ProtonReceiver receiver : receivers) {
-                            if (receiver != null) {
-                                receiver.close();
+                        synchronized (receivers) {
+                            for (ProtonReceiver receiver : receivers) {
+                                if (receiver != null) {
+                                    receiver.close();
+                                }
                             }
                         }
                     }),

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/AddressProbeClient.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/AddressProbeClient.java
@@ -15,14 +15,17 @@ import io.vertx.proton.ProtonSender;
 import org.apache.qpid.proton.Proton;
 import org.apache.qpid.proton.amqp.messaging.Accepted;
 import org.apache.qpid.proton.amqp.messaging.AmqpValue;
+import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
 import org.apache.qpid.proton.message.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -75,8 +78,10 @@ public class AddressProbeClient implements AutoCloseable {
         }
 
         String payload = String.format("PING %s", UUID.randomUUID().toString());
+        Map<String, Object> properties = Collections.singletonMap("probe", true);
         Message message = Proton.message();
         message.setBody(new AmqpValue(payload));
+        message.setApplicationProperties(new ApplicationProperties(properties));
 
         Set<String> passed = new ConcurrentHashSet<>();
         CountDownLatch done = new CountDownLatch(addresses.size());

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/AddressProbeClient.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/AddressProbeClient.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.controller.standard;
+
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import io.vertx.core.impl.ConcurrentHashSet;
+import io.vertx.proton.ProtonClient;
+import io.vertx.proton.ProtonClientOptions;
+import io.vertx.proton.ProtonConnection;
+import io.vertx.proton.ProtonReceiver;
+import io.vertx.proton.ProtonSender;
+import org.apache.qpid.proton.Proton;
+import org.apache.qpid.proton.amqp.messaging.Accepted;
+import org.apache.qpid.proton.amqp.messaging.AmqpValue;
+import org.apache.qpid.proton.message.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class AddressProbeClient implements AutoCloseable {
+    private static final Logger log = LoggerFactory.getLogger(AddressProbeClient.class);
+
+    private final Vertx vertx;
+    private final String containerId;
+
+    private Context context;
+    private ProtonConnection connection;
+    private final List<ProtonSender> senders = new ArrayList<>();
+    private final List<ProtonReceiver> receivers = new ArrayList<>();
+
+    public AddressProbeClient(Vertx vertx, String containerId) {
+        this.vertx = vertx;
+        this.containerId = containerId;
+    }
+
+    public void connect(String host, int port, ProtonClientOptions clientOptions, CompletableFuture<Void> promise) {
+        if (connection != null) {
+            log.debug("Already connected");
+            promise.complete(null);
+            return;
+        }
+
+        ProtonClient client = ProtonClient.create(vertx);
+        log.debug("Connecting to {}:{}", host, port);
+        client.connect(clientOptions, host, port, result -> {
+            if (result.succeeded()) {
+                log.debug("Connected to {}:{}", host, port);
+                connection = result.result();
+                context = vertx.getOrCreateContext();
+                connection.setContainer(containerId);
+                connection.open();
+                promise.complete(null);
+            } else {
+                log.info("Connection to {}:{} failed", host, port, result.cause());
+                promise.completeExceptionally(result.cause());
+            }
+        });
+    }
+
+    public Set<String> probeAddresses(Set<String> addresses, Duration timeout) {
+        if (connection == null) {
+            throw new RuntimeException("HelathProbeClient not connected");
+        }
+
+        String payload = String.format("PING %s", UUID.randomUUID().toString());
+        Message message = Proton.message();
+        message.setBody(new AmqpValue(payload));
+
+        Set<String> passed = new ConcurrentHashSet<>();
+        CountDownLatch done = new CountDownLatch(addresses.size());
+
+        runOnContext(context, () -> {
+            for (String address : addresses) {
+                ProtonReceiver receiver = connection.createReceiver(address);
+                receiver.handler((delivery, m) -> {
+                    String data = (String) ((AmqpValue) m.getBody()).getValue();
+                    delivery.disposition(Accepted.getInstance(), true);
+                    if (payload.equals(data)) {
+                        passed.add(address);
+                        done.countDown();
+                    }
+                });
+                receiver.openHandler(protonReceiverAsyncResult -> {
+                    if (protonReceiverAsyncResult.succeeded()) {
+                        ProtonSender sender = connection.createSender(address);
+                        sender.openHandler(protonSenderAsyncResult -> {
+                            if (protonSenderAsyncResult.succeeded()) {
+                                sender.send(message, protonDelivery -> {
+                                    log.debug("Message sent to {}!", address);
+                                });
+                            }
+                        });
+                        sender.closeHandler(remoteCloseHandler -> {
+                            if (remoteCloseHandler.failed()) {
+                                log.warn("Error closing sender for {}: {}", address, sender.getRemoteCondition().getDescription());
+                            }
+                        });
+                        vertx.setTimer(4000, h -> context.runOnContext(p -> {
+                            log.debug("Opening sender for {}", address);
+                            sender.open();
+                            synchronized (this.senders) {
+                                this.senders.add(sender);
+                            }
+                        }));
+                    }
+                });
+                receiver.closeHandler(remoteCloseHandler -> {
+                    if (remoteCloseHandler.failed()) {
+                        log.warn("Error closing receiver for {}: {}", address, receiver.getRemoteCondition().getDescription());
+                    }
+                });
+                synchronized (this.receivers) {
+                    this.receivers.add(receiver);
+                }
+                log.debug("Opening receiver for {}", address);
+                receiver.open();
+            }
+        });
+
+        try {
+            done.await(timeout.getSeconds(), TimeUnit.SECONDS);
+        } catch (InterruptedException ignored) {
+            Thread.currentThread().interrupt();
+        }
+        return new HashSet<>(passed);
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (context != null) {
+            CompletableFuture.allOf(
+                    runOnContext(context, () -> {
+                        for (ProtonSender sender : senders) {
+                            if (sender != null) {
+                                sender.close();
+                            }
+                        }
+                    }),
+                    runOnContext(context, () -> {
+                        for (ProtonReceiver receiver : receivers) {
+                            if (receiver != null) {
+                                receiver.close();
+                            }
+                        }
+                    }),
+                    runOnContext(context, () -> {
+                        if (connection != null) {
+                            connection.close();
+                        }
+                    })).get(1, TimeUnit.MINUTES);
+        }
+        senders.clear();
+        receivers.clear();
+        connection = null;
+    }
+
+    private static CompletableFuture<Void> runOnContext(Context context, Runnable runnable) {
+        CompletableFuture<Void> promise = new CompletableFuture<>();
+        context.runOnContext(h -> {
+            try {
+                runnable.run();
+                promise.complete(null);
+            } catch (Exception e) {
+                promise.completeExceptionally(e);
+            }
+        });
+        return promise;
+    }
+}

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/AddressProber.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/AddressProber.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.controller.standard;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.net.PemKeyCertOptions;
+import io.vertx.core.net.PemTrustOptions;
+import io.vertx.proton.ProtonClientOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+public class AddressProber {
+    private static final Logger log = LoggerFactory.getLogger(AddressProber.class);
+    private final Vertx vertx;
+    private final String containerId;
+    private final ProtonClientOptions options;
+    private final Duration probeTimeout;
+
+    public AddressProber(Vertx vertx, String containerId, ProtonClientOptions options, Duration probeTimeout) {
+        this.vertx = vertx;
+        this.containerId = containerId;
+        this.options = options;
+        this.probeTimeout = probeTimeout;
+    }
+
+    public static AddressProber withCertsInDir(Vertx vertx, String containerId, Duration queryTimeout, String certDir) {
+        ProtonClientOptions clientOptions = new ProtonClientOptions()
+                .setSsl(true)
+                .addEnabledSaslMechanism("EXTERNAL")
+                .setHostnameVerificationAlgorithm("")
+                .setPemTrustOptions(new PemTrustOptions()
+                        .addCertPath(new File(certDir, "ca.crt").getAbsolutePath()))
+                .setPemKeyCertOptions(new PemKeyCertOptions()
+                        .setCertPath(new File(certDir, "tls.crt").getAbsolutePath())
+                        .setKeyPath(new File(certDir, "tls.key").getAbsolutePath()));
+        return new AddressProber(vertx, containerId, clientOptions, queryTimeout);
+    }
+
+    public Set<String> run(String host, int port, Set<String> addresses) throws Exception {
+        Duration timeLeft = Duration.from(probeTimeout);
+        try (AddressProbeClient client = new AddressProbeClient(vertx, containerId)) {
+            CompletableFuture<Void> connected = new CompletableFuture<>();
+
+            long now = System.nanoTime();
+            log.debug("Connecting probe runner to {}:{} within {} seconds", host, port, timeLeft.getSeconds());
+            client.connect(host, port, options, connected);
+            connected.get(timeLeft.getSeconds(), TimeUnit.SECONDS);
+
+            timeLeft = timeLeft.minus(Duration.ofNanos(System.nanoTime() - now));
+            log.debug("Connected! Send/receive messages for {} within {} seconds", addresses, timeLeft.getSeconds());
+            return client.probeAddresses(addresses, timeLeft);
+        }
+    }
+}

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/StandardControllerOptions.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/StandardControllerOptions.java
@@ -31,6 +31,8 @@ public class StandardControllerOptions {
     private Duration kubernetesApiConnectTimeout;
     private Duration kubernetesApiReadTimeout;
     private Duration kubernetesApiWriteTimeout;
+    private Duration healthProbeTimeout;
+    private Duration healthCheckInterval;
 
     public String getCertDir() {
         return certDir;
@@ -193,6 +195,14 @@ public class StandardControllerOptions {
                 .map(i -> Duration.ofSeconds(Long.parseLong(i)))
                 .orElse(Duration.ofSeconds(30)));
 
+        options.setHealthProbeTimeout(getEnv(env, "HEALTH_PROBE_TIMEOUT")
+                .map(i -> Duration.ofSeconds(Long.parseLong(i)))
+                .orElse(Duration.ofSeconds(10)));
+
+        options.setHealthCheckInterval(getEnv(env, "HEALTH_CHECK_INTERVAL")
+                .map(i -> Duration.ofSeconds(Long.parseLong(i)))
+                .orElse(Duration.ofSeconds(30)));
+
         return options;
     }
 
@@ -243,6 +253,8 @@ public class StandardControllerOptions {
                 ", kubernetesApiConnectTimeout='" + kubernetesApiConnectTimeout + '\'' +
                 ", kubernetesApiReadTimeout='" + kubernetesApiReadTimeout + '\'' +
                 ", kubernetesApiWriteTimeout='" + kubernetesApiWriteTimeout + '\'' +
+                ", healthProbeTimeout='" + healthProbeTimeout + '\'' +
+                ", healthCheckInterval='" + healthCheckInterval + '\'' +
                 '}';
     }
 
@@ -298,4 +310,19 @@ public class StandardControllerOptions {
         this.kubernetesApiWriteTimeout = kubernetesApiWriteTimeout;
     }
 
+    public Duration getHealthProbeTimeout() {
+        return healthProbeTimeout;
+    }
+
+    public void setHealthProbeTimeout(Duration healthProbeTimeout) {
+        this.healthProbeTimeout = healthProbeTimeout;
+    }
+
+    public Duration getHealthCheckInterval() {
+        return healthCheckInterval;
+    }
+
+    public void setHealthCheckInterval(Duration healthCheckInterval) {
+        this.healthCheckInterval = healthCheckInterval;
+    }
 }

--- a/systemtests/src/main/java/io/enmasse/systemtest/monitoring/MonitoringQueries.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/monitoring/MonitoringQueries.java
@@ -11,6 +11,7 @@ public interface MonitoringQueries {
     String ENMASSE_ADDRESS_NOT_READY_TOTAL = "enmasse_addresses_not_ready_total";
     String ENMASSE_ADDRESS_CONFIGURING_TOTAL = "enmasse_addresses_configuring_total";
     String ENMASSE_ARTEMIS_DURABLE_MESSAGE_COUNT = "enmasse_artemis_durable_message_count";
+    String ENMASSE_ADDRESS_CANARY_HEALTH_FAILURES_TOTAL = "enmasse_address_canary_health_failures_total";
 
     String ENMASSE_ADDRESSSPACEPLAN_INFO = "enmasse_addressspaceplan_info";
     String ENMASSE_ADDRESSPLAN_INFO = "enmasse_addressplan_info";

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/monitoring/MonitoringTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/monitoring/MonitoringTest.java
@@ -165,6 +165,8 @@ class MonitoringTest extends TestBase implements ITestIsolatedStandard {
 
         getClientUtils().sendDurableMessages(resourcesManager, addressSpace, user, 10, queue);
 
+        assertDoesNotThrow(() -> monitoring.validateQueryAndWait(MonitoringQueries.ENMASSE_ADDRESS_CANARY_HEALTH_FAILURES_TOTAL, "0"));
+
         assertDoesNotThrow(() -> monitoring.validateQueryAndWait(MonitoringQueries.ENMASSE_ARTEMIS_DURABLE_MESSAGE_COUNT, "10",
                 Collections.singletonMap("address", queue.getSpec().getAddress())));
     }


### PR DESCRIPTION
Add a periodic health check for standard address space, where pre-configured canary addresses are added to the routers and brokers. The periodic check will perform a send and receive to the canary addresses, and report prometheus metrics with the result.
    
An example alert is provided that alerts on failed canaries for more than 5 minutes.
