### PR TITLE
Drop cleaning up device connection entries with Infinispan

### DIFF
--- a/iot/iot-tenant-cleaner/src/main/java/io/enmasse/iot/tools/cleanup/Application.java
+++ b/iot/iot-tenant-cleaner/src/main/java/io/enmasse/iot/tools/cleanup/Application.java
@@ -26,13 +26,11 @@ public class Application {
     }
 
     private static void cleanupDeviceConnection() throws Exception {
-        String connectionType = System.getenv("deviceConnection.type");
-        if (connectionType == null) {
-            connectionType = "<missing>";
-        }
+        final String connectionType = System.getenv()
+                .getOrDefault("deviceConnection.type", "<missing>");
 
         switch (connectionType) {
-            case "infinispan":
+            case "noop":
                 // nothing to clean up
                 break;
             case "jdbc":
@@ -46,12 +44,13 @@ public class Application {
     }
 
     private static void cleanupDeviceRegistry() throws Exception {
-        String registryTpe = System.getenv("registry.type");
-        if (registryTpe == null) {
-            registryTpe = "<missing>";
-        }
+        final String registryTpe = System.getenv()
+                .getOrDefault("registry.type", "<missing>");
 
         switch (registryTpe) {
+            case "noop":
+                // nothing to clean up
+                break;
             case "infinispan":
                 try (InfinispanDeviceRegistryCleaner app = new InfinispanDeviceRegistryCleaner()) {
                     app.run();

--- a/pkg/controller/iotproject/tenant_cleanup.go
+++ b/pkg/controller/iotproject/tenant_cleanup.go
@@ -208,8 +208,9 @@ func reconcileIoTTenantCleanerJob(ctx *finalizer.DeconstructorContext, job *batc
 
 		case iotv1alpha1.DeviceRegistryInfinispan:
 
-			// we need to set this, although we don't need the cleaner in this case
-			install.ApplyOrRemoveEnvSimple(container, "deviceConnection.type", "infinispan")
+			// we can set this to "noop", because we don't need cleaning
+			// but if the cleaner gets called, we let it know about that
+			install.ApplyOrRemoveEnvSimple(container, "deviceConnection.type", "noop")
 
 		case iotv1alpha1.DeviceConnectionJdbc:
 


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Refactoring

### Description

The entries in the device connection cache are supposed to expire automatically. With Infinispan that would mean that we do need need to delete them explicitly.

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
