### PR TITLE
Focus on the configuration error for the message field

### DIFF
--- a/templates/crds/iotconfigs.crd.yaml
+++ b/templates/crds/iotconfigs.crd.yaml
@@ -21,6 +21,10 @@ spec:
     type: string
     description: Phase of the IoT config
     JSONPath: .status.phase
+  - name: Message
+    type: string
+    description: Message
+    JSONPath: .status.message
   subresources:
     status: {}
   validation:


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Enhancement / new feature

### Description

This will put an emphasis on a terminal configuration error for the IoTConfig. Each configuration error will fail the IoTConfig and the message field (which will now be shown) will contain the configuration error, rather than a copy of the ready condition's message:

Before:

~~~
NAME      PHASE    MESSAGE
default   Failed   1 component out of 10 is non-ready: Configuration
~~~

After:

~~~
NAME      PHASE    MESSAGE
default   Failed   Configuration Error: Number of key owners (3) must not exceed number of replicas (2)
~~~

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
