### PR TITLE
Reduce log output for systemtests

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/iot/IoTTestSession.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/iot/IoTTestSession.java
@@ -12,7 +12,6 @@ import static io.enmasse.systemtest.iot.IoTTestSession.Adapter.MQTT;
 import static io.enmasse.systemtest.platform.Kubernetes.isOpenShiftCompatible;
 import static io.enmasse.systemtest.time.TimeoutBudget.ofDuration;
 import static java.time.Duration.ofMinutes;
-import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 
 import java.nio.file.Files;
@@ -714,7 +713,9 @@ public final class IoTTestSession implements AutoCloseable {
 
         config = config.editOrNewSpec()
                 .withNewLogging()
-                .withNewLevel("debug")
+                .withNewLevel("info")
+                .addToLoggers("org.eclipse.hono", "debug")
+                .addToLoggers("io.enmasse", "debug")
                 .endLogging()
                 .endSpec();
 


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Refactoring

### Description

The sets the default log level to "info" and only sets enmasse and hono channels to "debug".

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
