### PR TITLE
Ensure that broker plugin logs exception if connector fails.

### DIFF
--- a/broker-plugin/amqp-connector/src/main/java/org/apache/activemq/artemis/integration/amqp/AMQPConnectorServiceFactory.java
+++ b/broker-plugin/amqp-connector/src/main/java/org/apache/activemq/artemis/integration/amqp/AMQPConnectorServiceFactory.java
@@ -31,7 +31,6 @@ import org.apache.qpid.proton.amqp.Symbol;
 
 import java.util.*;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 
@@ -135,7 +134,7 @@ public class AMQPConnectorServiceFactory implements ConnectorServiceFactory {
          ActiveMQAMQPLogger.LOGGER.infof("Creating connector host %s port %s", configuration.get(TransportConstants.HOST_PROP_NAME), configuration.get(TransportConstants.PORT_PROP_NAME));
       }
 
-      ExecutorService nettyThreadPool = Executors.newFixedThreadPool(nettyThreads, new DefaultThreadFactory("connector-" + connectorName));
+      ExecutorService nettyThreadPool = ThreadPoolExecutor.newFixedThreadPool(nettyThreads, new DefaultThreadFactory("connector-" + connectorName));
       return new AMQPConnectorService(connectorName,
               connectorConfig,
               containerId,
@@ -156,4 +155,6 @@ public class AMQPConnectorServiceFactory implements ConnectorServiceFactory {
    public Set<String> getRequiredProperties() {
       return requiredProperties;
    }
+
+
 }

--- a/broker-plugin/amqp-connector/src/main/java/org/apache/activemq/artemis/integration/amqp/ThreadPoolExecutor.java
+++ b/broker-plugin/amqp-connector/src/main/java/org/apache/activemq/artemis/integration/amqp/ThreadPoolExecutor.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package org.apache.activemq.artemis.integration.amqp;
+
+import java.util.concurrent.*;
+
+public class ThreadPoolExecutor {
+   public static ExecutorService newSingleThreadExecutor(ThreadFactory threadFactory) {
+      return newFixedThreadPool(1, threadFactory);
+   }
+
+    public static ExecutorService newFixedThreadPool(int nThreads, ThreadFactory threadFactory) {
+       return new java.util.concurrent.ThreadPoolExecutor(nThreads, nThreads, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(), threadFactory) {
+          @Override
+          protected void afterExecute(Runnable r, Throwable t) {
+             super.afterExecute(r, t);
+             if (t == null && r instanceof Future<?>) {
+                try {
+                   Future<?> future = (Future<?>) r;
+                   if (future.isDone()) {
+                      future.get();
+                   }
+                } catch (CancellationException ce) {
+                   t = ce;
+                } catch (ExecutionException ee) {
+                   t = ee.getCause();
+                } catch (InterruptedException ie) {
+                   Thread.currentThread().interrupt();
+                }
+             }
+             if (t != null) {
+                if (t instanceof Error) {
+                   ActiveMQAMQPLogger.LOGGER.fatalf(t, "Connector service failed");
+                   Runtime.getRuntime().halt(1);
+                } else {
+                   ActiveMQAMQPLogger.LOGGER.warnf(t, "Connector service failed");
+                }
+             }
+          }
+       };
+    }
+}


### PR DESCRIPTION

### Type of change


- Bugfix

### Description

The `scheduledExecutorService` provided by Artemis does not log exceptions throws by submitted runnable.  This change ensure that any exception are logged by the plugin.

Also changed executors created by the plugin to log any exceptions thrown by submitted runnables.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
