### PR TITLE
Refactor messaging performance tests

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/scale/performance/ThroughputData.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/scale/performance/ThroughputData.java
@@ -16,10 +16,8 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
     private List<String> msgPerSecond;
 
-    private String perClientThroughput99p;
-    private String perClientThroughputMedian;
-    private String estimateTotalThroughput99p;
-    private String estimateTotalThroughputMedian;
+    private String averageThroughput;
+    private String totalThroughput;
 
     public String getName() {
         return name;
@@ -37,36 +35,19 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
         this.msgPerSecond = msgPerSecond;
     }
 
-    public String getPerClientThroughput99p() {
-        return perClientThroughput99p;
+    public String getTotalThroughput() {
+        return totalThroughput;
     }
 
-    public void setPerClientThroughput99p(String perClientThroughput99p) {
-        this.perClientThroughput99p = perClientThroughput99p;
+    public void setTotalThroughput(String totalThroughput) {
+        this.totalThroughput = totalThroughput;
     }
 
-    public String getPerClientThroughputMedian() {
-        return perClientThroughputMedian;
+    public String getAverageThroughput() {
+        return averageThroughput;
     }
 
-    public void setPerClientThroughputMedian(String perClientThroughputMedian) {
-        this.perClientThroughputMedian = perClientThroughputMedian;
+    public void setAverageThroughput(String averageThroughput) {
+        this.averageThroughput = averageThroughput;
     }
-
-    public String getEstimateTotalThroughput99p() {
-        return estimateTotalThroughput99p;
-    }
-
-    public void setEstimateTotalThroughput99p(String estimateTotalThroughput99p) {
-        this.estimateTotalThroughput99p = estimateTotalThroughput99p;
-    }
-
-    public String getEstimateTotalThroughputMedian() {
-        return estimateTotalThroughputMedian;
-    }
-
-    public void setEstimateTotalThroughputMedian(String estimateTotalThroughputMedian) {
-        this.estimateTotalThroughputMedian = estimateTotalThroughputMedian;
-    }
-
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/scale/ScaleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/scale/ScaleTest.java
@@ -84,6 +84,7 @@ import static io.enmasse.systemtest.TestTag.SCALE;
 import static io.enmasse.systemtest.utils.AssertionPredicate.isNotPresent;
 import static io.enmasse.systemtest.utils.AssertionPredicate.isPresent;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.any;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -194,66 +195,68 @@ class ScaleTest extends TestBase implements ITestBaseIsolated {
 
     @Test
     @Order(2)
-    void testMessagingPerformance() throws Exception {
-        final int initialAddresses = env.getPerfInitialAddresses();
-        final int addressesPerGroupIncrease = env.getPerfAddressesPerGroupIncrease();
-        final int anycastLinksPerConnIncrease = env.getPerfAnycastLinksPerConnIncrease();
-        final int queueLinksPerConnIncrease = env.getPerfQueueLinksPerConnIncrease();
+    void testMessagingPerformanceAnycast() throws Exception {
+        doMessagingPerformanceTest(AddressType.ANYCAST, anycastPlanName);
+    }
 
-        int anycastLinksPerConnection = env.getPerfInitialAnycastLinksPerConn();
-        int queueLinksPerConnection = env.getPerfInitialQueueLinksPerConn();
-        int addressesPerGroup = env.getPerfInitialAddressesPerGroup();
+    @Test
+    @Order(3)
+    void testMessagingPerformanceQueue() throws Exception {
+        doMessagingPerformanceTest(AddressType.QUEUE, queuePlanName);
+    }
 
-        var addresses = createInitialAddresses(initialAddresses);
+
+    void doMessagingPerformanceTest(AddressType addressType, String addressPlan) throws Exception {
+        int maxClients = 100;
+
+        String batchSuffix = UUID.randomUUID().toString();
+        Address[] addresses = IntStream.range(0, maxClients - 1)
+                .mapToObj(i -> new AddressBuilder()
+                    .withNewMetadata()
+                    .withNamespace(addressSpace.getMetadata().getNamespace())
+                    .withName(AddressUtils.generateAddressMetadataName(addressSpace, String.format("test-%s-%d-%s", addressType.toString(), i, batchSuffix)))
+                    .endMetadata()
+                    .withNewSpec()
+                    .withType(addressType.toString())
+                    .withAddress(String.format("test-%s-%d-%s", addressType.toString(), i, batchSuffix))
+                    .withPlan(addressPlan)
+                    .endSpec()
+                    .build())
+                .toArray(Address[]::new);
+
+
+        appendAddress(addresses);
+        AddressUtils.waitForDestinationsReady(addresses);
 
         var endpoint = AddressSpaceUtils.getMessagingRoute(addressSpace);
         ScaleTestManager manager = new ScaleTestManager(endpoint, userCredentials);
 
-        manager.getPerformanceResults().setTotalAddressesCreated(addresses.size());
-
+        manager.getPerformanceResults().setTotalAddressesCreated(addresses.length);
+        int clients = 0;
         try {
 
             Executors.newSingleThreadExecutor().execute(manager::monitorMetrics);
 
-            while (true) {
+            while (clients < addresses.length) {
                 //determine load
-                List<List<Address>> addressesGroups = new ArrayList<>();
-                for (int i = 0; i < addresses.size() / addressesPerGroup; i++) {
-                    addressesGroups.add(addresses.subList(i * addressesPerGroup, (i + 1) * addressesPerGroup));
-                }
-
                 //deploy clients and start messaging
-                for (var groupOfAddresses : addressesGroups) {
-                    checkMetrics(manager.getMonitoringResult());
-                    var config = new ScaleTestClientConfiguration();
-                    config.setAddressesPerTenant(addressesPerTenant);
-                    config.setSendMessagePeriod(env.getPerfSendMessagesPeriod());
-                    config.setReceiversPerTenant(env.getPerfReceiversPerTenant());
-                    config.setSendersPerTenant(env.getPerfSendersPerTenant());
-                    manager.deployTenantClient(kubernetes, groupOfAddresses, config);
-                    checkMetrics(manager.getMonitoringResult());
-                }
+                checkMetrics(manager.getMonitoringResult());
+                var config = new ScaleTestClientConfiguration();
+                config.setAddressesPerTenant(1);
+                config.setSendMessagePeriod(0);
+                config.setLinksPerConnection(2);
+                config.setReceiversPerTenant(env.getPerfReceiversPerTenant());
+                config.setSendersPerTenant(env.getPerfSendersPerTenant());
+                manager.deployTenantClient(kubernetes, Collections.singletonList(addresses[clients]), config);
+                checkMetrics(manager.getMonitoringResult());
 
                 manager.sleep();
 
                 checkMetrics(manager.getMonitoringResult());
 
-                //increase load
-                if (anycastLinksPerConnection % 2 == 0) {
-                    queueLinksPerConnection += queueLinksPerConnIncrease;
-                }
-                anycastLinksPerConnection += anycastLinksPerConnIncrease;
-
-                int tenantsPerGroup = addressesPerGroup / addressesPerTenant;
-                //because of messaging-client grouping algorithm linksPerConnection cannot be bigger than addresses passed to client
-                //and because one tenant has one queue, in every address group we will have the same number of tenants and queues
-                //this limit is likely to always apply before to queues than anycast addresses, because anycast addresses are 4 and queues only 1
-                if (queueLinksPerConnection > tenantsPerGroup) {
-                    addressesPerGroup += addressesPerGroupIncrease;
-                }
+                clients++;
                 LOGGER.info("#######################################");
-                LOGGER.info("Increasing load, creating groups of {} addresses, anycast addresses links per connection {}"
-                        + ", queues links per connection {}", addressesPerGroup, anycastLinksPerConnection, queueLinksPerConnection);
+                LOGGER.info("Increasing load to {} clients", clients);
                 LOGGER.info("#######################################");
             }
 
@@ -264,28 +267,21 @@ class ScaleTest extends TestBase implements ITestBaseIsolated {
             manager.gatherPerformanceResults();
             saveResultsFile("messaging_performance_results.json", manager.getPerformanceResults());
             Map<String, Object> data = new HashMap<>();
-            data.put("addresses", addresses.size());
+            data.put("addresses", addresses.length);
             data.put("connections", manager.getConnections());
-            data.put("anycastLinksPerConnection", anycastLinksPerConnection);
-            data.put("queueLinksPerConnection", queueLinksPerConnection);
-            data.put("anycastSenderMedianThroughput", manager.getPerformanceResults().getAddresses().get(AddressType.ANYCAST.toString()).getGlobalSenders().getEstimateTotalThroughputMedian());
-            data.put("anycastReceiverMedianThroughput", manager.getPerformanceResults().getAddresses().get(AddressType.ANYCAST.toString()).getGlobalReceivers().getEstimateTotalThroughputMedian());
-            data.put("queueSenderMedianThroughput", manager.getPerformanceResults().getAddresses().get(AddressType.QUEUE.toString()).getGlobalSenders().getEstimateTotalThroughputMedian());
-            data.put("queueReceiverMedianThroughput", manager.getPerformanceResults().getAddresses().get(AddressType.QUEUE.toString()).getGlobalReceivers().getEstimateTotalThroughputMedian());
+            data.put(String.format("%sSenderMedianThroughput", addressType.toString()), manager.getPerformanceResults().getAddresses().get(AddressType.ANYCAST.toString()).getGlobalSenders().getEstimateTotalThroughputMedian());
+            data.put(String.format("%sReceiverMedianThroughput", addressType.toString()), manager.getPerformanceResults().getAddresses().get(AddressType.ANYCAST.toString()).getGlobalReceivers().getEstimateTotalThroughputMedian());
             savePlotCSV("messaging_performance.csv", data);
             LOGGER.info("#######################################");
-            LOGGER.info("Total addresses created {}", addresses.size());
+            LOGGER.info("Total addresses created {}", addresses.length);
             LOGGER.info("Total connections created {}", manager.getConnections());
             LOGGER.info("Total clients deployed {}", manager.getClients());
-            LOGGER.info("Final addresses per group {}", addressesPerGroup);
-            LOGGER.info("Final anycast links per connection {}", anycastLinksPerConnection);
-            LOGGER.info("Final queue links per connection {}", queueLinksPerConnection);
             LOGGER.info("#######################################");
         }
     }
 
     @Test
-    @Order(3)
+    @Order(4)
     void testNumberOfSupportedAddresses() throws Exception {
         int operableAddresses;
         int iterator = 0;
@@ -338,7 +334,7 @@ class ScaleTest extends TestBase implements ITestBaseIsolated {
     }
 
     @Test
-    @Order(4)
+    @Order(5)
     public void testFailureRecovery() throws Exception {
         int addressesToCreate = env.getFaultToleranceInitialAddresses();
         int addressesPerGroup = env.getFaultToleranceAddressesPerGroup();

--- a/systemtests/src/test/java/io/enmasse/systemtest/scale/ScaleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/scale/ScaleTest.java
@@ -207,7 +207,7 @@ class ScaleTest extends TestBase implements ITestBaseIsolated {
 
 
     void doMessagingPerformanceTest(AddressType addressType, String addressPlan) throws Exception {
-        int maxClients = 2;
+        int maxClients = 30;
 
         String batchSuffix = UUID.randomUUID().toString();
         Address[] addresses = IntStream.range(0, maxClients)

--- a/systemtests/src/test/java/io/enmasse/systemtest/scale/ScaleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/scale/ScaleTest.java
@@ -243,7 +243,7 @@ class ScaleTest extends TestBase implements ITestBaseIsolated {
                 checkMetrics(manager.getMonitoringResult());
                 var config = new ScaleTestClientConfiguration();
                 config.setAddressesPerTenant(1);
-                config.setSendMessagePeriod(1);
+                config.setSendMessagePeriod(0);
                 config.setLinksPerConnection(2);
                 config.setReceiversPerTenant(env.getPerfReceiversPerTenant());
                 config.setSendersPerTenant(env.getPerfSendersPerTenant());

--- a/systemtests/src/test/java/io/enmasse/systemtest/scale/ScaleTestManagerTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/scale/ScaleTestManagerTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
@@ -39,17 +40,17 @@ public class ScaleTestManagerTest {
 
 
         ScaleTestManager manager = new ScaleTestManager(new Endpoint("host", 9999), new UserCredentials("foo"));
-        DoubleHistogram histogram = new DoubleHistogram(20000, 4);
+        List<Double> throughputValues = new ArrayList<>();
 
-        var data = manager.gatherPerformanceData("aaa", records, start, histogram);
+        var data = manager.gatherPerformanceData("aaa", records, start, throughputValues);
 
         for (String r : data.getMsgPerSecond()) {
             assertThat(r, equalTo("1.0 msg/sec"));
         }
 
-        var global = manager.gatherGlobalPerformanceData(histogram, 1);
-        assertThat(global.getPerClientThroughput99p(), equalTo("1.0 msg/sec"));
-        assertThat(global.getPerClientThroughputMedian(), equalTo("1.0 msg/sec"));
+        var global = manager.gatherGlobalPerformanceData(Collections.singletonMap("aaa", throughputValues));
+        assertThat(global.getAverageThroughput(), equalTo("1.00 msg/sec"));
+        assertThat(global.getTotalThroughput(), equalTo("1.00 msg/sec"));
 
     }
 
@@ -71,17 +72,17 @@ public class ScaleTestManagerTest {
             });
 
         ScaleTestManager manager = new ScaleTestManager(new Endpoint("host", 9999), new UserCredentials("foo"));
-        DoubleHistogram histogram = new DoubleHistogram(20000, 4);
+        List<Double> throughputValues = new ArrayList<>();
 
-        var data = manager.gatherPerformanceData("aaa", records, start, histogram);
+        var data = manager.gatherPerformanceData("aaa", records, start, throughputValues);
 
         for (String r : data.getMsgPerSecond()) {
             assertThat(r, equalTo("1.5 msg/sec"));
         }
 
-        var global = manager.gatherGlobalPerformanceData(histogram, 1);
-        assertThat(global.getPerClientThroughput99p(), equalTo("1.5 msg/sec"));
-        assertThat(global.getPerClientThroughputMedian(), equalTo("1.5 msg/sec"));
+        var global = manager.gatherGlobalPerformanceData(Collections.singletonMap("aaa", throughputValues));
+        assertThat(global.getAverageThroughput(), equalTo("1.50 msg/sec"));
+        assertThat(global.getTotalThroughput(), equalTo("1.50 msg/sec"));
 
     }
 
@@ -94,18 +95,17 @@ public class ScaleTestManagerTest {
         records.add(new MessagesCountRecord(4000, 5));
 
         ScaleTestManager manager = new ScaleTestManager(new Endpoint("host", 9999), new UserCredentials("foo"));
-        DoubleHistogram histogram = new DoubleHistogram(20000, 4);
+        List<Double> throughputValues = new ArrayList<>();
 
-        var data = manager.gatherPerformanceData("aaa", records, start, histogram);
+        var data = manager.gatherPerformanceData("aaa", records, start, throughputValues);
 
         for (String r : data.getMsgPerSecond()) {
             assertThat(r, equalTo("1.25 msg/sec"));
         }
 
-        var global = manager.gatherGlobalPerformanceData(histogram, 1);
-        assertThat(global.getPerClientThroughput99p(), equalTo("1.25 msg/sec"));
-        assertThat(global.getPerClientThroughputMedian(), equalTo("1.25 msg/sec"));
-
+        var global = manager.gatherGlobalPerformanceData(Collections.singletonMap("aaa", throughputValues));
+        assertThat(global.getAverageThroughput(), equalTo("1.25 msg/sec"));
+        assertThat(global.getTotalThroughput(), equalTo("1.25 msg/sec"));
     }
 
     @Test
@@ -117,17 +117,16 @@ public class ScaleTestManagerTest {
         records.add(new MessagesCountRecord(3000, 10));
 
         ScaleTestManager manager = new ScaleTestManager(new Endpoint("host", 9999), new UserCredentials("foo"));
-        DoubleHistogram histogram = new DoubleHistogram(20000, 4);
+        List<Double> throughputValues = new ArrayList<>();
 
-
-        var data = manager.gatherPerformanceData("aaa", records, start, histogram);
+        var data = manager.gatherPerformanceData("aaa", records, start, throughputValues);
         for (String r : data.getMsgPerSecond()) {
             assertThat(r, equalTo("3.33 msg/sec"));
         }
 
-        var global = manager.gatherGlobalPerformanceData(histogram, 1);
-        assertThat(global.getPerClientThroughput99p(), equalTo("3.33 msg/sec"));
-        assertThat(global.getPerClientThroughputMedian(), equalTo("3.33 msg/sec"));
+        var global = manager.gatherGlobalPerformanceData(Collections.singletonMap("aaa", throughputValues));
+        assertThat(global.getAverageThroughput(), equalTo("3.33 msg/sec"));
+        assertThat(global.getTotalThroughput(), equalTo("3.33 msg/sec"));
 
     }
 
@@ -149,18 +148,16 @@ public class ScaleTestManagerTest {
             });
 
         ScaleTestManager manager = new ScaleTestManager(new Endpoint("host", 9999), new UserCredentials("foo"));
-        DoubleHistogram histogram = new DoubleHistogram(20000, 4);
+        List<Double> throughputValues = new ArrayList<>();
 
-        var data = manager.gatherPerformanceData("aaa", records, start, histogram);
+        var data = manager.gatherPerformanceData("aaa", records, start, throughputValues);
 
         for (String r : data.getMsgPerSecond()) {
             assertThat(r, equalTo("0.67 msg/sec"));
         }
 
-        var global = manager.gatherGlobalPerformanceData(histogram, 1);
-        assertThat(global.getPerClientThroughput99p(), equalTo("0.67 msg/sec"));
-        assertThat(global.getPerClientThroughputMedian(), equalTo("0.67 msg/sec"));
-
+        var global = manager.gatherGlobalPerformanceData(Collections.singletonMap("aaa", throughputValues));
+        assertThat(global.getAverageThroughput(), equalTo("0.67 msg/sec"));
+        assertThat(global.getTotalThroughput(), equalTo("0.67 msg/sec"));
     }
-
 }


### PR DESCRIPTION
This modifies the messaging performance test into a test that tests
anycast and queue max throughput by initially creating a fixed number of
addresses, and gradually increasing the number of
clients (1 sender+receiver pair per client) until exhausing the number
of addresses.

Results is reported for each client that is added so that one can create scaling graphs from the results.