### PR TITLE
[Shared infra] Refactor broker management

### DIFF
--- a/pkg/amqpcommand/command_client.go
+++ b/pkg/amqpcommand/command_client.go
@@ -26,6 +26,7 @@ const (
 )
 
 type Client interface {
+	Addr() string
 	Start()
 	Stop()
 	ReconnectCount() int64
@@ -69,6 +70,10 @@ func NewCommandClient(addr string, commandAddress string, commandResponseAddress
 		connectOptions:         opts,
 		lastError:              nil,
 	}
+}
+
+func (c *CommandClient) Addr() string {
+	return c.addr
 }
 
 func (c *CommandClient) Start() {

--- a/pkg/amqpcommand/test/fake_client.go
+++ b/pkg/amqpcommand/test/fake_client.go
@@ -28,6 +28,10 @@ func NewFakeClient() *FakeClient {
 func (c *FakeClient) Start() {
 }
 
+func (c *FakeClient) Addr() string {
+	return ""
+}
+
 func (c *FakeClient) AwaitRunning() {
 }
 

--- a/pkg/state/broker_test.go
+++ b/pkg/state/broker_test.go
@@ -24,6 +24,7 @@ func TestInitializeBroker(t *testing.T) {
 		Port:          0,
 		initialized:   false,
 		commandClient: client,
+		entities:      make(map[BrokerEntityType]map[string]BrokerEntity, 0),
 	}
 
 	client.Handler = func(req *amqp.Message) (*amqp.Message, error) {
@@ -35,8 +36,8 @@ func TestInitializeBroker(t *testing.T) {
 
 	err := state.Initialize(time.Time{})
 	assert.Nil(t, err)
-	assert.NotNil(t, state.queues)
-	assert.Equal(t, 2, len(state.queues))
-	assert.True(t, state.queues["queue1"])
-	assert.True(t, state.queues["queue2"])
+	assert.NotNil(t, state.entities)
+	assert.Equal(t, 2, len(state.entities[BrokerQueueEntity]))
+	assert.NotNil(t, state.entities[BrokerQueueEntity]["queue1"])
+	assert.NotNil(t, state.entities[BrokerQueueEntity]["queue2"])
 }

--- a/pkg/state/broker_types.go
+++ b/pkg/state/broker_types.go
@@ -17,11 +17,29 @@ type BrokerState struct {
 	initialized    bool
 	nextResync     time.Time
 	commandClient  amqpcommand.Client
-	queues         map[string]bool
+	entities       map[BrokerEntityType]map[string]BrokerEntity
 	reconnectCount int64
 }
 
-type QueueConfiguration struct {
+type BrokerEntityType string
+
+const (
+	BrokerQueueEntity          BrokerEntityType = "queue"
+	BrokerAddressEntity        BrokerEntityType = "address"
+	BrokerDivertEntity         BrokerEntityType = "divert"
+	BrokerAddressSettingEntity BrokerEntityType = "address-setting"
+)
+
+type BrokerEntity interface {
+	Type() BrokerEntityType
+	GetName() string
+	Order() int
+	Equals(_ BrokerEntity) bool
+	Create(_ amqpcommand.Client) error
+	Delete(_ amqpcommand.Client) error
+}
+
+type BrokerQueue struct {
 	Name               string      `json:"name"`
 	Address            string      `json:"address"`
 	RoutingType        RoutingType `json:"routing-type"`
@@ -29,6 +47,11 @@ type QueueConfiguration struct {
 	Durable            bool        `json:"durable"`
 	AutoCreateAddress  bool        `json:"auto-create-address"`
 	PurgeOnNoConsumers bool        `json:"purge-on-no-consumers"`
+}
+
+type BrokerAddress struct {
+	Name        string      `json:"name"`
+	RoutingType RoutingType `json:"routing-type"`
 }
 
 type RoutingType string

--- a/pkg/state/infra_test.go
+++ b/pkg/state/infra_test.go
@@ -38,6 +38,7 @@ func TestUpdateRouters(t *testing.T) {
 		return &BrokerState{
 			Host:          host,
 			Port:          port,
+			entities:      make(map[BrokerEntityType]map[string]BrokerEntity, 0),
 			commandClient: bclient,
 		}
 	}, &testClock{})
@@ -67,6 +68,7 @@ func TestUpdateBrokers(t *testing.T) {
 		return &BrokerState{
 			Host:          host,
 			Port:          port,
+			entities:      make(map[BrokerEntityType]map[string]BrokerEntity, 0),
 			commandClient: bclient,
 		}
 	}, &testClock{})
@@ -117,6 +119,7 @@ func TestSyncConnectors(t *testing.T) {
 		return &BrokerState{
 			Host:          host,
 			Port:          port,
+			entities:      make(map[BrokerEntityType]map[string]BrokerEntity, 0),
 			commandClient: bclient,
 		}
 	}, &testClock{})


### PR DESCRIPTION
* Configure addresses explicitly
* Refactor broker management to easily support different entity types

@vbusch This should make it easier to wire in the per-address settings for shared infra.
