### PR TITLE
[Shared infra] Add support for topics

### DIFF
--- a/api-model/src/main/resources/schema/kube-schema.json
+++ b/api-model/src/main/resources/schema/kube-schema.json
@@ -230,6 +230,16 @@
     "github_com_enmasseproject_enmasse_pkg_apis_enmasse_v1beta2_MessagingAddressSpecQueue": {
       "type": "object",
       "description": "",
+      "properties": {
+        "deadLetterQueue": {
+          "type": "string",
+          "description": ""
+        },
+        "expiryQueue": {
+          "type": "string",
+          "description": ""
+        }
+      },
       "additionalProperties": true,
       "javaType": "MessagingAddressSpecQueue",
       "javaInterfaces": [
@@ -239,6 +249,12 @@
     "github_com_enmasseproject_enmasse_pkg_apis_enmasse_v1beta2_MessagingAddressSpecSubscription": {
       "type": "object",
       "description": "",
+      "properties": {
+        "topic": {
+          "type": "string",
+          "description": ""
+        }
+      },
       "additionalProperties": true,
       "javaType": "MessagingAddressSpecSubscription",
       "javaInterfaces": [

--- a/broker-plugin/plugin/src/main/resources/shared/broker.xml
+++ b/broker-plugin/plugin/src/main/resources/shared/broker.xml
@@ -79,8 +79,8 @@ under the License.
 
       <security-settings>
          <security-setting match="#">
-            <permission type="createNonDurableQueue" roles="manage"/>
-            <permission type="deleteNonDurableQueue" roles="manage"/>
+            <permission type="createNonDurableQueue" roles="manage,router"/>
+            <permission type="deleteNonDurableQueue" roles="manage,router"/>
             <permission type="createDurableQueue" roles="manage"/>
             <permission type="deleteDurableQueue" roles="manage"/>
             <permission type="createAddress" roles="manage"/>
@@ -99,10 +99,6 @@ under the License.
       <address-settings>
          <!--default for catch all-->
          <address-setting match="#">
-            <max-delivery-attempts>-1</max-delivery-attempts>
-            <redelivery-delay>1</redelivery-delay>
-            <redelivery-delay-multiplier>1.5</redelivery-delay-multiplier>
-            <max-redelivery-delay>10000</max-redelivery-delay>
             <!-- with -1 only the global-max-size is in use for limiting -->
             <max-size-bytes>-1</max-size-bytes>
             <message-counter-history-day-limit>10</message-counter-history-day-limit>

--- a/pkg/apis/enmasse/v1beta2/types_address.go
+++ b/pkg/apis/enmasse/v1beta2/types_address.go
@@ -53,12 +53,18 @@ type MessagingAddressSpecMulticast struct {
 }
 
 type MessagingAddressSpecQueue struct {
+	// Dead letter address (must be address with type deadLetter)
+	DeadLetterAddress string `json:"deadLetterAddress,omitempty"`
+	// Expiry queue address (must be address with type deadLetter)
+	ExpiryAddress string `json:"expiryAddress,omitempty"`
 }
 
 type MessagingAddressSpecTopic struct {
 }
 
 type MessagingAddressSpecSubscription struct {
+	// Topic address this subscription should be subscribed to.
+	Topic string `json:"topic"`
 }
 
 type MessagingAddressSpecDeadLetter struct {
@@ -108,6 +114,7 @@ type MessagingAddressConditionType string
 
 const (
 	MessagingAddressFoundTenant MessagingAddressConditionType = "FoundTenant"
+	MessagingAddressValidated   MessagingAddressConditionType = "Validated"
 	MessagingAddressScheduled   MessagingAddressConditionType = "Scheduled"
 	MessagingAddressCreated     MessagingAddressConditionType = "Created"
 	MessagingAddressReady       MessagingAddressConditionType = "Ready"

--- a/pkg/controller/messagingaddress/messagingaddress_controller.go
+++ b/pkg/controller/messagingaddress/messagingaddress_controller.go
@@ -216,7 +216,7 @@ func (r *ReconcileMessagingAddress) Reconcile(request reconcile.Request) (reconc
 							return reconcile.Result{}, err
 						}
 						if foundSub {
-							err := fmt.Errorf("subscriptions referencing this topic address exists")
+							err := fmt.Errorf("subscriptions referencing this topic address exist")
 							address.Status.Message = err.Error()
 							return reconcile.Result{Requeue: true}, nil
 						}
@@ -230,7 +230,7 @@ func (r *ReconcileMessagingAddress) Reconcile(request reconcile.Request) (reconc
 							return reconcile.Result{}, err
 						}
 						if foundQueue {
-							err := fmt.Errorf("queues referencing this deadletter address exists")
+							err := fmt.Errorf("queues referencing this deadletter address exist")
 							address.Status.Message = err.Error()
 							return reconcile.Result{Requeue: true}, nil
 						}

--- a/pkg/controller/messagingaddress/messagingaddress_controller.go
+++ b/pkg/controller/messagingaddress/messagingaddress_controller.go
@@ -56,10 +56,7 @@ func Add(mgr manager.Manager) error {
 }
 
 /**
- * TODO - Add support for topic addresses
  * TODO - Add support for scheduling based on broker load
- * TODO - Add support for subscription addresses
- * TODO - Add support for deadLetter addresses
  * TODO - Add support for per-address limits based on MessagingAddressPlan
  * TODO - Add support for migrating queues to different brokers based on scheduling decision
  */
@@ -150,6 +147,7 @@ func (r *ReconcileMessagingAddress) Reconcile(request reconcile.Request) (reconc
 
 	// Initialize phase and conditions and type
 	var foundTenant *v1beta2.MessagingAddressCondition
+	var validated *v1beta2.MessagingAddressCondition
 	var scheduled *v1beta2.MessagingAddressCondition
 	var created *v1beta2.MessagingAddressCondition
 	var ready *v1beta2.MessagingAddressCondition
@@ -171,6 +169,7 @@ func (r *ReconcileMessagingAddress) Reconcile(request reconcile.Request) (reconc
 			address.Status.Type = v1beta2.MessagingAddressTypeDeadLetter
 		}
 		foundTenant = address.Status.GetMessagingAddressCondition(v1beta2.MessagingAddressFoundTenant)
+		validated = address.Status.GetMessagingAddressCondition(v1beta2.MessagingAddressValidated)
 		scheduled = address.Status.GetMessagingAddressCondition(v1beta2.MessagingAddressScheduled)
 		created = address.Status.GetMessagingAddressCondition(v1beta2.MessagingAddressCreated)
 		ready = address.Status.GetMessagingAddressCondition(v1beta2.MessagingAddressReady)
@@ -207,8 +206,40 @@ func (r *ReconcileMessagingAddress) Reconcile(request reconcile.Request) (reconc
 						logger.Info("[Finalizer] Error looking up infra")
 						return reconcile.Result{}, err
 					}
+
+					if address.Spec.Topic != nil {
+						// For topics, make sure no subscriptions referencing this topic exists.
+						foundSub, err := matchAnyAddress(ctx, r.client, address.Namespace, func(a *v1beta2.MessagingAddress) bool {
+							return a.Spec.Subscription != nil && a.Spec.Subscription.Topic == address.GetAddress()
+						})
+						if err != nil {
+							return reconcile.Result{}, err
+						}
+						if foundSub {
+							err := fmt.Errorf("subscriptions referencing this topic address exists")
+							address.Status.Message = err.Error()
+							return reconcile.Result{Requeue: true}, nil
+						}
+					} else if address.Spec.DeadLetter != nil {
+						// For deadLetter addresses, make sure no queues are referencing it.
+						// For topics, make sure no subscriptions referencing this topic exists.
+						foundQueue, err := matchAnyAddress(ctx, r.client, address.Namespace, func(a *v1beta2.MessagingAddress) bool {
+							return a.Spec.Queue != nil && (a.Spec.Queue.DeadLetterAddress == address.GetAddress() || a.Spec.Queue.ExpiryAddress == address.GetAddress())
+						})
+						if err != nil {
+							return reconcile.Result{}, err
+						}
+						if foundQueue {
+							err := fmt.Errorf("queues referencing this deadletter address exists")
+							address.Status.Message = err.Error()
+							return reconcile.Result{Requeue: true}, nil
+						}
+					}
 					client := r.clientManager.GetClient(infra)
 					err = client.DeleteAddress(address)
+
+					// TODO: Notify Terminating deadLetter or topics referenced by this queue to speed up reconcile
+
 					logger.Info("[Finalizer] Deleted address", "err", err)
 					return reconcile.Result{}, err
 				},
@@ -221,6 +252,10 @@ func (r *ReconcileMessagingAddress) Reconcile(request reconcile.Request) (reconc
 		if result.Requeue {
 			// Update and requeue if changed
 			if !reflect.DeepEqual(original, address) {
+				if !reflect.DeepEqual(original.Status, address.Status) {
+					err := r.client.Status().Update(ctx, address)
+					return processorResult{Requeue: true}, err
+				}
 				err := r.client.Update(ctx, address)
 				return processorResult{Return: true}, err
 			}
@@ -249,13 +284,79 @@ func (r *ReconcileMessagingAddress) Reconcile(request reconcile.Request) (reconc
 		return result.Result(), err
 	}
 
-	// Schedule address. Scheduling and creation of addresses are separated and each step is persisted. This is to avoid
-	// the case where a scheduled address is forgotten if the operator crashes. Once persisted, the operator will
-	// be able to reconcile the broker state as specified in the address status.
+	// Perform validation of address
+	result, err = rc.Process(func(address *v1beta2.MessagingAddress) (processorResult, error) {
+		if address.Spec.Queue != nil &&
+			// Ensure any deadletter or expiry address exists
+			(address.Spec.Queue.DeadLetterAddress != "" || address.Spec.Queue.ExpiryAddress != "") {
+
+			deadLetterAddress := address.Spec.Queue.DeadLetterAddress
+			if deadLetterAddress != "" {
+				found, err := matchAnyAddress(ctx, r.client, address.Namespace, func(a *v1beta2.MessagingAddress) bool {
+					return a.Spec.DeadLetter != nil && a.GetAddress() == deadLetterAddress
+				})
+				if err != nil {
+					return processorResult{}, err
+				}
+				if !found {
+					err := fmt.Errorf("unable to find deadLetterAddress %s", deadLetterAddress)
+					validated.SetStatus(corev1.ConditionFalse, "", err.Error())
+					address.Status.Message = err.Error()
+					return processorResult{RequeueAfter: 10 * time.Second}, nil
+				}
+			}
+
+			expiryAddress := address.Spec.Queue.ExpiryAddress
+			if expiryAddress != "" {
+				found, err := matchAnyAddress(ctx, r.client, address.Namespace, func(a *v1beta2.MessagingAddress) bool {
+					return a.Spec.DeadLetter != nil && a.GetAddress() == expiryAddress
+				})
+				if err != nil {
+					return processorResult{}, err
+				}
+				if !found {
+					err := fmt.Errorf("unable to find expiryAddress %s", expiryAddress)
+					validated.SetStatus(corev1.ConditionFalse, "", err.Error())
+					address.Status.Message = err.Error()
+					return processorResult{RequeueAfter: 10 * time.Second}, nil
+				}
+			}
+		} else if address.Spec.Subscription != nil {
+			// Ensure our topic exists
+			topic := address.Spec.Subscription.Topic
+			if topic == "" {
+				err := fmt.Errorf("topic referenced by subscription must be non-empty")
+				validated.SetStatus(corev1.ConditionFalse, "", err.Error())
+				address.Status.Message = err.Error()
+				return processorResult{RequeueAfter: 10 * time.Second}, nil
+			}
+			found, err := matchAnyAddress(ctx, r.client, address.Namespace, func(a *v1beta2.MessagingAddress) bool {
+				return a.Spec.Topic != nil && a.GetAddress() == topic
+			})
+			if err != nil {
+				return processorResult{}, err
+			}
+
+			if !found {
+				err := fmt.Errorf("unable to find address for topic %s, required by subscription", topic)
+				validated.SetStatus(corev1.ConditionFalse, "", err.Error())
+				address.Status.Message = err.Error()
+				return processorResult{RequeueAfter: 10 * time.Second}, nil
+			}
+
+		}
+		validated.SetStatus(corev1.ConditionTrue, "", "")
+		return processorResult{}, nil
+	})
+	if result.ShouldReturn(err) {
+		return result.Result(), err
+	}
+
 	result, err = rc.Process(func(address *v1beta2.MessagingAddress) (processorResult, error) {
 		// TODO: Handle changes to partitions etc.
 		if len(address.Status.Brokers) > 0 {
 			// We're already scheduled so don't change
+			scheduled.SetStatus(corev1.ConditionTrue, "", "")
 			return processorResult{}, nil
 		}
 
@@ -324,6 +425,23 @@ func (r *ReconcileMessagingAddress) Reconcile(request reconcile.Request) (reconc
 		}
 	})
 	return result.Result(), err
+}
+
+type FilterFunc func(*v1beta2.MessagingAddress) bool
+
+func matchAnyAddress(ctx context.Context, c client.Client, namespace string, filter FilterFunc) (bool, error) {
+	list := &v1beta2.MessagingAddressList{}
+	err := c.List(ctx, list, client.InNamespace(namespace))
+	if err != nil {
+		return false, err
+	}
+
+	for _, address := range list.Items {
+		if filter(&address) {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 /*

--- a/pkg/state/broker_types.go
+++ b/pkg/state/broker_types.go
@@ -54,9 +54,21 @@ type BrokerAddress struct {
 	RoutingType RoutingType `json:"routing-type"`
 }
 
+type BrokerDivert struct {
+	Name                 string `json:"name"`
+	RoutingName          string `json:"routingName"`
+	Address              string `json:"address"`
+	ForwardingAddress    string `json:"forwardingAddress"`
+	Exclusive            bool   `json:"exclusive"`
+	FilterString         string `json:"filterString,omitempty"`
+	TransformerClassName string `json:"transformerClassName,omitempty"`
+}
+
 type RoutingType string
 
 const (
 	RoutingTypeAnycast   RoutingType = "ANYCAST"
 	RoutingTypeMulticast RoutingType = "MULTICAST"
+	RoutingTypePass      RoutingType = "PASS"
+	RoutingTypeStrip     RoutingType = "STRIP"
 )

--- a/pkg/state/router_types.go
+++ b/pkg/state/router_types.go
@@ -28,6 +28,7 @@ const (
 	RouterListenerEntity   RouterEntityType = "org.apache.qpid.dispatch.listener"
 	RouterConnectorEntity  RouterEntityType = "org.apache.qpid.dispatch.connector"
 	RouterAutoLinkEntity   RouterEntityType = "org.apache.qpid.dispatch.router.config.autoLink"
+	RouterLinkRouteEntity  RouterEntityType = "org.apache.qpid.dispatch.router.config.linkRoute"
 	RouterSslProfileEntity RouterEntityType = "org.apache.qpid.dispatch.sslProfile"
 )
 
@@ -105,8 +106,10 @@ type RouterAutoLink struct {
 }
 
 type RouterLinkRoute struct {
-	Prefix      string `json:"string"`
-	ContainerId string `json:"containerId"`
+	Name       string `json:"name"`
+	Prefix     string `json:"prefix"`
+	Direction  string `json:"direction"`
+	Connection string `json:"connection,omitempty"`
 }
 
 type RouterSslProfile struct {

--- a/systemtests/src/test/java/io/enmasse/systemtest/sharedinfra/MessagingAddressTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/sharedinfra/MessagingAddressTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.systemtest.sharedinfra;
+
+import io.enmasse.api.model.MessagingAddressBuilder;
+import io.enmasse.api.model.MessagingEndpoint;
+import io.enmasse.api.model.MessagingEndpointBuilder;
+import io.enmasse.api.model.MessagingEndpointPort;
+import io.enmasse.api.model.MessagingTenant;
+import io.enmasse.systemtest.Endpoint;
+import io.enmasse.systemtest.annotations.DefaultMessagingInfrastructure;
+import io.enmasse.systemtest.annotations.DefaultMessagingTenant;
+import io.enmasse.systemtest.annotations.ExternalClients;
+import io.enmasse.systemtest.bases.TestBase;
+import io.enmasse.systemtest.bases.isolated.ITestIsolatedSharedInfra;
+import io.enmasse.systemtest.messagingclients.ClientArgument;
+import io.enmasse.systemtest.messagingclients.ExternalMessagingClient;
+import io.enmasse.systemtest.messagingclients.proton.java.ProtonJMSClientReceiver;
+import io.enmasse.systemtest.messagingclients.proton.java.ProtonJMSClientSender;
+import io.enmasse.systemtest.messagingclients.rhea.RheaClientReceiver;
+import io.enmasse.systemtest.messagingclients.rhea.RheaClientSender;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static io.enmasse.systemtest.TestTag.ISOLATED_SHARED_INFRA;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag(ISOLATED_SHARED_INFRA)
+@DefaultMessagingInfrastructure
+@DefaultMessagingTenant
+@ExternalClients
+public class MessagingAddressTest extends TestBase implements ITestIsolatedSharedInfra {
+
+    private MessagingTenant tenant;
+    private MessagingEndpoint endpoint;
+
+    @BeforeAll
+    public void createEndpoint() {
+        tenant = infraResourceManager.getDefaultMessagingTenant();
+        endpoint = new MessagingEndpointBuilder()
+                .editOrNewMetadata()
+                .withNamespace(tenant.getMetadata().getNamespace())
+                .withName("app")
+                .endMetadata()
+                .editOrNewSpec()
+                .editOrNewTls()
+                .editOrNewSelfsigned()
+                .endSelfsigned()
+                .endTls()
+                .editOrNewCluster()
+                .endCluster()
+                .addToProtocols("AMQP", "AMQPS")
+                .endSpec()
+                .build();
+        infraResourceManager.createResource(endpoint);
+    }
+
+    @Test
+    public void testAnycast() throws Exception {
+        infraResourceManager.createResource(new MessagingAddressBuilder()
+                .editOrNewMetadata()
+                .withName("addr1")
+                .withNamespace(tenant.getMetadata().getNamespace())
+                .endMetadata()
+                .editOrNewSpec()
+                .editOrNewAnycast()
+                .endAnycast()
+                .endSpec()
+                .build());
+        doTestSendReceive("addr1", "addr1");
+    }
+
+    @Test
+    public void testMulticast() throws Exception {
+        infraResourceManager.createResource(new MessagingAddressBuilder()
+                .editOrNewMetadata()
+                .withName("multicast1")
+                .withNamespace(tenant.getMetadata().getNamespace())
+                .endMetadata()
+                .editOrNewSpec()
+                .editOrNewMulticast()
+                .endMulticast()
+                .endSpec()
+                .build());
+        doTestSendReceive(true, "multicast1", "multicast1", "multicast1", "multicast1");
+    }
+
+    @Test
+    public void testQueue() throws Exception {
+        infraResourceManager.createResource(new MessagingAddressBuilder()
+                .editOrNewMetadata()
+                .withName("queue1")
+                .withNamespace(tenant.getMetadata().getNamespace())
+                .endMetadata()
+                .editOrNewSpec()
+                .editOrNewQueue()
+                .endQueue()
+                .endSpec()
+                .build());
+        doTestSendReceive("queue1", "queue1");
+    }
+
+    @Test
+    public void testTopic() throws Exception {
+        infraResourceManager.createResource(new MessagingAddressBuilder()
+                .editOrNewMetadata()
+                .withName("topic1")
+                .withNamespace(tenant.getMetadata().getNamespace())
+                .endMetadata()
+                .editOrNewSpec()
+                .editOrNewTopic()
+                .endTopic()
+                .endSpec()
+                .build());
+        doTestSendReceive(true, "topic1", "topic1", "topic1", "topic1");
+    }
+
+    @Test
+    public void testSubscription() throws Exception {
+        infraResourceManager.createResource(new MessagingAddressBuilder()
+                .editOrNewMetadata()
+                .withName("topic1")
+                .withNamespace(tenant.getMetadata().getNamespace())
+                .endMetadata()
+                .editOrNewSpec()
+                .editOrNewTopic()
+                .endTopic()
+                .endSpec()
+                .build(),
+                new MessagingAddressBuilder()
+                .editOrNewMetadata()
+                .withName("sub1")
+                .withNamespace(tenant.getMetadata().getNamespace())
+                .endMetadata()
+                .editOrNewSpec()
+                .editOrNewSubscription()
+                .withTopic("topic1")
+                .endSubscription()
+                .endSpec()
+                .build(),
+                new MessagingAddressBuilder()
+                .editOrNewMetadata()
+                .withName("sub2")
+                .withNamespace(tenant.getMetadata().getNamespace())
+                .endMetadata()
+                .editOrNewSpec()
+                .editOrNewSubscription()
+                .withTopic("topic1")
+                .endSubscription()
+                .endSpec()
+                .build());
+        doTestSendReceive("topic1", "sub1", "sub2");
+    }
+
+    /**
+     * Send 10 messages on sender address, and receive 10 messages on each receiver address.
+     */
+    void doTestSendReceive(boolean waitReceivers, String senderAddress, String ... receiverAddresses) throws Exception {
+        int expectedMsgCount = 10;
+
+        Endpoint e = new Endpoint(endpoint.getStatus().getHost(), getPort("AMQP", endpoint));
+        ExternalMessagingClient senderClient = new ExternalMessagingClient(false)
+                .withClientEngine(new RheaClientSender())
+                .withMessagingRoute(e)
+                .withAddress(senderAddress)
+                .withCount(expectedMsgCount)
+                .withMessageBody("msg no. %d")
+                .withAdditionalArgument(ClientArgument.CONN_AUTH_MECHANISM, "ANONYMOUS")
+                .withTimeout(60);
+
+        List<ExternalMessagingClient> receiverClients = new ArrayList<>();
+        for (String receiverAddress : receiverAddresses) {
+            receiverClients.add(new ExternalMessagingClient(false)
+                    .withClientEngine(new RheaClientReceiver())
+                    .withMessagingRoute(e)
+                    .withAddress(receiverAddress)
+                    .withCount(expectedMsgCount)
+                    .withAdditionalArgument(ClientArgument.CONN_AUTH_MECHANISM, "ANONYMOUS")
+                    .withTimeout(60));
+        }
+
+        List<Future<Boolean>> receiverResults = new ArrayList<>();
+        for (ExternalMessagingClient receiverClient : receiverClients) {
+            receiverResults.add(ForkJoinPool.commonPool().submit((Callable<Boolean>) receiverClient::run));
+        }
+
+        if (waitReceivers) {
+            // To ensure receivers are attached and ready
+            Thread.sleep(10_000);
+        }
+
+        Future<Boolean> senderResult = ForkJoinPool.commonPool().submit((Callable<Boolean>) senderClient::run);
+
+        assertTrue(senderResult.get(1, TimeUnit.MINUTES), "Sender failed, expected return code 0");
+        for (Future<Boolean> receiverResult : receiverResults) {
+            assertTrue(receiverResult.get(1, TimeUnit.MINUTES), "Receiver failed, expected return code 0");
+        }
+
+        assertEquals(expectedMsgCount, senderClient.getMessages().size(),
+                String.format("Expected %d sent messages", expectedMsgCount));
+        for (ExternalMessagingClient receiverClient : receiverClients) {
+            assertEquals(expectedMsgCount, receiverClient.getMessages().size(),
+                    String.format("Expected %d received messages", expectedMsgCount));
+        }
+    }
+
+    void doTestSendReceive(String senderAddress, String ... receiverAddresses) throws Exception {
+        doTestSendReceive(false, senderAddress, receiverAddresses);
+    }
+
+    private static int getPort(String protocol, MessagingEndpoint endpoint) {
+        for (MessagingEndpointPort port : endpoint.getStatus().getPorts()) {
+            if (protocol.equals(port.getProtocol()))  {
+                return port.getPort();
+            }
+        }
+        return 0;
+    }
+}

--- a/templates/shared-infra/enmasse.io_messagingaddresses.yaml
+++ b/templates/shared-infra/enmasse.io_messagingaddresses.yaml
@@ -74,10 +74,24 @@ spec:
             queue:
               description: Queue addresses are addresses where messages are persisted
                 on a broker.
+              properties:
+                deadLetterAddress:
+                  description: Dead letter address (must be address with type deadLetter)
+                  type: string
+                expiryAddress:
+                  description: Expiry queue address (must be address with type deadLetter)
+                  type: string
               type: object
             subscription:
               description: Subscription addresses are durable subscription on a topic
                 stored on a broker.
+              properties:
+                topic:
+                  description: Topic address this subscription should be subscribed
+                    to.
+                  type: string
+              required:
+              - topic
               type: object
             topic:
               description: Topic addresses are fan-out addresses with messages persisted


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Add support for configuring router and broker for the topic, subscription and deadLetter address types and add systemtest for all currently supported types except deadLetter, which will be added separately. This PR requires #4692 which should be merged first.
                 
### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [x] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
