### PR TITLE
Fix dependency declaration of Prometheus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ replace (
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.0.0+incompatible
 	github.com/docker/docker => github.com/moby/moby v0.7.3-0.20190826074503-38ab9da00309
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20200117162508-e7ccdda6ba67
+	github.com/prometheus/prometheus => github.com/prometheus/prometheus v0.0.0-20200106144642-d9613e5c466c
 	k8s.io/api => k8s.io/api v0.0.0-20191016110408-35e52d86657a
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.0.0-20191016113550-5357c4baaf65
 	k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20191004115801-a2eda9f80ab8

--- a/go.sum
+++ b/go.sum
@@ -723,11 +723,8 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/procfs v0.0.5 h1:3+auTFlqw+ZaQYJARz6ArODtkaIwtvBTx3N2NehQlL8=
 github.com/prometheus/procfs v0.0.5/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
-github.com/prometheus/prometheus v0.0.0-20180315085919-58e2a31db8de/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
-github.com/prometheus/prometheus v2.3.2+incompatible h1:EekL1S9WPoPtJL2NZvL+xo38iMpraOnyEHOiyZygMDY=
-github.com/prometheus/prometheus v2.3.2+incompatible/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
-github.com/prometheus/prometheus v2.15.2+incompatible h1:6xLJiQb4NRmHure9iOQH68bDgL9RtI90TIL77ZGtf/o=
-github.com/prometheus/prometheus v2.15.2+incompatible/go.mod h1:7U90zPoLkWjEIQcy/rweQla82OCTUzxVHE51G3OhJbI=
+github.com/prometheus/prometheus v0.0.0-20200106144642-d9613e5c466c h1:1wJ3oer23Ou+5Ej+mAs3gpe5Iz6m24sNZPVAlbb7i4A=
+github.com/prometheus/prometheus v0.0.0-20200106144642-d9613e5c466c/go.mod h1:7U90zPoLkWjEIQcy/rweQla82OCTUzxVHE51G3OhJbI=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/prometheus/tsdb v0.8.0 h1:w1tAGxsBMLkuGrFMhqgcCeBkM5d1YI24udArs+aASuQ=
 github.com/prometheus/tsdb v0.8.0/go.mod h1:fSI0j+IUQrDd7+ZtR9WKIGtoYAYAJUKcKhYLG25tN4g=


### PR DESCRIPTION
This is battle between Golang authors and Prometheus authors (probably some others as well).

Golang requires semantic versioning, and Prometheus doesn't want submit to those rules:

* With Go 1.13 can no longer flag versions as incompatible, if the have a 'go.mod' file in their repository: https://github.com/golang/go/issues/35732
* Dropping the '+incompatible' suffix is not possible, because the module author (Prometheus) would need to add the suffix '/v2' to their module. Otherwise you run into: https://github.com/golang/go/issues/35732#issuecomment-557227639
* Prometheus doesn't care about Golang's idea of versioning and simply ignores it: https://github.com/prometheus/prometheus/issues/6048#issuecomment-534549253

You can still put a commit has into the go.mod file as version, but that gets translated to into a version from the past (for 2.15.2 prometheus this will resolve into 2.3.x or 1.8.x).

The solution to all of this insanity is, to declare the version you had in mind in the "requires" section. And then add a mapping entry into the "replace" section, pointing to the actual version, using a commit hash and the "v0.0.0" version.

### Type of change

<!--

_Select the type of your PR_

-->

- ~~Rant~~
- Bugfix

### Description

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
