### PR TITLE
Delete enmasse in case installation failed

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/listener/JunitCallbackListener.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/listener/JunitCallbackListener.java
@@ -94,6 +94,7 @@ public class JunitCallbackListener implements TestExecutionExceptionHandler, Lif
             });
         } catch (Exception ex) {
             beforeAllException = ex; //TODO remove it after upgrade to surefire plugin 3.0.0-M5
+            operatorManager.deleteEnmasseOlm();
         }
     }
 


### PR DESCRIPTION
Delete enmasse in case beforeall install fails, this will prevent situation where enmasse is in half installed state.