### PR TITLE
Fix deployment of secrets for plain Kubernetes

### DIFF
--- a/api-model/src/main/java/io/enmasse/iot/model/v1/DeviceRegistryServiceConfig.java
+++ b/api-model/src/main/java/io/enmasse/iot/model/v1/DeviceRegistryServiceConfig.java
@@ -23,6 +23,7 @@ import io.sundr.builder.annotations.Inline;
 public class DeviceRegistryServiceConfig {
     private InfinispanDeviceRegistry infinispan;
     private JdbcDeviceRegistry jdbc;
+    private ManagementConfig management;
 
     public InfinispanDeviceRegistry getInfinispan() {
         return infinispan;
@@ -38,6 +39,14 @@ public class DeviceRegistryServiceConfig {
 
     public JdbcDeviceRegistry getJdbc() {
         return jdbc;
+    }
+
+    public void setManagement(ManagementConfig management) {
+        this.management = management;
+    }
+
+    public ManagementConfig getManagement() {
+        return management;
     }
 
 }

--- a/api-model/src/main/java/io/enmasse/iot/model/v1/ManagementConfig.java
+++ b/api-model/src/main/java/io/enmasse/iot/model/v1/ManagementConfig.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.enmasse.iot.model.v1;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.fabric8.kubernetes.api.model.Doneable;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.Inline;
+
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = "io.fabric8.kubernetes.api.builder",
+        inline = @Inline(
+                type = Doneable.class,
+                prefix = "Doneable",
+                value = "done"))
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ManagementConfig {
+
+    private EndpointConfig endpoint;
+
+    public void setEndpoint(EndpointConfig endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public EndpointConfig getEndpoint() {
+        return endpoint;
+    }
+
+}

--- a/pkg/controller/iotconfig/adapter.go
+++ b/pkg/controller/iotconfig/adapter.go
@@ -480,7 +480,7 @@ func applyEndpointService(endpoint iotv1alpha1.EndpointConfig, service *corev1.S
 	} else {
 
 		if !util.IsOpenshift() {
-			return util.NewConfigurationError("not running in OpenShift, unable to use service CA, you need to provide a protocol adapter endpoint key/certificate")
+			return util.NewConfigurationError("not running in OpenShift, unable to use service CA, you need to provide an endpoint key/certificate for: %s", endpointSecretName)
 		}
 
 		// use service CA as fallback

--- a/systemtests/src/main/java/io/enmasse/systemtest/bases/JUnitWorkaround.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/bases/JUnitWorkaround.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.enmasse.systemtest.bases;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ * Workaround for some JUnit issue. Remove it after upgrade to surefire plugin 3.0.0-M5.
+ * <p>
+ * To use this you need to:
+ * <ul>
+ * <li>Extend your test class from {@link JUnitWorkaround}.
+ * <li>Wrap all code in {@code @BeforeAll} function using {@link #wrapBeforeAll(ThrowableRunner)}.
+ * </ul>
+ */
+public interface JUnitWorkaround {
+
+    /**
+     * Hold the internal global state.
+     */
+    static final class State {
+        private static final State INSTANCE = new State();
+
+        private List<Throwable> exceptions;
+
+        private State() {}
+    }
+
+    public static void wrapBeforeAll(final ThrowableRunner runner) {
+        try {
+            runner.run();
+        } catch (Throwable e) {
+            addBeforeAllException(e);
+        }
+    }
+
+    /**
+     * Record an exception from a {@code @BeforeAll} method.
+     *
+     * @param e The exception to store.
+     */
+    private static void addBeforeAllException(final Throwable e) {
+        if (State.INSTANCE.exceptions == null) {
+            State.INSTANCE.exceptions = new LinkedList<>();
+        }
+        State.INSTANCE.exceptions.add(e);
+    }
+
+    /**
+     * Fetch all stored exception and reset the state.
+     *
+     * @return All exception that had been recorded. May be {@code null}.
+     */
+    static List<Throwable> fetchBeforeAllExceptions() {
+        if (State.INSTANCE.exceptions == null) {
+            return null;
+        }
+        var result = State.INSTANCE.exceptions;
+        State.INSTANCE.exceptions = null;
+        return result;
+    }
+
+    /**
+     * Check if we have recorded "before all" exceptions.
+     *
+     * @throws Throwable if there was any recorded exception.
+     */
+    @BeforeEach
+    default void triggerBeforeAllException() throws Throwable {
+
+        // check if we have recorded exceptions ...
+
+        final List<Throwable> exceptions = fetchBeforeAllExceptions();
+        if (exceptions == null || exceptions.isEmpty()) {
+            // ... all good
+            return;
+        }
+
+        // build up exception
+
+        Throwable first = null;
+        for (Throwable e : exceptions) {
+            if (first == null) {
+                first = e;
+            } else {
+                first.addSuppressed(e);
+            }
+        }
+
+        // throw it
+
+        throw first;
+    }
+
+}

--- a/systemtests/src/main/java/io/enmasse/systemtest/iot/IoTTestSession.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/iot/IoTTestSession.java
@@ -744,6 +744,8 @@ public final class IoTTestSession implements AutoCloseable {
             secrets.put("iot-tenant-service", "systemtests-iot-tenant-service-tls");
             secrets.put("iot-device-connection", "systemtests-iot-device-connection-tls");
             secrets.put("iot-device-registry", "systemtests-iot-device-registry-tls");
+            secrets.put("iot-mesh-inter", "systemtests-iot-mesh-inter-tls");
+            secrets.put("iot-command-mesh", "systemtests-iot-command-mesh-tls");
 
             config = config
                     .editOrNewSpec()

--- a/systemtests/src/main/java/io/enmasse/systemtest/iot/IoTTests.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/iot/IoTTests.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.enmasse.systemtest.IndicativeSentences;
 import io.enmasse.systemtest.bases.ITestSeparator;
+import io.enmasse.systemtest.bases.JUnitWorkaround;
 import io.enmasse.systemtest.listener.JunitCallbackListener;
 import io.enmasse.systemtest.platform.Kubernetes;
 
@@ -24,11 +25,13 @@ import io.enmasse.systemtest.platform.Kubernetes;
 @ExtendWith(JunitCallbackListener.class)
 @DisplayNameGeneration(IndicativeSentences.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public interface IoTTests extends ITestSeparator {
+public interface IoTTests extends ITestSeparator, JUnitWorkaround {
 
     @BeforeAll
     public static void deployDefaultCerts() throws Exception {
-        IoTTestSession.deployDefaultCerts();
+        JUnitWorkaround.wrapBeforeAll( () -> {
+            IoTTestSession.deployDefaultCerts();
+        });
     }
 
     @BeforeEach

--- a/systemtests/src/main/java/io/enmasse/systemtest/iot/IoTTests.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/iot/IoTTests.java
@@ -7,6 +7,7 @@ package io.enmasse.systemtest.iot;
 
 import static io.enmasse.systemtest.bases.iot.ITestIoTBase.IOT_PROJECT_NAMESPACE;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.TestInstance;
@@ -24,6 +25,11 @@ import io.enmasse.systemtest.platform.Kubernetes;
 @DisplayNameGeneration(IndicativeSentences.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public interface IoTTests extends ITestSeparator {
+
+    @BeforeAll
+    public static void deployDefaultCerts() throws Exception {
+        IoTTestSession.deployDefaultCerts();
+    }
 
     @BeforeEach
     default void createNamespace() {


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

This fixes the missing secrets for the device registry, when testing on plain kubernetes.

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
