### PR TITLE
Gracefully handle missing Prometheus CRDs in some cases

### DIFF
--- a/pkg/util/templatehelper.go
+++ b/pkg/util/templatehelper.go
@@ -35,6 +35,7 @@ func NewTemplateHelper(extraParams map[string]string) *TemplateHelper {
 	templatePath := "/templates"
 	if _, err := os.Stat(templatePath); os.IsNotExist(err) {
 		// ENV VAR should be set for local deployments
+		// in the repository at 'controller-manager/src/main/resources/templates'
 		templatePath = os.Getenv("TEMPLATE_DIR")
 		if _, err := os.Stat(templatePath); os.IsNotExist(err) {
 			panic("cannot find templates")

--- a/systemtests/src/main/java/io/enmasse/systemtest/operator/EnmasseOperatorManager.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/operator/EnmasseOperatorManager.java
@@ -4,6 +4,21 @@
  */
 package io.enmasse.systemtest.operator;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+
 import io.enmasse.admin.model.v1.ConsoleService;
 import io.enmasse.admin.model.v1.ConsoleServiceSpec;
 import io.enmasse.systemtest.Environment;
@@ -18,20 +33,6 @@ import io.enmasse.systemtest.platform.OpenShift;
 import io.enmasse.systemtest.time.TimeoutBudget;
 import io.enmasse.systemtest.utils.TestUtils;
 import io.fabric8.kubernetes.api.model.EnvVar;
-import org.slf4j.Logger;
-
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.time.Duration;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class EnmasseOperatorManager {
 
@@ -197,6 +198,8 @@ public class EnmasseOperatorManager {
         generateTemplates();
         kube.createNamespace(kube.getInfraNamespace(), Collections.singletonMap("allowed", "true"));
         KubeCMDClient.applyFromFile(kube.getInfraNamespace(), Paths.get(Environment.getInstance().getTemplatesPath(), "install", "bundles", productName));
+        // by default metrics should be disabled, otherwise reconciliation will fail due to missing prometheus CRDs
+        enableOperatorMetrics(false);
     }
 
     public void installExamplePlans(String namespace) {


### PR DESCRIPTION
If monitoring is disabled, the IoT reconciler tries to "delete" the prometheus CRs. However that will fail if Prometheus CRDs are not installed.

It would be possible to add another flag or check, however I think the `ENABLE_MONTORING` env-var should already be enough. If monitoring is enabled, the prometheus CRD must be installed, otherwise it is an error. If monitoring is disabled, deleting the CR due to a missing CRD can be ignored. If the user chooses to enable monitoring without having the CRDs installed, an error is shown. It is still possible to install prometheus CRDs afterwards. The reconciler will try again and succeed the next time, as there are no stale caches. Using the `HasApi` methods would cache the outcome, which is ok for system resources, but wrong for CRDs.

In addition, the systemtests enable monitoring, although monitoring is not installed. This is fixed as well.

### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
