### PR TITLE
Do not overwrite the NodePort when running on plain Kubernetes

### DIFF
--- a/pkg/controller/iotconfig/device_registry.go
+++ b/pkg/controller/iotconfig/device_registry.go
@@ -179,14 +179,16 @@ func (r *ReconcileIoTConfig) reconcileDeviceRegistryManagementServiceExternal(co
 
 	service.Spec.Type = corev1.ServiceTypeLoadBalancer
 
-	service.Spec.Ports = []corev1.ServicePort{
-		{
-			Name:       "https",
-			Port:       31443,
-			TargetPort: intstr.FromInt(8443),
-			Protocol:   corev1.ProtocolTCP,
-		},
+	// set a single port, but don't overwrite the NodePort
+
+	if len(service.Spec.Ports) != 1 {
+		service.Spec.Ports = make([]corev1.ServicePort, 1)
 	}
+
+	service.Spec.Ports[0].Name = "https"
+	service.Spec.Ports[0].Port = 31443
+	service.Spec.Ports[0].TargetPort = intstr.FromInt(8443)
+	service.Spec.Ports[0].Protocol = corev1.ProtocolTCP
 
 	if service.Annotations == nil {
 		service.Annotations = make(map[string]string)


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

When running on plain Kubernetes, the node ports of the external load balancer services got overwritten each time.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
