### PR TITLE
Change EC curve to secp256r1 to fix issue in Go

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/iot/DeviceCertificateManager.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/iot/DeviceCertificateManager.java
@@ -79,7 +79,7 @@ public class DeviceCertificateManager {
         EC("EC", "SHA256withECDSA") {
             @Override
             public AlgorithmParameterSpec getSpec() {
-                return new ECGenParameterSpec("secp256k1");
+                return new ECGenParameterSpec("secp256r1");
             }
         },
         ;


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

This changes the elliptic curve, created by the system tests, to a version which both Java and Go support.

This should fix the test failure of `io.enmasse.systemtest.iot.isolated.x509.X509EcAuthenticationTests`.

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
