### PR TITLE
Ensure that addresses_ready event does not include addresses belonging to other address spaces.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@
 * #4631: Allow configuring CPU limits for infra
 * #4682: Avoid race when processing Artemis management responses when first connecting to broker
 
+## 0.31.4
+* #4721:  Standard address space agent erroneously processes addresses of other addressspaces in the same namespace
+
 ## 0.31.3
 * #4650: Install uncaught exception handler in address-space-controller and standard-controller
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,9 @@
 * #4600: [IoT] Allow configuring Pod affinities
 * #4631: Allow configuring CPU limits for infra
 * #4682: Avoid race when processing Artemis management responses when first connecting to broker
+* #4721: Standard address space agent erroneously processes addresses of other addressspaces in the same namespace
 
 ## 0.31.4
-* #4721: Standard address space agent erroneously processes addresses of other addressspaces in the same namespace
 * #4704: [OpenShift 3.11] Console returns 500 internal error when configured with custom certificate
 
 ## 0.31.3

--- a/agent/lib/internal_address_source.js
+++ b/agent/lib/internal_address_source.js
@@ -21,6 +21,7 @@ var events = require('events');
 var kubernetes = require('./kubernetes.js');
 var log = require('./log.js').logger();
 var myutils = require('./utils.js');
+var clone = require('clone');
 
 function extract_spec(def, env) {
     if (def.spec === undefined) {
@@ -33,7 +34,7 @@ function extract_spec(def, env) {
     o.addressSpaceNamespace = def.metadata ? def.metadata.namespace : process.env.ADDRESS_SPACE_NAMESPACE;
 
     if (def.status && def.status.brokerStatuses) {
-        o.allocated_to = def.status.brokerStatuses;
+        o.allocated_to = clone(def.status.brokerStatuses);
     }
     return o;
 }
@@ -131,13 +132,13 @@ AddressSource.prototype.start = function () {
     this.watcher.on('updated', this.updated.bind(this));
     this.readiness = {};
     this.last = {};
-}
+};
 
 util.inherits(AddressSource, events.EventEmitter);
 
 AddressSource.prototype.get_changes = function (name, addresses, unchanged) {
     var c = myutils.changes(this.last[name], addresses, address_compare, unchanged, description);
-    this.last[name] = addresses;
+    this.last[name] = clone(addresses);
     return c;
 };
 

--- a/agent/lib/internal_address_source.js
+++ b/agent/lib/internal_address_source.js
@@ -193,7 +193,7 @@ AddressSource.prototype.updated = function (objects) {
     if (changes) {
         this.update_readiness(changes);
         this.dispatch('addresses_defined', addresses, changes.description);
-        this.dispatch_if_changed('addresses_ready', objects.filter(ready).map(extract_spec), same_address_definition);
+        this.dispatch_if_changed('addresses_ready', addresses.filter(ready), same_address_definition);
     }
 };
 

--- a/agent/package.json
+++ b/agent/package.json
@@ -10,6 +10,7 @@
     },
     "dependencies": {
         "debug": "^3.1.*",
+        "clone": "^2.1.2",
         "p-limit": "^2.2.0",
         "rhea": "^1.0.13",
         "uuid": "^3.3.3"

--- a/agent/yarn.lock
+++ b/agent/yarn.lock
@@ -145,6 +145,11 @@ cliui@^5.0.0:
     strip-ansi "^5.2.0"
     wrap-ansi "^5.1.0"
 
+clone@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
+
 color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"


### PR DESCRIPTION

### Type of change


- Bugfix

### Description

addresses_ready event erroneously included addresses for other addressspaces colocated in the same namespace.

### Checklist


- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
