### PR TITLE
Ability to run tests against pure kubernetes

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/Kubernetes.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/Kubernetes.java
@@ -33,6 +33,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import io.enmasse.systemtest.platform.cluster.KubernetesCluster;
 import org.apache.commons.io.output.CloseShieldOutputStream;
 import org.slf4j.Logger;
 
@@ -154,7 +155,7 @@ public abstract class Kubernetes {
                 throw new RuntimeException(ex);
             }
             Environment env = Environment.getInstance();
-            if (cluster.toString().equals(MinikubeCluster.IDENTIFIER)) {
+            if (cluster.toString().equals(MinikubeCluster.IDENTIFIER) || cluster.toString().equals(KubernetesCluster.IDENTIFIER)) {
                 instance = new Minikube(env);
             } else {
                 instance = new OpenShift(env);

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/cluster/KubeCluster.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/cluster/KubeCluster.java
@@ -22,7 +22,7 @@ public interface KubeCluster {
     static KubeCluster detect() {
         Logger LOGGER = CustomLogger.getLogger();
 
-        KubeCluster[] clusters = new KubeCluster[]{new MinikubeCluster(), new CRCCluster(), new OpenShiftCluster()};
+        KubeCluster[] clusters = new KubeCluster[]{new MinikubeCluster(), new CRCCluster(), new OpenShiftCluster(), new KubernetesCluster()};
         KubeCluster cluster = null;
         String overrideCluster = Environment.getInstance().getOverrideClusterType();
         if (!Strings.isNullOrEmpty(overrideCluster)) {

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/cluster/KubeCluster.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/cluster/KubeCluster.java
@@ -22,7 +22,7 @@ public interface KubeCluster {
     static KubeCluster detect() {
         Logger LOGGER = CustomLogger.getLogger();
 
-        KubeCluster[] clusters = new KubeCluster[]{new MinikubeCluster(), new CRCCluster(), new OpenShiftCluster(), new KubernetesCluster()};
+        KubeCluster[] clusters = new KubeCluster[]{new MinikubeCluster(), new KubernetesCluster(), new CRCCluster(), new OpenShiftCluster()};
         KubeCluster cluster = null;
         String overrideCluster = Environment.getInstance().getOverrideClusterType();
         if (!Strings.isNullOrEmpty(overrideCluster)) {

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/cluster/KubernetesCluster.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/cluster/KubernetesCluster.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.systemtest.platform.cluster;
+
+import io.enmasse.systemtest.executor.Exec;
+
+import java.util.Arrays;
+
+public class KubernetesCluster implements KubeCluster {
+
+    public static final String IDENTIFIER = "kubernetes";
+
+    @Override
+    public boolean isAvailable() {
+        return Exec.isExecutableOnPath(IDENTIFIER);
+    }
+
+    @Override
+    public boolean isClusterUp() {
+        return Exec.execute(Arrays.asList(getKubeCmd(), "cluster-info"), false).getRetCode();
+    }
+
+    @Override
+    public String getKubeCmd() {
+        return "kubectl";
+    }
+
+    @Override
+    public String toString() {
+        return IDENTIFIER;
+    }
+}

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/cluster/KubernetesCluster.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/cluster/KubernetesCluster.java
@@ -14,7 +14,8 @@ public class KubernetesCluster implements KubeCluster {
 
     @Override
     public boolean isAvailable() {
-        return Exec.isExecutableOnPath(IDENTIFIER);
+        return Exec.isExecutableOnPath(getKubeCmd()) &&
+                !Exec.execute(Arrays.asList(getKubeCmd(), "api-resources"), false).getStdOut().contains("openshift.io");
     }
 
     @Override


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Enhancement / new feature

### Description

<!--

_Please describe your pull request_

-->

ability to run tests against pure kubernetes, it autodetect if cluster is kubernetes. In additionals PR for 1.0 version we should more focus on running tests on pure kubernetes implementations.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
