### PR TITLE
Enhance brokered address space's address controller (agent) to populate address plan status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * #4631: Allow configuring CPU limits for infra
 * #4682: Avoid race when processing Artemis management responses when first connecting to broker
 * #4721: Standard address space agent erroneously processes addresses of other addressspaces in the same namespace
+* #4730: Enhance brokered address space's address controller (agent) to populate address plan status
 
 ## 0.31.4
 * #4704: [OpenShift 3.11] Console returns 500 internal error when configured with custom certificate

--- a/agent/lib/internal_addressplan_source.js
+++ b/agent/lib/internal_addressplan_source.js
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2020 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+var util = require('util');
+var events = require('events');
+var kubernetes = require('./kubernetes.js');
+var log = require('./log.js').logger();
+var myutils = require('./utils.js');
+var clone = require('clone');
+
+function AddressPlanSource(config) {
+    this.config = config || {};
+    events.EventEmitter.call(this);
+}
+
+AddressPlanSource.prototype.start = function (addressspaceplansource) {
+    var self = this;
+    var options = myutils.merge({api: '/apis/admin.enmasse.io/v1beta2/'}, this.config);
+    var started = false;
+    addressspaceplansource.on('addressspaceplan_defined', (addressspaceplan) => {
+        if (!started) {
+            self.watcher = kubernetes.watch('addressplans', options);
+            self.watcher.on('updated', self.updated.bind(self));
+            started = true;
+        }
+        self.addressspaceplan = addressspaceplan;
+        if ('addressplans_defined' in self.last) {
+            self.updated(self.last['addressplans_defined']);
+        } else {
+            self.updated([]);
+        }
+    });
+    this.last = {};
+};
+
+util.inherits(AddressPlanSource, events.EventEmitter);
+
+AddressPlanSource.prototype.get_changes = function (name, addressplans, unchanged) {
+    var c = myutils.changes(this.last[name], addressplans, addressplan_compare, unchanged, description);
+    this.last[name] = clone(addressplans);
+    return c;
+};
+
+AddressPlanSource.prototype.dispatch = function (name, addresses, description) {
+    log.info('%s: %s', name, description);
+    this.emit(name, addresses);
+};
+
+AddressPlanSource.prototype.updated = function (objects) {
+    log.debug('addressplans updated: %j', objects);
+    var self = this;
+    var addressplans = objects.filter(ap => ap.metadata
+        && self.addressspaceplan
+        && self.addressspaceplan.spec
+        && self.addressspaceplan.spec.addressPlans
+        && self.addressspaceplan.spec.addressPlans.includes(ap.metadata.name));
+    var changes = this.get_changes('addressplans_defined', addressplans, same_addressplan_definition_and_status);
+    if (changes) {
+        this.dispatch('addressplans_defined', addressplans, changes.description);
+    }
+};
+
+function same_addressplan_definition_and_status(a, b) {
+    return same_addressplan_definition(a.spec, b.spec) && same_addressplan_status(a.status, b.status);
+}
+
+function same_addressplan_definition(a, b) {
+    return a.addressType === b.addressType && same_addressplan_resources(a.resources, b.resources);
+}
+
+function same_addressplan_resources(a, b) {
+    if (a === undefined) return b === undefined;
+    return a.broker === b.broker && a.router === b.router;
+}
+
+function same_addressplan_status(a, b) {
+    if (a === undefined) return b === undefined;
+    if (a === null) return b === null;
+    return b && a.isReady === b.isReady && a.phase === b.phase && same_messages(a.messages, b.messages);
+}
+
+function addressplan_compare(a, b) {
+    return myutils.string_compare(a.name, b.name);
+}
+
+function by_addressplan_name(a) {
+    return a.metadata.name;
+}
+
+function description(list) {
+    const max = 5;
+    if (list.length > max) {
+        return list.slice(0, max).map(by_addressplan_name).join(', ') + ' and ' + (list.length - max) + ' more';
+    } else {
+        return JSON.stringify(list.map(by_addressplan_name));
+    }
+}
+
+function same_messages(a, b) {
+    if (a === b) {
+        return true;
+    } else if (a == null || b == null || a.length !== b.length) {
+        return false;
+    }
+
+    for (var i in a) {
+        if (!b.includes(a[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+module.exports = AddressPlanSource;

--- a/agent/lib/internal_addressspaceplan_source.js
+++ b/agent/lib/internal_addressspaceplan_source.js
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2020 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+var util = require('util');
+var events = require('events');
+var kubernetes = require('./kubernetes.js');
+var log = require('./log.js').logger();
+var myutils = require('./utils.js');
+var clone = require('clone');
+
+
+function AddressSpacePlanSource(config) {
+    this.config = config || {};
+    this.selector = "";
+    events.EventEmitter.call(this);
+};
+
+AddressSpacePlanSource.prototype.start = function () {
+    this.addressSpacePlan = this.config.ADDRESS_SPACE_PLAN;
+    var options = myutils.merge({api: '/apis/admin.enmasse.io/v1beta2/'}, this.config);
+    this.watcher = kubernetes.watch('addressspaceplans', options);
+    this.watcher.on('updated', this.updated.bind(this));
+
+    this.last = {};
+};
+
+util.inherits(AddressSpacePlanSource, events.EventEmitter);
+
+AddressSpacePlanSource.prototype.get_changes = function (name, addressspaceplan, unchanged) {
+    var c = myutils.changes(this.last[name], addressspaceplan, addressspaceplan_compare, unchanged, description);
+    this.last[name] = clone(addressspaceplan);
+    return c;
+};
+
+AddressSpacePlanSource.prototype.dispatch = function (name, addresses, description) {
+    log.info('%s: %s', name, description);
+    this.emit(name, addresses);
+};
+
+AddressSpacePlanSource.prototype.updated = function (objects) {
+    log.debug('addressspaceplans updated: %j', objects);
+    var self = this;
+    var addressspaceplans = objects.filter(asp => asp.metadata && self.addressSpacePlan === asp.metadata.name);
+    var changes = this.get_changes('addressspaceplan_defined', addressspaceplans, same_addressspaceplan_spec_and_status);
+    if (changes) {
+        this.dispatch('addressspaceplan_defined', addressspaceplans[0], changes.description);
+    }
+};
+
+function same_addressspaceplan_spec_and_status(a, b) {
+    return same_addressspaceplan_definition(a.spec, b.spec) && same_addressspaceplan_status(a.status, b.status);
+}
+
+function same_addressspaceplan_definition(a, b) {
+    return same_addressplans(a.addressPlans, b.addressPlans);
+}
+
+function same_addressplans(a, b) {
+    if (a === undefined) return b === undefined;
+    if (a.length !== b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+        var found  = false;
+        for (var j = 0; j < b.length; j++) {
+            if (b[j] === a[i]) {
+                found = true;
+                break
+            }
+        }
+        if (!found) {
+            return false;
+        }
+    }
+    return true;
+}
+
+function same_addressspaceplan_status(a, b) {
+    if (a === undefined) return b === undefined;
+    return a.isReady === b.isReady && a.phase === b.phase && same_messages(a.messages, b.messages);
+}
+
+function addressspaceplan_compare(a, b) {
+    return myutils.string_compare(a.name, b.name);
+}
+
+function by_addressspaceplan_name(a) {
+    return a.metadata.name;
+}
+
+function description(list) {
+    const max = 5;
+    if (list.length > max) {
+        return list.slice(0, max).map(by_addressplan_name).join(', ') + ' and ' + (list.length - max) + ' more';
+    } else {
+        return JSON.stringify(list.map(by_addressspaceplan_name));
+    }
+}
+
+function same_messages(a, b) {
+    if (a === b) {
+        return true;
+    } else if (a == null || b == null || a.length !== b.length) {
+        return false;
+    }
+
+    for (var i in a) {
+        if (!b.includes(a[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+module.exports = AddressSpacePlanSource;

--- a/agent/lib/kubernetes.js
+++ b/agent/lib/kubernetes.js
@@ -87,15 +87,19 @@ function get_path(base, resource, options, timeout) {
     return path;
 }
 
+function build_api_from_resource(resource) {
+    return resource.startsWith("address") ? '/apis/enmasse.io/v1beta1/' : '/api/v1/';
+}
+
 function list_options(resource, baseOptions) {
-    var base = resource.startsWith("address") ? '/apis/enmasse.io/v1beta1/namespaces/' : '/api/v1/namespaces/';
+    let base = ("api" in baseOptions ?  baseOptions.api : build_api_from_resource(resource)) + "namespaces/";
     let path = get_path(base, resource, baseOptions);
     var options = get_options(baseOptions, path);
     return myutils.merge({requestTimeout: baseOptions.requestTimeout || process.env.REQUEST_TIMEOUT || 120}, options);
 }
 
 function watch_options(resource, baseOptions) {
-    var base = resource.startsWith("address") ? '/apis/enmasse.io/v1beta1/watch/namespaces/' : '/api/v1/watch/namespaces/';
+    var base = ("api" in baseOptions ?  baseOptions.api : build_api_from_resource(resource)) + "watch/namespaces/";
     var timeout = baseOptions.requestTimeout || process.env.RESYNC_INTERVAL;
     var options = get_options(baseOptions, get_path(base, resource, baseOptions, timeout));
     return myutils.merge({requestTimeout: timeout}, options);

--- a/agent/test/internal_address_source.js
+++ b/agent/test/internal_address_source.js
@@ -180,6 +180,7 @@ describe('address source', function() {
         address_plans_source.emit("addressplans_defined", [{
             kind: 'AddressPlan',
             metadata: {name: 'myplan'},
+            spec: {addressType: 'queue'}
         }]);
         source.watcher.close();
         source.on('addresses_defined', function (addresses) {
@@ -200,6 +201,7 @@ describe('address source', function() {
         address_plans_source.emit("addressplans_defined", [{
             kind: 'AddressPlan',
             metadata: {name: 'myplan'},
+            spec: {addressType: 'queue'}
         }]);
         source.once('addresses_defined', function (addresses) {
             source.check_status({foo:{propagated:100}}).then(function () {
@@ -245,6 +247,7 @@ describe('address source', function() {
             kind: 'AddressPlan',
             metadata: {name: 'myplan'},
             spec: {
+                addressType: 'queue',
                 resources: {
                     broker: 0.01
                 }

--- a/agent/test/internal_addressplan_source.js
+++ b/agent/test/internal_addressplan_source.js
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2020 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+var assert = require('assert');
+var EventEmitter = require('events');
+
+var AddressPlanSource = require('../lib/internal_addressplan_source');
+var AddressServer = require('../testlib/mock_resource_server.js').AddressServer;
+
+describe('addressplan source', function() {
+    var address_server;
+    var address_space_plan_source;
+
+    beforeEach(function(done) {
+        address_space_plan_source = new EventEmitter();
+        address_server = new AddressServer();
+        address_server.listen(0, done);
+    });
+
+    afterEach(function(done) {
+        address_server.close(done);
+    });
+
+    it('retrieves address plans', function(done) {
+        address_server.add_address_plan({plan_name:'small', address_type:'queue'});
+        address_server.add_address_plan({plan_name:'medium', address_type:'queue'});
+        address_server.add_address_plan({plan_name:'large', address_type:'queue'});
+        address_server.add_address_plan({plan_name:'belongs_to_another_space_plan', address_type:'queue'});
+
+        var source = new AddressPlanSource({port:address_server.port, host:'localhost', token:'foo', namespace:'default'});
+        source.start(address_space_plan_source);
+        address_space_plan_source.emit("addressspaceplan_defined", {
+            kind: 'AddressPlan',
+            metadata: {name: 'spaceplan'},
+            spec: {
+                addressPlans: ['small', 'medium', 'large'],
+            }
+        });
+
+        source.on('addressplans_defined', function (addressplans) {
+            source.watcher.close();
+            assert.equal(addressplans.length, 3);
+            done();
+        });
+    });
+
+    it('watches for changes - additional plan', function(done) {
+
+        address_server.add_address_plan({plan_name:'small', address_type:'queue'});
+        address_server.add_address_plan({plan_name:'large', address_type:'queue'});
+
+        var source = new AddressPlanSource({port:address_server.port, host:'localhost', token:'foo', namespace:'default', ADDRESS_SPACE_PLAN: 'space', ADDRESS_SPACE_PREFIX: 's1.'});
+        source.start(address_space_plan_source);
+        address_space_plan_source.emit("addressspaceplan_defined", {
+            kind: 'AddressPlan',
+            metadata: {name: 'spaceplan'},
+            spec: {
+                addressPlans: ['small', 'large'],
+            }
+        });
+        source.once('addressplans_defined', (addressplans) => {
+            assert.equal(addressplans.length, 2);
+            process.nextTick(() => {
+                address_server.add_address_plan({plan_name:'medium', address_type:'queue'});
+                address_space_plan_source.emit("addressspaceplan_defined", {
+                    kind: 'AddressPlan',
+                    metadata: {name: 'spaceplan'},
+                    spec: {
+                        addressPlans: ['small', 'medium', 'large'],
+                    }
+                });
+            });
+
+            source.on('addressplans_defined', (update) => {
+                source.watcher.close();
+                assert.equal(update.length, 3);
+                done();
+            });
+        });
+    });
+
+    it('watches for changes - redefined plan', function(done) {
+
+        address_server.add_address_plan({plan_name:'small', address_type:'queue', resources: {broker: 0.4}});
+
+        var source = new AddressPlanSource({port:address_server.port, host:'localhost', token:'foo', namespace:'default', ADDRESS_SPACE_PLAN: 'space', ADDRESS_SPACE_PREFIX: 's1.'});
+        source.start(address_space_plan_source);
+        address_space_plan_source.emit("addressspaceplan_defined", {
+            kind: 'AddressPlan',
+            metadata: {name: 'spaceplan'},
+            spec: {
+                addressPlans: ['small'],
+            }
+        });
+        source.once('addressplans_defined', (addressplans) => {
+            assert.equal(addressplans.length, 1);
+            process.nextTick(() => {
+                address_server.update_address_plan({plan_name:'small', address_type:'queue', resources: {broker: 0.5}});
+            });
+
+            source.on('addressplans_defined', (update) => {
+                source.watcher.close();
+                assert.equal(update.length, 1);
+                done();
+            });
+        });
+    });
+});

--- a/agent/test/internal_addressspaceplan_source.js
+++ b/agent/test/internal_addressspaceplan_source.js
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+var assert = require('assert');
+
+var AddressSpacePlanSource = require('../lib/internal_addressspaceplan_source');
+var AddressServer = require('../testlib/mock_resource_server.js').AddressServer;
+
+describe('addressspaceplan source', function() {
+    var address_server;
+
+    beforeEach(function(done) {
+        address_server = new AddressServer();
+        address_server.listen(0, done);
+    });
+
+    afterEach(function(done) {
+        address_server.close(done);
+    });
+
+    it('retrieves addressspace plan', function(done) {
+        address_server.add_address_space_plan({plan_name:'space', address_plans:['small', 'medium', 'large']});
+        address_server.add_address_space_plan({plan_name:'anotherplan', address_plans:['small', 'medium', 'large']});
+
+        var source = new AddressSpacePlanSource({port:address_server.port, host:'localhost', token:'foo', namespace:'default', ADDRESS_SPACE_PLAN: 'space'});
+        source.start();
+        source.watcher.close();
+        source.on('addressspaceplan_defined', (addressspaceplan) => {
+            assert.equal(addressspaceplan.metadata.name, "space");
+            assert.deepEqual(addressspaceplan.spec.addressPlans, ['small', 'medium', 'large']);
+
+            done();
+        });
+    });
+
+    it('watches for changes', function(done) {
+        address_server.add_address_space_plan({plan_name:'space', address_plans:['small', 'medium', 'large']});
+        var source = new AddressSpacePlanSource({port:address_server.port, host:'localhost', token:'foo', namespace:'default', ADDRESS_SPACE_PLAN: 'space', ADDRESS_SPACE_PREFIX: 's1.'});
+        source.start();
+        source.once('addressspaceplan_defined', (addressspaceplan) => {
+            assert.equal(addressspaceplan.metadata.name, "space");
+            process.nextTick(() => {
+                address_server.update_address_space_plan({plan_name:'space', address_plans:['small', 'medium', 'large', 'xlarge']});
+            });
+
+            source.on('addressspaceplan_defined', (update) => {
+                source.watcher.close();
+                assert.equal(update.metadata.name, "space");
+                assert.deepEqual(update.spec.addressPlans, ['small', 'medium', 'large', 'xlarge']);
+                done();
+            });
+        });
+    });
+});

--- a/agent/test/ragent.js
+++ b/agent/test/ragent.js
@@ -25,7 +25,6 @@ var http = require('http');
 var rhea = require('rhea');
 
 var Ragent = require('../lib/ragent.js');
-var BrokerAddressSettings = require('../lib/broker_address_settings.js');
 var tls_options = require('../lib/tls_options.js');
 var MockBroker = require('../testlib/mock_broker.js');
 var MockRouter = require('../testlib/mock_router.js');

--- a/agent/testlib/mock_resource_server.js
+++ b/agent/testlib/mock_resource_server.js
@@ -288,6 +288,7 @@ ResourceServer.prototype.update_resource = function (type, name, updated) {
         var externalized = this.resources[type].map(this.externalize)[i];
         if (externalized.metadata.name === name) {
             this.update(type, i, updated);
+            this.resource_modified(type, updated);
             return true;
         }
     }
@@ -369,22 +370,18 @@ AddressServer.prototype.add_address_definitions = function (defs) {
     }
 };
 
-AddressServer.prototype.add_address_space_plan = function (params) {
-    var plan = {
-        kind: 'AddressSpacePlan',
-        metadata: {name: params.plan_name},
-        displayName: params.display_name,
-        shortDescription: params.shortDescription,
-        longDescription: params.longDescription,
-        displayOrder: params.displayOrder,
-        addressSpaceType: params.address_space_type,
-        addressPlans: params.address_plans
-    };
-    if (params.required_resources) {
-        plan.requiredResources = params.required_resources;
+AddressServer.prototype.update_address_definition = function (def, name, infra_uuid, annotations, status) {
+    var address = {kind: 'Address', metadata: {name: name || def.address}, spec:def};
+    if (annotations) {
+        address.metadata.annotations = annotations;
     }
-    this.add_resource('addressspaceplans', plan);
-}
+    address.metadata.labels = {};
+    if (infra_uuid) {
+        address.metadata.labels.infraUuid = infra_uuid;
+    }
+    address.status = status || { phase: 'Active' };
+    this.update_resource('addresses', address.metadata.name, address);
+};
 
 AddressServer.prototype.add_address_plan = function (params) {
     var plan = {
@@ -396,12 +393,67 @@ AddressServer.prototype.add_address_plan = function (params) {
             longDescription: params.longDescription,
             displayOrder: params.displayOrder,
             addressType: params.address_type,
+            ttl: params.ttl,
         }
     };
     if (params.resources) {
         plan.resources = params.resources;
     }
     this.add_resource('addressplans', plan);
+};
+
+AddressServer.prototype.update_address_plan = function (params) {
+    var plan = {
+        kind: 'AddressPlan',
+        metadata: {name: params.plan_name},
+        spec: {
+            displayName: params.display_name,
+            shortDescription: params.shortDescription,
+            longDescription: params.longDescription,
+            displayOrder: params.displayOrder,
+            addressType: params.address_type,
+            ttl: params.ttl,
+        }
+    };
+    if (params.required_resources) {
+        plan.requiredResources = params.required_resources;
+    }
+    this.update_resource('addressplans', params.plan_name, plan);
+};
+
+AddressServer.prototype.add_address_space_plan = function (params) {
+    var plan = {
+        kind: 'AddressSpacePlan',
+        metadata: {name: params.plan_name},
+        spec: {
+            displayName: params.display_name,
+            shortDescription: params.shortDescription,
+            longDescription: params.longDescription,
+            displayOrder: params.displayOrder,
+            addressSpaceType: params.address_space_type,
+            addressPlans: params.address_plans
+        }
+    };
+    if (params.required_resources) {
+        plan.requiredResources = params.required_resources;
+    }
+    this.add_resource('addressspaceplans', plan);
+};
+
+AddressServer.prototype.update_address_space_plan = function(params) {
+    var plan = {
+        kind: 'AddressSpacePlan',
+        metadata: {name: params.plan_name},
+        spec: {
+            displayName: params.display_name,
+            shortDescription: params.shortDescription,
+            longDescription: params.longDescription,
+            displayOrder: params.displayOrder,
+            addressSpaceType: params.address_space_type,
+            addressPlans: params.address_plans
+        }
+    };
+    this.update_resource('addressspaceplans', params.plan_name, plan);
 };
 
 AddressServer.prototype.resource_initialiser = function (resource) {

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/plans/PlansTestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/plans/PlansTestBase.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.enmasse.systemtest.bases.plans;
+
+import io.enmasse.address.model.Address;
+import io.enmasse.address.model.AddressBuilder;
+import io.enmasse.address.model.AddressSpace;
+import io.enmasse.systemtest.bases.TestBase;
+import io.enmasse.systemtest.logs.CustomLogger;
+import io.enmasse.systemtest.platform.Kubernetes;
+import io.enmasse.systemtest.utils.AddressUtils;
+import io.enmasse.systemtest.utils.TestUtils;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.StringDescription;
+import org.hamcrest.TypeSafeMatcher;
+import org.slf4j.Logger;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PlansTestBase extends TestBase {
+    private static Logger log = CustomLogger.getLogger();
+
+
+    public static Matcher<Address> assertAddressStatusNotReady(final String messageContains) {
+        return PlansTestBase.assertAddressStatus(false, Optional.empty(), Optional.of(messageContains));
+    }
+
+    public static Matcher<Address> assertAddressStatusReady(String actualPlan) {
+        return PlansTestBase.assertAddressStatus(true, Optional.of(actualPlan), Optional.empty());
+    }
+
+    public static Matcher<Address> assertAddressStatus(final boolean ready, final Optional<String> actualPlan, final Optional<String> messageContains) {
+        return new TypeSafeMatcher<>() {
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("should match ready ").appendValue(ready);
+                actualPlan.ifPresent(s -> description.appendText("should match plan ").appendValue(s));
+                messageContains.ifPresent(s -> description.appendText("should status should contain ").appendValue(s));
+            }
+
+            @Override
+            protected void describeMismatchSafely(Address a, Description description) {
+                if (a.getStatus() == null) {
+                    description.appendText("address.status is absent");
+                }
+                if (ready != a.getStatus().isReady()) {
+                    description.appendText("ready was ").appendValue(a.getStatus().isReady());
+                }
+                if (actualPlan.isPresent()) {
+                    if (a.getStatus().getPlanStatus() == null) {
+                        description.appendText("address.status.planStatus is absent");
+                    } else if (!actualPlan.get().equals(a.getStatus().getPlanStatus().getName())) {
+                        description.appendText("actual plan was ").appendValue(a.getStatus().getPlanStatus().getName());
+                    }
+                }
+                if (messageContains.isPresent()) {
+                    String cc = String.join(":", a.getStatus().getMessages());
+                    description.appendText("messages were: ").appendValue(cc);
+                }
+
+            }
+
+            @Override
+            public boolean matchesSafely(Address a) {
+                if (a.getStatus() == null) {
+                    return false;
+                }
+                if (ready != a.getStatus().isReady()) {
+                    return false;
+                }
+                if (actualPlan.isPresent() && !actualPlan.get().equals(a.getStatus().getPlanStatus().getName())) {
+                    return false;
+                }
+                if (messageContains.isPresent()) {
+                    Optional<String> match = a.getStatus().getMessages().stream().filter(m -> m.contains(messageContains.get())).findFirst();
+                    return match.isPresent();
+                } else {
+                    return true;
+                }
+            }
+        };
+    }
+
+    public void doTestUnknownAddressPlan(AddressSpace addressSpace, List<StageHolder> stageHolders) throws Exception {
+
+       resourcesManager.createAddressSpace(addressSpace);
+
+        do {
+            log.info("Starting stage");
+
+            List<StageHolder.Stage> stages = stageHolders.stream().filter(StageHolder::hasStage).map(StageHolder::popStage).collect(Collectors.toList());
+
+            if (stages.isEmpty()) {
+                break;
+            }
+
+            stages.stream().map(StageHolder.Stage::getAddress).forEach(address -> {
+                Kubernetes.getInstance().getAddressClient(address.getMetadata().getNamespace()).createOrReplace(address);
+            });
+
+            stages.forEach(s -> {
+                AtomicReference<String> lastMatch = new AtomicReference<>();
+
+                boolean rv = TestUtils.waitUntilCondition(() -> {
+                    Address current = resourcesManager.getAddress(s.getAddress().getMetadata().getNamespace(), s.getAddress());
+                    Matcher<Address> matcher = s.getMatcher();
+                    boolean matches = matcher.matches(current);
+                    StringDescription desc = new StringDescription();
+                    matcher.describeMismatch(current, desc);
+                    lastMatch.set(desc.toString());
+                    if (matches) {
+                        log.info("Address {} is now in expected state: {}", current.getMetadata().getName(), current.getStatus());
+                    } else {
+                        log.info("Address {} is not in expected state: {} {}", current.getMetadata().getName(), lastMatch, current.getStatus());
+                    }
+                    return matches;
+                }, Duration.ofMinutes(2), Duration.ofSeconds(10));
+                assertTrue(rv, String.format("address %s did not reach desired state : %s", s.getAddress().getMetadata().getName(), lastMatch));
+            });
+        } while(true);
+    }
+
+    public class StageHolder {
+        private final AddressSpace addressSpace;
+        private final String addressName;
+        private final List<Stage> stages = new ArrayList<>();
+
+        public class Stage {
+            private final String plan;
+            private final Matcher<Address> matcher;
+
+            Stage(Matcher<Address> matcher, String plan) {
+                this.plan = plan;
+                this.matcher = matcher;
+            }
+
+            public Address getAddress() {
+                return new AddressBuilder()
+                        .withNewMetadata()
+                        .withNamespace(addressSpace.getMetadata().getNamespace())
+                        .withName(AddressUtils.generateAddressMetadataName(addressSpace, addressName))
+                        .endMetadata()
+                        .withNewSpec()
+                        .withType("queue")
+                        .withAddress(StageHolder.this.addressName)
+                        .withPlan(this.plan)
+                        .endSpec()
+                        .build();
+            }
+
+            public Matcher<Address> getMatcher() {
+                return matcher;
+            }
+        }
+
+        public StageHolder(AddressSpace addressSpace, String addressName) {
+            this.addressSpace = addressSpace;
+            this.addressName = addressName;
+        }
+
+        public StageHolder addStage(String plan, Matcher<Address> addressMatcher) {
+            stages.add(new Stage(addressMatcher, plan));
+            return this;
+        }
+
+        public boolean hasStage() {
+            return !stages.isEmpty();
+        }
+
+        public Stage popStage() {
+            return stages.remove(0);
+        }
+    }
+}

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/plans/standard/PlansTestStandard.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/plans/standard/PlansTestStandard.java
@@ -23,16 +23,14 @@ import io.enmasse.admin.model.v1.StandardInfraConfigSpecBrokerBuilder;
 import io.enmasse.config.AnnotationKeys;
 import io.enmasse.systemtest.UserCredentials;
 import io.enmasse.systemtest.amqp.AmqpClient;
-import io.enmasse.systemtest.bases.TestBase;
 import io.enmasse.systemtest.bases.isolated.ITestIsolatedStandard;
+import io.enmasse.systemtest.bases.plans.PlansTestBase;
 import io.enmasse.systemtest.logs.CustomLogger;
 import io.enmasse.systemtest.model.address.AddressType;
 import io.enmasse.systemtest.model.addressplan.DestinationPlan;
 import io.enmasse.systemtest.model.addressspace.AddressSpacePlans;
 import io.enmasse.systemtest.model.addressspace.AddressSpaceType;
-import io.enmasse.systemtest.platform.Kubernetes;
 import io.enmasse.systemtest.annotations.SeleniumFirefox;
-import io.enmasse.systemtest.selenium.SeleniumProvider;
 import io.enmasse.systemtest.shared.standard.QueueTest;
 import io.enmasse.systemtest.shared.standard.TopicTest;
 import io.enmasse.systemtest.time.TimeoutBudget;
@@ -40,22 +38,15 @@ import io.enmasse.systemtest.utils.AddressSpaceUtils;
 import io.enmasse.systemtest.utils.AddressUtils;
 import io.enmasse.systemtest.utils.PlanUtils;
 import io.enmasse.systemtest.utils.TestUtils;
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.hamcrest.StringDescription;
-import org.hamcrest.TypeSafeMatcher;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -67,9 +58,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
-class PlansTestStandard extends TestBase implements ITestIsolatedStandard {
+class PlansTestStandard extends PlansTestBase implements ITestIsolatedStandard {
     private static Logger log = CustomLogger.getLogger();
-    SeleniumProvider selenium = SeleniumProvider.getInstance();
 
     @Test
     void testCreateAddressSpacePlan() throws Exception {
@@ -1160,105 +1150,24 @@ class PlansTestStandard extends TestBase implements ITestIsolatedStandard {
                 .endSpec()
                 .build();
 
-        resourcesManager.createAddressSpace(addressSpace);
-
-        class StageHolder {
-            class Stage {
-                private final String plan;
-                private final Matcher<Address> matcher;
-
-                Stage(Matcher<Address> matcher, String plan) {
-                    this.plan = plan;
-                    this.matcher = matcher;
-                }
-
-                public Address getAddress() {
-                    return new AddressBuilder()
-                            .withNewMetadata()
-                            .withNamespace(addressSpace.getMetadata().getNamespace())
-                            .withName(AddressUtils.generateAddressMetadataName(addressSpace, addressName))
-                            .endMetadata()
-                            .withNewSpec()
-                            .withType("queue")
-                            .withAddress(StageHolder.this.addressName)
-                            .withPlan(plan)
-                            .endSpec()
-                            .build();
-                }
-
-                public Matcher<Address> getMatcher() {
-                    return matcher;
-                }
-            }
-            private String addressName;
-            private final List<Stage> stages = new ArrayList<>();
-
-            public StageHolder(String addressName) {
-                this.addressName = addressName;
-            }
-
-            public StageHolder addStage(String plan, Matcher<Address> addressMatcher) {
-                stages.add(new Stage(addressMatcher, plan));
-                return this;
-            }
-
-            public boolean hasStage() {
-                return !stages.isEmpty();
-            }
-
-            public Stage popStage() {
-                return stages.remove(0);
-            }
-        }
 
         String unknownPlan = "unknown-plan";
         String unknownPlanMessages = String.format("Unknown address plan '%s'", unknownPlan);
         List<StageHolder> stageHolders = new ArrayList<>();
-        stageHolders.add(new StageHolder("initial-unknown-plan")
+        stageHolders.add(new StageHolder(addressSpace, "initial-unknown-plan")
                 .addStage(unknownPlan, assertAddressStatusNotReady(unknownPlanMessages)));
-        stageHolders.add(new StageHolder("initial-unknown-plan-for-type")
+        stageHolders.add(new StageHolder(addressSpace, "initial-unknown-plan-for-type")
                 .addStage(DestinationPlan.STANDARD_SMALL_ANYCAST, assertAddressStatusNotReady(String.format("Unknown address plan '%s'", DestinationPlan.STANDARD_SMALL_ANYCAST)))
                 .addStage(DestinationPlan.STANDARD_SMALL_QUEUE, assertAddressStatusReady(DestinationPlan.STANDARD_SMALL_QUEUE)));
-        stageHolders.add(new StageHolder("becomes-unknown-plan")
+        stageHolders.add(new StageHolder(addressSpace, "becomes-unknown-plan")
                 .addStage( DestinationPlan.STANDARD_SMALL_QUEUE, assertAddressStatusReady(DestinationPlan.STANDARD_SMALL_QUEUE))
                 .addStage(unknownPlan, assertAddressStatusNotReady(unknownPlanMessages)));
-        stageHolders.add(new StageHolder("good").addStage(DestinationPlan.STANDARD_SMALL_QUEUE,
+        stageHolders.add(new StageHolder(addressSpace, "good").addStage(DestinationPlan.STANDARD_SMALL_QUEUE,
                 assertAddressStatusReady(DestinationPlan.STANDARD_SMALL_QUEUE)));
 
-        do {
-            log.info("Starting stage");
-
-            List<StageHolder.Stage> stages = stageHolders.stream().filter(StageHolder::hasStage).map(StageHolder::popStage).collect(Collectors.toList());
-
-            if (stages.isEmpty()) {
-                break;
-            }
-
-            stages.stream().map(StageHolder.Stage::getAddress).forEach(address -> {
-                Kubernetes.getInstance().getAddressClient(address.getMetadata().getNamespace()).createOrReplace(address);
-            });
-
-            stages.forEach(s -> {
-                AtomicReference<String> lastMatch = new AtomicReference<>();
-
-                boolean rv = TestUtils.waitUntilCondition(() -> {
-                    Address current = resourcesManager.getAddress(s.getAddress().getMetadata().getNamespace(), s.getAddress());
-                    Matcher<Address> matcher = s.getMatcher();
-                    boolean matches = matcher.matches(current);
-                    StringDescription desc = new StringDescription();
-                    matcher.describeMismatch(current, desc);
-                    lastMatch.set(desc.toString());
-                    if (matches) {
-                        log.info("Address {} is now in expected state: {}", current.getMetadata().getName(), current.getStatus());
-                    } else {
-                        log.info("Address {} is not in expected state: {} {}", current.getMetadata().getName(), lastMatch, current.getStatus());
-                    }
-                    return matches;
-                }, Duration.ofMinutes(2), Duration.ofSeconds(10));
-                assertTrue(rv, String.format("address %s did not reach desired state : %s", s.getAddress().getMetadata().getName(), lastMatch));
-            });
-        } while(true);
+        doTestUnknownAddressPlan(addressSpace, stageHolders);
     }
+
 
     //------------------------------------------------------------------------------------------------
     // Help methods
@@ -1309,65 +1218,6 @@ class PlansTestStandard extends TestBase implements ITestIsolatedStandard {
         }
 
         resourcesManager.deleteAddresses(addressSpace);
-    }
-
-    private static Matcher<Address> assertAddressStatusNotReady(final String messageContains) {
-        return assertAddressStatus(false, Optional.empty(), Optional.of(messageContains));
-    }
-
-    private static Matcher<Address> assertAddressStatusReady(String actualPlan) {
-        return assertAddressStatus(true, Optional.of(actualPlan), Optional.empty());
-    }
-
-    private static Matcher<Address> assertAddressStatus(final boolean ready, final Optional<String> actualPlan, final Optional<String> messageContains) {
-        return new TypeSafeMatcher<>() {
-            @Override
-            public void describeTo(Description description) {
-                description.appendText("should match ready ").appendValue(ready);
-                actualPlan.ifPresent(s -> description.appendText("should match plan ").appendValue(s));
-                messageContains.ifPresent(s -> description.appendText("should status should contain ").appendValue(s));
-            }
-
-            @Override
-            protected void describeMismatchSafely(Address a, Description description) {
-                if (a.getStatus() == null) {
-                    description.appendText("address.status is absent");
-                }
-                if (ready != a.getStatus().isReady()) {
-                    description.appendText("ready was ").appendValue(a.getStatus().isReady());
-                }
-                if (actualPlan.isPresent())
-                    if (a.getStatus().getPlanStatus() == null) {
-                        description.appendText("address.status.planStatus is absent");
-                    } else if (!actualPlan.get().equals(a.getStatus().getPlanStatus().getName())) {
-                        description.appendText("actual plan was ").appendValue(a.getStatus().getPlanStatus().getName());
-                    }
-                if (messageContains.isPresent()) {
-                    String cc = String.join(":", a.getStatus().getMessages());
-                    description.appendText("messages were: ").appendValue(cc);
-                }
-
-            }
-
-            @Override
-            public boolean matchesSafely(Address a) {
-                if (a.getStatus() == null) {
-                    return false;
-                }
-                if (ready != a.getStatus().isReady()) {
-                    return false;
-                }
-                if (actualPlan.isPresent() && !actualPlan.get().equals(a.getStatus().getPlanStatus().getName())) {
-                    return false;
-                }
-                if (messageContains.isPresent()) {
-                    Optional<String> match = a.getStatus().getMessages().stream().filter(m -> m.contains(messageContains.get())).findFirst();
-                    return match.isPresent();
-                } else {
-                    return true;
-                }
-            }
-        };
     }
 
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Enhance brokered address space's address controller (agent) to populate address plan status in the same manner that is already done for the standard address space.

This change supports the max address size / message TTL work.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [x] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
