### PR TITLE
[System tests] SupportToolingTest -  Log the stdout/stderr if support tool invocation fails

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/support/SupportToolingTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/support/SupportToolingTest.java
@@ -111,7 +111,8 @@ class SupportToolingTest extends TestBase implements ITestBaseIsolated {
                     String.format("https://localhost:8161/console/jolokia/read/org.apache.activemq.artemis:broker=\"%s\"/AddressMemoryUsage", podName));
 
 
-            assertThat(jmxResponse.getRetCode(), is(true));
+            assertThat(String.format("Support tool invocation failed %s : %s", jmxResponse.getStdErr(), jmxResponse.getStdOut()),
+                    jmxResponse.getRetCode(), is(true));
             Map<String, Object> readValue = jsonResponseToMap(jmxResponse.getStdOut());
             assertThat(readValue.get("status"), is(200));
 
@@ -125,7 +126,8 @@ class SupportToolingTest extends TestBase implements ITestBaseIsolated {
                     "--user", supportUser,
                     "--password", supportPassword
             );
-            assertThat(artemisCmdResponse.getRetCode(), is(true));
+            assertThat(String.format("Support tool invocation failed %s : %s", jmxResponse.getStdErr(), jmxResponse.getStdOut()),
+                    artemisCmdResponse.getRetCode(), is(true));
             List<String> addresses = Arrays.asList(artemisCmdResponse.getStdOut().split("\n"));
             assertThat(addresses, hasItem(addr.getSpec().getAddress()));
 


### PR DESCRIPTION
### Type of change


- Bugfix

### Description

We occasionally see SupportToolingTest fail in CI runs.  Logging the stdout/stderr should help identify root cause.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
