### PR TITLE
Prevent the router from racing with the agent and causing addresses/queues to be autocreated.

### DIFF
--- a/agent/lib/broker_controller.js
+++ b/agent/lib/broker_controller.js
@@ -375,6 +375,9 @@ function translate(addresses_in, excluded_names, excluded_types) {
             continue;
         }
         if (a.name) {
+            if ((a.type === 'queue' || a.type === "subscription") && !a.durable) {
+                log.error("Address %s (type: %s) is unexpectedly not durable: %j", a.name, a.type, a);
+            }
             addresses_out[name] = {address:a.name, type: a.type};
         } else {
             log.warn('Skipping address with no name: %j', a);
@@ -541,6 +544,7 @@ BrokerController.prototype._set_sync_status = function (stale, missing) {
 
 BrokerController.prototype._sync_broker_addresses = function (retry) {
     var self = this;
+
     return this.broker.listAddresses().then(function (results) {
         var actual = translate(results, excluded_addresses, self.excluded_types);
         var stale = values(difference(actual, self.addresses, same_address));

--- a/broker-plugin/plugin/src/main/resources/standard/login.config
+++ b/broker-plugin/plugin/src/main/resources/standard/login.config
@@ -21,7 +21,7 @@ activemq {
        use_tls="true"
        truststore_path="${AUTH_TRUSTSTORE_PATH}"
        truststore_password="enmasse"
-       valid_cert_users="admin.${INFRA_UUID}:admin;router.${INFRA_UUID}:admin;broker.${INFRA_UUID}:admin;subserv.${INFRA_UUID}:admin"
+       valid_cert_users="admin.${INFRA_UUID}:admin;router.${INFRA_UUID}:router;broker.${INFRA_UUID}:admin;subserv.${INFRA_UUID}:admin"
        default_roles_authenticated="all"
        default_roles_unauthenticated="admin"
        security_settings="enmasse"

--- a/broker-plugin/sasl-delegation/src/main/java/io/enmasse/artemis/sasl_delegation/SaslGroupBasedSecuritySettingsPlugin.java
+++ b/broker-plugin/sasl-delegation/src/main/java/io/enmasse/artemis/sasl_delegation/SaslGroupBasedSecuritySettingsPlugin.java
@@ -27,6 +27,7 @@ public class SaslGroupBasedSecuritySettingsPlugin implements SecuritySettingPlug
     private static final String NAME = "name";
     private static final String USE_GROUPS_FROM_SASL_DELEGATION = "useGroupsFromSaslDelegation";
     private static final String ADMIN_GROUP = "admin";
+    private static final String ROUTER_GROUP = "router";
     private static final String MANAGE_GROUP = "manage";
     private static final String ALL_GROUP = "all";
     private String name;
@@ -46,6 +47,7 @@ public class SaslGroupBasedSecuritySettingsPlugin implements SecuritySettingPlug
 
         // "admin" (console or other internal process) can do anything
         roles.add(new Role(ADMIN_GROUP, true, true, true, true, true, true, true, true, true, true));
+        roles.add(new Role(ROUTER_GROUP, true, true, false, false, true, true, false, false, false, false));
 
         if(!useGroupsFromSaslDelegation) {
             // "all" users can create/delete queues (but not addresses)
@@ -102,13 +104,13 @@ public class SaslGroupBasedSecuritySettingsPlugin implements SecuritySettingPlug
             if (parts.length == 2) {
                 char singleWord = DEFAULT_SINGLE_WORD;
                 char anyWords = DEFAULT_ANY_WORDS;
-                char delimeter = DEFAULT_DELIMITER;
+                char delimiter = DEFAULT_DELIMITER;
                 try {
                     String address = parts[1].replace('*', '#');
                     if(knownAddresses.add(address)) {
 
                         String singleWordString = String.valueOf(singleWord);
-                        String delimeterString = String.valueOf(delimeter);
+                        String delimeterString = String.valueOf(delimiter);
                         String anyWordsString = String.valueOf(anyWords);
 
                         Set<Role> roles = new HashSet<>();


### PR DESCRIPTION
### Type of change
- Bugfix

### Description


Prevent the router from racing with the agent and causing ddresses/queues to be autocreated.

Uses @lulf's idea to assign the router's user a role that denies it create/delete address and create/delete durable queue.  This means if the router attaches its link before the agent has done its work, the Broker's autocreate will fail to cause the address/queue to come into existence with the wrong properties.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
