### PR TITLE
Add convenient target for working with kubernetes in docker (kind)

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -67,6 +67,18 @@ This can be run at the top level or within each module. You can also run the `bu
 *Note*: If you are using OKD and `oc cluster up`, you can push images directly to the built-in registry
 by setting `DOCKER_ORG=myproject` and `DOCKER_REGISTRY=172.30.1.1:5000` instead.
 
+#### Full build and load images in a local [KIND](https://kind.sigs.k8s.io/) instance
+
+    IMAGE_PULL_POLICY=IfNotPresent make buildpushkind
+
+*Note*: Using the IfNotPresent policy prevents KIND from attempting to pull the images from the
+external registries.
+
+#### Build a single component and load image in a local [KIND](https://kind.sigs.k8s.io/) instance
+
+    make -C <component> buildpushkind
+    kubectl delete pod <component pod>
+
 #### Deploying to a Kubernetes instance assuming already logged in with cluster-admin permissions
 
     kubectl create namespace enmasse-infra

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ DOCKER_DIRS = \
 FULL_BUILD       = true
 GOOPTS          ?= -mod=vendor
 
-DOCKER_TARGETS   = docker_build docker_tag docker_push clean
+DOCKER_TARGETS   = docker_build docker_tag docker_push kind_load_image clean
 INSTALLDIR       = $(CURDIR)/templates/install
 SKIP_TESTS      ?= false
 SKIP_MANIFESTS  ?= false
@@ -98,6 +98,12 @@ buildpush:
 	$(MAKE) docker_build
 	$(MAKE) docker_tag
 	$(MAKE) docker_push
+
+buildpushkind:
+	$(MAKE)
+	$(MAKE) docker_build
+	$(MAKE) docker_tag
+	$(MAKE) kind_load_image
 
 clean_java:
 	mvn -q clean $(MAVEN_ARGS)
@@ -174,6 +180,6 @@ endif
 
 #endregion
 
-.PHONY: test_go_vet test_go_plain build_go imageenv
+.PHONY: test_go_vet test_go_plain build_go imageenv buildpushkind
 .PHONY: all $(GO_DIRS) $(DOCKER_TARGETS) $(DOCKER_DIRS) build_java test_go systemtests clean_java docu_html docu_check docu_clean templates
 .PHONY: manifests

--- a/Makefile.common
+++ b/Makefile.common
@@ -48,5 +48,14 @@ docker_push:
 		bash $(TOPDIR)/scripts/docker_push.sh "$(DOCKER) push $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(TAG)" 10 10 ; \
 	fi
 
+kind_load_image:
+	if [ -f Dockerfile ]; \
+	then \
+		kind load docker-image $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(TAG) ; \
+	fi
 
-.PHONY: all init build test package clean docker_build docker_tag docker_push
+buildpushkind: all docker_build docker_tag kind_load_image
+	:
+
+
+.PHONY: all init build test package clean docker_build docker_tag docker_push kind_load_image buildpushkind buildpush


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Documentation

### Description

Add convenient target for local development with [kubernetes in docker](https://kind.sigs.k8s.io/). (I could only get kind working using docker and not podman, but the quick turnaround you can get with this approach makes it worth switching if you're in podman-land).

##### Full build and load images

```
IMAGE_PULL_POLICY=IfNotPresent make buildpushkind
```

##### Build a single component

```
IMAGE_PULL_POLICY=IfNotPresent make -C <component> buildpushkind
kubectl delete pod <component pod>
```

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
