### PR TITLE
Manifest image build retry and clean

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/apps/SystemtestsKubernetesApps.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/apps/SystemtestsKubernetesApps.java
@@ -862,7 +862,7 @@ public class SystemtestsKubernetesApps {
                         .build())
                 .withContainers(new ContainerBuilder()
                         .withName("kaniko")
-                        .withImage("gcr.io/kaniko-project/executor:v0.19.0")
+                        .withImage("gcr.io/kaniko-project/executor:v0.23.0")
                         .withArgs(
                                 "--context=dir:///workspace",
                                 "--destination=" + destinationImage,
@@ -937,12 +937,14 @@ public class SystemtestsKubernetesApps {
             if (reason.equals("Error")) {
                 log.error("Operator registry image build failed because of error");
                 collectContainerBuildLogs(kubeClient);
+                cleanBuiltContainerImages(kubeClient);
                 Assertions.fail("Failed to build custom operator registry because of error");
             }
             log.info("Operator registry image successfully built");
         } catch (InterruptedException e) {
             log.error("Operator registry image build failed because of timeout");
             collectContainerBuildLogs(kubeClient);
+            cleanBuiltContainerImages(kubeClient);
             Assertions.fail("Failed to build custom operator registry because of timeout");
         }
 


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

<!--

_Please describe your pull request_

-->

I saw in logs that if first attempt of image build failed the rest in retry cycle failed as well because it didn't start new build becasue old kaniko pod was still present, so I added cleaning namespace if build fail.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
