### PR TITLE
Console-UI Add validation for name field in create address space

### DIFF
--- a/console/console-init/ui/src/modules/address-space/dialogs/CreateMessagingProject/CreateMessagingProject.tsx
+++ b/console/console-init/ui/src/modules/address-space/dialogs/CreateMessagingProject/CreateMessagingProject.tsx
@@ -25,7 +25,6 @@ import { ConfiguringRoutes } from "./ConfiguringRoutes";
 import { EndpointConfiguration } from "modules/address-space/components";
 import { IAddressSpaceSchema } from "schema/ResponseTypes";
 import { useQuery } from "@apollo/react-hooks";
-
 export interface IRouteConf {
   protocol: string;
   hostname?: string;

--- a/console/console-init/ui/src/modules/address-space/dialogs/CreateMessagingProject/MessagingProjectConfiguration.tsx
+++ b/console/console-init/ui/src/modules/address-space/dialogs/CreateMessagingProject/MessagingProjectConfiguration.tsx
@@ -17,6 +17,7 @@ import {
 } from "graphql-module/queries";
 import { Loading } from "use-patternfly";
 import { IAddressSpaceSchema } from "schema/ResponseTypes";
+import { dnsSubDomainRfc1123NameRegexp } from "utils";
 
 export interface IMessagingProjectConfigurationProps {
   projectDetail: IMessagingProject;
@@ -90,7 +91,11 @@ const MessagingProjectConfiguration: React.FunctionComponent<IMessagingProjectCo
     setProjectDetail({ ...projectDetail, namespace: value });
   };
   const handleNameChange = (value: string) => {
-    setProjectDetail({ ...projectDetail, name: value });
+    setProjectDetail({
+      ...projectDetail,
+      isNameValid: dnsSubDomainRfc1123NameRegexp.test(value),
+      name: value
+    });
   };
   const handleTypeChange = (_: boolean, event: any) => {
     setProjectDetail({
@@ -110,6 +115,7 @@ const MessagingProjectConfiguration: React.FunctionComponent<IMessagingProjectCo
     setProjectDetail({ ...projectDetail, authService: value });
   };
 
+  console.log("as", projectDetail);
   const getNameSpaceOptions = () => {
     let nameSpaceOptions: IOptionForKeyValueLabel[];
     nameSpaceOptions = namespaces.map(namespace => ({

--- a/console/console-init/ui/src/modules/address-space/dialogs/CreateMessagingProject/MessagingProjectConfiguration.tsx
+++ b/console/console-init/ui/src/modules/address-space/dialogs/CreateMessagingProject/MessagingProjectConfiguration.tsx
@@ -115,7 +115,6 @@ const MessagingProjectConfiguration: React.FunctionComponent<IMessagingProjectCo
     setProjectDetail({ ...projectDetail, authService: value });
   };
 
-  console.log("as", projectDetail);
   const getNameSpaceOptions = () => {
     let nameSpaceOptions: IOptionForKeyValueLabel[];
     nameSpaceOptions = namespaces.map(namespace => ({

--- a/console/console-init/ui/src/modules/address/dialogs/CreateAddress/CreateAddress.tsx
+++ b/console/console-init/ui/src/modules/address/dialogs/CreateAddress/CreateAddress.tsx
@@ -14,7 +14,7 @@ import {
   RETURN_ADDRESS_SPACE_DETAIL
 } from "graphql-module/queries";
 import { IDropdownOption } from "components";
-import { messagingAddressNameRegexp } from "utils";
+import { dnsSubDomainRfc1123NameRegexp } from "utils";
 import { useStoreContext, types } from "context-state-reducer";
 import { IAddressSpacesResponse } from "schema/ResponseTypes";
 import { FetchPolicy } from "constant";
@@ -76,7 +76,7 @@ export const CreateAddress: React.FunctionComponent = () => {
 
   const handleAddressChange = (name: string) => {
     setAddressName(name);
-    !messagingAddressNameRegexp.test(name)
+    !dnsSubDomainRfc1123NameRegexp.test(name)
       ? setIsNameValid(false)
       : setIsNameValid(true);
   };


### PR DESCRIPTION
### Type of change
- Bugfix
### Description
After endpoint changes. A bug come up that input validation for name field in configuration step of create address space is not working 
Fix- Add validation on name input 
### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
