### PR TITLE
Modify PVC instead of statefulset claim template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * #4682: Avoid race when processing Artemis management responses when first connecting to broker
 * #4721: Standard address space agent erroneously processes addresses of other addressspaces in the same namespace
 * #4730: Enhance brokered address space's address controller (agent) to populate address plan status
+* #4753: Resizing broker volumes broken on OpenShift 4
 
 ## 0.31.4
 * #4704: [OpenShift 3.11] Console returns 500 internal error when configured with custom certificate

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/AddressController.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/AddressController.java
@@ -551,10 +551,9 @@ public class AddressController implements Watcher<Address> {
                     log.info("Upgrading broker {}", cluster.getClusterId());
                     cluster.updateResources(upgradedCluster, desiredConfig);
                     boolean updatePersistentVolumeClaim = desiredConfig.getUpdatePersistentVolumeClaim();
-                    boolean shouldReplaceStatefulSet = cluster.shouldReplace();
                     List<HasMetadata> itemsToBeApplied = new ArrayList<>(cluster.getResources().getItems());
                     try {
-                        kubernetes.apply(cluster.getResources(), updatePersistentVolumeClaim, shouldReplaceStatefulSet, itemsToBeApplied::remove);
+                        kubernetes.apply(cluster.getResources(), updatePersistentVolumeClaim, itemsToBeApplied::remove);
                     } catch (KubernetesClientException original) {
                         // Workaround for #2880 Failure executing: PATCH... Message: Unable to access invalid index: 20.
                         if (!itemsToBeApplied.isEmpty() && original.getMessage() != null && original.getMessage().contains("Unable to access invalid index")) {
@@ -572,7 +571,7 @@ public class AddressController implements Watcher<Address> {
                                         spec.setReplicas(0);
                                     }
                                     Kubernetes.addObjectAnnotation(failedResource, AnnotationKeys.APPLIED_INFRA_CONFIG, new ObjectMapper().writeValueAsString(currentConfig));
-                                    kubernetes.apply(failedResource, updatePersistentVolumeClaim, shouldReplaceStatefulSet);
+                                    kubernetes.apply(failedResource, updatePersistentVolumeClaim);
                                     log.warn("Applied #2880 workaround for {} of {}, next upgrade cycle should complete upgrade.", failedResource.getMetadata(), cluster.getClusterId());
                                 } catch (KubernetesClientException e) {
                                     log.error("Failed to apply failed resource {} of {} for #2880 workaround. " +

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/Kubernetes.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/Kubernetes.java
@@ -47,9 +47,9 @@ public interface Kubernetes {
 
     void create(KubernetesList resources);
 
-    void apply(KubernetesList resources, boolean patchPersistentVolumeClaims, boolean replaceStatefulSets, Consumer<HasMetadata> failedResourceSupplier);
+    void apply(KubernetesList resources, boolean patchPersistentVolumeClaims, Consumer<HasMetadata> failedResourceSupplier);
 
-    void apply(HasMetadata resource, boolean patchPersistentVolumeClaims, boolean replaceStatefulSets);
+    void apply(HasMetadata resource, boolean patchPersistentVolumeClaims);
 
     void delete(KubernetesList resources);
 

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/KubernetesHelper.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/KubernetesHelper.java
@@ -120,9 +120,9 @@ public class KubernetesHelper implements Kubernetes {
     }
 
     @Override
-    public void apply(KubernetesList resources, boolean patchPersistentVolumeClaims, boolean replaceStatefulSets, Consumer<HasMetadata> appliedResourceConsumer) {
+    public void apply(KubernetesList resources, boolean patchPersistentVolumeClaims, Consumer<HasMetadata> appliedResourceConsumer) {
         for (HasMetadata resource : resources.getItems()) {
-            apply(resource, patchPersistentVolumeClaims, replaceStatefulSets);
+            apply(resource, patchPersistentVolumeClaims);
             if (appliedResourceConsumer != null) {
                 appliedResourceConsumer.accept(resource);
             }
@@ -130,7 +130,7 @@ public class KubernetesHelper implements Kubernetes {
     }
 
     @Override
-    public void apply(HasMetadata resource, boolean patchPersistentVolumeClaims, boolean replaceStatefulSets) {
+    public void apply(HasMetadata resource, boolean patchPersistentVolumeClaims) {
         try {
             if (resource instanceof ConfigMap) {
                 client.configMaps().withName(resource.getMetadata().getName()).patch((ConfigMap) resource);
@@ -139,11 +139,7 @@ public class KubernetesHelper implements Kubernetes {
             } else if (resource instanceof Deployment) {
                 client.apps().deployments().withName(resource.getMetadata().getName()).patch((Deployment) resource);
             } else if (resource instanceof StatefulSet) {
-                if (replaceStatefulSets) {
-                    client.apps().statefulSets().withName(resource.getMetadata().getName()).cascading(false).replace((StatefulSet) resource);
-                } else {
-                    client.apps().statefulSets().withName(resource.getMetadata().getName()).cascading(false).patch((StatefulSet) resource);
-                }
+                client.apps().statefulSets().withName(resource.getMetadata().getName()).cascading(false).patch((StatefulSet) resource);
             } else if (resource instanceof Service) {
                 client.services().withName(resource.getMetadata().getName()).patch((Service) resource);
             } else if (resource instanceof ServiceAccount) {

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/infra/InfraTestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/infra/InfraTestBase.java
@@ -6,6 +6,7 @@ package io.enmasse.systemtest.bases.infra;
 
 import io.enmasse.address.model.AddressSpace;
 import io.enmasse.admin.model.v1.AddressPlan;
+import io.enmasse.systemtest.UserCredentials;
 import io.enmasse.systemtest.bases.ITestBase;
 import io.enmasse.systemtest.bases.TestBase;
 import io.enmasse.systemtest.executor.ExecutionResultData;
@@ -14,6 +15,7 @@ import io.enmasse.systemtest.logs.CustomLogger;
 import io.enmasse.systemtest.platform.KubeCMDClient;
 import io.enmasse.systemtest.time.TimeoutBudget;
 import io.enmasse.systemtest.utils.TestUtils;
+import io.enmasse.user.model.v1.User;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
@@ -41,6 +43,7 @@ public abstract class InfraTestBase extends TestBase implements ITestBase {
     private static Logger log = CustomLogger.getLogger();
     protected AddressPlan exampleAddressPlan;
     protected AddressSpace exampleAddressSpace;
+    protected UserCredentials exampleUser = new UserCredentials("test", "test");
 
     protected void assertBroker(InfraConfiguration brokerConfig) {
         log.info("Checking broker infra");

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/infra/standard/InfraTestStandard.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/infra/standard/InfraTestStandard.java
@@ -26,6 +26,7 @@ import io.enmasse.systemtest.bases.infra.InfraTestBase;
 import io.enmasse.systemtest.bases.isolated.ITestIsolatedStandard;
 import io.enmasse.systemtest.infra.InfraConfiguration;
 import io.enmasse.systemtest.logs.CustomLogger;
+import io.enmasse.systemtest.messagingclients.ClientArgument;
 import io.enmasse.systemtest.messagingclients.ExternalMessagingClient;
 import io.enmasse.systemtest.messagingclients.proton.java.ProtonJMSClientReceiver;
 import io.enmasse.systemtest.messagingclients.proton.java.ProtonJMSClientSender;
@@ -187,6 +188,7 @@ class InfraTestStandard extends InfraTestBase implements ITestIsolatedStandard {
                 .withClientEngine(new ProtonJMSClientSender())
                 .withCredentials(exampleUser)
                 .withMessagingRoute(Objects.requireNonNull(AddressSpaceUtils.getInternalEndpointByName(exampleAddressSpace, "messaging", "amqps")))
+                .withAdditionalArgument(ClientArgument.MSG_DURABLE, "true")
                 .withCount(5)
                 .withAddress(exampleAddress)) {
             assertTrue(client.run());

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/infra/standard/InfraTestStandard.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/infra/standard/InfraTestStandard.java
@@ -185,6 +185,7 @@ class InfraTestStandard extends InfraTestBase implements ITestIsolatedStandard {
 
         try (ExternalMessagingClient client = new ExternalMessagingClient()
                 .withClientEngine(new ProtonJMSClientSender())
+                .withCredentials(exampleUser)
                 .withMessagingRoute(Objects.requireNonNull(AddressSpaceUtils.getInternalEndpointByName(exampleAddressSpace, "messaging", "amqps")))
                 .withCount(5)
                 .withAddress(exampleAddress)) {
@@ -253,6 +254,7 @@ class InfraTestStandard extends InfraTestBase implements ITestIsolatedStandard {
 
         try (ExternalMessagingClient client = new ExternalMessagingClient()
                 .withClientEngine(new ProtonJMSClientReceiver())
+                .withCredentials(exampleUser)
                 .withMessagingRoute(Objects.requireNonNull(AddressSpaceUtils.getInternalEndpointByName(exampleAddressSpace, "messaging", "amqps")))
                 .withCount(5)
                 .withAddress(exampleAddress)) {

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/infra/standard/InfraTestStandard.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/infra/standard/InfraTestStandard.java
@@ -157,7 +157,7 @@ class InfraTestStandard extends InfraTestBase implements ITestIsolatedStandard {
     @Test
     @Tag(ACCEPTANCE)
     void testDecrementInfra() throws Exception {
-        testReplaceInfra(InfraConfiguration.broker("250m", "256Mi", null, "512Mi", null),
+        testReplaceInfra(InfraConfiguration.broker("250m", "256Mi", null, "1Gi", null),
                 InfraConfiguration.router("250m", "128Mi", null, 1),
                 InfraConfiguration.admin("250m", "256Mi", null));
     }


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix


### Description

This works around a limitation in Kubernetes where the statefulset
volume claim template cannot be modified (i.e. when resizing a
volume). The previous workaround was to use replace instead of patch,
which has now stopped working. The new workaround will ensure that the
existing claim template will stay as is, and instead the persistent
volume claim that was generated from the template previously, is now modified.

Fixes #4753


### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [x] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
