### PR TITLE
Increased severity levels on router alerts

### DIFF
--- a/controller-manager/src/main/resources/templates/PrometheusRules-enmasse.yaml
+++ b/controller-manager/src/main/resources/templates/PrometheusRules-enmasse.yaml
@@ -73,13 +73,13 @@ spec:
       annotations:
         description: Router mesh(s) have not been fully connected for over 5 minutes
         value: "{{ "{{" }} $value {{ "}}" }}"
-        severity: warning
+        severity: critical
       expr: enmasse_router_mesh_not_connected_total > 0
       for: 300s
     - alert: RouterMeshUndeliveredHealth
       annotations:
         description: Router mesh(s) have undelivered messages for over 5 minutes
         value: "{{ "{{" }} $value {{ "}}" }}"
-        severity: warning
+        severity: critical
       expr: enmasse_router_mesh_undelivered_total > 0
       for: 300s


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Changed the severity level of the following alerts to critical:
* RouterMeshConnectivityHealth
* RouterMeshUndeliveredHealth

### Checklist

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
