### PR TITLE
Fix testing IoT on Minikube

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/apiclients/PrometheusApiClient.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/apiclients/PrometheusApiClient.java
@@ -10,6 +10,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import io.enmasse.systemtest.Endpoint;
+import io.enmasse.systemtest.platform.Kubernetes;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
@@ -17,8 +18,11 @@ import io.vertx.ext.web.codec.BodyCodec;
 
 public class PrometheusApiClient extends ApiClient {
 
+    private String token;
+
     public PrometheusApiClient(Endpoint endpoint) {
         super(() -> endpoint, "");
+        this.token = Kubernetes.getInstance().getApiToken();
     }
 
     @Override

--- a/systemtests/src/main/java/io/enmasse/systemtest/bases/iot/ITestIoTBase.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/bases/iot/ITestIoTBase.java
@@ -6,6 +6,7 @@ package io.enmasse.systemtest.bases.iot;
 
 import org.junit.jupiter.api.BeforeAll;
 
+import io.enmasse.systemtest.iot.DeviceManagementApi;
 import io.enmasse.systemtest.iot.IoTTestSession;
 
 public interface ITestIoTBase {
@@ -28,5 +29,10 @@ public interface ITestIoTBase {
      @BeforeAll
      public static void deployDefaultCerts() throws Exception {
          IoTTestSession.deployDefaultCerts();
+     }
+
+     @BeforeAll
+     public static void createDeviceManager() throws Exception {
+         DeviceManagementApi.createManagementServiceAccount();
      }
 }

--- a/systemtests/src/main/java/io/enmasse/systemtest/iot/CredentialsRegistryClient.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/iot/CredentialsRegistryClient.java
@@ -5,6 +5,8 @@
 
 package io.enmasse.systemtest.iot;
 
+import static io.enmasse.systemtest.iot.DeviceManagementApi.getManagementToken;
+
 import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -37,8 +39,8 @@ public class CredentialsRegistryClient extends HonoApiClient {
     private static final String CREDENTIALS_PATH = "v1/credentials";
     private static final Random rnd = new SecureRandom();
 
-    public CredentialsRegistryClient(Endpoint endpoint) {
-        super(() -> endpoint);
+    public CredentialsRegistryClient(final Endpoint endpoint) {
+        super(() -> endpoint, getManagementToken());
     }
 
     @Override

--- a/systemtests/src/main/java/io/enmasse/systemtest/iot/DeviceManagementApi.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/iot/DeviceManagementApi.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.enmasse.systemtest.iot;
+
+import io.enmasse.iot.model.v1.IoTCrd;
+import io.enmasse.systemtest.platform.Kubernetes;
+
+public final class DeviceManagementApi {
+
+    public static final String CLUSTER_ROLE_NAME = "test.iot.enmasse.io:device-manager";
+    public static final String SERVICE_ACCOUNT_NAME = "iot-device-management";
+
+    private DeviceManagementApi() {}
+
+    /**
+     * Get the token for managing devices.
+     *
+     * @return The token, which can be used as a "Bearer Token".
+     */
+    public static String getManagementToken() {
+        return Kubernetes.getServiceAccountToken(Kubernetes.getInstance().getInfraNamespace(), SERVICE_ACCOUNT_NAME);
+    }
+
+    public static void createManagementServiceAccount() throws Exception {
+
+        var client = Kubernetes.getInstance().getClient();
+        var ns = Kubernetes.getInstance().getInfraNamespace();
+
+        // create a service account for working with devices
+
+        client
+                .serviceAccounts()
+                .inNamespace(ns)
+
+                .createOrReplaceWithNew()
+
+                .withNewMetadata()
+                .withNamespace(ns)
+                .withName(SERVICE_ACCOUNT_NAME)
+                .addToLabels("app", "enmasse")
+                .addToLabels("component", "iot")
+                .endMetadata()
+
+                .done();
+
+        // create a cluster wide role
+
+        client
+                .rbac().clusterRoles()
+
+                .createOrReplaceWithNew()
+
+                .withNewMetadata()
+                .withName(CLUSTER_ROLE_NAME)
+                .addToLabels("app", "enmasse")
+                .addToLabels("component", "iot")
+                .endMetadata()
+
+                .addNewRule()
+                .withApiGroups(IoTCrd.GROUP)
+                .withResources(IoTCrd.project().getSpec().getNames().getPlural().toLowerCase())
+                .withVerbs("create", "get", "list", "patch", "update")
+                .endRule()
+
+                .done();
+
+        // map the role to the service account
+
+        client
+                .rbac().clusterRoleBindings()
+                .createOrReplaceWithNew()
+
+                .withNewMetadata()
+                .withName(CLUSTER_ROLE_NAME + "-" + SERVICE_ACCOUNT_NAME)
+                .addToLabels("app", "enmasse")
+                .addToLabels("component", "iot")
+                .endMetadata()
+
+                .withNewRoleRef()
+                .withApiGroup("rbac.authorization.k8s.io")
+                .withKind("ClusterRole")
+                .withName(CLUSTER_ROLE_NAME)
+                .endRoleRef()
+
+                .addNewSubject()
+                .withKind("ServiceAccount")
+                .withNamespace(ns)
+                .withName(SERVICE_ACCOUNT_NAME)
+                .endSubject()
+
+                .done();
+    }
+}

--- a/systemtests/src/main/java/io/enmasse/systemtest/iot/DeviceManagementApi.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/iot/DeviceManagementApi.java
@@ -62,7 +62,7 @@ public final class DeviceManagementApi {
                 .addNewRule()
                 .withApiGroups(IoTCrd.GROUP)
                 .withResources(IoTCrd.project().getSpec().getNames().getPlural().toLowerCase())
-                .withVerbs("create", "get", "list", "patch", "update")
+                .withVerbs("create", "get", "list", "patch", "update", "delete")
                 .endRule()
 
                 .done();

--- a/systemtests/src/main/java/io/enmasse/systemtest/iot/DeviceRegistryClient.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/iot/DeviceRegistryClient.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2019, EnMasse authors.
+ * Copyright 2019-2020, EnMasse authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 
 package io.enmasse.systemtest.iot;
+
+import static io.enmasse.systemtest.iot.DeviceManagementApi.getManagementToken;
 
 import java.net.HttpURLConnection;
 
@@ -20,8 +22,8 @@ public class DeviceRegistryClient extends HonoApiClient {
 
     private static final String DEVICES_PATH = "v1/devices";
 
-    public DeviceRegistryClient(Endpoint endpoint) {
-        super(() -> endpoint);
+    public DeviceRegistryClient(final Endpoint endpoint) {
+        super(() -> endpoint, getManagementToken());
     }
 
     @Override

--- a/systemtests/src/main/java/io/enmasse/systemtest/iot/HttpAdapterClient.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/iot/HttpAdapterClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, EnMasse authors.
+ * Copyright 2019-2020, EnMasse authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 
@@ -45,8 +45,8 @@ public class HttpAdapterClient extends ApiClient {
     protected static final Logger log = CustomLogger.getLogger();
 
     private final Set<String> tlsVersions;
-
     private final Buffer keyStoreBuffer;
+    private final String authzString;
 
     public HttpAdapterClient(final Endpoint endpoint, final PrivateKey key, final X509Certificate certificate, final Set<String> tlsVersions) throws Exception {
         this(endpoint, null, null, null, key, certificate, tlsVersions);
@@ -227,7 +227,7 @@ public class HttpAdapterClient extends ApiClient {
         return send(EVENT, payload, expectedCodePredicate);
     }
 
-    private String getBasicAuth(final String user, final String password) {
+    private static String getBasicAuth(final String user, final String password) {
         return "Basic " + Base64.getEncoder().encodeToString((user + ":" + password).getBytes(StandardCharsets.UTF_8));
     }
 

--- a/systemtests/src/main/java/io/enmasse/systemtest/iot/IoTTestSession.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/iot/IoTTestSession.java
@@ -898,4 +898,5 @@ public final class IoTTestSession implements AutoCloseable {
                         "CLI", KubeCMDClient.getCMD(),
                         "PREFIX", "systemtests-"));
     }
+
 }

--- a/systemtests/src/main/java/io/enmasse/systemtest/iot/IoTTests.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/iot/IoTTests.java
@@ -33,6 +33,11 @@ public interface IoTTests extends ITestSeparator {
         IoTTestSession.deployDefaultCerts();
     }
 
+    @BeforeAll
+    public static void createDeviceManager() throws Exception {
+        DeviceManagementApi.createManagementServiceAccount();
+    }
+
     @BeforeEach
     default void createNamespace() {
         Kubernetes.getInstance().createNamespace(IOT_PROJECT_NAMESPACE);

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/api/UserApiTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/api/UserApiTest.java
@@ -4,6 +4,22 @@
  */
 package io.enmasse.systemtest.shared.standard.api;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+
 import io.enmasse.address.model.Address;
 import io.enmasse.address.model.AddressBuilder;
 import io.enmasse.address.model.AddressSpace;
@@ -15,27 +31,13 @@ import io.enmasse.systemtest.bases.shared.ITestSharedStandard;
 import io.enmasse.systemtest.logs.CustomLogger;
 import io.enmasse.systemtest.model.addressplan.DestinationPlan;
 import io.enmasse.systemtest.platform.KubeCMDClient;
+import io.enmasse.systemtest.platform.Kubernetes;
 import io.enmasse.systemtest.utils.AddressUtils;
 import io.enmasse.systemtest.utils.UserUtils;
 import io.enmasse.user.model.v1.DoneableUser;
 import io.enmasse.user.model.v1.Operation;
 import io.enmasse.user.model.v1.User;
 import io.enmasse.user.model.v1.UserAuthorizationBuilder;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class UserApiTest extends TestBase implements ITestSharedStandard {
 
@@ -118,7 +120,7 @@ public class UserApiTest extends TestBase implements ITestSharedStandard {
         try {
             resourcesManager.createUserServiceAccount(getSharedAddressSpace(), serviceAccount);
             UserCredentials messagingUser = new UserCredentials("@@serviceaccount@@",
-                    kubernetes.getServiceaccountToken(serviceAccount.getUsername(), environment.namespace()));
+                    Kubernetes.getServiceAccountToken(environment.namespace(), serviceAccount.getUsername()));
             LOGGER.info("username: {}, password: {}", messagingUser.getUsername(), messagingUser.getPassword());
 
             getClientUtils().assertCanConnect(getSharedAddressSpace(), messagingUser, Collections.singletonList(queue), resourcesManager);


### PR DESCRIPTION
The final missing piece was the access token. Which you don't have
initially with Minikube. So now a service account, with an appropriate
role and binding will be created and the token used instead of the
default Kubernetes client API token.

This approach should properly work on all types of Kubernetes.

### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
