### PR TITLE
Revert "Prevent the router from racing with the agent and causing addresses/queues to be autocreated. (#4739)"

### DIFF
--- a/agent/lib/broker_controller.js
+++ b/agent/lib/broker_controller.js
@@ -400,9 +400,6 @@ function translate(addresses_in, excluded_names, excluded_types) {
             continue;
         }
         if (a.name) {
-            if ((a.type === 'queue' || a.type === "subscription") && !a.durable) {
-                log.error("Address %s (type: %s) is unexpectedly not durable: %j", a.name, a.type, a);
-            }
             addresses_out[name] = {address:a.name, type: a.type};
         } else {
             log.warn('Skipping address with no name: %j', a);
@@ -584,7 +581,6 @@ BrokerController.prototype._set_sync_status = function (stale, missing) {
 
 BrokerController.prototype._sync_broker_addresses = function (retry) {
     var self = this;
-
     return this.broker.listAddresses().then(function (results) {
         var addrSettings = self.sync_addresssettings(values(self.addresses).filter((o) => o.type === 'subscription' || o.type === 'queue'));
         var actual = translate(results, excluded_addresses, self.excluded_types);

--- a/broker-plugin/plugin/src/main/resources/standard/login.config
+++ b/broker-plugin/plugin/src/main/resources/standard/login.config
@@ -21,7 +21,7 @@ activemq {
        use_tls="true"
        truststore_path="${AUTH_TRUSTSTORE_PATH}"
        truststore_password="enmasse"
-       valid_cert_users="admin.${INFRA_UUID}:admin;router.${INFRA_UUID}:router;broker.${INFRA_UUID}:admin;subserv.${INFRA_UUID}:admin"
+       valid_cert_users="admin.${INFRA_UUID}:admin;router.${INFRA_UUID}:admin;broker.${INFRA_UUID}:admin;subserv.${INFRA_UUID}:admin"
        default_roles_authenticated="all"
        default_roles_unauthenticated="admin"
        security_settings="enmasse"

--- a/broker-plugin/sasl-delegation/src/main/java/io/enmasse/artemis/sasl_delegation/SaslGroupBasedSecuritySettingsPlugin.java
+++ b/broker-plugin/sasl-delegation/src/main/java/io/enmasse/artemis/sasl_delegation/SaslGroupBasedSecuritySettingsPlugin.java
@@ -27,7 +27,6 @@ public class SaslGroupBasedSecuritySettingsPlugin implements SecuritySettingPlug
     private static final String NAME = "name";
     private static final String USE_GROUPS_FROM_SASL_DELEGATION = "useGroupsFromSaslDelegation";
     private static final String ADMIN_GROUP = "admin";
-    private static final String ROUTER_GROUP = "router";
     private static final String MANAGE_GROUP = "manage";
     private static final String ALL_GROUP = "all";
     private String name;
@@ -47,7 +46,6 @@ public class SaslGroupBasedSecuritySettingsPlugin implements SecuritySettingPlug
 
         // "admin" (console or other internal process) can do anything
         roles.add(new Role(ADMIN_GROUP, true, true, true, true, true, true, true, true, true, true));
-        roles.add(new Role(ROUTER_GROUP, true, true, false, false, true, true, false, false, false, false));
 
         if(!useGroupsFromSaslDelegation) {
             // "all" users can create/delete queues (but not addresses)
@@ -104,13 +102,13 @@ public class SaslGroupBasedSecuritySettingsPlugin implements SecuritySettingPlug
             if (parts.length == 2) {
                 char singleWord = DEFAULT_SINGLE_WORD;
                 char anyWords = DEFAULT_ANY_WORDS;
-                char delimiter = DEFAULT_DELIMITER;
+                char delimeter = DEFAULT_DELIMITER;
                 try {
                     String address = parts[1].replace('*', '#');
                     if(knownAddresses.add(address)) {
 
                         String singleWordString = String.valueOf(singleWord);
-                        String delimeterString = String.valueOf(delimiter);
+                        String delimeterString = String.valueOf(delimeter);
                         String anyWordsString = String.valueOf(anyWords);
 
                         Set<Role> roles = new HashSet<>();


### PR DESCRIPTION

This reverts commit 6fb365a5a2749e828610f87b43ddbec7babb1206.

### Type of change


- Bugfix

### Description

The change caused a regression to TopicTest#testTopicWildcardsSharded and TopicTest#testTopicWildcardsPooled.  For those use cases the router user needs to be able to create the address, which the PR didn't accommodate.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
