### PR TITLE
Fixed Queue test

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/model/addressplan/DestinationPlan.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/model/addressplan/DestinationPlan.java
@@ -9,6 +9,7 @@ public interface DestinationPlan {
     String BROKERED_TOPIC = "brokered-topic";
     String STANDARD_SMALL_QUEUE = "standard-small-queue";
     String STANDARD_SMALL_TOPIC = "standard-small-topic";
+    String STANDARD_MEDIUM_QUEUE = "standard-medium-queue";
     String STANDARD_LARGE_QUEUE = "standard-large-queue";
     String STANDARD_LARGE_TOPIC = "standard-large-topic";
     String STANDARD_XLARGE_QUEUE = "standard-xlarge-queue";

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/QueueTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/QueueTest.java
@@ -368,7 +368,7 @@ public class QueueTest extends TestBase implements ITestSharedStandard {
                 .withPlan(DestinationPlan.STANDARD_LARGE_QUEUE)
                 .endSpec()
                 .build();
-        Address small = new AddressBuilder()
+        Address medium = new AddressBuilder()
                 .withNewMetadata()
                 .withNamespace(getSharedAddressSpace().getMetadata().getNamespace())
                 .withName(AddressUtils.generateAddressMetadataName(getSharedAddressSpace(), "scalequeue"))
@@ -376,11 +376,11 @@ public class QueueTest extends TestBase implements ITestSharedStandard {
                 .withNewSpec()
                 .withType("queue")
                 .withAddress("scalequeue")
-                .withPlan(DestinationPlan.STANDARD_SMALL_QUEUE)
+                .withPlan(DestinationPlan.STANDARD_MEDIUM_QUEUE)
                 .endSpec()
                 .build();
 
-        testScale(small, large, true);
+        testScale(medium, large, true);
         testScale(large, xlarge, false);
     }
 
@@ -395,7 +395,7 @@ public class QueueTest extends TestBase implements ITestSharedStandard {
 
         AmqpClient client = getAmqpClientFactory().createQueueClient();
         final List<String> prefixes = Arrays.asList("foo", "bar", "baz", "quux");
-        final int numMessages = 500;
+        final int numMessages = 450;
         final int totalNumMessages = numMessages * prefixes.size();
         final int numReceiveBeforeDraining = numMessages / 2;
         final int numReceivedAfterScaled = totalNumMessages - numReceiveBeforeDraining;


### PR DESCRIPTION
### Type of change

- Test fix

### Description

Per address-settings for global-max-size has limited the maxSizeBytes per queue.  Used a medium plan (instead of small), to send the messages without exceeding the resource-limit.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
