### PR TITLE
[Shared infra] Add support for deadletter and expiry settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ $(CONTROLLER_GEN):
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	GOPATH=$(abspath $(LOCALBIN)/../) go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.5 ;\
+	GOPATH=$(abspath $(LOCALBIN)/../) go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 

--- a/pkg/state/broker/broker_test.go
+++ b/pkg/state/broker/broker_test.go
@@ -29,10 +29,18 @@ func TestInitializeBroker(t *testing.T) {
 	}
 
 	client.Handler = func(req *amqp.Message) (*amqp.Message, error) {
-		return &amqp.Message{
-			ApplicationProperties: map[string]interface{}{"_AMQ_OperationSucceeded": true},
-			Value:                 "[[\"queue1\",\"queue2\"]]",
-		}, nil
+		op := req.ApplicationProperties["_AMQ_OperationName"]
+		if op == "getAddressSettingsAsJSON" {
+			return &amqp.Message{
+				ApplicationProperties: map[string]interface{}{"_AMQ_OperationSucceeded": true},
+				Value:                 "[]",
+			}, nil
+		} else {
+			return &amqp.Message{
+				ApplicationProperties: map[string]interface{}{"_AMQ_OperationSucceeded": true},
+				Value:                 "[[\"queue1\",\"queue2\"]]",
+			}, nil
+		}
 	}
 
 	err := state.Initialize(time.Time{})

--- a/pkg/state/broker/types.go
+++ b/pkg/state/broker/types.go
@@ -65,6 +65,51 @@ type BrokerDivert struct {
 	TransformerClassName string `json:"transformerClassName,omitempty"`
 }
 
+type BrokerAddressSetting struct {
+	Name                     string             `json:"name"`
+	DeadLetterAddress        string             `json:"DLA,omitempty"`
+	ExpiryAddress            string             `json:"expiryAddress,omitempty"`
+	ExpiryDelay              int64              `json:"expiryDelay,omitempty"`
+	LastValueQueue           bool               `json:"lastValueQueue,omitempty"`
+	DeliveryAttempts         int32              `json:"deliveryAttempts,omitempty"`
+	MaxSizeBytes             int64              `json:"maxSizeBytes,omitempty"`
+	PageSizeBytes            int32              `json:"pageSizeBytes,omitempty"`
+	PageMaxCacheSize         int32              `json:"pageMaxCacheSize,omitempty"`
+	RedeliveryDelay          int64              `json:"redeliveryDelay,omitempty"`
+	RedeliveryMultiplier     float64            `json:"redeliveryMultiplier,omitempty"`
+	MaxRedeliveryDelay       int64              `json:"maxRedeliveryDelay,omitempty"`
+	RedistributionDelay      int64              `json:"redistributionDelay,omitempty"`
+	SendToDLAOnNoRoute       bool               `json:"sendToDLAOnNoRoute,omitempty"`
+	AddressFullMessagePolicy AddressFullPolicy  `json:"addressFullMessagePolicy,omitempty"`
+	SlowConsumerThreshold    int64              `json:"slowConsumerThreshold,omitempty"`
+	SlowConsumerCheckPeriod  int64              `json:"slowConsumerCheckPeriod,omitempty"`
+	SlowConsumerPolicy       SlowConsumerPolicy `json:"slowConsumerPolicy,omitempty"`
+	AutoCreateJmsQueues      bool               `json:"autoCreateJmsQueues,omitempty"`
+	AutoDeleteJmsQueues      bool               `json:"autoDeleteJmsQueues,omitempty"`
+	AutoCreateJmsTopics      bool               `json:"autoCreateJmsTopics,omitempty"`
+	AutoDeleteJmsTopics      bool               `json:"autoDeleteJmsTopics,omitempty"`
+	AutoCreateQueues         bool               `json:"autoCreateQueues,omitempty"`
+	AutoDeleteQueues         bool               `json:"autoDeleteQueues,omitempty"`
+	AutoCreateAddresses      bool               `json:"autoCreateAddresses,omitempty"`
+	AutoDeleteAddresses      bool               `json:"autoDeleteAddresses,omitempty"`
+}
+
+type AddressFullPolicy string
+
+const (
+	AddressFullPolicyDrop  AddressFullPolicy = "DROP"
+	AddressFullPolicyPage  AddressFullPolicy = "PAGE"
+	AddressFullPolicyFail  AddressFullPolicy = "FAIL"
+	AddressFullPolicyBlock AddressFullPolicy = "BLOCK"
+)
+
+type SlowConsumerPolicy string
+
+const (
+	SlowConsumerPolicyKill   SlowConsumerPolicy = "KILL"
+	SlowConsumerPolicyNotify SlowConsumerPolicy = "NOTIFY"
+)
+
 type RoutingType string
 
 const (

--- a/pkg/state/infra_test.go
+++ b/pkg/state/infra_test.go
@@ -99,10 +99,18 @@ func TestSyncConnectors(t *testing.T) {
 	assert.NotNil(t, i)
 
 	bclient.Handler = func(req *amqp.Message) (*amqp.Message, error) {
-		return &amqp.Message{
-			ApplicationProperties: map[string]interface{}{"_AMQ_OperationSucceeded": true},
-			Value:                 "[[\"q1\",\"q2\"]]",
-		}, nil
+		op := req.ApplicationProperties["_AMQ_OperationName"]
+		if op == "getAddressSettingsAsJSON" {
+			return &amqp.Message{
+				ApplicationProperties: map[string]interface{}{"_AMQ_OperationSucceeded": true},
+				Value:                 "[]",
+			}, nil
+		} else {
+			return &amqp.Message{
+				ApplicationProperties: map[string]interface{}{"_AMQ_OperationSucceeded": true},
+				Value:                 "[[\"q1\",\"q2\"]]",
+			}, nil
+		}
 	}
 
 	rclient.Handler = func(req *amqp.Message) (*amqp.Message, error) {

--- a/systemtests/src/main/java/io/enmasse/systemtest/amqp/DeliveryHandler.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/amqp/DeliveryHandler.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.systemtest.amqp;
+
+import io.vertx.proton.ProtonDelivery;
+
+public interface DeliveryHandler {
+    void handle(ProtonDelivery protonDelivery);
+}

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/GenericKubernetes.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/GenericKubernetes.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.systemtest.platform;
+
+import io.enmasse.systemtest.Endpoint;
+import io.enmasse.systemtest.Environment;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServicePort;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.utils.HttpClientUtils;
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+
+import java.util.Collections;
+
+public class GenericKubernetes extends Kubernetes {
+
+    private static final String OLM_NAMESPACE = "operators";
+
+    protected GenericKubernetes(Environment environment) {
+        super(environment, () -> {
+            Config config = new ConfigBuilder().build();
+            OkHttpClient httpClient = HttpClientUtils.createHttpClient(config);
+            // Workaround https://github.com/square/okhttp/issues/3146
+            httpClient = httpClient.newBuilder()
+                    .protocols(Collections.singletonList(Protocol.HTTP_1_1))
+                    .connectTimeout(environment.getKubernetesApiConnectTimeout())
+                    .writeTimeout(environment.getKubernetesApiWriteTimeout())
+                    .readTimeout(environment.getKubernetesApiReadTimeout())
+                    .build();
+            return new DefaultKubernetesClient(httpClient, config);
+        });
+    }
+
+    @Override
+    public Endpoint getMasterEndpoint() {
+        return new Endpoint(client.getMasterUrl());
+    }
+
+    @Override
+    public Endpoint getRestEndpoint() {
+        return new Endpoint(client.getMasterUrl());
+    }
+
+    @Override
+    public Endpoint getKeycloakEndpoint() {
+        return getExternalEndpoint("standard-authservice");
+    }
+
+    @Override
+    public Endpoint getExternalEndpoint(String name) {
+        return getExternalEndpoint(name, infraNamespace);
+    }
+
+    @Override
+    public Endpoint getExternalEndpoint(String name, String namespace) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void createExternalEndpoint(String name, String namespace, Service service, ServicePort targetPort) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void deleteExternalEndpoint(String namespace, String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getHost() {
+        return getNodeHost();
+    }
+
+    @Override
+    public String getOlmNamespace() {
+        return OLM_NAMESPACE;
+    }
+
+    @Override
+    public String getClusterExternalImageRegistry() {
+        return null;
+    }
+
+    @Override
+    public String getClusterInternalImageRegistry() {
+        return null;
+    }
+}

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/cluster/MinikubeCluster.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/cluster/MinikubeCluster.java
@@ -5,6 +5,7 @@
 package io.enmasse.systemtest.platform.cluster;
 
 import io.enmasse.systemtest.executor.Exec;
+import io.enmasse.systemtest.executor.ExecutionResultData;
 
 import java.util.Arrays;
 
@@ -14,7 +15,7 @@ public class MinikubeCluster implements KubeCluster {
 
     @Override
     public boolean isAvailable() {
-        return Exec.isExecutableOnPath(IDENTIFIER);
+        return Exec.isExecutableOnPath(IDENTIFIER) && Exec.execute(IDENTIFIER, "status").getRetCode();
     }
 
     @Override

--- a/systemtests/src/test/java/io/enmasse/systemtest/sharedinfra/MessagingEndpointTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/sharedinfra/MessagingEndpointTest.java
@@ -62,18 +62,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class MessagingEndpointTest extends TestBase implements ITestIsolatedSharedInfra {
 
     @Test
-    @Kubernetes(type = ClusterType.MINIKUBE)
-    public void testNodePortEndpointMinikube() throws Exception {
-        testNodePortEndpoint();
-    }
-
-    @Test
-    @OpenShift(type = ClusterType.CRC)
-    public void testNodePortEndpointCRC() throws Exception {
-        testNodePortEndpoint();
-    }
-
-    private void testNodePortEndpoint() throws Exception {
+    public void testNodePortEndpoint() throws Exception {
         MessagingTenant tenant = infraResourceManager.getDefaultMessagingTenant();
         MessagingEndpoint endpoint = new MessagingEndpointBuilder()
                 .editOrNewMetadata()
@@ -81,7 +70,7 @@ public class MessagingEndpointTest extends TestBase implements ITestIsolatedShar
                 .withName("app")
                 .endMetadata()
                 .editOrNewSpec()
-                .withHost(kubernetes.getHost())
+                .withHost(kubernetes.getNodeHost())
                 .addToProtocols("AMQP")
                 .editOrNewNodePort()
                 .endNodePort()

--- a/templates/shared-infra/enmasse.io_messagingaddresses.yaml
+++ b/templates/shared-infra/enmasse.io_messagingaddresses.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: messagingaddresses.enmasse.io
 spec:

--- a/templates/shared-infra/enmasse.io_messagingendpoints.yaml
+++ b/templates/shared-infra/enmasse.io_messagingendpoints.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: messagingendpoints.enmasse.io
 spec:

--- a/templates/shared-infra/enmasse.io_messaginginfrastructures.yaml
+++ b/templates/shared-infra/enmasse.io_messaginginfrastructures.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: messaginginfrastructures.enmasse.io
 spec:

--- a/templates/shared-infra/enmasse.io_messagingtenants.yaml
+++ b/templates/shared-infra/enmasse.io_messagingtenants.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: messagingtenants.enmasse.io
 spec:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description
Default settings are set to broker defaults, except broker full
policy, which is set to FAIL. More settings will be exposed at a later
point.

Add systemtests for deadletter and expiry behavior, modify the AMQP
client to be able to reject messages so that they end up in the dead
letter queue.

Make more tests run in multiple Kubernetes environments by retrieving
a node ip and using nodeport to expose service.

Issue #4469

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [x] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
