### PR TITLE
Switch back to service CA for testing certificate re-creation

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/iot/isolated/tls/ReloadCertificatesTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/iot/isolated/tls/ReloadCertificatesTest.java
@@ -55,6 +55,14 @@ public class ReloadCertificatesTest extends TestBase implements ITestIoTIsolated
                         .withNewServiceCAStrategy()
                         .endServiceCAStrategy()
                         .endInterServiceCertificates()
+
+                        .editOrNewAdapters()
+                        .editOrNewHttp()
+                        // reset to use service CA endpoint secret
+                        .withNewEndpoint().endEndpoint()
+                        .endHttp()
+                        .endAdapters()
+
                         .endSpec();
                 })
                 .run((session) -> {


### PR DESCRIPTION
For X.509 certificates we are using the manually created certificates
for the HTTP protocol adapter now. However, that will not create
the expected certificate, and also will not automatically re-create it.

So in this test, we explicitly switch back to the service CA for HTTP.

### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
