### PR TITLE
Iot cert auth shared infra

### DIFF
--- a/pkg/controller/iotconfig/auth.go
+++ b/pkg/controller/iotconfig/auth.go
@@ -7,7 +7,11 @@ package iotconfig
 
 import (
 	"context"
+	"fmt"
+
 	iotv1alpha1 "github.com/enmasseproject/enmasse/pkg/apis/iot/v1alpha1"
+	"github.com/enmasseproject/enmasse/pkg/controller/messaginginfra"
+	"github.com/enmasseproject/enmasse/pkg/controller/messaginginfra/cert"
 	"github.com/enmasseproject/enmasse/pkg/util"
 	"github.com/enmasseproject/enmasse/pkg/util/cchange"
 	"github.com/enmasseproject/enmasse/pkg/util/recon"
@@ -75,6 +79,33 @@ func (r *ReconcileIoTConfig) processAdapterPskCredentials(ctx context.Context, c
 		})
 
 	}
+
+	return rc.Result()
+
+}
+
+func (r *ReconcileIoTConfig) processAdapterInfraCert(ctx context.Context, config *iotv1alpha1.IoTConfig, configTracker *configTracker) (reconcile.Result, error) {
+
+	rc := &recon.ReconcileContext{}
+
+	// for all adapters
+
+	infra, err := messaginginfra.LookupInfra(ctx, r.client, config.Namespace)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// TODO: Set desired DNS names
+	_, err = r.certController.ReconcileCert(ctx, nil, infra, config, "iot-adapters")
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// TODO: Inject the following into adapter deployments
+	certSecretName := cert.GetCertSecretName(config.Name)
+	host := fmt.Sprintf("%s-internal", infra.Name)
+	port := 55667
+	log.Info("Reconcile adapter cert", "secret", certSecretName, "host", host, "port", port)
 
 	return rc.Result()
 

--- a/pkg/controller/iotconfig/auth.go
+++ b/pkg/controller/iotconfig/auth.go
@@ -103,7 +103,7 @@ func (r *ReconcileIoTConfig) processAdapterInfraCert(ctx context.Context, config
 
 	// TODO: Inject the following into adapter deployments
 	certSecretName := cert.GetCertSecretName(config.Name)
-	host := fmt.Sprintf("%s-internal", infra.Name)
+	host := fmt.Sprintf("%s-cluster", infra.Name)
 	port := 55667
 	log.Info("Reconcile adapter cert", "secret", certSecretName, "host", host, "port", port)
 

--- a/pkg/controller/messaginginfra/router/controller.go
+++ b/pkg/controller/messaginginfra/router/controller.go
@@ -123,7 +123,7 @@ func (r *RouterController) ReconcileRouters(ctx context.Context, logger logr.Log
 	certShaSum = certSha.Sum(certShaSum)
 	routerCertSha := hex.EncodeToString(certShaSum[:])
 
-	meshServiceName := fmt.Sprintf("%s-mesh", routerInfraName)
+	meshServiceName := fmt.Sprintf("%s", routerInfraName)
 
 	// Reconcile statefulset of the router
 	statefulset := &appsv1.StatefulSet{
@@ -169,11 +169,11 @@ func (r *RouterController) ReconcileRouters(ctx context.Context, logger logr.Log
 				},
 				{
 					ContainerPort: 55671,
-					Name:          "operator-management",
+					Name:          "operator",
 				},
 				{
 					ContainerPort: 55667,
-					Name:          "cluster-internal",
+					Name:          "cluster",
 				},
 				{
 					ContainerPort: 7777,
@@ -263,7 +263,7 @@ func (r *RouterController) ReconcileRouters(ctx context.Context, logger logr.Log
 	}
 
 	// Reconcile internal cluster router service
-	internalClusterServiceName := fmt.Sprintf("%s-internal", routerInfraName)
+	internalClusterServiceName := fmt.Sprintf("%s-cluster", routerInfraName)
 	internalClusterService := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{Namespace: infra.Namespace, Name: internalClusterServiceName},
 	}
@@ -278,8 +278,8 @@ func (r *RouterController) ReconcileRouters(ctx context.Context, logger logr.Log
 			{
 				Port:       55667,
 				Protocol:   corev1.ProtocolTCP,
-				TargetPort: intstr.FromString("cluster-internal"),
-				Name:       "cluster-internal",
+				TargetPort: intstr.FromString("cluster"),
+				Name:       "cluster",
 			},
 		}
 

--- a/pkg/controller/messaginginfra/router/router_config.go
+++ b/pkg/controller/messaginginfra/router/router_config.go
@@ -92,6 +92,19 @@ func generateConfig(router *v1beta2.MessagingInfrastructureSpecRouter) routerCon
 					"httpRootDir":      "invalid",
 				},
 			},
+			[]interface{}{
+				// Listener for cluster-internal components
+				"listener",
+				map[string]interface{}{
+					"name":             "cluster-internal",
+					"host":             "0.0.0.0",
+					"port":             55667,
+					"requireSsl":       true,
+					"saslMechanisms":   "EXTERNAL",
+					"sslProfile":       "infra_tls",
+					"authenticatePeer": true,
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
This PR creates an internal listener + service for the shared infra that can be used by cluster-internal components such as iot adapters (it could also reuse the same port as the operator management, but it feels cleaner to separate that). 

The second commit that changes the iotconfig controller is just an example on how you can reconcile the client certificate and get the information that you need to inject into the adapters. I'm not sure where you think this should belong, but this is anyway how it would look. I can split out the first part in a PR if you think this approach looks good.