### PR TITLE
Fix the maven build

### DIFF
--- a/templates/pom.xml
+++ b/templates/pom.xml
@@ -9,6 +9,11 @@
   <packaging>pom</packaging>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>templates</artifactId>
+
+  <properties>
+    <image.version>latest</image.version>
+  </properties>
+
   <build>
     <plugins>
       <plugin>
@@ -22,7 +27,7 @@
               <goal>single</goal>
             </goals>
             <configuration>
-              <finalName>${application.bundle.prefix}-${env.IMAGE_VERSION}</finalName>
+              <finalName>${application.bundle.prefix}-${image.version}</finalName>
               <appendAssemblyId>false</appendAssemblyId>
               <ignoreMissingDescriptor>false</ignoreMissingDescriptor>
               <descriptors>
@@ -35,4 +40,19 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>image-version-from-env</id>
+      <activation>
+        <property>
+          <name>env.IMAGE_VERSION</name>
+        </property>
+      </activation>
+      <properties>
+        <image.version>${env.IMAGE_VERSION}</image.version>
+      </properties>
+    </profile>
+  </profiles>
+
 </project>

--- a/templates/src/assembly/unix-dist.xml
+++ b/templates/src/assembly/unix-dist.xml
@@ -24,11 +24,11 @@
         <format>tar.gz</format>
         <format>zip</format>
     </formats>
-    <includeBaseDirectory>False</includeBaseDirectory>
+    <includeBaseDirectory>false</includeBaseDirectory>
     <fileSets>
       <fileSet>
-        <directory>${project.basedir}/build/enmasse-${env.IMAGE_VERSION}</directory>
-        <outputDirectory>${application.bundle.prefix}-${env.IMAGE_VERSION}</outputDirectory>
+        <directory>${project.basedir}/build/enmasse-${image.version}</directory>
+        <outputDirectory>${application.bundle.prefix}-${image.version}</outputDirectory>
         <includes>
            <include>**/*</include>
         </includes>


### PR DESCRIPTION
### Type of change

Currently `mvn clean install` fails in the `template` project, because no env-var `IMAGE_VERSION` is set by default in the maven context. Adding a default value (same as as the makefile) and overriding when the env-var is set fixes this, and brings back plain maven compilation.

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
