### PR TITLE
Bump version of maven-assembly-plugin to 3.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,7 @@
         <maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
         <maven-site-plugin.version>3.5.1</maven-site-plugin.version>
         <maven-project-info-reports-plugin.version>2.9</maven-project-info-reports-plugin.version>
+        <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
         <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
         <security-versions-plugin.version>1.0.6</security-versions-plugin.version>
         <dependency-check-maven-plugin.version>4.0.2</dependency-check-maven-plugin.version>
@@ -764,6 +765,11 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>properties-maven-plugin</artifactId>
                     <version>${properties-maven-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>${maven-assembly-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/templates/pom.xml
+++ b/templates/pom.xml
@@ -9,6 +9,11 @@
   <packaging>pom</packaging>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>templates</artifactId>
+
+  <properties>
+    <image.version>latest</image.version>
+  </properties>
+
   <build>
     <plugins>
       <plugin>
@@ -22,7 +27,7 @@
               <goal>single</goal>
             </goals>
             <configuration>
-              <finalName>${application.bundle.prefix}-${env.IMAGE_VERSION}</finalName>
+              <finalName>${application.bundle.prefix}-${image.version}</finalName>
               <appendAssemblyId>false</appendAssemblyId>
               <ignoreMissingDescriptor>false</ignoreMissingDescriptor>
               <descriptors>
@@ -35,4 +40,19 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>image-version-from-env</id>
+      <activation>
+        <property>
+          <name>env.IMAGE_VERSION</name>
+        </property>
+      </activation>
+      <properties>
+        <image.version>${env.IMAGE_VERSION}</image.version>
+      </properties>
+    </profile>
+  </profiles>
+
 </project>

--- a/templates/src/assembly/unix-dist.xml
+++ b/templates/src/assembly/unix-dist.xml
@@ -24,11 +24,11 @@
         <format>tar.gz</format>
         <format>zip</format>
     </formats>
-    <includeBaseDirectory>False</includeBaseDirectory>
+    <includeBaseDirectory>false</includeBaseDirectory>
     <fileSets>
       <fileSet>
-        <directory>${project.basedir}/build/enmasse-${env.IMAGE_VERSION}</directory>
-        <outputDirectory>${application.bundle.prefix}-${env.IMAGE_VERSION}</outputDirectory>
+        <directory>${project.basedir}/build/enmasse-${image.version}</directory>
+        <outputDirectory>${application.bundle.prefix}-${image.version}</outputDirectory>
         <includes>
            <include>**/*</include>
         </includes>


### PR DESCRIPTION
### Type of change

**Note:** This builds upon #4791

Changing the version of the maven assembly plugin (actually defining it, because right now it is not managed at all) to a 3.x version allows to run multi-threaded builds without warnings. Which really improves build times:

Standard build (`mvn clean install`):
~~~
[INFO] Total time:  01:39 min
~~~

Multithreaded build (`mvn clean install -T1C`):
~~~
[INFO] Total time:  35.018 s (Wall Clock)
~~~

Of course this highly depends on the number of cores you have available, but still it should improve build times on all multi-core systems.

<!--

_Select the type of your PR_

-->

- Enhancement / new feature

### Description

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
