### PR TITLE
[systemtests] Investigate ApiServerTest failure on CRC

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/api/ApiServerTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/api/ApiServerTest.java
@@ -404,8 +404,7 @@ class ApiServerTest extends TestBase implements ITestIsolatedStandard {
     @Test
     void testCreateAddressSpaceViaApiNonAdmin() throws Exception {
         String namespace = "pepinator";
-        UserCredentials user = new UserCredentials("jarda", "jarda");
-
+        UserCredentials user = Credentials.userCredentials();
         try {
             KubeCMDClient.loginUser(user.getUsername(), user.getPassword());
             KubeCMDClient.createNamespace(namespace);

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/api/ApiServerTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/api/ApiServerTest.java
@@ -60,6 +60,8 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static io.enmasse.systemtest.TestTag.ACCEPTANCE;
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -165,7 +167,7 @@ class ApiServerTest extends TestBase implements ITestIsolatedStandard {
                 .endSpec()
                 .build();
         Throwable exception = assertThrows(KubernetesClientException.class, () -> resourcesManager.setAddresses(destWithoutAddress));
-        assertTrue(exception.getMessage().contains("spec.address in body is required"), "Incorrect response from server on missing address: '" + exception.getMessage() + "'");
+        assertThat(exception.getMessage(), anyOf(containsString("spec.address in body is required"), containsString("spec.address: Required value")));
 
         Address destWithoutType = new AddressBuilder()
                 .withNewMetadata()
@@ -178,7 +180,7 @@ class ApiServerTest extends TestBase implements ITestIsolatedStandard {
                 .endSpec()
                 .build();
         exception = assertThrows(KubernetesClientException.class, () -> resourcesManager.setAddresses(destWithoutType));
-        assertTrue(exception.getMessage().contains("spec.type in body is required"), "Incorrect response from server on missing address: '" + exception.getMessage() + "'");
+        assertThat(exception.getMessage(), anyOf(containsString("spec.type in body is required"), containsString("spec.type: Required value")));
 
         Address destWithoutPlan = new AddressBuilder()
                 .withNewMetadata()
@@ -191,7 +193,7 @@ class ApiServerTest extends TestBase implements ITestIsolatedStandard {
                 .endSpec()
                 .build();
         exception = assertThrows(KubernetesClientException.class, () -> resourcesManager.setAddresses(destWithoutPlan));
-        assertTrue(exception.getMessage().contains("spec.plan in body is required"), "Incorrect response from server on missing address: '" + exception.getMessage() + "'");
+        assertThat(exception.getMessage(), anyOf(containsString("spec.plan in body is required"), containsString("spec.plan: Required value")));
     }
 
     @Test

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/api/CustomResourceDefinitionAddressSpacesTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/api/CustomResourceDefinitionAddressSpacesTest.java
@@ -76,7 +76,7 @@ class CustomResourceDefinitionAddressSpacesTest extends TestBase implements ITes
         resourcesManager.deleteAddressSpace(brokered);
         TestUtils.waitForNamespaceDeleted(kubernetes, brokered.getMetadata().getName());
         TestUtils.waitUntilCondition(() -> {
-            ExecutionResultData allAddresses = KubeCMDClient.getAddressSpace(environment.namespace(), "-a");
+            ExecutionResultData allAddresses = KubeCMDClient.getAddressSpace(environment.namespace(), Optional.empty());
             return allAddresses.getStdOut() + allAddresses.getStdErr();
         }, "No resources found.", new TimeoutBudget(30, TimeUnit.SECONDS));
     }
@@ -155,7 +155,7 @@ class CustomResourceDefinitionAddressSpacesTest extends TestBase implements ITes
         KubeCMDClient.deleteAddressSpace(environment.namespace(), brokered.getMetadata().getName());
         AddressSpaceUtils.waitForAddressSpaceDeleted(brokered);
         TestUtils.waitUntilCondition(() -> {
-            ExecutionResultData allAddresses = KubeCMDClient.getAddressSpace(environment.namespace(), "-a");
+            ExecutionResultData allAddresses = KubeCMDClient.getAddressSpace(environment.namespace(), Optional.empty());
             return allAddresses.getStdErr();
         }, "No resources found.", new TimeoutBudget(30, TimeUnit.SECONDS));
     }

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/api/CustomResourceDefinitionAddressSpacesTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/api/CustomResourceDefinitionAddressSpacesTest.java
@@ -202,7 +202,7 @@ class CustomResourceDefinitionAddressSpacesTest extends TestBase implements ITes
     @Test
     void testCliOutput() throws Exception {
         String namespace = "cli-output";
-        UserCredentials user = new UserCredentials("pepan", "pepan");
+        UserCredentials user = Credentials.userCredentials();
         try {
             //===========================
             // AddressSpace part

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/api/CustomResourceDefinitionAddressSpacesTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/api/CustomResourceDefinitionAddressSpacesTest.java
@@ -78,7 +78,7 @@ class CustomResourceDefinitionAddressSpacesTest extends TestBase implements ITes
         TestUtils.waitUntilCondition(() -> {
             ExecutionResultData allAddresses = KubeCMDClient.getAddressSpace(environment.namespace(), Optional.empty());
             return allAddresses.getStdOut() + allAddresses.getStdErr();
-        }, "No resources found.", new TimeoutBudget(30, TimeUnit.SECONDS));
+        }, "No resources found", new TimeoutBudget(30, TimeUnit.SECONDS));
     }
 
     @Test
@@ -157,7 +157,7 @@ class CustomResourceDefinitionAddressSpacesTest extends TestBase implements ITes
         TestUtils.waitUntilCondition(() -> {
             ExecutionResultData allAddresses = KubeCMDClient.getAddressSpace(environment.namespace(), Optional.empty());
             return allAddresses.getStdErr();
-        }, "No resources found.", new TimeoutBudget(30, TimeUnit.SECONDS));
+        }, "No resources found", new TimeoutBudget(30, TimeUnit.SECONDS));
     }
 
     @Test
@@ -191,7 +191,7 @@ class CustomResourceDefinitionAddressSpacesTest extends TestBase implements ITes
             TestUtils.waitUntilCondition(() -> {
                 ExecutionResultData allAddresses = KubeCMDClient.getAddressSpace(namespace, Optional.empty());
                 return allAddresses.getStdOut() + allAddresses.getStdErr();
-            }, "No resources found.", new TimeoutBudget(30, TimeUnit.SECONDS));
+            }, "No resources found", new TimeoutBudget(30, TimeUnit.SECONDS));
         } finally {
             KubeCMDClient.loginUser(environment.getApiToken());
             KubeCMDClient.switchProject(environment.namespace());

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/api/CustomResourceDefinitionAddressesTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/api/CustomResourceDefinitionAddressesTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -105,7 +106,7 @@ public class CustomResourceDefinitionAddressesTest extends TestBase implements I
         KubeCMDClient.deleteAddress(environment.namespace(), dest2.getMetadata().getName());
 
         TestUtils.waitUntilCondition(() -> {
-            ExecutionResultData allAddresses = KubeCMDClient.getAddress(environment.namespace(), "-a");
+            ExecutionResultData allAddresses = KubeCMDClient.getAddress(environment.namespace());
             return allAddresses.getStdErr() + allAddresses.getStdOut();
         }, "No resources found.", new TimeoutBudget(30, TimeUnit.SECONDS));
     }
@@ -162,7 +163,7 @@ public class CustomResourceDefinitionAddressesTest extends TestBase implements I
 
         AddressUtils.waitForDestinationsReady(dest1, dest2);
 
-        result = KubeCMDClient.getAddress(environment.namespace(), "-a");
+        result = KubeCMDClient.getAddress(environment.namespace());
         output = result.getStdOut().trim();
 
         assertTrue(output.contains(Objects.requireNonNull(dest1.getMetadata().getName())),
@@ -179,7 +180,7 @@ public class CustomResourceDefinitionAddressesTest extends TestBase implements I
         resourcesManager.deleteAddresses(dest2);
 
         TestUtils.waitUntilCondition(() -> {
-            ExecutionResultData addresses = KubeCMDClient.getAddress(environment.namespace(), "-a");
+            ExecutionResultData addresses = KubeCMDClient.getAddress(environment.namespace());
             return addresses.getStdOut() + addresses.getStdErr();
         }, "No resources found.", new TimeoutBudget(30, TimeUnit.SECONDS));
     }

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/api/CustomResourceDefinitionAddressesTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/api/CustomResourceDefinitionAddressesTest.java
@@ -108,7 +108,7 @@ public class CustomResourceDefinitionAddressesTest extends TestBase implements I
         TestUtils.waitUntilCondition(() -> {
             ExecutionResultData allAddresses = KubeCMDClient.getAddress(environment.namespace());
             return allAddresses.getStdErr() + allAddresses.getStdOut();
-        }, "No resources found.", new TimeoutBudget(30, TimeUnit.SECONDS));
+        }, "No resources found", new TimeoutBudget(30, TimeUnit.SECONDS));
     }
 
     @Test
@@ -182,6 +182,6 @@ public class CustomResourceDefinitionAddressesTest extends TestBase implements I
         TestUtils.waitUntilCondition(() -> {
             ExecutionResultData addresses = KubeCMDClient.getAddress(environment.namespace());
             return addresses.getStdOut() + addresses.getStdErr();
-        }, "No resources found.", new TimeoutBudget(30, TimeUnit.SECONDS));
+        }, "No resources found", new TimeoutBudget(30, TimeUnit.SECONDS));
     }
 }


### PR DESCRIPTION
### Type of change


- Bugfix

### Description

Make testRestApiAddressResourceParams compatible for OCP4.3 responses

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
