### PR TITLE
Fix #3560: Add securityContext field to the brokered/standard infra config tables

### DIFF
--- a/documentation/kubernetes/master.adoc
+++ b/documentation/kubernetes/master.adoc
@@ -11,6 +11,7 @@ include::common/attributes.adoc[]
 :OperatorMarketplaceNamespace: marketplace
 
 :KubePlatformRbacURL: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+:KubePlatformSecurityContextURL: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 
 = Documentation for {ProductName} on Kubernetes
 

--- a/documentation/modules/ref-brokered-infra-config-fields.adoc
+++ b/documentation/modules/ref-brokered-infra-config-fields.adoc
@@ -27,6 +27,7 @@ This table shows the fields available for the brokered infrastructure configurat
 |`broker.podTemplate.spec.affinity` |Specifies the affinity settings for the broker Pod so you can specify where on particular nodes a Pod runs, or if it cannot run together with other instances.
 |`broker.podTemplate.spec.priorityClassName` |Specifies the priority class to use for the broker Pod so you can prioritize broker Pods over other Pods in the {KubePlatform} cluster.
 |`broker.podTemplate.spec.tolerations` |Specifies the toleration settings for the broker Pod, which allows this Pod to run on certain nodes that other Pods cannot run on.
+|`broker.podTemplate.spec.securityContext` |Specifies the link:{KubePlatformSecurityContextURL}[security context] for the broker Pod.
 |`broker.podTemplate.spec.containers.env` |Specifies environment variables for the broker Pod.
 |`broker.podTemplate.spec.containers.livenessProbe.failureThreshold` |Specifies the number of times that {KubePlatform} tries when a broker Pod starts and the probe fails before restarting the container.
 |`broker.podTemplate.spec.containers.livenessProbe.initialDelaySeconds` |Specifies the probe delay value in seconds for the broker Pod.

--- a/documentation/modules/ref-standard-infra-config-fields.adoc
+++ b/documentation/modules/ref-standard-infra-config-fields.adoc
@@ -27,6 +27,7 @@ This table shows the fields available for the standard infrastructure configurat
 |`broker.podTemplate.spec.affinity` |Specifies the affinity settings for the broker Pod so you can specify where on particular nodes a Pod runs, or if it cannot run together with other instances.
 |`broker.podTemplate.spec.priorityClassName` |Specifies the priority class to use for the broker Pod so you can prioritize broker Pods over other Pods in the {KubePlatform} cluster.
 |`broker.podTemplate.spec.tolerations` |Specifies the toleration settings for the broker Pod, which allow this Pod to run on certain nodes on which other Pods cannot run.
+|`broker.podTemplate.spec.securityContext` |Specifies the link:{KubePlatformSecurityContextURL}[security context] for the broker Pod.
 |`broker.podTemplate.spec.containers.env` |Specifies environment variables for the broker Pod.
 |`broker.podTemplate.spec.containers.livenessProbe.failureThreshold` |Specifies the number of times that {KubePlatform} tries when a broker Pod starts and the probe fails before restarting the container.
 |`broker.podTemplate.spec.containers.livenessProbe.initialDelaySeconds` |Specifies the probe delay value in seconds for the broker Pod.
@@ -47,6 +48,7 @@ This table shows the fields available for the standard infrastructure configurat
 |`router.podTemplate.spec.affinity` |Specifies the affinity settings for the router Pod so you can specify where on particular nodes a pod runs, or if it cannot run together with other instances.
 |`router.podTemplate.spec.priorityClassName` |Specifies the priority class to use for the router Pod so you can prioritize router pods over other pods in the {KubePlatform} cluster.
 |`router.podTemplate.spec.tolerations` |Specifies the toleration settings for the router Pod, which allow this Pod to run on certain nodes on which other Pods cannot run.
+|`broker.podTemplate.spec.securityContext` |Specifies the link:{KubePlatformSecurityContextURL}[security context] for the router Pod.
 |`router.podTemplate.spec.containers.env` |Specifies the environment variables for the router Pod.
 |`router.podTemplate.spec.containers.livenessProbe.failureThreshold` |Specifies the number of times that {KubePlatform} tries when a router Pod starts and the probe fails before restarting the container.
 |`router.podTemplate.spec.containers.livenessProbe.initialDelaySeconds` |Specifies the probe delay value in seconds for the router Pod.

--- a/documentation/openshift/master.adoc
+++ b/documentation/openshift/master.adoc
@@ -11,7 +11,7 @@ include::common/attributes.adoc[]
 :OperatorMarketplaceNamespace: openshift-marketplace
 
 :KubePlatformRbacURL: https://access.redhat.com/documentation/en-us/openshift_container_platform/3.11/html-single/cluster_administration/index#admin-guide-manage-rbac
-
+:KubePlatformSecurityContextURL: https://access.redhat.com/documentation/en-us/openshift_container_platform/3.11/html-single/cluster_administration/index#admin-guide-manage-rbac
 
 = Documentation for {ProductName} on OpenShift
 


### PR DESCRIPTION

### Type of change


- Documentation

### Description

Add securityContext field to the brokered/standard infra config tables

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
