### PR TITLE
Missed the renaming of the ttl field in the address status section

### DIFF
--- a/templates/crds/addresses.crd.yaml
+++ b/templates/crds/addresses.crd.yaml
@@ -174,9 +174,9 @@ spec:
                   type: integer
                 resources:
                   type: object
-            ttl:
+            messageTtl:
               type: object
-              description: "Applied message TTL properties"
+              description: "Applied message TTL properties."
               properties:
                 maximum:
                   description: "Maximum TTL value"


### PR DESCRIPTION
### Type of change


- Bugfix

### Description

Missed the renaming of the `ttl` field in the address status section.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
