### PR TITLE
Console-UI Filter on type and status in address space list is not working when combined together

### DIFF
--- a/console/console-init/ui/src/graphql-module/queries/AddressSpace.ts
+++ b/console/console-init/ui/src/graphql-module/queries/AddressSpace.ts
@@ -46,15 +46,16 @@ const ALL_ADDRESS_SPACES_FILTER = (
     filter += " AND ";
   }
 
-  //filter tye
+  //filter type
   if (filterType) {
     filter += generateFilterPattern("spec.type", [
       { value: filterType.toLowerCase(), isExact: true }
     ]);
   }
 
-  //filter tye
+  //filter status
   if (filterStatus) {
+    filter += " AND ";
     if (filterStatus !== "Pending") {
       filter += generateFilterPattern("status.phase", [
         { value: filterStatus, isExact: true }

--- a/console/console-init/ui/src/modules/address-space/containers/MessagingToolbarContainer/MessagingToolbarContainer.tsx
+++ b/console/console-init/ui/src/modules/address-space/containers/MessagingToolbarContainer/MessagingToolbarContainer.tsx
@@ -82,8 +82,6 @@ export const MessagingToolbarContainer: React.FunctionComponent<IMessagingToolba
   const resettInitialState = () => {
     setNameInput("");
     setNamespaceInput("");
-    setTypeSelected(null);
-    setStatusSelected(null);
   };
 
   const onFilterSelect = (value: string) => {


### PR DESCRIPTION
### Type of change

- Bugfix
### Description
On selection of filter type, the previous selected filter got removed which is not expected.
### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
