### PR TITLE
Console Mock server - remove duplicate address plan from mock server for topic

### DIFF
--- a/console/console-init/ui/mock-console-server/mock-console-server.js
+++ b/console/console-init/ui/mock-console-server/mock-console-server.js
@@ -384,15 +384,6 @@ const availableAddressPlans = [
         "broker": 0
       },
       7),
-  createAddressPlan("standard-small-topic",
-      "topic",
-      "Small Topic",
-      "Creates a small topic sharing underlying broker with other topics.",
-      "Creates a small topic sharing underlying broker with other topics.",
-      {
-        "broker": 0
-      },
-      8),
   createAddressPlan("standard-medium-topic",
       "topic",
       "Medium Topic",
@@ -401,7 +392,7 @@ const availableAddressPlans = [
       {
         "broker": 0
       },
-      9),
+      8),
   createAddressPlan("standard-small-subscription",
       "subscription",
       "Small Subscription",
@@ -410,7 +401,7 @@ const availableAddressPlans = [
       {
         "broker": 0
       },
-      10),
+      9),
   createAddressPlan("brokered-queue",
       "queue",
       "Brokered Queue",


### PR DESCRIPTION
### Type of change

- Bugfix
### Description
Bug - There is a duplicate address plan for topic i.e "statndard-small-topic" in mockserver
### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
