### PR TITLE
Fix appending content

### DIFF
--- a/pkg/util/install/utils.go
+++ b/pkg/util/install/utils.go
@@ -575,23 +575,26 @@ func AppendEnvVarValue(container *corev1.Container, name string, value string) {
 		container.Env = make([]corev1.EnvVar, 0)
 	}
 
-	opts := ""
-
-	for _, env := range container.Env {
+	for i, env := range container.Env {
 		if env.Name == name {
-			opts = env.Value
+			opts := env.Value
+
+			if len(opts) > 0 {
+				opts += " "
+			}
+
+			opts += value
+
+			env.Value = opts
+			container.Env[i] = env
+
+			return
 		}
 	}
 
-	if len(opts) > 0 {
-		opts += " "
-	}
-
-	opts += value
-
 	container.Env = append(container.Env, corev1.EnvVar{
 		Name:  name,
-		Value: opts,
+		Value: value,
 	})
 }
 

--- a/pkg/util/install/utils_test.go
+++ b/pkg/util/install/utils_test.go
@@ -216,3 +216,30 @@ func TestComputeConfigMapHash(t *testing.T) {
 	assert.Equal(t, hash(data1), hash(data2))
 	assert.NotEqual(t, hash(bar), hash(data2))
 }
+
+func TestAppendEnvVar(t *testing.T) {
+
+	container := corev1.Container{}
+
+	assert.Nil(t, container.Env)
+	assert.Len(t, container.Env, 0)
+
+	// append first element
+
+	AppendEnvVarValue(&container, JavaOptsEnvVarName, "foo")
+
+	assert.NotNil(t, container.Env)
+	assert.Len(t, container.Env, 1)
+	assert.Equal(t, JavaOptsEnvVarName, container.Env[0].Name)
+	assert.Equal(t, "foo", container.Env[0].Value)
+
+	// append second element
+
+	AppendEnvVarValue(&container, JavaOptsEnvVarName, "bar")
+
+	assert.NotNil(t, container.Env)
+	assert.Len(t, container.Env, 1)
+	assert.Equal(t, JavaOptsEnvVarName, container.Env[0].Name)
+	assert.Equal(t, "foo bar", container.Env[0].Value)
+
+}


### PR DESCRIPTION
### Type of change

Fix an issue with append to env-vars. Currently this creates a new env-var every time.

- Bugfix

### Description

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
