### PR TITLE
Add services to iotconfig crd

### DIFF
--- a/templates/crds/iotconfigs.crd.yaml
+++ b/templates/crds/iotconfigs.crd.yaml
@@ -13,18 +13,18 @@ spec:
     plural: iotconfigs
     singular: iotconfig
     shortNames:
-    - icfg
+      - icfg
     categories:
-    - enmasse
+      - enmasse
   additionalPrinterColumns:
-  - name: Phase
-    type: string
-    description: Phase of the IoT config
-    JSONPath: .status.phase
-  - name: Message
-    type: string
-    description: Message
-    JSONPath: .status.message
+    - name: Phase
+      type: string
+      description: Phase of the IoT config
+      JSONPath: .status.phase
+    - name: Message
+      type: string
+      description: Message
+      JSONPath: .status.message
   subresources:
     status: {}
   validation:
@@ -120,6 +120,18 @@ spec:
                 sigfox:
                   type: object
                 lorawan:
+                  type: object
+
+            services:
+              type: object
+              properties:
+                deviceConnection:
+                  type: object
+                deviceRegistry:
+                  type: object
+                authentication:
+                  type: object
+                tenant:
                   type: object
 
             tracing:

--- a/templates/crds/iotconfigs.crd.yaml
+++ b/templates/crds/iotconfigs.crd.yaml
@@ -13,18 +13,18 @@ spec:
     plural: iotconfigs
     singular: iotconfig
     shortNames:
-      - icfg
+    - icfg
     categories:
-      - enmasse
+    - enmasse
   additionalPrinterColumns:
-    - name: Phase
-      type: string
-      description: Phase of the IoT config
-      JSONPath: .status.phase
-    - name: Message
-      type: string
-      description: Message
-      JSONPath: .status.message
+  - name: Phase
+    type: string
+    description: Phase of the IoT config
+    JSONPath: .status.phase
+  - name: Message
+    type: string
+    description: Message
+    JSONPath: .status.message
   subresources:
     status: {}
   validation:


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix


### Description

These changes should fix validation issue on kubernetes 1.18 and add ability to run SimpleK8sDeployTest on minikube/other kube cluster.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
