### PR TITLE
[system tests] address settings / messaging ttl tests - fail early if test observation getAddressSettingsAsJSON fails

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/broker/ArtemisUtils.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/broker/ArtemisUtils.java
@@ -59,6 +59,7 @@ public class ArtemisUtils {
                 "--user", String.format("%s:%s", supportCredentials.getUsername(), supportCredentials.getPassword()),
                 "-H", "Origin: https://localhost:8161",
                 String.format("https://localhost:8161/console/jolokia/exec/org.apache.activemq.artemis:broker=\"%s\"/getAddressSettingsAsJSON/%s", brokerPodName, addressName));
+        assertThat(String.format("Failed to invoke getAddressSettingsAsJSON query: %s : %s", jmxResponse.getStdOut(), jmxResponse.getStdErr()), jmxResponse.getRetCode(), is(true));
 
         String responseJson = jmxResponse.getTrimmedStdOut();
         Map<String, Object> map = jsonResponseToMap(responseJson);


### PR DESCRIPTION

### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

Small bug fix to  address settings / messaging ttl tests to fail early if test's observation getAddressSettingsAsJSON fails.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
