### PR TITLE
Console-UI Filter on type and status in address space list is not working when combined together

### DIFF
--- a/console/console-init/ui/src/graphql-module/queries/AddressSpace.ts
+++ b/console/console-init/ui/src/graphql-module/queries/AddressSpace.ts
@@ -40,8 +40,7 @@ const ALL_ADDRESS_SPACES_FILTER = (
   if (
     ((filterNamesLength && filterNamesLength > 0) ||
       (filterNameSpacesLength && filterNameSpacesLength > 0)) &&
-    filterType &&
-    filterType.trim() !== ""
+    (filterType?.trim() || filterStatus?.trim())
   ) {
     filter += " AND ";
   }
@@ -51,6 +50,10 @@ const ALL_ADDRESS_SPACES_FILTER = (
     filter += generateFilterPattern("spec.type", [
       { value: filterType.toLowerCase(), isExact: true }
     ]);
+  }
+
+  if (filterType?.trim() && filterStatus?.trim()) {
+    filter += " AND ";
   }
 
   //filter tye

--- a/console/console-init/ui/src/modules/address-space/containers/MessagingToolbarContainer/MessagingToolbarContainer.tsx
+++ b/console/console-init/ui/src/modules/address-space/containers/MessagingToolbarContainer/MessagingToolbarContainer.tsx
@@ -79,16 +79,14 @@ export const MessagingToolbarContainer: React.FunctionComponent<IMessagingToolba
   };
 
   //this function used to clear value of type ahead select input field on filter change
-  const resettInitialState = () => {
+  const resetInitialState = () => {
     setNameInput("");
     setNamespaceInput("");
-    setTypeSelected(null);
-    setStatusSelected(null);
   };
 
   const onFilterSelect = (value: string) => {
     setFilterSelected(value);
-    resettInitialState();
+    resetInitialState();
   };
 
   const onNameSelect = (e: any, selection: SelectOptionObject) => {


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description
Fixed following issues
1.Fixed filter on name and status together in address space list 
2. Fixed filter on name, namespace, type and status apply all together 

![image](https://user-images.githubusercontent.com/11775081/85542960-3eb92900-b637-11ea-973d-fa36fc19f54a.png)

![image](https://user-images.githubusercontent.com/11775081/85543052-55f81680-b637-11ea-96b4-675444e222b0.png)

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
