### PR TITLE
Chore: add function to reset pagination upon filtering

### DIFF
--- a/console/console-init/ui/src/modules/address-detail/containers/AddressLinks/AddressLinksPage.tsx
+++ b/console/console-init/ui/src/modules/address-detail/containers/AddressLinks/AddressLinksPage.tsx
@@ -22,6 +22,7 @@ import {
 } from "modules/address-detail/containers";
 import { TablePagination } from "components/TablePagination";
 import { IFilterValue } from "modules/address/utils";
+import { useSearchParamsPageChange } from "hooks";
 
 interface IAddressLinksListPageProps {
   addressspace_name: string;
@@ -49,6 +50,9 @@ const AddressLinksPage: React.FunctionComponent<IAddressLinksListPageProps> = ({
     []
   );
   const [filterRole, setFilterRole] = useState<string | null>();
+
+  useSearchParamsPageChange([filterNames, filterContainers, filterRole]);
+
   const renderPagination = () => {
     return (
       <TablePagination

--- a/console/console-init/ui/src/modules/address-space/AddressSpacePage.tsx
+++ b/console/console-init/ui/src/modules/address-space/AddressSpacePage.tsx
@@ -24,7 +24,7 @@ import { compareObject } from "utils";
 import { useStoreContext, types, MODAL_TYPES } from "context-state-reducer";
 import { getHeaderForDeleteDialog, getDetailForDeleteDialog } from "./utils";
 import { TablePagination } from "components";
-import { useMutationQuery } from "hooks";
+import { useMutationQuery, useSearchParamsPageChange } from "hooks";
 
 export default function AddressSpacePage() {
   const { dispatch } = useStoreContext();
@@ -50,6 +50,13 @@ export default function AddressSpacePage() {
     DELETE_ADDRESS_SPACE,
     refetchQueries
   );
+
+  useSearchParamsPageChange([
+    filterType,
+    filterStatus,
+    filterNamespaces,
+    filterNames
+  ]);
 
   const onDeleteAll = () => {
     dispatch({

--- a/console/console-init/ui/src/modules/connection-detail/components/ConnectionLinksWithToolbar/ConnectionLinksWithToolbar.tsx
+++ b/console/console-init/ui/src/modules/connection-detail/components/ConnectionLinksWithToolbar/ConnectionLinksWithToolbar.tsx
@@ -19,6 +19,7 @@ import { GridStylesForTableHeader } from "modules/address/AddressPage";
 import { ConnectionLinksContainer } from "modules/connection-detail/containers";
 import { TablePagination } from "components";
 import { ConnectionLinksToolbarContainer } from "modules/connection-detail/containers";
+import { useSearchParamsPageChange } from "hooks";
 interface IConnectionDetailToolbarProps {
   name?: string;
   namespace?: string;
@@ -38,6 +39,8 @@ export const ConnectionLinksWithToolbar: React.FunctionComponent<IConnectionDeta
   const [filterAddresses, setFilterAddresses] = useState<Array<string>>([]);
   const [filterRole, setFilterRole] = useState<string | null>();
   const [sortDropDownValue, setSortDropdownValue] = useState<ISortBy>();
+
+  useSearchParamsPageChange([filterNames, filterAddresses, filterRole]);
 
   const renderPagination = (page: number, perPage: number) => {
     return (

--- a/console/console-init/ui/src/modules/connection/ConnectionPage.tsx
+++ b/console/console-init/ui/src/modules/connection/ConnectionPage.tsx
@@ -27,7 +27,7 @@ import {
   getHeaderTextForCloseAll,
   getDetailTextForCloseAll
 } from "./utils";
-import { useMutationQuery } from "hooks";
+import { useMutationQuery, useSearchParamsPageChange } from "hooks";
 import { CLOSE_CONNECTION } from "graphql-module";
 
 export default function ConnectionPage() {
@@ -43,6 +43,8 @@ export default function ConnectionPage() {
   const searchParams = new URLSearchParams(location.search);
   const page = parseInt(searchParams.get("page") || "", 10) || 1;
   const perPage = parseInt(searchParams.get("perPage") || "", 10) || 10;
+
+  useSearchParamsPageChange([hostnames, containerIds]);
 
   const [selectedConnections, setSelectedConnections] = useState<IConnection[]>(
     []


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Enhancement

### Description

This PR sets the lists to the first page upon applying filters.

### Checklist

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
