### PR TITLE
Fix: failing UI unit tests upon patternfly upgrade

### DIFF
--- a/console/console-init/ui/package.json
+++ b/console/console-init/ui/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --env=jest-environment-jsdom-sixteen",
     "eject": "react-scripts eject",
     "format": "prettier --write 'src/**/*.{js,ts,tsx,json}'",
     "storybook": "start-storybook -p 9009",
@@ -83,6 +83,7 @@
     "babel-loader": "^8.0.6",
     "handlebars": "4.7.6",
     "husky": ">=3.1.0",
+    "jest-environment-jsdom-sixteen": "^1.0.3",
     "lint-staged": ">=9.4.3",
     "prettier": "^1.19.1",
     "react-testing-library": "^8.0.1",

--- a/console/console-init/ui/src/App.test.tsx
+++ b/console/console-init/ui/src/App.test.tsx
@@ -7,6 +7,14 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { MemoryRouter } from "react-router";
 import App from "./App";
+import { StyleSheetTestUtils } from "aphrodite";
+
+afterEach(() => {
+  return new Promise(resolve => {
+    StyleSheetTestUtils.clearBufferAndResumeStyleInjection();
+    return process.nextTick(resolve);
+  });
+});
 
 it("renders without crashing", () => {
   const div = document.createElement("div");

--- a/console/console-init/ui/src/modules/address-space/containers/AddressSpaceListContainer/AddressSpaceListContainer.test.tsx
+++ b/console/console-init/ui/src/modules/address-space/containers/AddressSpaceListContainer/AddressSpaceListContainer.test.tsx
@@ -5,17 +5,20 @@
 
 import React from "react";
 import ReactDom from "react-dom";
-import { render, cleanup, wait } from "@testing-library/react";
+import { render, cleanup, waitFor } from "@testing-library/react";
 import { MockedProvider } from "@apollo/react-testing";
 import { AddressSpaceListContainer } from "./AddressSpaceListContainer";
 import { RETURN_ALL_ADDRESS_SPACES } from "graphql-module/queries";
+import { MemoryRouter } from "react-router";
 
 afterEach(cleanup);
 
 const setup = (mocks: any, props: any) => {
   return render(
     <MockedProvider mocks={mocks} addTypename={false}>
-      <AddressSpaceListContainer {...props} />
+      <MemoryRouter>
+        <AddressSpaceListContainer {...props} />
+      </MemoryRouter>
     </MockedProvider>
   );
 };
@@ -36,36 +39,34 @@ describe("<AddressSpaceListContainer/>", () => {
     onSelectAllAddressSpace: jest.fn()
   };
 
-  const addressSpaces = {
-    addressSpaces: [
-      {
-        metadata: {
-          namespace: "app1_ns",
-          name: "jupiter_as1",
-          creationTimestamp: "2020-03-29T18:19:15.068Z"
-        },
-        spec: {
-          type: "standard",
-          plan: {
-            metadata: {
-              name: "standard-small"
-            },
-            spec: {
-              displayName: "Small"
-            }
+  const addressSpaces = [
+    {
+      metadata: {
+        namespace: "app1_ns",
+        name: "jupiter_as1",
+        creationTimestamp: "2020-03-29T18:19:15.068Z"
+      },
+      spec: {
+        type: "standard",
+        plan: {
+          metadata: {
+            name: "standard-small"
           },
-          authenticationService: {
-            name: "none-authservice"
+          spec: {
+            displayName: "Small"
           }
         },
-        status: {
-          isReady: true,
-          phase: "Active",
-          messages: []
+        authenticationService: {
+          name: "none-authservice"
         }
+      },
+      status: {
+        isReady: true,
+        phase: "Active",
+        messages: []
       }
-    ]
-  };
+    }
+  ];
 
   it("should render without crashing", () => {
     const div = document.createElement("div");
@@ -81,7 +82,7 @@ describe("<AddressSpaceListContainer/>", () => {
   it("should render loader if loading is true", () => {
     const { container } = setup([], props);
     // expect(container).toHaveTextContent("Loading");
-    wait(() => expect(container).toHaveTextContent("Loading"));
+    waitFor(() => expect(container).toHaveTextContent("Loading"));
   });
 
   it("should not render loader if loading false", async () => {
@@ -98,7 +99,7 @@ describe("<AddressSpaceListContainer/>", () => {
 
     const { container } = setup(mocks, props);
     //wait for response
-    await wait(() => expect(container).not.toHaveTextContent("Loading"));
+    await waitFor(() => expect(container).not.toHaveTextContent("Loading"));
   });
 
   it("should render <AddressSpaceList/> component if loading is false", async () => {
@@ -115,7 +116,7 @@ describe("<AddressSpaceListContainer/>", () => {
     const { container } = setup(mocks, props);
     //wait for response
     //check table headers
-    await wait(() => expect(container).toHaveTextContent("Name"));
+    await waitFor(() => expect(container).toHaveTextContent("Name"));
     expect(container).toHaveTextContent("Namespace");
   });
 
@@ -136,7 +137,7 @@ describe("<AddressSpaceListContainer/>", () => {
       }
     ];
     const { container } = setup(mocks, props);
-    await wait(() =>
+    await waitFor(() =>
       expect(container).toHaveTextContent("Create an address space")
     );
   });
@@ -160,7 +161,7 @@ describe("<AddressSpaceListContainer/>", () => {
 
     const { container } = setup(mocks, props);
     cleanup();
-    await wait(() =>
+    await waitFor(() =>
       expect(container).not.toHaveTextContent("Create an address space")
     );
   });
@@ -189,13 +190,9 @@ describe("<AddressSpaceListContainer/>", () => {
 
     cleanup();
     // await wait(0);
-    await wait(() =>
-      expect(
-        findByText(addressSpaces.addressSpaces[0].metadata.name)
-      ).toBeDefined()
+    await waitFor(() =>
+      expect(findByText(addressSpaces[0].metadata.name)).toBeDefined()
     );
-    expect(
-      findByText(addressSpaces.addressSpaces[0].metadata.namespace)
-    ).toBeDefined();
+    expect(findByText(addressSpaces[0].metadata.namespace)).toBeDefined();
   });
 });

--- a/console/console-init/ui/src/modules/address/containers/AddressListContainer/AddressListContainer.test.tsx
+++ b/console/console-init/ui/src/modules/address/containers/AddressListContainer/AddressListContainer.test.tsx
@@ -6,7 +6,7 @@
 import React from "react";
 import ReactDom from "react-dom";
 import { MemoryRouter } from "react-router";
-import { render, cleanup, wait } from "@testing-library/react";
+import { render, cleanup, waitFor } from "@testing-library/react";
 import { MockedProvider } from "@apollo/react-testing";
 import { AddressListContainer } from "./AddressListContainer";
 import { RETURN_ALL_ADDRESS_FOR_ADDRESS_SPACE } from "graphql-module/queries";
@@ -87,7 +87,7 @@ describe("<AddressListContainer/>", () => {
 
   it("should render loader if loading is true", () => {
     const { container } = setup([], props);
-    wait(() => expect(container).toHaveTextContent("Loading"));
+    waitFor(() => expect(container).toHaveTextContent("Loading"));
   });
 
   it("should not render loader if loading false", async () => {
@@ -113,7 +113,7 @@ describe("<AddressListContainer/>", () => {
 
     const { container } = setup(mocks, props);
     //wait for response
-    await wait(() => expect(container).not.toHaveTextContent("Loading"));
+    await waitFor(() => expect(container).not.toHaveTextContent("Loading"));
   });
 
   it("should render <AddressList/> component if loading is false", async () => {
@@ -140,7 +140,7 @@ describe("<AddressListContainer/>", () => {
     const { container } = setup(mocks, props);
     //wait for response
     //check table headers
-    await wait(() => expect(container).toHaveTextContent("Address"));
+    await waitFor(() => expect(container).toHaveTextContent("Address"));
     expect(container).toHaveTextContent("Status");
   });
 
@@ -166,7 +166,9 @@ describe("<AddressListContainer/>", () => {
     ];
 
     const { container } = setup(mocks, props);
-    await wait(() => expect(container).toHaveTextContent("Create an address"));
+    await waitFor(() =>
+      expect(container).toHaveTextContent("Create an address")
+    );
   });
 
   it("should not render <EmptyAddress/> component if total links is greater than zero (0)", async () => {
@@ -192,7 +194,7 @@ describe("<AddressListContainer/>", () => {
 
     const { container } = setup(mocks, props);
     cleanup();
-    await wait(() =>
+    await waitFor(() =>
       expect(container).not.toHaveTextContent("Create an address")
     );
   });

--- a/console/console-init/ui/src/modules/connection-detail/containers/ConnectionLinksContainer/ConnectionLinksContainer.test.tsx
+++ b/console/console-init/ui/src/modules/connection-detail/containers/ConnectionLinksContainer/ConnectionLinksContainer.test.tsx
@@ -5,7 +5,7 @@
 
 import React from "react";
 import ReactDom from "react-dom";
-import { render, cleanup, wait } from "@testing-library/react";
+import { render, cleanup, waitFor } from "@testing-library/react";
 import { MockedProvider } from "@apollo/react-testing";
 import { ConnectionLinksContainer } from "./ConnectionLinksContainer";
 import { RETURN_CONNECTION_LINKS } from "graphql-module/queries";
@@ -93,7 +93,7 @@ describe("<ConnectionLinksContainer/>", () => {
 
   it("should render loader if loading is true", () => {
     const { container } = setup([], props);
-    wait(() => expect(container).toHaveTextContent("Loading"));
+    waitFor(() => expect(container).toHaveTextContent("Loading"));
   });
 
   it("should not render loader if loading false", async () => {
@@ -120,7 +120,7 @@ describe("<ConnectionLinksContainer/>", () => {
 
     const { container } = setup(mocks, props);
     //wait for response
-    wait(() => expect(container).not.toHaveTextContent("Loading"));
+    waitFor(() => expect(container).not.toHaveTextContent("Loading"));
   });
 
   it("should render <ConnectionLinksList/> component if loading is false", async () => {
@@ -148,7 +148,7 @@ describe("<ConnectionLinksContainer/>", () => {
     const { container, getByText } = setup(mocks, props);
     //wait for response
     //check table headers
-    await wait(() => expect(container).toHaveTextContent("Role"));
+    await waitFor(() => expect(container).toHaveTextContent("Role"));
     expect(container).toHaveTextContent("Name");
     expect(container).toHaveTextContent("Address");
   });
@@ -176,7 +176,7 @@ describe("<ConnectionLinksContainer/>", () => {
     ];
 
     const { container } = setup(mocks, props);
-    await wait(() =>
+    await waitFor(() =>
       expect(container).toHaveTextContent("You currently don't have any links")
     );
   });
@@ -205,7 +205,7 @@ describe("<ConnectionLinksContainer/>", () => {
 
     const { container } = setup(mocks, props);
     cleanup();
-    await wait(() =>
+    await waitFor(() =>
       expect(container).not.toHaveTextContent(
         "You currently don't have any links"
       )

--- a/console/console-init/ui/src/modules/connection/containers/ConnectionContainer/ConnectionContainer.test.tsx
+++ b/console/console-init/ui/src/modules/connection/containers/ConnectionContainer/ConnectionContainer.test.tsx
@@ -5,7 +5,7 @@
 
 import React from "react";
 import ReactDom from "react-dom";
-import { render, cleanup, wait } from "@testing-library/react";
+import { render, cleanup, waitFor } from "@testing-library/react";
 import { MockedProvider } from "@apollo/react-testing";
 import { ConnectionContainer } from "./ConnectionContainer";
 import { RETURN_ALL_CONECTION_LIST } from "graphql-module/queries";
@@ -47,7 +47,7 @@ describe("<ConnectionContainer/>", () => {
 
   it("should render loader if loading is true", () => {
     const { container } = setup([], props);
-    wait(() => expect(container).toHaveTextContent("Loading"));
+    waitFor(() => expect(container).toHaveTextContent("Loading"));
   });
 
   it("should not render loader if loading false", async () => {
@@ -73,7 +73,7 @@ describe("<ConnectionContainer/>", () => {
     const { container } = setup(mocks, props);
     //wait for response
 
-    await wait(() => expect(container).not.toHaveTextContent("Loading"));
+    await waitFor(() => expect(container).not.toHaveTextContent("Loading"));
   });
 
   it("should render <ConnectionList/> component if loading is false", async () => {
@@ -100,7 +100,7 @@ describe("<ConnectionContainer/>", () => {
     //wait for response
 
     //check table headers
-    await wait(() => expect(container).toHaveTextContent("Hostname"));
+    await waitFor(() => expect(container).toHaveTextContent("Hostname"));
     expect(container).toHaveTextContent("Protocol");
   });
 
@@ -126,7 +126,7 @@ describe("<ConnectionContainer/>", () => {
 
     const { container } = setup(mocks, props);
 
-    await wait(() => expect(container).toHaveTextContent("No connections"));
+    await waitFor(() => expect(container).toHaveTextContent("No connections"));
     expect(container).toHaveTextContent(
       "You currently don't have any connections"
     );
@@ -147,7 +147,7 @@ describe("<ConnectionContainer/>", () => {
           )
         },
         result: {
-          data: { connections: { total: 5 } }
+          data: { connections: { total: 5, connections: [] } }
         }
       }
     ];
@@ -155,7 +155,9 @@ describe("<ConnectionContainer/>", () => {
     const { container } = setup(mocks, props);
     cleanup();
 
-    await wait(() => expect(container).not.toHaveTextContent("No connections"));
+    await waitFor(() =>
+      expect(container).not.toHaveTextContent("No connections")
+    );
     expect(container).not.toHaveTextContent(
       "You currently don't have any connections"
     );

--- a/console/console-init/ui/src/modules/iot-project-detail/components/GeneralInfo/GeneralInfo.tsx
+++ b/console/console-init/ui/src/modules/iot-project-detail/components/GeneralInfo/GeneralInfo.tsx
@@ -69,8 +69,8 @@ const GeneralInfo: React.FunctionComponent<IGeneralInfoProps> = ({
           <b className={css(styles.style_margin)}>Events address name</b>
           {eventAddresses &&
             eventAddresses.length > 0 &&
-            eventAddresses.map((address: string) => (
-              <>
+            eventAddresses.map((address: string, index: number) => (
+              <React.Fragment key={`navlink-gi-command-${address}-${index}`}>
                 <Link
                   //TODO:=modify route
                   to={""}
@@ -80,14 +80,14 @@ const GeneralInfo: React.FunctionComponent<IGeneralInfoProps> = ({
                 >
                   {address}
                 </Link>{" "}
-              </>
+              </React.Fragment>
             ))}
           <br />
           <b className={css(styles.style_margin)}>Telemetry address name</b>
           {telemetryAddresses &&
             telemetryAddresses.length > 0 &&
-            telemetryAddresses.map((address: string) => (
-              <>
+            telemetryAddresses.map((address: string, index: number) => (
+              <React.Fragment key={`navlink-gi-command-${address}-${index}`}>
                 <Link
                   //TODO:=modify route
                   to={""}
@@ -97,14 +97,14 @@ const GeneralInfo: React.FunctionComponent<IGeneralInfoProps> = ({
                 >
                   {address}
                 </Link>{" "}
-              </>
+              </React.Fragment>
             ))}
           <br />
           <b className={css(styles.style_margin)}>Command address name</b>
           {commandAddresses &&
             commandAddresses.length > 0 &&
-            commandAddresses.map((address: string) => (
-              <>
+            commandAddresses.map((address: string, index: number) => (
+              <React.Fragment key={`navlink-gi-command-${address}-${index}`}>
                 <Link
                   //TODO:=modify route
                   to={""}
@@ -114,7 +114,7 @@ const GeneralInfo: React.FunctionComponent<IGeneralInfoProps> = ({
                 >
                   {address}
                 </Link>{" "}
-              </>
+              </React.Fragment>
             ))}
           <br />
           <br />

--- a/console/console-init/ui/yarn.lock
+++ b/console/console-init/ui/yarn.lock
@@ -1457,6 +1457,17 @@
     jest-message-util "^24.9.0"
     jest-mock "^24.9.0"
 
+"@jest/fake-timers@^25.1.0":
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-25.5.0.tgz#46352e00533c024c90c2bc2ad9f2959f7f114185"
+  integrity sha512-9y2+uGnESw/oyOI3eww9yaxdZyHq7XvprfP/eeoCsjqKYts2yRlsHS/SgjPDV8FyMfn2nbMy8YzUk6nyvdLOpQ==
+  dependencies:
+    "@jest/types" "^25.5.0"
+    jest-message-util "^25.5.0"
+    jest-mock "^25.5.0"
+    jest-util "^25.5.0"
+    lolex "^5.0.0"
+
 "@jest/reporters@^24.9.0":
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-24.9.0.tgz#86660eff8e2b9661d042a8e98a028b8d631a5b43"
@@ -1711,6 +1722,13 @@
   integrity sha512-kdk4qvNYXOH7mVJCP/URokp5J+1HCR+tT1Zgtp8X9hLywn6WoKlU/tQ2ECB/NPOHrZjp/DGXWeQBAchLXV8q2w==
   dependencies:
     ramda "^0.26.0"
+
+"@sinonjs/commons@^1.7.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.0.tgz#c8d68821a854c555bba172f3b06959a0039b236d"
+  integrity sha512-wEj54PfsZ5jGSwMX68G8ZXFawcSglQSXqCftWX3ec8MDUzQdHgcKvw97awHbY0efQEL5iKUOAmmVtoYgmrSG4Q==
+  dependencies:
+    type-detect "4.0.8"
 
 "@storybook/addon-actions@^5.3.19":
   version "5.3.19"
@@ -2981,7 +2999,7 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-abab@^2.0.0:
+abab@^2.0.0, abab@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.3.tgz#623e2075e02eb2d3f2475e49f99c91846467907a"
   integrity sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==
@@ -3014,6 +3032,14 @@ acorn-globals@^4.1.0, acorn-globals@^4.3.0:
     acorn "^6.0.1"
     acorn-walk "^6.0.1"
 
+acorn-globals@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-6.0.0.tgz#46cdd39f0f8ff08a876619b55f5ac8a6dc770b45"
+  integrity sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==
+  dependencies:
+    acorn "^7.1.1"
+    acorn-walk "^7.1.1"
+
 acorn-jsx@^5.1.0, acorn-jsx@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.2.0.tgz#4c66069173d6fdd68ed85239fc256226182b2ebe"
@@ -3024,7 +3050,7 @@ acorn-walk@^6.0.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.2.0.tgz#123cb8f3b84c2171f1f7fb252615b1c78a6b1a8c"
   integrity sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==
 
-acorn-walk@^7.0.0:
+acorn-walk@^7.0.0, acorn-walk@^7.1.1:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
@@ -5420,10 +5446,15 @@ csso@^4.0.2:
   dependencies:
     css-tree "1.0.0-alpha.39"
 
-cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0", cssom@^0.3.4:
+cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0", cssom@^0.3.4, cssom@~0.3.6:
   version "0.3.8"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.8.tgz#9f1276f5b2b463f2114d3f2c75250af8c1a36f4a"
   integrity sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==
+
+cssom@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.4.4.tgz#5a66cf93d2d0b661d80bf6a44fb65f5c2e4e0a10"
+  integrity sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==
 
 cssstyle@^1.0.0, cssstyle@^1.1.1:
   version "1.4.0"
@@ -5431,6 +5462,13 @@ cssstyle@^1.0.0, cssstyle@^1.1.1:
   integrity sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==
   dependencies:
     cssom "0.3.x"
+
+cssstyle@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-2.3.0.tgz#ff665a0ddbdc31864b09647f34163443d90b0852"
+  integrity sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
+  dependencies:
+    cssom "~0.3.6"
 
 csstype@^2.2.0, csstype@^2.5.7, csstype@^2.6.7:
   version "2.6.10"
@@ -5555,6 +5593,15 @@ data-urls@^1.0.0, data-urls@^1.1.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
+data-urls@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-2.0.0.tgz#156485a72963a970f5d5821aaf642bef2bf2db9b"
+  integrity sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==
+  dependencies:
+    abab "^2.0.3"
+    whatwg-mimetype "^2.3.0"
+    whatwg-url "^8.0.0"
+
 date-fns@^2.14.0:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.14.0.tgz#359a87a265bb34ef2e38f93ecf63ac453f9bc7ba"
@@ -5590,6 +5637,11 @@ decamelize@^1.0.0, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
+
+decimal.js@^10.2.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.2.0.tgz#39466113a9e036111d02f82489b5fd6b0b5ed231"
+  integrity sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw==
 
 decode-uri-component@^0.2.0:
   version "0.2.0"
@@ -5884,6 +5936,13 @@ domexception@^1.0.1:
   integrity sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==
   dependencies:
     webidl-conversions "^4.0.2"
+
+domexception@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/domexception/-/domexception-2.0.1.tgz#fb44aefba793e1574b0af6aed2801d057529f304"
+  integrity sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==
+  dependencies:
+    webidl-conversions "^5.0.0"
 
 domhandler@^2.3.0:
   version "2.4.2"
@@ -6195,6 +6254,18 @@ escodegen@^1.11.0, escodegen@^1.12.0, escodegen@^1.9.1:
   version "1.14.2"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.2.tgz#14ab71bf5026c2aa08173afba22c6f3173284a84"
   integrity sha512-InuOIiKk8wwuOFg6x9BQXbzjrQhtyXh46K9bqVTPzSo2FnyMBaYGBMC6PhQy7yxxil9vIedFBweQBMK74/7o8A==
+  dependencies:
+    esprima "^4.0.1"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    optionator "^0.8.1"
+  optionalDependencies:
+    source-map "~0.6.1"
+
+escodegen@^1.14.1:
+  version "1.14.3"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.3.tgz#4e7b81fba61581dc97582ed78cab7f0e8d63f503"
+  integrity sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==
   dependencies:
     esprima "^4.0.1"
     estraverse "^4.2.0"
@@ -7268,7 +7339,7 @@ good-listener@^1.2.2:
   dependencies:
     delegate "^3.1.2"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.2:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.4:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
@@ -7584,6 +7655,13 @@ html-encoding-sniffer@^1.0.2:
   integrity sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==
   dependencies:
     whatwg-encoding "^1.0.1"
+
+html-encoding-sniffer@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz#42a6dc4fd33f00281176e8b23759ca4e4fa185f3"
+  integrity sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==
+  dependencies:
+    whatwg-encoding "^1.0.5"
 
 html-entities@^1.2.0, html-entities@^1.2.1:
   version "1.3.1"
@@ -8350,6 +8428,11 @@ is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
+is-potential-custom-element-name@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz#0c52e54bcca391bb2c494b21e8626d7336c6e397"
+  integrity sha1-DFLlS8yjkbssSUsh6GJtczbG45c=
+
 is-promise@^2.0.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.2.2.tgz#39ab959ccbf9a774cf079f7b40c7a26f763135f1"
@@ -8654,6 +8737,16 @@ jest-environment-jsdom-fourteen@1.0.1:
     jest-util "^24.0.0"
     jsdom "^14.1.0"
 
+jest-environment-jsdom-sixteen@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom-sixteen/-/jest-environment-jsdom-sixteen-1.0.3.tgz#e222228fac537ef15cca5ad470b19b47d9690165"
+  integrity sha512-CwMqDUUfSl808uGPWXlNA1UFkWFgRmhHvyAjhCmCry6mYq4b/nn80MMN7tglqo5XgrANIs/w+mzINPzbZ4ZZrQ==
+  dependencies:
+    "@jest/fake-timers" "^25.1.0"
+    jest-mock "^25.1.0"
+    jest-util "^25.1.0"
+    jsdom "^16.2.1"
+
 jest-environment-jsdom@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-24.9.0.tgz#4b0806c7fc94f95edb369a69cc2778eec2b7375b"
@@ -8770,12 +8863,33 @@ jest-message-util@^24.9.0:
     slash "^2.0.0"
     stack-utils "^1.0.1"
 
+jest-message-util@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-25.5.0.tgz#ea11d93204cc7ae97456e1d8716251185b8880ea"
+  integrity sha512-ezddz3YCT/LT0SKAmylVyWWIGYoKHOFOFXx3/nA4m794lfVUskMcwhip6vTgdVrOtYdjeQeis2ypzes9mZb4EA==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@jest/types" "^25.5.0"
+    "@types/stack-utils" "^1.0.1"
+    chalk "^3.0.0"
+    graceful-fs "^4.2.4"
+    micromatch "^4.0.2"
+    slash "^3.0.0"
+    stack-utils "^1.0.1"
+
 jest-mock@^24.0.0, jest-mock@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-24.9.0.tgz#c22835541ee379b908673ad51087a2185c13f1c6"
   integrity sha512-3BEYN5WbSq9wd+SyLDES7AHnjH9A/ROBwmz7l2y+ol+NtSFO8DYiEBzoO1CeFc9a8DYy10EO4dDFVv/wN3zl1w==
   dependencies:
     "@jest/types" "^24.9.0"
+
+jest-mock@^25.1.0, jest-mock@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-25.5.0.tgz#a91a54dabd14e37ecd61665d6b6e06360a55387a"
+  integrity sha512-eXWuTV8mKzp/ovHc5+3USJMYsTBhyQ+5A1Mak35dey/RG8GlM4YWVylZuGgVXinaW6tpvk/RSecmF37FKUlpXA==
+  dependencies:
+    "@jest/types" "^25.5.0"
 
 jest-pnp-resolver@^1.2.1:
   version "1.2.1"
@@ -8902,6 +9016,17 @@ jest-util@^24.0.0, jest-util@^24.9.0:
     mkdirp "^0.5.1"
     slash "^2.0.0"
     source-map "^0.6.0"
+
+jest-util@^25.1.0, jest-util@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-25.5.0.tgz#31c63b5d6e901274d264a4fec849230aa3fa35b0"
+  integrity sha512-KVlX+WWg1zUTB9ktvhsg2PXZVdkI1NBevOJSkTKYAyXyH4QSvh+Lay/e/v+bmaFfrkfx43xD8QTfgobzlEXdIA==
+  dependencies:
+    "@jest/types" "^25.5.0"
+    chalk "^3.0.0"
+    graceful-fs "^4.2.4"
+    is-ci "^2.0.0"
+    make-dir "^3.0.0"
 
 jest-validate@^24.9.0:
   version "24.9.0"
@@ -9084,6 +9209,38 @@ jsdom@^14.1.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^7.0.0"
     ws "^6.1.2"
+    xml-name-validator "^3.0.0"
+
+jsdom@^16.2.1:
+  version "16.2.2"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-16.2.2.tgz#76f2f7541646beb46a938f5dc476b88705bedf2b"
+  integrity sha512-pDFQbcYtKBHxRaP55zGXCJWgFHkDAYbKcsXEK/3Icu9nKYZkutUXfLBwbD+09XDutkYSHcgfQLZ0qvpAAm9mvg==
+  dependencies:
+    abab "^2.0.3"
+    acorn "^7.1.1"
+    acorn-globals "^6.0.0"
+    cssom "^0.4.4"
+    cssstyle "^2.2.0"
+    data-urls "^2.0.0"
+    decimal.js "^10.2.0"
+    domexception "^2.0.1"
+    escodegen "^1.14.1"
+    html-encoding-sniffer "^2.0.1"
+    is-potential-custom-element-name "^1.0.0"
+    nwsapi "^2.2.0"
+    parse5 "5.1.1"
+    request "^2.88.2"
+    request-promise-native "^1.0.8"
+    saxes "^5.0.0"
+    symbol-tree "^3.2.4"
+    tough-cookie "^3.0.1"
+    w3c-hr-time "^1.0.2"
+    w3c-xmlserializer "^2.0.0"
+    webidl-conversions "^6.0.0"
+    whatwg-encoding "^1.0.5"
+    whatwg-mimetype "^2.3.0"
+    whatwg-url "^8.0.0"
+    ws "^7.2.3"
     xml-name-validator "^3.0.0"
 
 jsesc@^2.5.1:
@@ -9506,6 +9663,13 @@ loglevel@^1.6.6:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.8.tgz#8a25fb75d092230ecd4457270d80b54e28011171"
   integrity sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA==
 
+lolex@^5.0.0:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-5.1.2.tgz#953694d098ce7c07bc5ed6d0e42bc6c0c6d5a367"
+  integrity sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
+
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
@@ -9556,7 +9720,7 @@ make-dir@^2.0.0, make-dir@^2.1.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
-make-dir@^3.0.2:
+make-dir@^3.0.0, make-dir@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
@@ -10221,7 +10385,7 @@ number-is-nan@^1.0.0:
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
-nwsapi@^2.0.7, nwsapi@^2.1.3:
+nwsapi@^2.0.7, nwsapi@^2.1.3, nwsapi@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.0.tgz#204879a9e3d068ff2a55139c2c772780681a38b7"
   integrity sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==
@@ -10665,7 +10829,7 @@ parse5@5.1.0:
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.0.tgz#c59341c9723f414c452975564c7c00a68d58acd2"
   integrity sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==
 
-parse5@^5.0.0:
+parse5@5.1.1, parse5@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.1.tgz#f68e4e5ba1852ac2cadc00f4555fff6c2abb6178"
   integrity sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==
@@ -12821,7 +12985,7 @@ request-promise-core@1.1.3:
   dependencies:
     lodash "^4.17.15"
 
-request-promise-native@^1.0.5:
+request-promise-native@^1.0.5, request-promise-native@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.8.tgz#a455b960b826e44e2bf8999af64dff2bfe58cb36"
   integrity sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==
@@ -12830,7 +12994,7 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-request@2.88.2, request@^2.87.0, request@^2.88.0:
+request@2.88.2, request@^2.87.0, request@^2.88.0, request@^2.88.2:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
@@ -13119,6 +13283,13 @@ saxes@^3.1.9:
   integrity sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==
   dependencies:
     xmlchars "^2.1.1"
+
+saxes@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/saxes/-/saxes-5.0.1.tgz#eebab953fa3b7608dbe94e5dadb15c888fa6696d"
+  integrity sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==
+  dependencies:
+    xmlchars "^2.2.0"
 
 scheduler@^0.19.1:
   version "0.19.1"
@@ -14039,7 +14210,7 @@ symbol-observable@^1.0.2:
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
-symbol-tree@^3.2.2:
+symbol-tree@^3.2.2, symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
@@ -14316,12 +14487,28 @@ tough-cookie@^2.3.3, tough-cookie@^2.3.4, tough-cookie@^2.5.0, tough-cookie@~2.5
     psl "^1.1.28"
     punycode "^2.1.1"
 
+tough-cookie@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-3.0.1.tgz#9df4f57e739c26930a018184887f4adb7dca73b2"
+  integrity sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==
+  dependencies:
+    ip-regex "^2.1.0"
+    psl "^1.1.28"
+    punycode "^2.1.1"
+
 tr46@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
   integrity sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=
   dependencies:
     punycode "^2.1.0"
+
+tr46@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-2.0.2.tgz#03273586def1595ae08fedb38d7733cee91d2479"
+  integrity sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==
+  dependencies:
+    punycode "^2.1.1"
 
 trim-lines@^1.0.0:
   version "1.1.3"
@@ -14435,6 +14622,11 @@ type-check@~0.3.2:
   integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 type-fest@^0.11.0:
   version "0.11.0"
@@ -15198,7 +15390,7 @@ vue-template-compiler@^2.0.0:
     de-indent "^1.0.2"
     he "^1.1.0"
 
-w3c-hr-time@^1.0.1:
+w3c-hr-time@^1.0.1, w3c-hr-time@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz#0a89cdf5cc15822df9c360543676963e0cc308cd"
   integrity sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==
@@ -15212,6 +15404,13 @@ w3c-xmlserializer@^1.1.2:
   dependencies:
     domexception "^1.0.1"
     webidl-conversions "^4.0.2"
+    xml-name-validator "^3.0.0"
+
+w3c-xmlserializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz#3e7104a05b75146cc60f564380b7f683acf1020a"
+  integrity sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==
+  dependencies:
     xml-name-validator "^3.0.0"
 
 walker@^1.0.7, walker@~1.0.5:
@@ -15262,6 +15461,16 @@ webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
+
+webidl-conversions@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"
+  integrity sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==
+
+webidl-conversions@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"
+  integrity sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
 
 webpack-dev-middleware@^3.7.0, webpack-dev-middleware@^3.7.2:
   version "3.7.2"
@@ -15462,6 +15671,15 @@ whatwg-url@^7.0.0:
     lodash.sortby "^4.7.0"
     tr46 "^1.0.1"
     webidl-conversions "^4.0.2"
+
+whatwg-url@^8.0.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-8.1.0.tgz#c628acdcf45b82274ce7281ee31dd3c839791771"
+  integrity sha512-vEIkwNi9Hqt4TV9RdnaBPNt+E2Sgmo3gePebCRgZ1R7g6d23+53zCTnuB0amKI4AXq6VM8jj2DUAa0S1vjJxkw==
+  dependencies:
+    lodash.sortby "^4.7.0"
+    tr46 "^2.0.2"
+    webidl-conversions "^5.0.0"
 
 which-module@^2.0.0:
   version "2.0.0"
@@ -15753,12 +15971,17 @@ ws@^6.1.2, ws@^6.2.1:
   dependencies:
     async-limiter "~1.0.0"
 
+ws@^7.2.3:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.3.0.tgz#4b2f7f219b3d3737bc1a2fbf145d825b94d38ffd"
+  integrity sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==
+
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
-xmlchars@^2.1.1:
+xmlchars@^2.1.1, xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==


### PR DESCRIPTION
### Type of change

- Enhancement
- Bugfix

### Description

The UI unit tests were failing because of the arphodite dependency and since react-scripts have not been updated latest versions of react-script.

The following github threads have been referred to fix it:

https://github.com/testing-library/dom-testing-library/releases/tag/v7.0.0
https://github.com/Khan/aphrodite/issues/62

Note: the jest-environment-jsdom-sixteen dependency has to be removed when react-scripts updates to the latest version of Jest.

### Checklist

- [ ] Update/write design documentation in `./documentation/design`
- [x] Write tests and make sure they pass
- [ ] Resolve all warnings
- [ ] Update license
- [ ] Write test cases for null checks in Unit Tests
- [ ] Reference relevant issue(s) and close them after merging