### PR TITLE
Bump Jackson 2.10.0 -> 2.10.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,10 +50,10 @@
         <lucene.version>7.7.1</lucene.version>
         <hibernate.validator.version>6.0.18.Final</hibernate.validator.version>
         <jackson-annotations.version>2.10.0</jackson-annotations.version>
-        <jackson-core.version>2.10.0</jackson-core.version>
-        <jackson-databind.version>2.10.0</jackson-databind.version>
-        <jackson-module-jsonSchema.version>2.10.0</jackson-module-jsonSchema.version>
-        <jackson-module-jaxb-annotations.version>2.10.0</jackson-module-jaxb-annotations.version>
+        <jackson-core.version>2.10.4</jackson-core.version>
+        <jackson-databind.version>2.10.4</jackson-databind.version>
+        <jackson-module-jsonSchema.version>2.10.4</jackson-module-jsonSchema.version>
+        <jackson-module-jaxb-annotations.version>2.10.4</jackson-module-jaxb-annotations.version>
         <javax.validation.version>2.0.1.Final</javax.validation.version>
         <jboss.el.api.version>1.0.13.Final</jboss.el.api.version>
         <json-patch.version>1.9</json-patch.version>


### PR DESCRIPTION
### Type of change


- Bugfix

### Description

Bump Jackson libraries from 2.10.0 -> 2.10.4 to take the latest defect fixes on the 2.10 line.


### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
