### PR TITLE
Add Maven Dependency override for jackson-jaxrs-json-provider.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
         <jackson-databind.version>2.10.0</jackson-databind.version>
         <jackson-module-jsonSchema.version>2.10.0</jackson-module-jsonSchema.version>
         <jackson-module-jaxb-annotations.version>2.10.0</jackson-module-jaxb-annotations.version>
+        <jackson-jaxrs-json-provider.version>2.10.0</jackson-jaxrs-json-provider.version>     
         <javax.validation.version>2.0.1.Final</javax.validation.version>
         <jboss.el.api.version>1.0.13.Final</jboss.el.api.version>
         <json-patch.version>1.9</json-patch.version>
@@ -504,6 +505,11 @@
                 <groupId>com.fasterxml.jackson.module</groupId>
                 <artifactId>jackson-module-jaxb-annotations</artifactId>
                 <version>${jackson-module-jaxb-annotations.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                <artifactId>jackson-jaxrs-json-provider</artifactId>
+                <version>${jackson-jaxrs-json-provider.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION

### Type of change


- Refactoring

### Description

Add Maven Dependency override for jackson-jaxrs-json-provider.version.  We already control most Jackson dependencies, this one was absent.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
