### PR TITLE
[Shared infra] Add support for brokered queues and topics

### DIFF
--- a/api-model/src/main/resources/schema/kube-schema.json
+++ b/api-model/src/main/resources/schema/kube-schema.json
@@ -1135,6 +1135,15 @@
       "type": "object",
       "description": "",
       "properties": {
+        "capabilities": {
+          "type": "array",
+          "description": "",
+          "javaOmitEmpty": true,
+          "items": {
+            "type": "string",
+            "description": ""
+          }
+        },
         "messagingInfrastructureRef": {
           "$ref": "#/definitions/github_com_enmasseproject_enmasse_pkg_apis_enmasse_v1beta2_MessagingInfrastructureReference",
           "javaType": "MessagingInfrastructureReference"
@@ -1150,6 +1159,19 @@
       "type": "object",
       "description": "",
       "properties": {
+        "broker": {
+          "$ref": "#/definitions/github_com_enmasseproject_enmasse_pkg_apis_enmasse_v1beta2_MessagingAddressBroker",
+          "javaType": "MessagingAddressBroker"
+        },
+        "capabilities": {
+          "type": "array",
+          "description": "",
+          "javaOmitEmpty": true,
+          "items": {
+            "type": "string",
+            "description": ""
+          }
+        },
         "conditions": {
           "type": "array",
           "description": "",

--- a/broker-plugin/plugin/src/main/resources/shared/broker.xml
+++ b/broker-plugin/plugin/src/main/resources/shared/broker.xml
@@ -85,7 +85,7 @@ under the License.
             <permission type="deleteNonDurableQueue" roles="manage,router"/>
             <permission type="createDurableQueue" roles="manage"/>
             <permission type="deleteDurableQueue" roles="manage"/>
-            <permission type="createAddress" roles="manage"/>
+            <permission type="createAddress" roles="manage,router"/>
             <permission type="deleteAddress" roles="manage"/>
             <permission type="consume" roles="manage,router"/>
             <permission type="browse" roles="manage"/>

--- a/pkg/apis/enmasse/v1beta2/types_common.go
+++ b/pkg/apis/enmasse/v1beta2/types_common.go
@@ -22,6 +22,12 @@ type NamespaceSelector struct {
 	MatchNames []string `json:"matchNames,omitempty"`
 }
 
+type MessagingCapability string
+
+const (
+	MessagingCapabilityTransactional MessagingCapability = "transactional"
+)
+
 type MessagingInfrastructureReference struct {
 	// Name of referenced MessagingInfra.
 	Name string `json:"name"`

--- a/pkg/apis/enmasse/v1beta2/types_endpoint.go
+++ b/pkg/apis/enmasse/v1beta2/types_endpoint.go
@@ -26,7 +26,7 @@ import (
 // +kubebuilder:printcolumn:name="Host",type="string",JSONPath=".status.host",description="The hostname."
 // +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.message",priority=1,description="Message describing the reason for the current Phase."
 // +kubebuilder:printcolumn:name="Protocols",type="string",JSONPath=".spec.protocols",priority=1,description="Supported protocols."
-// +kubebuilder:printcolumn:name="CertficateExpiry",type="string",JSONPath=".status.tls.certificateInfo.notAfter",priority=1,description="Certificate expiry."
+// +kubebuilder:printcolumn:name="CertficateExpiry",type="string",JSONPath=".status.tls.certificateValidity.notAfter",priority=1,description="Certificate expiry."
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type MessagingEndpoint struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/enmasse/v1beta2/types_tenant.go
+++ b/pkg/apis/enmasse/v1beta2/types_tenant.go
@@ -32,6 +32,8 @@ type MessagingTenant struct {
 type MessagingTenantSpec struct {
 	// Reference to a specific MessagingInfra to use (must be available for this tenant).
 	MessagingInfrastructureRef *MessagingInfrastructureReference `json:"messagingInfrastructureRef,omitempty"`
+	// The desired capabilities common to all addresses for this tenant.
+	Capabilities []MessagingCapability `json:"capabilities,omitempty"`
 }
 
 type MessagingTenantStatus struct {
@@ -41,6 +43,10 @@ type MessagingTenantStatus struct {
 	// MessagingInfra this tenant is bound to.
 	MessagingInfrastructureRef MessagingInfrastructureReference `json:"messagingInfrastructureRef,omitempty"`
 	Conditions                 []MessagingTenantCondition       `json:"conditions,omitempty"`
+	// The actual capabilities common to all addresses for this tenant.
+	Capabilities []MessagingCapability `json:"capabilities,omitempty"`
+	// For transactional tenants, the broker addresses should be scheduled todo
+	Broker *MessagingAddressBroker `json:"broker,omitempty"`
 }
 
 type MessagingTenantCondition struct {
@@ -56,6 +62,8 @@ type MessagingTenantConditionType string
 const (
 	MessagingTenantBound     MessagingTenantConditionType = "Bound"
 	MessagingTenantCaCreated MessagingTenantConditionType = "CaCreated"
+	MessagingTenantScheduled MessagingTenantConditionType = "Scheduled"
+	MessagingTenantCreated   MessagingTenantConditionType = "Created"
 	MessagingTenantReady     MessagingTenantConditionType = "Ready"
 )
 

--- a/pkg/apis/enmasse/v1beta2/zz_generated.deepcopy.go
+++ b/pkg/apis/enmasse/v1beta2/zz_generated.deepcopy.go
@@ -1116,6 +1116,11 @@ func (in *MessagingTenantSpec) DeepCopyInto(out *MessagingTenantSpec) {
 		*out = new(MessagingInfrastructureReference)
 		**out = **in
 	}
+	if in.Capabilities != nil {
+		in, out := &in.Capabilities, &out.Capabilities
+		*out = make([]MessagingCapability, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 
@@ -1139,6 +1144,16 @@ func (in *MessagingTenantStatus) DeepCopyInto(out *MessagingTenantStatus) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.Capabilities != nil {
+		in, out := &in.Capabilities, &out.Capabilities
+		*out = make([]MessagingCapability, len(*in))
+		copy(*out, *in)
+	}
+	if in.Broker != nil {
+		in, out := &in.Broker, &out.Broker
+		*out = new(MessagingAddressBroker)
+		**out = **in
 	}
 	return
 }

--- a/pkg/controller/iotconfig/auth.go
+++ b/pkg/controller/iotconfig/auth.go
@@ -90,7 +90,7 @@ func (r *ReconcileIoTConfig) processAdapterInfraCert(ctx context.Context, config
 
 	// for all adapters
 
-	infra, err := messaginginfra.LookupInfra(ctx, r.client, config.Namespace)
+	_, infra, err := messaginginfra.LookupInfra(ctx, r.client, config.Namespace)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/messagingendpoint/messagingendpoint_controller.go
+++ b/pkg/controller/messagingendpoint/messagingendpoint_controller.go
@@ -180,7 +180,7 @@ func (r *ReconcileMessagingEndpoint) Reconcile(request reconcile.Request) (recon
 	// Retrieve the MessagingInfra for this MessagingEndpoint
 	var infra *v1beta2.MessagingInfrastructure
 	result, err = rc.Process(func(endpoint *v1beta2.MessagingEndpoint) (processorResult, error) {
-		i, err := messaginginfra.LookupInfra(ctx, r.client, found.Namespace)
+		_, i, err := messaginginfra.LookupInfra(ctx, r.client, found.Namespace)
 		if err != nil && (k8errors.IsNotFound(err) || utilerrors.IsNotBound(err)) {
 			endpoint.Status.GetMessagingEndpointCondition(v1beta2.MessagingEndpointFoundTenant).SetStatus(corev1.ConditionFalse, "", err.Error())
 			endpoint.Status.Message = err.Error()
@@ -330,7 +330,7 @@ func (r *ReconcileMessagingEndpoint) reconcileFinalizer(ctx context.Context, log
 					return reconcile.Result{}, fmt.Errorf("provided wrong object type to finalizer, only supports MessagingEndpoint")
 				}
 
-				infra, err := messaginginfra.LookupInfra(ctx, r.client, endpoint.Namespace)
+				_, infra, err := messaginginfra.LookupInfra(ctx, r.client, endpoint.Namespace)
 				if err != nil {
 					// Not bound - allow dropping finalizer
 					if utilerrors.IsNotBound(err) || utilerrors.IsNotFound(err) {

--- a/pkg/state/errors/errors.go
+++ b/pkg/state/errors/errors.go
@@ -9,6 +9,8 @@ import (
 )
 
 var (
+	BrokerInUseError    error = fmt.Errorf("broker in use")
+	NotTenantError      error = fmt.Errorf("not tenant found")
 	NotInitializedError error = fmt.Errorf("not initialized")
 	NotSyncedError      error = fmt.Errorf("not synchronized")
 	NoEndpointsError    error = fmt.Errorf("no endpoints")

--- a/pkg/state/errors/errors.go
+++ b/pkg/state/errors/errors.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	BrokerInUseError    error = fmt.Errorf("broker in use")
-	NotTenantError      error = fmt.Errorf("not tenant found")
+	TenantNotFoundError error = fmt.Errorf("tenant not found")
 	NotInitializedError error = fmt.Errorf("not initialized")
 	NotSyncedError      error = fmt.Errorf("not synchronized")
 	NoEndpointsError    error = fmt.Errorf("no endpoints")

--- a/pkg/state/infra.go
+++ b/pkg/state/infra.go
@@ -530,7 +530,7 @@ func (i *infraClient) ScheduleAddress(address *v1beta2.MessagingAddress) error {
 
 	tenant, ok := i.tenants[resourceKey{Name: "default", Namespace: address.GetNamespace()}]
 	if !ok {
-		return NotTenantError
+		return TenantNotFoundError
 	}
 
 	brokers := make([]*BrokerState, 0)

--- a/pkg/state/infra_test.go
+++ b/pkg/state/infra_test.go
@@ -57,14 +57,14 @@ func TestUpdateBrokers(t *testing.T) {
 	}, &testClock{})
 	assert.NotNil(t, i)
 
-	err := i.updateBrokers(context.TODO(), []Host{{Hostname: "b1.example.com", Ip: "10.0.0.1"}, {Hostname: "b2.example.com", Ip: "10.0.0.2"}})
+	err := i.updateBrokers(context.TODO(), []Host{{Hostname: "b1.example.com", Ip: "10.0.0.1"}, {Hostname: "b2.example.com", Ip: "10.0.0.2"}}, true)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(i.brokers))
 	assert.Equal(t, 2, len(i.hostMap))
 	assertBroker(t, i, "b1.example.com", "10.0.0.1")
 	assertBroker(t, i, "b2.example.com", "10.0.0.2")
 
-	err = i.updateBrokers(context.TODO(), []Host{{Hostname: "b1.example.com", Ip: "10.0.0.3"}, {Hostname: "b2.example.com", Ip: "10.0.0.2"}})
+	err = i.updateBrokers(context.TODO(), []Host{{Hostname: "b1.example.com", Ip: "10.0.0.3"}, {Hostname: "b2.example.com", Ip: "10.0.0.2"}}, true)
 	assert.Nil(t, err)
 	assertBroker(t, i, "b1.example.com", "10.0.0.3")
 	assertBroker(t, i, "b2.example.com", "10.0.0.2")

--- a/pkg/state/scheduler/dummy.go
+++ b/pkg/state/scheduler/dummy.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package scheduler
+
+import (
+	"fmt"
+
+	"github.com/enmasseproject/enmasse/pkg/apis/enmasse/v1beta2"
+	"github.com/enmasseproject/enmasse/pkg/state/broker"
+)
+
+/*
+ * Very dumb scheduler that doesn't look at broker capacity.
+ */
+type dummyScheduler struct {
+}
+
+var _ Scheduler = &dummyScheduler{}
+
+func NewDummyScheduler() Scheduler {
+	return &dummyScheduler{}
+}
+
+func (s *dummyScheduler) ScheduleTenant(tenant *v1beta2.MessagingTenant, brokers []*broker.BrokerState) error {
+	if len(brokers) > 0 {
+		broker := brokers[0]
+		tenant.Status.Broker = &v1beta2.MessagingAddressBroker{
+			State: v1beta2.MessagingAddressBrokerScheduled,
+			Host:  broker.Host().Hostname,
+		}
+	} else {
+		return fmt.Errorf("no brokers available")
+	}
+	return nil
+}
+
+func (s *dummyScheduler) ScheduleAddress(address *v1beta2.MessagingAddress, brokers []*broker.BrokerState) error {
+	if len(brokers) > 0 {
+		broker := brokers[0]
+		address.Status.Brokers = append(address.Status.Brokers, v1beta2.MessagingAddressBroker{
+			State: v1beta2.MessagingAddressBrokerScheduled,
+			Host:  broker.Host().Hostname,
+		})
+	} else {
+		return fmt.Errorf("no brokers available")
+	}
+	return nil
+}

--- a/pkg/state/scheduler/scheduler.go
+++ b/pkg/state/scheduler/scheduler.go
@@ -3,7 +3,7 @@
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 
-package state
+package scheduler
 
 import (
 	v1beta2 "github.com/enmasseproject/enmasse/pkg/apis/enmasse/v1beta2"
@@ -11,5 +11,8 @@ import (
 )
 
 type Scheduler interface {
+	// Schedule an address to a broker. The implication is that all addresses will be configured on the same broker.
+	ScheduleTenant(tenant *v1beta2.MessagingTenant, brokers []*broker.BrokerState) error
+	// Schedule an address to a broker.
 	ScheduleAddress(address *v1beta2.MessagingAddress, brokers []*broker.BrokerState) error
 }

--- a/pkg/state/test/fakeinfra.go
+++ b/pkg/state/test/fakeinfra.go
@@ -52,6 +52,10 @@ func (m *FakeManager) DeleteClient(infra *v1beta2.MessagingInfrastructure) error
 func (i *FakeClient) Start() {
 }
 
+func (i *FakeClient) DeleteBroker(host string) error {
+	return nil
+}
+
 func (i *FakeClient) SyncAll(routers []Host, brokers []Host, tlsConfig *tls.Config) ([]state.ConnectorStatus, error) {
 	i.Routers = routers
 	i.Brokers = brokers
@@ -73,7 +77,11 @@ func (i *FakeClient) DeleteEndpoint(endpoint *v1beta2.MessagingEndpoint) error {
 	return nil
 }
 
-func (i *FakeClient) ScheduleAddress(address *v1beta2.MessagingAddress, scheduler state.Scheduler) error {
+func (i *FakeClient) ScheduleTenant(tenant *v1beta2.MessagingTenant) error {
+	return nil
+}
+
+func (i *FakeClient) ScheduleAddress(address *v1beta2.MessagingAddress) error {
 	return nil
 }
 
@@ -82,6 +90,14 @@ func (i *FakeClient) SyncAddress(address *v1beta2.MessagingAddress) error {
 }
 
 func (i *FakeClient) DeleteAddress(address *v1beta2.MessagingAddress) error {
+	return nil
+}
+
+func (i *FakeClient) SyncTenant(tenant *v1beta2.MessagingTenant) error {
+	return nil
+}
+
+func (i *FakeClient) DeleteTenant(tenant *v1beta2.MessagingTenant) error {
 	return nil
 }
 

--- a/pkg/state/types.go
+++ b/pkg/state/types.go
@@ -35,12 +35,20 @@ type InfraClient interface {
 	SyncAll(routers []common.Host, brokers []common.Host, tlsConfig *tls.Config) ([]ConnectorStatus, error)
 	// Stop and cleanup client resources
 	Shutdown() error
+	// Check if broker is in use by any address or tenant and delete it
+	DeleteBroker(host string) error
+	// Schedule tenant
+	ScheduleTenant(tenant *v1beta2.MessagingTenant) error
 	// Schedule durable address for tenant
-	ScheduleAddress(address *v1beta2.MessagingAddress, scheduler Scheduler) error
+	ScheduleAddress(address *v1beta2.MessagingAddress) error
 	// Synchronize address
 	SyncAddress(address *v1beta2.MessagingAddress) error
 	// Delete address
 	DeleteAddress(address *v1beta2.MessagingAddress) error
+	// Synchronize tenant
+	SyncTenant(tenant *v1beta2.MessagingTenant) error
+	// Delete tenant
+	DeleteTenant(tenant *v1beta2.MessagingTenant) error
 	// Allocate endpoint ports
 	AllocatePorts(endpoint *v1beta2.MessagingEndpoint, protocols []v1beta2.MessagingEndpointProtocol) error
 	// Free endpoint ports

--- a/systemtests/src/main/java/io/enmasse/systemtest/Environment.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/Environment.java
@@ -65,6 +65,7 @@ public class Environment {
     private static final String OCP4_EXTERNAL_IMAGE_REGISTRY = "OCP4_EXTERNAL_IMAGE_REGISTRY";
     private static final String OCP4_INTERNAL_IMAGE_REGISTRY = "OCP4_INTERNAL_IMAGE_REGISTRY";
     private static final String OVERRIDE_CLUSTER_TYPE = "OVERRIDE_CLUSTER_TYPE";
+    private static final String IMAGE_PULL_POLICY = "IMAGE_PULL_POLICY";
 
     //Config paths
     private static final String scaleConfig = System.getenv().getOrDefault(SCALE_CONFIG, Paths.get(System.getProperty("user.dir"), "scale-config.json").toAbsolutePath().toString());
@@ -100,6 +101,7 @@ public class Environment {
     private final String templatesPath = getOrDefault(jsonEnv, TEMPLATES_PATH, Paths.get(System.getProperty("user.dir"), "..", "templates", "build", "enmasse-latest").toString());
     private final String clusterExternalImageRegistry = getOrDefault(jsonEnv, OCP4_EXTERNAL_IMAGE_REGISTRY, "");
     private final String clusterInternalImageRegistry = getOrDefault(jsonEnv, OCP4_INTERNAL_IMAGE_REGISTRY, "");
+    private final String imagePullPolicy = getOrDefault(jsonEnv, IMAGE_PULL_POLICY, "Always");
 
     //Default values
     private final UserCredentials managementCredentials = new UserCredentials("artemis-admin", "artemis-admin");
@@ -323,6 +325,10 @@ public class Environment {
 
     public String getOverrideClusterType() {
         return overrideClusterType;
+    }
+
+    public String getImagePullPolicy() {
+        return imagePullPolicy;
     }
 
     private String getOrDefault(JsonNode jsonConfig, String varName, String defaultValue) {

--- a/systemtests/src/main/java/io/enmasse/systemtest/logs/GlobalLogCollector.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/logs/GlobalLogCollector.java
@@ -338,10 +338,12 @@ public class GlobalLogCollector {
             }
 
             //resource specific logs
-            Files.writeString(path.resolve("describe_addressspaces.txt"), KubeCMDClient.runOnClusterWithoutLogger("describe", "addressspaces", "--all-namespaces").getStdOut());
-            Files.writeString(path.resolve("describe_addresses.txt"), KubeCMDClient.runOnClusterWithoutLogger("describe", "addresses", "--all-namespaces").getStdOut());
-            Files.writeString(path.resolve("addressspaces.yml"), KubeCMDClient.runOnClusterWithoutLogger("get", "addressspaces", "-o", "yaml", "--all-namespaces").getStdOut());
-            Files.writeString(path.resolve("addresses.yml"), KubeCMDClient.runOnClusterWithoutLogger("get", "addresses", "-o", "yaml", "--all-namespaces").getStdOut());
+            Files.writeString(path.resolve("describe_tenants.txt"), KubeCMDClient.runOnClusterWithoutLogger("describe", "messagingtenants", "--all-namespaces").getStdOut());
+            Files.writeString(path.resolve("describe_addresses.txt"), KubeCMDClient.runOnClusterWithoutLogger("describe", "messagingaddresses", "--all-namespaces").getStdOut());
+            Files.writeString(path.resolve("describe_endpoints.txt"), KubeCMDClient.runOnClusterWithoutLogger("describe", "messagingendpoints", "--all-namespaces").getStdOut());
+            Files.writeString(path.resolve("tenants.yml"), KubeCMDClient.runOnClusterWithoutLogger("get", "messagingtenants", "-o", "yaml", "--all-namespaces").getStdOut());
+            Files.writeString(path.resolve("addresses.yml"), KubeCMDClient.runOnClusterWithoutLogger("get", "messagingaddresses", "-o", "yaml", "--all-namespaces").getStdOut());
+            Files.writeString(path.resolve("endpoints.yml"), KubeCMDClient.runOnClusterWithoutLogger("get", "messagingendpoints", "-o", "yaml", "--all-namespaces").getStdOut());
             Files.writeString(path.resolve("catalogsources.yml"), KubeCMDClient.runOnClusterWithoutLogger("get", "catalogsources", "-o", "yaml", "--all-namespaces").getStdOut());
             Files.writeString(path.resolve("csvs.yml"), KubeCMDClient.runOnClusterWithoutLogger("get", "csvs", "-o", "yaml", "--all-namespaces").getStdOut());
             Files.writeString(path.resolve("users.yml"), KubeCMDClient.runOnClusterWithoutLogger("get", "messaginguser", "-o", "yaml", "--all-namespaces").getStdOut());

--- a/systemtests/src/main/java/io/enmasse/systemtest/logs/GlobalLogCollector.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/logs/GlobalLogCollector.java
@@ -341,9 +341,11 @@ public class GlobalLogCollector {
             Files.writeString(path.resolve("describe_tenants.txt"), KubeCMDClient.runOnClusterWithoutLogger("describe", "messagingtenants", "--all-namespaces").getStdOut());
             Files.writeString(path.resolve("describe_addresses.txt"), KubeCMDClient.runOnClusterWithoutLogger("describe", "messagingaddresses", "--all-namespaces").getStdOut());
             Files.writeString(path.resolve("describe_endpoints.txt"), KubeCMDClient.runOnClusterWithoutLogger("describe", "messagingendpoints", "--all-namespaces").getStdOut());
+            Files.writeString(path.resolve("describe_messaginginfras.txt"), KubeCMDClient.runOnClusterWithoutLogger("describe", "messaginginfrastructures", "--all-namespaces").getStdOut());
             Files.writeString(path.resolve("tenants.yml"), KubeCMDClient.runOnClusterWithoutLogger("get", "messagingtenants", "-o", "yaml", "--all-namespaces").getStdOut());
             Files.writeString(path.resolve("addresses.yml"), KubeCMDClient.runOnClusterWithoutLogger("get", "messagingaddresses", "-o", "yaml", "--all-namespaces").getStdOut());
             Files.writeString(path.resolve("endpoints.yml"), KubeCMDClient.runOnClusterWithoutLogger("get", "messagingendpoints", "-o", "yaml", "--all-namespaces").getStdOut());
+            Files.writeString(path.resolve("messaginginfras.yml"), KubeCMDClient.runOnClusterWithoutLogger("get", "messaginginfrastructures", "-o", "yaml", "--all-namespaces").getStdOut());
             Files.writeString(path.resolve("catalogsources.yml"), KubeCMDClient.runOnClusterWithoutLogger("get", "catalogsources", "-o", "yaml", "--all-namespaces").getStdOut());
             Files.writeString(path.resolve("csvs.yml"), KubeCMDClient.runOnClusterWithoutLogger("get", "csvs", "-o", "yaml", "--all-namespaces").getStdOut());
             Files.writeString(path.resolve("users.yml"), KubeCMDClient.runOnClusterWithoutLogger("get", "messaginguser", "-o", "yaml", "--all-namespaces").getStdOut());

--- a/systemtests/src/main/java/io/enmasse/systemtest/messaginginfra/resources/MessagingEndpointResourceType.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/messaginginfra/resources/MessagingEndpointResourceType.java
@@ -71,4 +71,10 @@ public class MessagingEndpointResourceType implements ResourceType<MessagingEndp
         }
         return null;
     }
+
+    public static int getPort(String protocol, MessagingEndpoint endpoint) {
+        return endpoint.getStatus().getPorts().stream()
+                .filter(p -> p.getProtocol().equals(protocol))
+                .findAny().orElseThrow().getPort();
+    }
 }

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/GenericKubernetes.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/GenericKubernetes.java
@@ -72,11 +72,6 @@ public class GenericKubernetes extends Kubernetes {
     }
 
     @Override
-    public String getHost() {
-        return getNodeHost();
-    }
-
-    @Override
     public String getOlmNamespace() {
         return OLM_NAMESPACE;
     }

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/Kubernetes.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/Kubernetes.java
@@ -35,6 +35,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import io.enmasse.api.model.MessagingEndpoint;
 import io.enmasse.systemtest.platform.cluster.KubernetesCluster;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapList;
@@ -187,13 +188,6 @@ public abstract class Kubernetes {
     public abstract void deleteExternalEndpoint(String namespace, String name);
 
     public abstract String getOlmNamespace();
-
-    /**
-     * Retrieve host or ip address of Kubernetes node.
-     */
-    public String getHost() {
-        return "localhost";
-    }
 
     public List<Route> listRoutes(String namespace, Map<String, String> labels) {
         throw new UnsupportedOperationException();
@@ -1245,7 +1239,10 @@ public abstract class Kubernetes {
     /**
      * Return the external IP for the first node found in the cluster.
      */
-    public String getNodeHost() {
+    public String getHost() {
+        if (isCRC()) {
+            return "api.crc.testing";
+        }
         List<NodeAddress> addresses = client.nodes().list().getItems().stream()
                 .peek(n -> CustomLogger.getLogger().info("Found node: {}", n))
                 .flatMap(n -> n.getStatus().getAddresses().stream()

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/OpenShift.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/OpenShift.java
@@ -161,15 +161,6 @@ public class OpenShift extends Kubernetes {
     }
 
     @Override
-    public String getHost() {
-        if (isCRC()) {
-            return "api.crc.testing";
-        } else {
-            throw new UnsupportedOperationException();
-        }
-    }
-
-    @Override
     public List<Route> listRoutes(String namespace, Map<String, String> labels) {
         return client.adapt(OpenShiftClient.class).routes().inNamespace(namespace).withLabels(labels).list().getItems();
     }

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/apps/SystemtestsKubernetesApps.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/apps/SystemtestsKubernetesApps.java
@@ -216,7 +216,7 @@ public class SystemtestsKubernetesApps {
     public static String deployMessagingClientApp() throws Exception {
         kube.createNamespace(MESSAGING_PROJECT);
         kube.createDeploymentFromResource(MESSAGING_PROJECT, getMessagingAppDeploymentResource());
-        TestUtils.waitForExpectedReadyPods(kube, MESSAGING_PROJECT, 1, new TimeoutBudget(1, TimeUnit.MINUTES));
+        TestUtils.waitForExpectedReadyPods(kube, MESSAGING_PROJECT, 1, new TimeoutBudget(5, TimeUnit.MINUTES));
         return getMessagingAppPodName();
     }
 
@@ -1051,6 +1051,7 @@ public class SystemtestsKubernetesApps {
                 .addNewContainer()
                 .withName(MESSAGING_CLIENTS)
                 .withImage("quay.io/enmasse/systemtests-clients:latest")
+                .withImagePullPolicy(env.getImagePullPolicy())
                 .withCommand("sleep")
                 .withArgs("infinity")
                 .withEnv(new EnvVarBuilder().withName("PN_TRACE_FRM").withValue("true").build())

--- a/systemtests/src/main/java/io/enmasse/systemtest/utils/JmsProvider.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/utils/JmsProvider.java
@@ -27,7 +27,6 @@ import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.LinkedList;
 import java.util.List;
@@ -68,12 +67,10 @@ public class JmsProvider {
             identification = "topic.";
         }
 
-        return new HashMap<>() {{
-            put(identification + getAddress(destination), getAddress(destination));
-        }};
+        return Map.of(identification + getAddress(destination), getAddress(destination));
     }
 
-    private HashMap<String, String> createAddressMap(Address destination) {
+    private Map<String, String> createAddressMap(Address destination) {
         String identification;
         if (destination.getSpec().getType().equals(AddressType.QUEUE.toString())) {
             identification = "queue.";
@@ -81,9 +78,7 @@ public class JmsProvider {
             identification = "topic.";
         }
 
-        return new HashMap<String, String>() {{
-            put(identification + destination.getSpec().getAddress(), destination.getSpec().getAddress());
-        }};
+        return Map.of(identification + destination.getSpec().getAddress(), destination.getSpec().getAddress());
     }
 
     public Context createContext(String host, int port, boolean tls, String username, String password, String clientID, MessagingAddress address) throws NamingException {

--- a/systemtests/src/main/java/io/enmasse/systemtest/utils/JmsProvider.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/utils/JmsProvider.java
@@ -60,7 +60,7 @@ public class JmsProvider {
         return address.getMetadata().getName();
     }
 
-    private HashMap<String, String> createAddressMap(MessagingAddress destination) {
+    private Map<String, String> createAddressMap(MessagingAddress destination) {
         String identification;
         if (destination.getSpec().getQueue() != null) {
             identification = "queue.";

--- a/systemtests/src/test/java/io/enmasse/systemtest/sharedinfra/MessagingAddressJMSTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/sharedinfra/MessagingAddressJMSTest.java
@@ -17,11 +17,22 @@ import io.enmasse.systemtest.messaginginfra.resources.MessagingEndpointResourceT
 import io.enmasse.systemtest.resolvers.JmsProviderParameterResolver;
 import io.enmasse.systemtest.utils.JmsProvider;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 
-import javax.jms.*;
+import javax.jms.Connection;
+import javax.jms.DeliveryMode;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageListener;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.Topic;
 import javax.naming.Context;
 import javax.naming.NamingException;
 import java.util.ArrayList;
@@ -32,7 +43,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @DefaultMessagingInfrastructure
 @ExtendWith(JmsProviderParameterResolver.class)

--- a/systemtests/src/test/java/io/enmasse/systemtest/sharedinfra/MessagingAddressJMSTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/sharedinfra/MessagingAddressJMSTest.java
@@ -1,0 +1,680 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.systemtest.sharedinfra;
+
+import io.enmasse.api.model.MessagingAddress;
+import io.enmasse.api.model.MessagingAddressBuilder;
+import io.enmasse.api.model.MessagingEndpoint;
+import io.enmasse.api.model.MessagingEndpointBuilder;
+import io.enmasse.api.model.MessagingTenant;
+import io.enmasse.api.model.MessagingTenantBuilder;
+import io.enmasse.systemtest.annotations.DefaultMessagingInfrastructure;
+import io.enmasse.systemtest.bases.TestBase;
+import io.enmasse.systemtest.logs.CustomLogger;
+import io.enmasse.systemtest.messaginginfra.resources.MessagingEndpointResourceType;
+import io.enmasse.systemtest.resolvers.JmsProviderParameterResolver;
+import io.enmasse.systemtest.utils.JmsProvider;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+
+import javax.jms.*;
+import javax.naming.Context;
+import javax.naming.NamingException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DefaultMessagingInfrastructure
+@ExtendWith(JmsProviderParameterResolver.class)
+public class MessagingAddressJMSTest extends TestBase {
+    private static Logger log = CustomLogger.getLogger();
+
+    private MessagingTenant tenant;
+    private MessagingEndpoint endpoint;
+
+    @BeforeAll
+    public void createTenant() {
+        tenant = new MessagingTenantBuilder()
+                .editOrNewMetadata()
+                .withName("default")
+                .withNamespace(environment.namespace())
+                .endMetadata()
+                .editOrNewSpec()
+                .addToCapabilities("transactional")
+                .endSpec()
+                .build();
+        endpoint = new MessagingEndpointBuilder()
+                .editOrNewMetadata()
+                .withName("messaging")
+                .withNamespace(environment.namespace())
+                .endMetadata()
+                .editOrNewSpec()
+                .editOrNewNodePort()
+                .endNodePort()
+                .withHost(kubernetes.getHost())
+                .addToProtocols("AMQP")
+                .endSpec()
+                .build();
+        resourceManager.createResource(tenant, endpoint);
+    }
+
+    private Context createContext(JmsProvider jmsProvider, MessagingAddress address) throws NamingException {
+        return jmsProvider.createContext(endpoint.getStatus().getHost(), MessagingEndpointResourceType.getPort("AMQP", endpoint), false, null, null, "jmsCliId", address);
+    }
+
+    @Test
+    @DisplayName("testTransactionCommitRejectQueue")
+    @Disabled("Transaction test needs looking into")
+    void testTransactionCommitRejectQueue(JmsProvider jmsProvider) throws Exception {
+        MessagingAddress addressQueue = new MessagingAddressBuilder()
+                .withNewMetadata()
+                .withNamespace(tenant.getMetadata().getNamespace())
+                .withName("jms-queue-commit")
+                .endMetadata()
+                .withNewSpec()
+                .editOrNewQueue()
+                .endQueue()
+                .withAddress("jmsQueueCommit")
+                .endSpec()
+                .build();
+        resourceManager.createResource(addressQueue);
+
+        Context context = createContext(jmsProvider, addressQueue);
+
+        Connection connection = jmsProvider.createConnection(context);
+        connection.start();
+        Session session = connection.createSession(true, Session.SESSION_TRANSACTED);
+        Queue testQueue = (Queue) jmsProvider.getDestination(addressQueue.getSpec().getAddress());
+
+        MessageProducer sender = session.createProducer(testQueue);
+        MessageConsumer receiver = session.createConsumer(testQueue);
+        List<javax.jms.Message> recvd;
+
+        int count = 50;
+
+        List<javax.jms.Message> listMsgs = jmsProvider.generateMessages(session, count);
+
+        //send messages and commit
+        jmsProvider.sendMessages(sender, listMsgs);
+        session.commit();
+        log.info("messages sent commit");
+
+        //receive commit messages
+        recvd = jmsProvider.receiveMessages(receiver, count, 1000);
+        for (javax.jms.Message message : recvd) {
+            assertNotNull(message, "No message received");
+        }
+        session.commit();
+        log.info("messages received commit");
+
+        //send messages rollback
+        jmsProvider.sendMessages(sender, listMsgs);
+        session.rollback();
+        log.info("messages sent rollback");
+        Thread.sleep(10_000);
+
+        //check if queue is empty
+        javax.jms.Message received = receiver.receive(1000);
+        assertNull(received, "Queue should be empty");
+        log.info("queue is empty");
+
+        //send messages
+        jmsProvider.sendMessages(sender, listMsgs);
+        session.commit();
+        log.info("messages sent commit");
+
+        //receive messages rollback
+        recvd.clear();
+        recvd = jmsProvider.receiveMessages(receiver, count, 1000);
+        for (javax.jms.Message message : recvd) {
+            assertNotNull(message, "No message received");
+        }
+        session.rollback();
+        log.info("messages received rollback");
+
+        //receive messages
+        recvd.clear();
+        recvd = jmsProvider.receiveMessages(receiver, count, 1000);
+        for (javax.jms.Message message : recvd) {
+            assertNotNull(message, "No message received");
+        }
+        session.commit();
+        log.info("messages received commit");
+
+        sender.close();
+        receiver.close();
+    }
+
+    @Test
+    @DisplayName("testLoadMessagesQueue")
+    void testLoadMessagesQueue(JmsProvider jmsProvider) throws Exception {
+        MessagingAddress addressQueue = new MessagingAddressBuilder()
+                .withNewMetadata()
+                .withNamespace(tenant.getMetadata().getNamespace())
+                .withName("jms-queue-load")
+                .endMetadata()
+                .withNewSpec()
+                .editOrNewQueue()
+                .endQueue()
+                .withAddress("jmsQueueLoad")
+                .endSpec()
+                .build();
+        resourceManager.createResource(addressQueue);
+
+        Context context = createContext(jmsProvider, addressQueue);
+        Connection connection = jmsProvider.createConnection(context);
+        connection.start();
+        Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+        Queue testQueue = (Queue) jmsProvider.getDestination(addressQueue.getSpec().getAddress());
+
+        MessageProducer sender = session.createProducer(testQueue);
+        MessageConsumer receiver = session.createConsumer(testQueue);
+        List<javax.jms.Message> recvd;
+        List<javax.jms.Message> recvd2;
+
+        int count = 60_895;
+        int batch = new java.util.Random().nextInt(count) + 1;
+
+        List<javax.jms.Message> listMsgs = jmsProvider.generateMessages(session, count);
+
+        jmsProvider.sendMessages(sender, listMsgs);
+        log.info("{} messages sent", count);
+
+        recvd = jmsProvider.receiveMessages(receiver, batch, 1000);
+        assertThat("Wrong count of received messages", recvd.size(), Matchers.is(batch));
+        log.info("{} messages received", batch);
+
+        recvd2 = jmsProvider.receiveMessages(receiver, count - batch, 1000);
+        assertThat("Wrong count of received messages", recvd2.size(), Matchers.is(count - batch));
+        log.info("{} messages received", count - batch);
+
+        jmsProvider.sendMessages(sender, listMsgs);
+        log.info("{} messages sent", count);
+
+        recvd = jmsProvider.receiveMessages(receiver, count, 1000);
+        assertThat("Wrong count of received messages", recvd.size(), Matchers.is(count));
+        log.info("{} messages received", count);
+        sender.close();
+        receiver.close();
+    }
+
+    @Test
+    @DisplayName("testLargeMessagesQueue")
+    void testLargeMessagesQueue(JmsProvider jmsProvider) throws Exception {
+        MessagingAddress addressQueue = new MessagingAddressBuilder()
+                .withNewMetadata()
+                .withNamespace(tenant.getMetadata().getNamespace())
+                .withName("jms-queue-large")
+                .endMetadata()
+                .withNewSpec()
+                .editOrNewQueue()
+                .endQueue()
+                .withAddress("jmsQueueLarge")
+                .endSpec()
+                .build();
+        resourceManager.createResource(addressQueue);
+
+        Context context = createContext(jmsProvider, addressQueue);
+        Connection connection = jmsProvider.createConnection(context);
+        connection.start();
+
+        assertSendReceiveLargeMessageQueue(jmsProvider, 1, addressQueue, 1);
+        assertSendReceiveLargeMessageQueue(jmsProvider, 0.5, addressQueue, 1);
+        assertSendReceiveLargeMessageQueue(jmsProvider, 0.25, addressQueue, 1);
+        assertSendReceiveLargeMessageQueue(jmsProvider, 1, addressQueue, 1, DeliveryMode.PERSISTENT);
+        assertSendReceiveLargeMessageQueue(jmsProvider, 0.5, addressQueue, 1, DeliveryMode.PERSISTENT);
+        assertSendReceiveLargeMessageQueue(jmsProvider, 0.25, addressQueue, 1, DeliveryMode.PERSISTENT);
+        connection.stop();
+        connection.close();
+    }
+
+    @Test
+    @DisplayName("testMessageNonDurableSubscription")
+    void testMessageNonDurableSubscription(JmsProvider jmsProvider) throws Exception {
+        MessagingAddress addressTopic = new MessagingAddressBuilder()
+                .withNewMetadata()
+                .withNamespace(tenant.getMetadata().getNamespace())
+                .withName("jms-topic-mess")
+                .endMetadata()
+                .withNewSpec()
+                .editOrNewTopic()
+                .endTopic()
+                .withAddress("jmsTopicMess")
+                .endSpec()
+                .build();
+        resourceManager.createResource(addressTopic);
+
+        Context context = createContext(jmsProvider, addressTopic);
+        Connection connection = jmsProvider.createConnection(context);
+        connection.start();
+        Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+        Topic testTopic = (Topic) jmsProvider.getDestination(addressTopic.getSpec().getAddress());
+
+        MessageConsumer subscriber1 = session.createConsumer(testTopic);
+        MessageProducer messageProducer = session.createProducer(testTopic);
+
+        int count = 1000;
+        List<javax.jms.Message> listMsgs = jmsProvider.generateMessages(session, count);
+
+        CompletableFuture<List<Message>> received = new CompletableFuture<>();
+
+        List<javax.jms.Message> recvd = new ArrayList<>();
+        AtomicInteger i = new AtomicInteger(0);
+        MessageListener myListener = message -> {
+            recvd.add(message);
+            if (i.incrementAndGet() == count) {
+                received.complete(recvd);
+            }
+        };
+        subscriber1.setMessageListener(myListener);
+
+        jmsProvider.sendMessages(messageProducer, listMsgs);
+        log.info("messages sent");
+
+        assertThat("Wrong count of messages received", received.get(30, TimeUnit.SECONDS).size(), is(count));
+        log.info("messages received");
+
+        subscriber1.close();
+        messageProducer.close();
+    }
+
+    @Test
+    @Disabled("Not yet supported")
+    @DisplayName("testMessageDurableSubscription")
+    void testMessageDurableSubscription(JmsProvider jmsProvider) throws Exception {
+        MessagingAddress addressTopic = new MessagingAddressBuilder()
+                .withNewMetadata()
+                .withNamespace(tenant.getMetadata().getNamespace())
+                .withName("jms-topic-dur-subs")
+                .endMetadata()
+                .withNewSpec()
+                .editOrNewTopic()
+                .endTopic()
+                .withAddress("jmsTopicDurSubs")
+                .endSpec()
+                .build();
+        MessagingAddress addressSub1= new MessagingAddressBuilder()
+                .withNewMetadata()
+                .withNamespace(tenant.getMetadata().getNamespace())
+                .withName("jms-topic-dur-sub-1")
+                .endMetadata()
+                .withNewSpec()
+                .editOrNewSubscription()
+                .withTopic("jmsTopicDurSubs")
+                .endSubscription()
+                .withAddress("sub1DurSub")
+                .endSpec()
+                .build();
+        MessagingAddress addressSub2= new MessagingAddressBuilder()
+                .withNewMetadata()
+                .withNamespace(tenant.getMetadata().getNamespace())
+                .withName("jms-topic-dur-sub-2")
+                .endMetadata()
+                .withNewSpec()
+                .editOrNewSubscription()
+                .withTopic("jmsTopicDurSubs")
+                .endSubscription()
+                .withAddress("sub2DurSub")
+                .endSpec()
+                .build();
+        resourceManager.createResource(addressTopic, addressSub1, addressSub2);
+
+        Context context = createContext(jmsProvider, addressTopic);
+        Connection connection = jmsProvider.createConnection(context);
+        connection.start();
+        Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+        Topic testTopic = (Topic) jmsProvider.getDestination(addressTopic.getSpec().getAddress());
+
+        String sub1ID = addressSub1.getSpec().getAddress();
+        String sub2ID = addressSub2.getSpec().getAddress();
+        MessageConsumer subscriber1 = session.createDurableSubscriber(testTopic, sub1ID);
+        MessageConsumer subscriber2 = session.createDurableSubscriber(testTopic, sub2ID);
+        MessageProducer messageProducer = session.createProducer(testTopic);
+
+        int count = 100;
+        String batchPrefix = "First";
+        List<javax.jms.Message> listMsgs = jmsProvider.generateMessages(session, batchPrefix, count);
+        jmsProvider.sendMessages(messageProducer, listMsgs);
+        log.info("First batch messages sent");
+
+        List<javax.jms.Message> recvd1 = jmsProvider.receiveMessages(subscriber1, count);
+        List<javax.jms.Message> recvd2 = jmsProvider.receiveMessages(subscriber2, count);
+
+        assertThat("Wrong count of messages received: by " + sub1ID, recvd1.size(), is(count));
+        jmsProvider.assertMessageContent(recvd1, batchPrefix);
+        log.info(sub1ID + " :First batch messages received");
+
+        assertThat("Wrong count of messages received: by " + sub2ID, recvd2.size(), is(count));
+        jmsProvider.assertMessageContent(recvd2, batchPrefix);
+        log.info(sub2ID + " :First batch messages received");
+
+        subscriber1.close();
+        log.info(sub1ID + " : closed");
+
+        batchPrefix = "Second";
+        listMsgs = jmsProvider.generateMessages(session, batchPrefix, count);
+        jmsProvider.sendMessages(messageProducer, listMsgs);
+        log.info("Second batch messages sent");
+
+        recvd2 = jmsProvider.receiveMessages(subscriber2, count);
+        assertThat("Wrong count of messages received: by " + sub2ID, recvd2.size(), is(count));
+        jmsProvider.assertMessageContent(recvd2, batchPrefix);
+        log.info(sub2ID + " :Second batch messages received");
+
+        subscriber1 = session.createDurableSubscriber(testTopic, sub1ID);
+        log.info(sub1ID + " :connected");
+
+        recvd1 = jmsProvider.receiveMessages(subscriber1, count);
+        assertThat("Wrong count of messages received: by " + sub1ID, recvd1.size(), is(count));
+        jmsProvider.assertMessageContent(recvd1, batchPrefix);
+        log.info(sub1ID + " :Second batch messages received");
+
+        subscriber1.close();
+        subscriber2.close();
+
+        session.unsubscribe(sub1ID);
+        session.unsubscribe(sub2ID);
+    }
+
+    @Test
+    @Disabled("Not yet supported")
+    @DisplayName("testMessageDurableSubscriptionTransacted")
+    void testMessageDurableSubscriptionTransacted(JmsProvider jmsProvider) throws Exception {
+        String topicAddress = "jmsTopicTrans";
+        String sub1ID = "sub1DurSubTrans";
+        String sub2ID = "sub2DurSubTrans";
+        MessagingAddress addressTopic = new MessagingAddressBuilder()
+                .withNewMetadata()
+                .withNamespace(tenant.getMetadata().getNamespace())
+                .withName("jms-topic-trans")
+                .endMetadata()
+                .withNewSpec()
+                .editOrNewTopic()
+                .endTopic()
+                .withAddress(topicAddress)
+                .endSpec()
+                .build();
+        MessagingAddress addressSub1= new MessagingAddressBuilder()
+                .withNewMetadata()
+                .withNamespace(tenant.getMetadata().getNamespace())
+                .withName("jms-topic-trans-sub1")
+                .endMetadata()
+                .withNewSpec()
+                .editOrNewSubscription()
+                .withTopic(topicAddress)
+                .endSubscription()
+                .withAddress(sub1ID)
+                .endSpec()
+                .build();
+        MessagingAddress addressSub2= new MessagingAddressBuilder()
+                .withNewMetadata()
+                .withNamespace(tenant.getMetadata().getNamespace())
+                .withName("jms-topic-trans-sub2")
+                .endMetadata()
+                .withNewSpec()
+                .editOrNewSubscription()
+                .withTopic(topicAddress)
+                .endSubscription()
+                .withAddress(sub2ID)
+                .endSpec()
+                .build();
+        resourceManager.createResource(addressTopic, addressSub1, addressSub2);
+
+        Context context = createContext(jmsProvider, addressTopic);
+        Connection connection = jmsProvider.createConnection(context);
+        connection.start();
+        Session session = connection.createSession(true, Session.SESSION_TRANSACTED);
+        Topic testTopic = (Topic) jmsProvider.getDestination(addressTopic.getSpec().getAddress());
+
+
+        MessageConsumer subscriber1 = session.createDurableSubscriber(testTopic, sub1ID);
+        MessageConsumer subscriber2 = session.createDurableSubscriber(testTopic, sub2ID);
+        MessageProducer messageProducer = session.createProducer(testTopic);
+
+        int count = 100;
+        List<javax.jms.Message> listMsgs = jmsProvider.generateMessages(session, count);
+        jmsProvider.sendMessages(messageProducer, listMsgs);
+        session.commit();
+        log.info("messages sent");
+
+        List<javax.jms.Message> recvd1 = jmsProvider.receiveMessages(subscriber1, count);
+        session.commit();
+        List<javax.jms.Message> recvd2 = jmsProvider.receiveMessages(subscriber2, count);
+        session.commit();
+
+        log.info(sub1ID + " :messages received");
+        log.info(sub2ID + " :messages received");
+
+        assertAll(
+                () -> assertThat("Wrong count of messages received: by " + sub1ID, recvd1.size(), is(count)),
+                () -> assertThat("Wrong count of messages received: by " + sub2ID, recvd2.size(), is(count)));
+
+        subscriber1.close();
+        subscriber2.close();
+
+        session.unsubscribe(sub1ID);
+        session.unsubscribe(sub2ID);
+    }
+
+    @Test
+    @Disabled("Not yet supported")
+    @DisplayName("testSharedDurableSubscription")
+    void testSharedDurableSubscription(JmsProvider jmsProvider) throws Exception {
+        String topicAddress = "jmsTopicDurable";
+        String subID = "sharedConsumerDurable123";
+        MessagingAddress addressTopic = new MessagingAddressBuilder()
+                .withNewMetadata()
+                .withNamespace(tenant.getMetadata().getNamespace())
+                .withName("jms-topic-durable")
+                .endMetadata()
+                .withNewSpec()
+                .editOrNewTopic()
+                .endTopic()
+                .withAddress(topicAddress)
+                .endSpec()
+                .build();
+        MessagingAddress addressSub1= new MessagingAddressBuilder()
+                .withNewMetadata()
+                .withNamespace(tenant.getMetadata().getNamespace())
+                .withName("jms-topic-durable-sub")
+                .endMetadata()
+                .withNewSpec()
+                .editOrNewSubscription()
+                .withTopic(topicAddress)
+                .endSubscription()
+                .withAddress(subID)
+                .endSpec()
+                .build();
+        resourceManager.createResource(addressTopic, addressSub1);
+
+        Context context1 = createContext(jmsProvider, addressTopic);
+        Connection connection1 = jmsProvider.createConnection(context1);
+        Context context2 = createContext(jmsProvider, addressTopic);
+        Connection connection2 = jmsProvider.createConnection(context2);
+        connection1.start();
+        connection2.start();
+
+        Session session = connection1.createSession(false, Session.AUTO_ACKNOWLEDGE);
+        Session session2 = connection2.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+        Topic testTopic = (Topic) jmsProvider.getDestination(topicAddress);
+
+        log.info("Creating subscriber 1");
+        MessageConsumer subscriber1 = session.createSharedDurableConsumer(testTopic, subID);
+        log.info("Creating subscriber 2");
+        MessageConsumer subscriber2 = session2.createSharedDurableConsumer(testTopic, subID);
+        log.info("Creating producer");
+        MessageProducer messageProducer = session.createProducer(testTopic);
+        messageProducer.setDeliveryMode(DeliveryMode.PERSISTENT);
+
+        int count = 10;
+        List<javax.jms.Message> listMsgs = jmsProvider.generateMessages(session, count);
+        jmsProvider.sendMessages(messageProducer, listMsgs);
+        log.info("messages sent");
+
+        List<javax.jms.Message> recvd1 = jmsProvider.receiveMessages(subscriber1, count, 1);
+        List<javax.jms.Message> recvd2 = jmsProvider.receiveMessages(subscriber2, count, 1);
+
+        log.info(subID + " :messages received");
+
+        assertThat("Wrong count of messages received: by both receivers",
+                recvd1.size() + recvd2.size(), is(2 * count));
+
+        subscriber1.close();
+        subscriber2.close();
+        session.unsubscribe(subID);
+        session2.unsubscribe(subID);
+        connection1.stop();
+        connection2.stop();
+        session.close();
+        session2.close();
+        connection1.close();
+        connection2.close();
+    }
+
+    @Test
+    @Disabled("javax.jms.JMSException: Remote peer does not support shared subscriptions")
+    @DisplayName("testSharedNonDurableSubscription")
+    void testSharedNonDurableSubscription(JmsProvider jmsProvider) throws Exception {
+        String topicAddress = "jmsTopicNonDurable";
+        String subID = "sharedConsumerDurable123";
+        MessagingAddress addressTopic = new MessagingAddressBuilder()
+                .withNewMetadata()
+                .withNamespace(tenant.getMetadata().getNamespace())
+                .withName("jms-topic-nondurable")
+                .endMetadata()
+                .withNewSpec()
+                .editOrNewTopic()
+                .endTopic()
+                .withAddress(topicAddress)
+                .endSpec()
+                .build();
+        resourceManager.createResource(addressTopic);
+
+        Context context1 = createContext(jmsProvider, addressTopic);
+        Connection connection1 = jmsProvider.createConnection(context1);
+        Context context2 = createContext(jmsProvider, addressTopic);
+        Connection connection2 = jmsProvider.createConnection(context2);
+        connection1.start();
+        connection2.start();
+
+        Session session = connection1.createSession(false, Session.AUTO_ACKNOWLEDGE);
+        Session session2 = connection2.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+        Topic testTopic = (Topic) jmsProvider.getDestination(addressTopic.getSpec().getAddress());
+        MessageConsumer subscriber1 = session.createSharedConsumer(testTopic, subID);
+        MessageConsumer subscriber2 = session2.createSharedConsumer(testTopic, subID);
+        MessageConsumer subscriber3 = session2.createSharedConsumer(testTopic, subID);
+        MessageProducer messageProducer = session.createProducer(testTopic);
+        messageProducer.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
+
+        int count = 10;
+        List<javax.jms.Message> listMsgs = jmsProvider.generateMessages(session, count);
+        List<CompletableFuture<List<javax.jms.Message>>> results = jmsProvider.receiveMessagesAsync(count, subscriber1, subscriber2, subscriber3);
+        jmsProvider.sendMessages(messageProducer, listMsgs);
+        log.info("messages sent");
+
+        assertThat("Each message should be received only by one consumer",
+                results.get(0).get(20, TimeUnit.SECONDS).size() +
+                        results.get(1).get(20, TimeUnit.SECONDS).size() +
+                        results.get(2).get(20, TimeUnit.SECONDS).size(),
+                is(count));
+        log.info("messages received");
+
+        connection1.stop();
+        connection2.stop();
+        subscriber1.close();
+        subscriber2.close();
+        subscriber3.close();
+        session.close();
+        session2.close();
+        connection1.close();
+        connection2.close();
+    }
+
+    @Test
+    @DisplayName("testLargeMessages")
+    void testLargeMessages(JmsProvider jmsProvider) throws Exception {
+        MessagingAddress addressTopic = new MessagingAddressBuilder()
+                .withNewMetadata()
+                .withNamespace(tenant.getMetadata().getNamespace())
+                .withName("jms-topic-large")
+                .endMetadata()
+                .withNewSpec()
+                .editOrNewTopic()
+                .endTopic()
+                .withAddress("jmsTopicLarge")
+                .endSpec()
+                .build();
+        resourceManager.createResource(addressTopic);
+
+        Context context = createContext(jmsProvider, addressTopic);
+        Connection connection = jmsProvider.createConnection(context);
+        connection.start();
+
+        assertSendReceiveLargeMessageTopic(jmsProvider, 1, addressTopic, 1);
+        assertSendReceiveLargeMessageTopic(jmsProvider, 0.5, addressTopic, 1);
+        assertSendReceiveLargeMessageTopic(jmsProvider, 0.25, addressTopic, 1);
+        connection.stop();
+        connection.close();
+    }
+
+    private void assertSendReceiveLargeMessageQueue(JmsProvider jmsProvider, double sizeInMB, MessagingAddress dest, int count) throws Exception {
+        assertSendReceiveLargeMessageQueue(jmsProvider, sizeInMB, dest, count, DeliveryMode.NON_PERSISTENT);
+    }
+
+    private void assertSendReceiveLargeMessageQueue(JmsProvider jmsProvider, double sizeInMB, MessagingAddress dest, int count, int mode) throws Exception {
+        int size = (int) (sizeInMB * 1024 * 1024);
+
+        Session session = jmsProvider.getConnection().createSession(false, Session.AUTO_ACKNOWLEDGE);
+        javax.jms.Queue testQueue = (javax.jms.Queue) jmsProvider.getDestination(dest.getSpec().getAddress());
+        List<javax.jms.Message> messages = jmsProvider.generateMessages(session, count, size);
+
+        MessageProducer sender = session.createProducer(testQueue);
+        MessageConsumer receiver = session.createConsumer(testQueue);
+
+        assertSendReceiveLargeMessage(jmsProvider, sender, receiver, sizeInMB, mode, count, messages);
+
+    }
+
+    private void assertSendReceiveLargeMessageTopic(JmsProvider jmsProvider, double sizeInMB, MessagingAddress dest, int count) throws Exception {
+        assertSendReceiveLargeMessageTopic(jmsProvider, sizeInMB, dest, count, DeliveryMode.NON_PERSISTENT);
+    }
+
+    private void assertSendReceiveLargeMessageTopic(JmsProvider jmsProvider, double sizeInMB, MessagingAddress dest, int count, int mode) throws Exception {
+        int size = (int) (sizeInMB * 1024 * 1024);
+
+        Session session = jmsProvider.getConnection().createSession(false, Session.AUTO_ACKNOWLEDGE);
+        javax.jms.Topic testTopic = (javax.jms.Topic) jmsProvider.getDestination(dest.getSpec().getAddress());
+        List<javax.jms.Message> messages = jmsProvider.generateMessages(session, count, size);
+
+        MessageProducer sender = session.createProducer(testTopic);
+        MessageConsumer receiver = session.createConsumer(testTopic);
+
+        assertSendReceiveLargeMessage(jmsProvider, sender, receiver, sizeInMB, mode, count, messages);
+        session.close();
+        sender.close();
+        receiver.close();
+    }
+
+    private void assertSendReceiveLargeMessage(JmsProvider jmsProvider, MessageProducer sender, MessageConsumer receiver, double sizeInMB, int mode, int count, List<javax.jms.Message> messages) {
+        List<javax.jms.Message> recvd;
+
+        jmsProvider.sendMessages(sender, messages, mode, javax.jms.Message.DEFAULT_PRIORITY, javax.jms.Message.DEFAULT_TIME_TO_LIVE);
+        log.info("{}MB {} message sent", sizeInMB, mode == DeliveryMode.PERSISTENT ? "durable" : "non-durable");
+
+        recvd = jmsProvider.receiveMessages(receiver, count, 2000);
+        assertThat("Wrong count of received messages", recvd.size(), Matchers.is(count));
+        log.info("{}MB {} message received", sizeInMB, mode == DeliveryMode.PERSISTENT ? "durable" : "non-durable");
+    }
+}

--- a/systemtests/src/test/java/io/enmasse/systemtest/sharedinfra/MessagingAddressTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/sharedinfra/MessagingAddressTest.java
@@ -32,7 +32,12 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -269,64 +274,6 @@ public class MessagingAddressTest extends TestBase {
 
         assertThat("Wrong count of messages received",
                 recvResults.get(1, TimeUnit.MINUTES).size(), is(msgs.size() * 2));
-        /*
-        int count = 4;
-
-        ExternalMessagingClient receiver = new ExternalMessagingClient(false)
-                .withClientEngine(new RheaClientReceiver())
-                .withAdditionalArgument(ClientArgument.CONN_AUTH_MECHANISM, "ANONYMOUS")
-                .withTimeout(60)
-                .withAddress("topic/#")
-                .withCount(count * 3)
-                .withMessagingRoute(new Endpoint(endpoint.getStatus().getHost(), getPort("AMQP", endpoint)));
-
-        Future<Boolean> receiverResult = ForkJoinPool.commonPool().submit((Callable<Boolean>) receiver::run);
-
-        for (String suffix : List.of("foo", "bar", "baz/foobar")) {
-            try (ExternalMessagingClient sender = new ExternalMessagingClient(false)
-                    .withClientEngine(new RheaClientSender())
-                    .withAdditionalArgument(ClientArgument.CONN_AUTH_MECHANISM, "ANONYMOUS")
-                    .withTimeout(60)
-                    .withMessageBody("hello")
-                    .withCount(count)
-                    .withAddress(String.format("%s/%s", t0.getMetadata().getName(), suffix))
-                    .withMessagingRoute(new Endpoint(endpoint.getStatus().getHost(), getPort("AMQP", endpoint)))) {
-
-                sender.run();
-            }
-        }
-
-        assertTrue(receiverResult.get(1, TimeUnit.MINUTES));
-        receiver.close();
-
-
-        receiver = new ExternalMessagingClient(false)
-                .withClientEngine(new RheaClientReceiver())
-                .withAdditionalArgument(ClientArgument.CONN_AUTH_MECHANISM, "ANONYMOUS")
-                .withTimeout(60)
-                .withCount(count * 2)
-                .withAddress("topic/world/+")
-                .withMessagingRoute(new Endpoint(endpoint.getStatus().getHost(), getPort("AMQP", endpoint)));
-
-        receiverResult = ForkJoinPool.commonPool().submit((Callable<Boolean>) receiver::run);
-
-        for (String suffix : List.of("world/africa", "world/europe", "world/asia/maldives")) {
-            try (ExternalMessagingClient sender = new ExternalMessagingClient(false)
-                    .withClientEngine(new RheaClientSender())
-                    .withAdditionalArgument(ClientArgument.CONN_AUTH_MECHANISM, "ANONYMOUS")
-                    .withTimeout(60)
-                    .withMessageBody("hello")
-                    .withCount(count)
-                    .withAddress(String.format("%s/%s", t0.getMetadata().getName(), suffix))
-                    .withMessagingRoute(new Endpoint(endpoint.getStatus().getHost(), getPort("AMQP", endpoint)))) {
-
-                sender.run();
-            }
-        }
-
-        assertTrue(receiverResult.get(1, TimeUnit.MINUTES));
-        receiver.close();
-         */
     }
 
     @Test

--- a/systemtests/src/test/java/io/enmasse/systemtest/sharedinfra/MessagingAddressTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/sharedinfra/MessagingAddressTest.java
@@ -4,6 +4,7 @@
  */
 package io.enmasse.systemtest.sharedinfra;
 
+import io.enmasse.api.model.MessagingAddress;
 import io.enmasse.api.model.MessagingAddressBuilder;
 import io.enmasse.api.model.MessagingEndpoint;
 import io.enmasse.api.model.MessagingEndpointBuilder;
@@ -13,6 +14,7 @@ import io.enmasse.systemtest.Endpoint;
 import io.enmasse.systemtest.amqp.AmqpClient;
 import io.enmasse.systemtest.amqp.AmqpConnectOptions;
 import io.enmasse.systemtest.amqp.QueueTerminusFactory;
+import io.enmasse.systemtest.amqp.TopicTerminusFactory;
 import io.enmasse.systemtest.annotations.DefaultMessagingInfrastructure;
 import io.enmasse.systemtest.annotations.DefaultMessagingTenant;
 import io.enmasse.systemtest.annotations.ExternalClients;
@@ -25,14 +27,12 @@ import io.vertx.proton.ProtonClientOptions;
 import io.vertx.proton.ProtonQoS;
 import org.apache.qpid.proton.amqp.messaging.Rejected;
 import org.apache.qpid.proton.amqp.messaging.Source;
+import org.apache.qpid.proton.message.Message;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -40,6 +40,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -154,7 +156,7 @@ public class MessagingAddressTest extends TestBase {
                 .editOrNewSpec()
                 .editOrNewNodePort()
                 .endNodePort()
-                .withHost(kubernetes.getNodeHost())
+                .withHost(kubernetes.getHost())
                 .addToProtocols("AMQP")
                 .endSpec()
                 .build();
@@ -210,6 +212,121 @@ public class MessagingAddressTest extends TestBase {
                 .endSpec()
                 .build());
         doTestSendReceive(true, "topic1", "topic1", "topic1", "topic1");
+    }
+
+    @Test
+    @Disabled("Topic support not yet implemented")
+    void testTopicWildcards() throws Exception {
+        MessagingEndpoint nodePort = new MessagingEndpointBuilder()
+                .editOrNewMetadata()
+                .withNamespace(tenant.getMetadata().getNamespace())
+                .withName("app-nodeport")
+                .endMetadata()
+                .editOrNewSpec()
+                .editOrNewNodePort()
+                .endNodePort()
+                .withHost(kubernetes.getHost())
+                .addToProtocols("AMQP")
+                .endSpec()
+                .build();
+        MessagingAddress t0 = new MessagingAddressBuilder()
+                .withNewMetadata()
+                .withNamespace(tenant.getMetadata().getNamespace())
+                .withName("topic-wild")
+                .endMetadata()
+                .withNewSpec()
+                .withAddress("topic-wild")
+                .editOrNewTopic()
+                .endTopic()
+                .endSpec()
+                .build();
+
+        resourceManager.createResource(nodePort, t0);
+
+        AmqpClient amqpClient = resourceManager.getAmqpClientFactory().createClient(new AmqpConnectOptions()
+                .setSaslMechanism("ANONYMOUS")
+                .setQos(ProtonQoS.AT_LEAST_ONCE)
+                .setEndpoint(new Endpoint(nodePort.getStatus().getHost(), getPort("AMQP", nodePort)))
+                .setProtonClientOptions(new ProtonClientOptions())
+                .setTerminusFactory(new TopicTerminusFactory()));
+
+        List<String> msgs = Arrays.asList("foo", "bar", "baz", "qux");
+
+        Future<List<Message>> recvResults = amqpClient.recvMessages("topic-wild/#", msgs.size() * 3);
+
+        amqpClient.sendMessages(t0.getSpec().getAddress() + "/foo", msgs);
+        amqpClient.sendMessages(t0.getSpec().getAddress() + "/bar", msgs);
+        amqpClient.sendMessages(t0.getSpec().getAddress() + "/baz/foobar", msgs);
+
+        assertThat("Wrong count of messages received",
+                recvResults.get(1, TimeUnit.MINUTES).size(), is(msgs.size() * 3));
+
+        recvResults = amqpClient.recvMessages("topic-wild/world/+", msgs.size() * 2);
+
+        amqpClient.sendMessages(t0.getSpec().getAddress() + "/world/africa", msgs);
+        amqpClient.sendMessages(t0.getSpec().getAddress() + "/world/europe", msgs);
+        amqpClient.sendMessages(t0.getSpec().getAddress() + "/world/asia/maldives", msgs);
+
+        assertThat("Wrong count of messages received",
+                recvResults.get(1, TimeUnit.MINUTES).size(), is(msgs.size() * 2));
+        /*
+        int count = 4;
+
+        ExternalMessagingClient receiver = new ExternalMessagingClient(false)
+                .withClientEngine(new RheaClientReceiver())
+                .withAdditionalArgument(ClientArgument.CONN_AUTH_MECHANISM, "ANONYMOUS")
+                .withTimeout(60)
+                .withAddress("topic/#")
+                .withCount(count * 3)
+                .withMessagingRoute(new Endpoint(endpoint.getStatus().getHost(), getPort("AMQP", endpoint)));
+
+        Future<Boolean> receiverResult = ForkJoinPool.commonPool().submit((Callable<Boolean>) receiver::run);
+
+        for (String suffix : List.of("foo", "bar", "baz/foobar")) {
+            try (ExternalMessagingClient sender = new ExternalMessagingClient(false)
+                    .withClientEngine(new RheaClientSender())
+                    .withAdditionalArgument(ClientArgument.CONN_AUTH_MECHANISM, "ANONYMOUS")
+                    .withTimeout(60)
+                    .withMessageBody("hello")
+                    .withCount(count)
+                    .withAddress(String.format("%s/%s", t0.getMetadata().getName(), suffix))
+                    .withMessagingRoute(new Endpoint(endpoint.getStatus().getHost(), getPort("AMQP", endpoint)))) {
+
+                sender.run();
+            }
+        }
+
+        assertTrue(receiverResult.get(1, TimeUnit.MINUTES));
+        receiver.close();
+
+
+        receiver = new ExternalMessagingClient(false)
+                .withClientEngine(new RheaClientReceiver())
+                .withAdditionalArgument(ClientArgument.CONN_AUTH_MECHANISM, "ANONYMOUS")
+                .withTimeout(60)
+                .withCount(count * 2)
+                .withAddress("topic/world/+")
+                .withMessagingRoute(new Endpoint(endpoint.getStatus().getHost(), getPort("AMQP", endpoint)));
+
+        receiverResult = ForkJoinPool.commonPool().submit((Callable<Boolean>) receiver::run);
+
+        for (String suffix : List.of("world/africa", "world/europe", "world/asia/maldives")) {
+            try (ExternalMessagingClient sender = new ExternalMessagingClient(false)
+                    .withClientEngine(new RheaClientSender())
+                    .withAdditionalArgument(ClientArgument.CONN_AUTH_MECHANISM, "ANONYMOUS")
+                    .withTimeout(60)
+                    .withMessageBody("hello")
+                    .withCount(count)
+                    .withAddress(String.format("%s/%s", t0.getMetadata().getName(), suffix))
+                    .withMessagingRoute(new Endpoint(endpoint.getStatus().getHost(), getPort("AMQP", endpoint)))) {
+
+                sender.run();
+            }
+        }
+
+        assertTrue(receiverResult.get(1, TimeUnit.MINUTES));
+        receiver.close();
+         */
     }
 
     @Test

--- a/systemtests/src/test/java/io/enmasse/systemtest/sharedinfra/MessagingEndpointTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/sharedinfra/MessagingEndpointTest.java
@@ -66,7 +66,7 @@ public class MessagingEndpointTest extends TestBase {
                 .withName("app")
                 .endMetadata()
                 .editOrNewSpec()
-                .withHost(kubernetes.getNodeHost())
+                .withHost(kubernetes.getHost())
                 .addToProtocols("AMQP")
                 .editOrNewNodePort()
                 .endNodePort()

--- a/systemtests/src/test/java/io/enmasse/systemtest/sharedinfra/MessagingTenantTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/sharedinfra/MessagingTenantTest.java
@@ -13,9 +13,7 @@ import io.enmasse.systemtest.bases.TestBase;
 import io.enmasse.systemtest.messaginginfra.resources.MessagingTenantResourceType;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class MessagingTenantTest extends TestBase {
 
@@ -101,6 +99,4 @@ public class MessagingTenantTest extends TestBase {
                         MessagingTenantResourceType.getCondition(messagingTenant.getStatus().getConditions(), "Bound").getStatus() != null &&
                         MessagingTenantResourceType.getCondition(messagingTenant.getStatus().getConditions(), "Bound").getStatus().equals("False")));
     }
-
-
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/sharedinfra/MessagingTenantTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/sharedinfra/MessagingTenantTest.java
@@ -13,7 +13,9 @@ import io.enmasse.systemtest.bases.TestBase;
 import io.enmasse.systemtest.messaginginfra.resources.MessagingTenantResourceType;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MessagingTenantTest extends TestBase {
 

--- a/templates/crds/enmasse.io_messagingaddresses.yaml
+++ b/templates/crds/enmasse.io_messagingaddresses.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: messagingaddresses.enmasse.io
 spec:

--- a/templates/crds/enmasse.io_messagingendpoints.yaml
+++ b/templates/crds/enmasse.io_messagingendpoints.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: messagingendpoints.enmasse.io
 spec:
@@ -31,7 +31,7 @@ spec:
     name: Protocols
     priority: 1
     type: string
-  - JSONPath: .status.tls.certificateInfo.notAfter
+  - JSONPath: .status.tls.certificateValidity.notAfter
     description: Certificate expiry.
     name: CertficateExpiry
     priority: 1

--- a/templates/crds/enmasse.io_messaginginfrastructures.yaml
+++ b/templates/crds/enmasse.io_messaginginfrastructures.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: messaginginfrastructures.enmasse.io
 spec:

--- a/templates/crds/enmasse.io_messagingtenants.yaml
+++ b/templates/crds/enmasse.io_messagingtenants.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: messagingtenants.enmasse.io
 spec:
@@ -53,6 +53,12 @@ spec:
           type: object
         spec:
           properties:
+            capabilities:
+              description: The desired capabilities common to all addresses for this
+                tenant.
+              items:
+                type: string
+              type: array
             messagingInfrastructureRef:
               description: Reference to a specific MessagingInfra to use (must be
                 available for this tenant).
@@ -69,6 +75,21 @@ spec:
           type: object
         status:
           properties:
+            broker:
+              description: For transactional tenants, the broker addresses should
+                be scheduled todo
+              properties:
+                host:
+                  type: string
+                state:
+                  type: string
+              type: object
+            capabilities:
+              description: The actual capabilities common to all addresses for this
+                tenant.
+              items:
+                type: string
+              type: array
             conditions:
               items:
                 properties:


### PR DESCRIPTION
* Synchronize and store messaging tenants in infra state. This will be
used to lookup the tenant of an address to determine how that address
will be configured. It will also later be used to drive the creation
of vhost policies.
* Add scheduling of tenants that are transactional to ensure that addresses 
for that tenant end up on the same broker.
* If a tenant is transactional, instead of creating multiple autolinks
and linkroutes on the router, create a single in+out link route pair
with the prefix of the tenant (per endpoint for now) so that all
links for that tenant go directly to the broker.
* Add systemtest that verifies basic transactions work for queues and
topics. Tests for durable subscriptions are disabled for now.
* Prevent deletion of brokers that are in use.

Issue #4469