### PR TITLE
Ensure address space controller and standard controller record stacktrace of startup failure 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## 0.33.0
 
 * #4839: Agent leaks memory if qdrouter is restarted. 
+* #4860: Ensure address space controller and standard controller record stacktrace
 
 ## 0.32.0
 

--- a/address-space-controller/src/main/java/io/enmasse/controller/AddressSpaceController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/AddressSpaceController.java
@@ -276,9 +276,11 @@ public class AddressSpaceController {
             controller = new AddressSpaceController(options);
             controller.start();
         } catch (IllegalArgumentException e) {
+            log.error("Unable to parse arguments", e);
             System.out.println(String.format("Unable to parse arguments: %s", e.getMessage()));
             System.exit(1);
         } catch (Exception e) {
+            log.error("Error starting address space controller", e);
             System.out.println("Error starting address space controller: " + e.getMessage());
             System.exit(1);
         } finally {

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/StandardController.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/StandardController.java
@@ -59,10 +59,12 @@ public class StandardController {
             standardController = new StandardController(options);
             standardController.start();
         } catch (IllegalArgumentException e) {
+            log.error("Unable to parse arguments", e);
             System.out.println(String.format("Unable to parse arguments: %s", e.getMessage()));
             System.exit(1);
         } catch (Exception e) {
-            System.out.println("Error starting address space controller: " + e.getMessage());
+            log.error("Error starting standard controller", e);
+            System.out.println("Error starting standard controller: " + e.getMessage());
             System.exit(1);
         } finally {
             if (standardController != null) {


### PR DESCRIPTION

### Type of change


- Bugfix

### Description

Ensure address space controller and standard controller record stacktrace of startup failure

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
