### PR TITLE
Prevent unexpected fields at the root of addresspaace etc failing the controller loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 * #4839: Agent leaks memory if qdrouter is restarted. 
 * #4860: Ensure address space controller and standard controller record stacktrace
+* #4873: Prevent unexpected fields at the root of addresspace etc failing the controller loop
 
 ## 0.32.0
 

--- a/api-model/src/main/java/io/enmasse/address/model/Address.java
+++ b/api-model/src/main/java/io/enmasse/address/model/Address.java
@@ -10,6 +10,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.enmasse.common.model.AbstractHasMetadata;
 import io.enmasse.common.model.DefaultCustomResource;
 import io.enmasse.model.validation.AddressName;
@@ -35,6 +36,7 @@ import io.sundr.builder.annotations.Inline;
         )
 @DefaultCustomResource
 @SuppressWarnings("serial")
+@JsonIgnoreProperties(ignoreUnknown = true)
 @AddressName
 public class Address extends AbstractHasMetadata<Address> {
 

--- a/api-model/src/main/java/io/enmasse/address/model/AddressSpace.java
+++ b/api-model/src/main/java/io/enmasse/address/model/AddressSpace.java
@@ -9,6 +9,7 @@ import java.util.Objects;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.enmasse.common.model.AbstractHasMetadata;
 import io.enmasse.common.model.DefaultCustomResource;
 import io.enmasse.model.validation.AddressSpaceName;
@@ -36,6 +37,7 @@ import io.sundr.builder.annotations.Inline;
 @SuppressWarnings("serial")
 @AddressSpaceName
 @KubeMetadataName
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class AddressSpace extends AbstractHasMetadata<AddressSpace> {
 
     public static final String KIND = "AddressSpace";

--- a/api-model/src/main/java/io/enmasse/user/model/v1/User.java
+++ b/api-model/src/main/java/io/enmasse/user/model/v1/User.java
@@ -7,6 +7,7 @@ package io.enmasse.user.model.v1;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.enmasse.common.model.AbstractHasMetadata;
 import io.enmasse.common.model.DefaultCustomResource;
 import io.fabric8.kubernetes.api.model.Doneable;
@@ -27,6 +28,7 @@ import io.sundr.builder.annotations.Inline;
         )
 @DefaultCustomResource
 @SuppressWarnings("serial")
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class User extends AbstractHasMetadata<User> {
 
     private static final Pattern NAME_PATTERN = Pattern.compile("^[a-z]+([a-z0-9\\-]*[a-z0-9]+|[a-z0-9]*)\\.[a-z0-9]+([a-z0-9@.\\-]*[a-z0-9]+|[a-z0-9]*)$");

--- a/systemtests/src/main/java/io/enmasse/systemtest/manager/ResourceManager.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/manager/ResourceManager.java
@@ -419,6 +419,10 @@ public abstract class ResourceManager {
         return kubernetes.getAddressClient().inNamespace(namespace).withName(destination.getMetadata().getName()).get();
     }
 
+    public Address getAddress(String addressName) {
+        return kubernetes.getAddressClient().withName(addressName).get();
+    }
+
     //================================================================================================
     //======================================= User methods ===========================================
     //================================================================================================

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/api/CustomResourceDefinitionAddressSpacesTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/api/CustomResourceDefinitionAddressSpacesTest.java
@@ -21,6 +21,7 @@ import io.enmasse.systemtest.model.addressplan.DestinationPlan;
 import io.enmasse.systemtest.model.addressspace.AddressSpacePlans;
 import io.enmasse.systemtest.model.addressspace.AddressSpaceType;
 import io.enmasse.systemtest.platform.KubeCMDClient;
+import io.enmasse.systemtest.platform.Kubernetes;
 import io.enmasse.systemtest.resources.CliOutputData;
 import io.enmasse.systemtest.time.TimeoutBudget;
 import io.enmasse.systemtest.utils.AddressSpaceUtils;
@@ -36,6 +37,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
@@ -419,5 +421,27 @@ class CustomResourceDefinitionAddressSpacesTest extends TestBase implements ITes
             KubeCMDClient.loginUser(environment.getApiToken());
             KubeCMDClient.switchProject(environment.namespace());
         }
+    }
+
+    @Test
+    void testAddressSpaceWithAdditionalFieldsBecomesReady() throws Exception {
+        String name = "addprops-space";
+
+        JsonObject space = new JsonObject();
+        space.put("apiVersion", "enmasse.io/v1beta1");
+        space.put("kind", "AddressSpace");
+        space.put("foo", "unexpected");
+        space.put("unexpected", "toplevelelement");
+        space.put("metadata", Map.of("bar", "unexpected",
+                "name", name));
+        space.put("spec", Map.of("baz", "unexpected",
+                "type", AddressSpaceType.STANDARD.toString(),
+                "plan", AddressSpacePlans.STANDARD_SMALL));
+
+        KubeCMDClient.createCR(kubernetes.getInfraNamespace(), space.toString());
+
+        AddressSpace read = isolatedResourcesManager.getAddressSpace(name);
+        isolatedResourcesManager.addToAddressSpaces(read);
+        isolatedResourcesManager.waitForAddressSpaceReady(read);
     }
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/api/CustomResourceDefinitionAddressSpacesTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/api/CustomResourceDefinitionAddressSpacesTest.java
@@ -33,6 +33,7 @@ import io.enmasse.user.model.v1.User;
 import io.enmasse.user.model.v1.UserAuthorizationBuilder;
 import io.enmasse.user.model.v1.UserBuilder;
 import io.vertx.core.json.JsonObject;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 
@@ -42,6 +43,7 @@ import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
+import static io.enmasse.systemtest.TestTag.ACCEPTANCE;
 import static io.enmasse.systemtest.platform.KubeCMDClient.createCR;
 import static io.enmasse.systemtest.platform.KubeCMDClient.patchCR;
 import static io.enmasse.systemtest.platform.KubeCMDClient.updateCR;
@@ -424,6 +426,7 @@ class CustomResourceDefinitionAddressSpacesTest extends TestBase implements ITes
     }
 
     @Test
+    @Tag(ACCEPTANCE)
     void testAddressSpaceWithAdditionalFieldsBecomesReady() throws Exception {
         String name = "addprops-space";
 

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/api/CustomResourceDefinitionAddressesTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/api/CustomResourceDefinitionAddressesTest.java
@@ -24,6 +24,7 @@ import io.enmasse.systemtest.time.TimeoutBudget;
 import io.enmasse.systemtest.utils.AddressUtils;
 import io.enmasse.systemtest.utils.TestUtils;
 import io.vertx.core.json.JsonObject;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -34,6 +35,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
+import static io.enmasse.systemtest.TestTag.ACCEPTANCE;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -191,6 +193,7 @@ public class CustomResourceDefinitionAddressesTest extends TestBase implements I
 
     @ParameterizedTest(name = "testAddressWithAdditionalFieldsBecomesReady-{0}-space")
     @ValueSource(strings = {"standard", "brokered"})
+    @Tag(ACCEPTANCE)
     void testAddressWithAdditionalFieldsBecomesReady(String type) throws Exception {
         boolean standard = type.equals(AddressSpaceType.STANDARD.toString());
         AddressSpace addressSpace = new AddressSpaceBuilder()


### PR DESCRIPTION


### Type of change

- Bugfix

### Description

Prevent unexpected fields at the root of addresspaace, address and message from causing the controller loops to fail
We were already using `@JsonIgnoreProperties(ignoreUnknown = true)` at the root of some IoT objects.  This seemed to the least unobtrusive change.

Added supporting tests.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [x] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
