### PR TITLE
Add initial helm chart

### DIFF
--- a/templates/Makefile
+++ b/templates/Makefile
@@ -94,7 +94,9 @@ HELM_CHART=$(PACKAGE_INSTALL_DIR)/helm
 $(HELM_CHART): replace_images
 	mkdir -p $(HELM_CHART)/templates
 	cp $(BUILDDIR)/replaced/helm/Chart.yaml $(HELM_CHART)/
-	for i in crds enmasse-operator console-server $(IOT_MODULES); do \
+	cp -r $(BUILDDIR)/replaced/crds $(HELM_CHART)/
+	cp -r ../LICENSE $(HELM_CHART)/
+	for i in enmasse-operator console-server $(IOT_MODULES); do \
 		cp $(BUILDDIR)/replaced/$$i/*.yaml $(HELM_CHART)/templates; \
 	done
 	sed -i -e 's/$(DEFAULT_PROJECT)/{{ .Release.Namespace }}/g' $(HELM_CHART)/templates/*

--- a/templates/Makefile
+++ b/templates/Makefile
@@ -18,10 +18,10 @@ IOT_MODULES=\
 MODULES=\
 	$(IOT_MODULES) \
 	enmasse-operator \
+	helm \
 	crds \
 	console-server \
 	example-roles \
-	example-plans \
 	example-console \
 	example-olm \
 	iot/examples \
@@ -90,6 +90,15 @@ replace_images: prepare
 component_install: replace_images
 	cp -r $(BUILDDIR)/replaced/* $(PACKAGE_INSTALL_DIR)/components/
 
+HELM_CHART=$(PACKAGE_INSTALL_DIR)/helm
+$(HELM_CHART): replace_images
+	mkdir -p $(HELM_CHART)/templates
+	cp $(BUILDDIR)/replaced/helm/Chart.yaml $(HELM_CHART)/
+	for i in crds enmasse-operator console-server $(IOT_MODULES); do \
+		cp $(BUILDDIR)/replaced/$$i/*.yaml $(HELM_CHART)/templates; \
+	done
+	sed -i -e 's/$(DEFAULT_PROJECT)/{{ .Release.Namespace }}/g' $(HELM_CHART)/templates/*
+
 ENMASSE_BUNDLE=$(PACKAGE_INSTALL_DIR)/bundles/enmasse
 $(ENMASSE_BUNDLE): replace_images
 	mkdir -p $(ENMASSE_BUNDLE)
@@ -97,7 +106,7 @@ $(ENMASSE_BUNDLE): replace_images
 		cp $(BUILDDIR)/replaced/$$i/*.yaml $(ENMASSE_BUNDLE)/; \
 	done
 
-install: component_install $(ENMASSE_BUNDLE)
+install: component_install $(ENMASSE_BUNDLE) $(HELM_CHART)
 	@echo "Preparing installation bundle"
 
 package: prepare install
@@ -105,4 +114,4 @@ package: prepare install
 
 coverage:
 
-.PHONY: prepare package clean $(ENMASSE_BUNDLE)
+.PHONY: prepare package clean $(ENMASSE_BUNDLE) $(HELM_CHART)

--- a/templates/helm/Chart.yaml
+++ b/templates/helm/Chart.yaml
@@ -1,6 +1,23 @@
 apiVersion: v2
 name: enmasse
-description: A Helm chart for deploying EnMasse
+description: EnMasse provides messaging as a managed service on Kubernetes
 type: application
 version: ${MAVEN_VERSION}
 appVersion: ${MAVEN_VERSION}
+home: https://enmasse.io
+sources:
+  - https://github.com/EnMasseProject/enmasse
+maintainers:
+  - name: EnMasse Community
+    email: enmasse@redhat.com
+    url: https://enmasse.io/community
+icon: https://raw.githubusercontent.com/EnMasseProject/enmasse/master/documentation/_images/logo/enmasse_icon.svg
+keywords:
+  - amqp
+  - messaging
+  - event
+  - iot
+  - integration
+  - mqtt
+  - lorawan
+  - sigfox

--- a/templates/helm/Chart.yaml
+++ b/templates/helm/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: enmasse
+description: A Helm chart for deploying EnMasse
+type: application
+version: ${MAVEN_VERSION}
+appVersion: ${MAVEN_VERSION}


### PR DESCRIPTION
Not a lot of customization other than namespace right now, but its probably a nice installation option to have given that Helm is a widely used tool. We can probably expand options later on.