### PR TITLE
Requeue finalizer if resource is in use

### DIFF
--- a/pkg/controller/messagingaddress/messagingaddress_controller.go
+++ b/pkg/controller/messagingaddress/messagingaddress_controller.go
@@ -217,7 +217,9 @@ func (r *ReconcileMessagingAddress) Reconcile(request reconcile.Request) (reconc
 					}
 					client := r.clientManager.GetClient(infra)
 					err = client.DeleteAddress(address)
-
+					if err != nil && errors.Is(err, stateerrors.ResourceInUseError) {
+						return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+					}
 					// TODO: Notify Terminating deadLetter or topics referenced by this queue to speed up reconcile
 
 					logger.Info("[Finalizer] Deleted address", "err", err)

--- a/pkg/controller/messagingendpoint/messagingendpoint_controller.go
+++ b/pkg/controller/messagingendpoint/messagingendpoint_controller.go
@@ -343,7 +343,11 @@ func (r *ReconcileMessagingEndpoint) reconcileFinalizer(ctx context.Context, log
 				client := r.clientManager.GetClient(infra)
 				err = client.DeleteEndpoint(endpoint)
 				if err != nil {
-					return reconcile.Result{}, err
+					if errors.Is(err, stateerrors.ResourceInUseError) {
+						return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+					} else {
+						return reconcile.Result{}, err
+					}
 				}
 
 				err = r.certController.DeleteEndpointCert(ctx, logger, infra, endpoint)

--- a/pkg/state/errors/errors.go
+++ b/pkg/state/errors/errors.go
@@ -9,10 +9,11 @@ import (
 )
 
 var (
-	BrokerInUseError    error = fmt.Errorf("broker in use")
+	BrokerInUseError     error = fmt.Errorf("broker in use")
 	ProjectNotFoundError error = fmt.Errorf("project not found")
-	NotInitializedError error = fmt.Errorf("not initialized")
-	NotSyncedError      error = fmt.Errorf("not synchronized")
-	NoEndpointsError    error = fmt.Errorf("no endpoints")
-	NotDeletedError     error = fmt.Errorf("error deleting")
+	NotInitializedError  error = fmt.Errorf("not initialized")
+	NotSyncedError       error = fmt.Errorf("not synchronized")
+	NoEndpointsError     error = fmt.Errorf("no endpoints")
+	NotDeletedError      error = fmt.Errorf("error deleting")
+	ResourceInUseError   error = fmt.Errorf("resource is in use")
 )

--- a/pkg/state/infra.go
+++ b/pkg/state/infra.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/enmasseproject/enmasse/pkg/apis/enmasse/v1"
+	v1 "github.com/enmasseproject/enmasse/pkg/apis/enmasse/v1"
 	. "github.com/enmasseproject/enmasse/pkg/state/broker"
 	. "github.com/enmasseproject/enmasse/pkg/state/common"
 	. "github.com/enmasseproject/enmasse/pkg/state/errors"
@@ -1307,7 +1307,7 @@ func (i *infraClient) doDelete() {
 		var err error
 		for key, _ := range i.addresses {
 			if resource.GetNamespace() == key.Namespace {
-				err = fmt.Errorf("resource still in use by addresses")
+				err = ResourceInUseError
 				break
 			}
 		}


### PR DESCRIPTION

### Type of change

- Bugfix

### Description

This ensures that reconciler is called again to recheck finalization of
the resource.

@kornys I've not tested if this fixes your issue, but I could see from the operator logs that it failed to remove first because address was still present, but it didn't attempt to reconcile the endpoint again, so this should ensure that it tries again after 10 seconds. Usually it tries again on errors, but maybe that is not guaranteed by framework, so explicit scheduling is probably better.

### Checklist

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
