### PR TITLE
Fix endpoint management

### DIFF
--- a/pkg/controller/messagingaddress/messagingaddress_controller.go
+++ b/pkg/controller/messagingaddress/messagingaddress_controller.go
@@ -242,7 +242,7 @@ func (r *ReconcileMessagingAddress) Reconcile(request reconcile.Request) (reconc
 				return processorResult{Return: true}, err
 			}
 		}
-		return processorResult{Requeue: result.Requeue}, nil
+		return processorResult{Requeue: result.Requeue, RequeueAfter: result.RequeueAfter}, nil
 	})
 	if result.ShouldReturn(err) {
 		return result.Result(), err

--- a/pkg/controller/messagingendpoint/messagingendpoint_controller.go
+++ b/pkg/controller/messagingendpoint/messagingendpoint_controller.go
@@ -344,6 +344,7 @@ func (r *ReconcileMessagingEndpoint) reconcileFinalizer(ctx context.Context, log
 				err = client.DeleteEndpoint(endpoint)
 				if err != nil {
 					if errors.Is(err, stateerrors.ResourceInUseError) {
+						logger.Info("[Finalizer] Endpoint is still in use, rescheduling")
 						return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 					} else {
 						return reconcile.Result{}, err
@@ -401,7 +402,7 @@ func (r *ReconcileMessagingEndpoint) reconcileFinalizer(ctx context.Context, log
 			return processorResult{Return: true}, err
 		}
 	}
-	return processorResult{Requeue: result.Requeue}, nil
+	return processorResult{Requeue: result.Requeue, RequeueAfter: result.RequeueAfter}, nil
 }
 
 // Reconcile the service and external resources for a given endpoint.

--- a/pkg/controller/messaginginfra/broker/controller.go
+++ b/pkg/controller/messaginginfra/broker/controller.go
@@ -238,6 +238,12 @@ func (b *BrokerController) reconcileBroker(ctx context.Context, logger logr.Logg
 			install.ApplyVolumeMountSimple(container, "init", "/opt/apache-artemis/custom", false)
 			install.ApplyVolumeMountSimple(container, "certs", "/etc/enmasse-certs", false)
 
+			// TODO: Make configurable
+			container.Resources = corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceMemory: *resource.NewScaledQuantity(1, resource.Giga)},
+				Limits:   corev1.ResourceList{corev1.ResourceMemory: *resource.NewScaledQuantity(1, resource.Giga)},
+			}
+
 			container.Ports = []corev1.ContainerPort{
 				{
 					ContainerPort: 5671,

--- a/pkg/controller/messaginginfra/cert/controller.go
+++ b/pkg/controller/messaginginfra/cert/controller.go
@@ -367,7 +367,9 @@ func (c *CertController) applyCertSecret(secret *corev1.Secret, caSecret *corev1
 		if err != nil {
 			return nil, err
 		}
-		secret.Data = make(map[string][]byte)
+		if secret.Data == nil {
+			secret.Data = make(map[string][]byte)
+		}
 
 		if config.key != "" {
 			secret.Data[config.key] = key
@@ -427,7 +429,10 @@ func (c *CertController) applyCertSecret(secret *corev1.Secret, caSecret *corev1
 		if err != nil {
 			return nil, err
 		}
-		secret.Data = make(map[string][]byte)
+
+		if secret.Data == nil {
+			secret.Data = make(map[string][]byte)
+		}
 
 		if config.key != "" {
 			secret.Data[config.key] = key


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Improve on the fix in  #4913 so that RequeueAfter is propagated so that reconcile loop does not continue if resource is in use which leaves it in a flip-flop state.

When having multiple endpoints with TLS certs, the secret containing the certificates get rewritten for each endpoint. The fix ensures that the secret is only initialized if it was not already.

When running tests with many endpoints and queues, the broker becomes unresponsive, so the default broker memory will be set to 1GB with a TODO to make this configurable in the MessagingInfrastructure later.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
