### PR TITLE
Enable framework unit tests without kube connection

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/framework/TestPlanExecutionListener.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/framework/TestPlanExecutionListener.java
@@ -17,7 +17,6 @@ import org.slf4j.Logger;
  */
 public class TestPlanExecutionListener implements TestExecutionListener {
     private static final Logger LOGGER = LoggerUtils.getLogger();
-    EnmasseOperatorManager operator = EnmasseOperatorManager.getInstance();
     Environment env = Environment.getInstance();
 
     @Override
@@ -28,9 +27,15 @@ public class TestPlanExecutionListener implements TestExecutionListener {
 
     @Override
     public void testPlanExecutionFinished(TestPlan testPlan) {
+        var tags = TestPlanInfo.getInstance().getTestRunTags();
+        if (tags != null && tags.size() == 1 && tags.get(0).equals(TestTag.FRAMEWORK)) {
+            LOGGER.info("Running framework tests, no cleanup performed");
+            return;
+        }
+
         try {
             if (!env.skipUninstall()) {
-                operator.deleteEnmasseBundle();
+                EnmasseOperatorManager.getInstance().deleteEnmasseBundle();
             }
         } catch (Exception | AssertionError ex) {
             LOGGER.error(ex.getMessage());


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

<!--

_Please describe your pull request_

-->

Fix for running framework tests without kubernetes cluster connection
