### PR TITLE
Fix Kubernetes annotation to match all kube cluster imlementation

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/condition/AssumeKubernetesCondition.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/condition/AssumeKubernetesCondition.java
@@ -20,7 +20,8 @@ public class AssumeKubernetesCondition implements ExecutionCondition {
         if (annotation.isPresent()) {
             ClusterType cluster = annotation.get().type();
             MultinodeCluster multinode = annotation.get().multinode();
-            if (!io.enmasse.systemtest.platform.Kubernetes.getInstance().getCluster().toString().equals(cluster.toString().toLowerCase()) &&
+            boolean isOpenshift = io.enmasse.systemtest.platform.Kubernetes.isOpenShift();
+            if (isOpenshift || (cluster != ClusterType.WHATEVER && !io.enmasse.systemtest.platform.Kubernetes.getInstance().getCluster().toString().equals(cluster.toString().toLowerCase())) &&
                     (multinode == MultinodeCluster.WHATEVER || multinode == io.enmasse.systemtest.platform.Kubernetes.getInstance().isClusterMultinode())) {
                 return ConditionEvaluationResult.disabled("Test is not supported on current cluster");
             } else {

--- a/systemtests/src/main/java/io/enmasse/systemtest/condition/Kubernetes.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/condition/Kubernetes.java
@@ -16,6 +16,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @ExtendWith(AssumeKubernetesCondition.class)
 public @interface Kubernetes {
-    ClusterType type() default ClusterType.MINIKUBE;
+    ClusterType type() default ClusterType.WHATEVER;
     MultinodeCluster multinode() default MultinodeCluster.WHATEVER;
 }

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/cluster/ClusterType.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/cluster/ClusterType.java
@@ -7,5 +7,7 @@ package io.enmasse.systemtest.platform.cluster;
 public enum ClusterType {
     MINIKUBE,
     OPENSHIFT,
-    CRC
+    CRC,
+    KUBERNETES,
+    WHATEVER,
 }


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

<!--

_Please describe your pull request_

-->

Allow to match all kubernetes implementation not only minikube

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
