### PR TITLE
Multiple endpoints per namespace support

### DIFF
--- a/Makefile.env.mk
+++ b/Makefile.env.mk
@@ -23,7 +23,7 @@ IMAGE_VERSION          ?= $(TAG)
 
 # External images
 
-ROUTER_IMAGE ?= quay.io/interconnectedcloud/qdrouterd:1.12.0
+ROUTER_IMAGE ?= docker.io/lulf/qdrouterd:master
 BROKER_IMAGE ?= quay.io/enmasse/artemis-base:2.13.0-ARTEMIS-2810
 PROMETHEUS_IMAGE ?= prom/prometheus:v2.4.3
 ALERTMANAGER_IMAGE ?= prom/alertmanager:v0.15.2

--- a/controller-manager/Dockerfile
+++ b/controller-manager/Dockerfile
@@ -3,7 +3,7 @@
 # License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
 #
 
-FROM scratch
+FROM centos:8
 
 ARG version
 ARG revision

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -29,7 +29,7 @@ cp -dR "$SCRIPTPATH/../" "$TMPPROJ"
 "$SCRIPTPATH/run-codegen.sh" --output-base "$TMPBASE"
 
 echo "Comparing existing generated code with temporarily generated code"
-if diff -Nur --exclude=.git --exclude=systemtests --exclude=target/ --no-dereference "$SCRIPTPATH/.." "$TMPPROJ" -x "go-bin"; then
+if diff -Nur --exclude=.git --exclude=.idea --exclude=systemtests --exclude=target/ --no-dereference "$SCRIPTPATH/.." "$TMPPROJ" -x "go-bin"; then
     echo "No changes detected in generated code"
 else
     echo "Generated code is out of date. Run hack/update-codegen.sh and commit the changes."

--- a/pkg/controller/messagingaddress/messagingaddress_controller.go
+++ b/pkg/controller/messagingaddress/messagingaddress_controller.go
@@ -391,6 +391,13 @@ func (r *ReconcileMessagingAddress) Reconcile(request reconcile.Request) (reconc
 
 	// Update address status
 	result, err = rc.Process(func(address *v1.MessagingAddress) (processorResult, error) {
+		// TODO: This ensures that autolinks and linkroutes have a chance to become active
+		// on the broker and router. This should be replaced with a mechanism in the infra
+		// state to collect the auto link status when synchronizing an address.
+		// See https://github.com/EnMasseProject/enmasse/issues/4945
+		if address.Status.Phase != v1.MessagingAddressActive {
+			time.Sleep(5 * time.Second)
+		}
 		originalStatus := address.Status.DeepCopy()
 		address.Status.Phase = v1.MessagingAddressActive
 		address.Status.Message = ""

--- a/pkg/controller/messaginginfra/messaginginfra_controller.go
+++ b/pkg/controller/messaginginfra/messaginginfra_controller.go
@@ -189,31 +189,6 @@ func add(mgr manager.Manager, r *ReconcileMessagingInfra) error {
 		return err
 	}
 
-	// Watch changes to addresses that map to our infra
-	err = c.Watch(&source.Kind{Type: &v1.MessagingAddress{}}, &handler.EnqueueRequestsFromMapFunc{
-		ToRequests: handler.ToRequestsFunc(func(o handler.MapObject) []reconcile.Request {
-			address := o.Object.(*v1.MessagingAddress)
-			project := &v1.MessagingProject{}
-			err := r.client.Get(context.Background(), client.ObjectKey{Name: messagingproject.PROJECT_RESOURCE_NAME, Namespace: address.Namespace}, project)
-			if err != nil || !project.IsBound() {
-				// Skip triggering if we can't find project
-				return []reconcile.Request{}
-			}
-
-			return []reconcile.Request{
-				{
-					NamespacedName: types.NamespacedName{
-						Namespace: project.Status.MessagingInfrastructureRef.Namespace,
-						Name:      project.Status.MessagingInfrastructureRef.Name,
-					},
-				},
-			}
-		}),
-	})
-	if err != nil {
-		return err
-	}
-
 	// Watch changes to endpoints that map to our infra
 	err = c.Watch(&source.Kind{Type: &v1.MessagingEndpoint{}}, &handler.EnqueueRequestsFromMapFunc{
 		ToRequests: handler.ToRequestsFunc(func(o handler.MapObject) []reconcile.Request {

--- a/pkg/controller/messaginginfra/router/router_config.go
+++ b/pkg/controller/messaginginfra/router/router_config.go
@@ -120,6 +120,9 @@ func generateConfig(i *v1.MessagingInfrastructure, router *v1.MessagingInfrastru
 					"port":       authServicePort,
 					"realm":      globalAuthHost,
 					"sslProfile": "infra_tls",
+				},
+			},
+
 			[]interface{}{
 				// Enable policy
 				"policy",
@@ -127,6 +130,7 @@ func generateConfig(i *v1.MessagingInfrastructure, router *v1.MessagingInfrastru
 					"enableVhostPolicy": true,
 				},
 			},
+
 			[]interface{}{
 				// Enable policy
 				"vhost",

--- a/pkg/controller/messaginginfra/router/router_config.go
+++ b/pkg/controller/messaginginfra/router/router_config.go
@@ -133,7 +133,7 @@ func generateConfig(i *v1.MessagingInfrastructure, router *v1.MessagingInfrastru
 				map[string]interface{}{
 					"hostname":         "$default",
 					"allowUnknownUser": true,
-					Groups: map[string]interface{}{
+					"groups": map[string]interface{}{
 						"$default": map[string]interface{}{
 							"remoteHosts":          "*",
 							"sources":              "*",

--- a/pkg/controller/messaginginfra/router/router_config.go
+++ b/pkg/controller/messaginginfra/router/router_config.go
@@ -129,7 +129,7 @@ func generateConfig(i *v1.MessagingInfrastructure, router *v1.MessagingInfrastru
 			},
 			[]interface{}{
 				// Enable policy
-				"system-vhost",
+				"vhost",
 				map[string]interface{}{
 					"hostname":         "$default",
 					"allowUnknownUser": true,

--- a/pkg/controller/messaginginfra/router/router_config.go
+++ b/pkg/controller/messaginginfra/router/router_config.go
@@ -127,6 +127,23 @@ func generateConfig(i *v1.MessagingInfrastructure, router *v1.MessagingInfrastru
 					"enableVhostPolicy": true,
 				},
 			},
+			[]interface{}{
+				// Enable policy
+				"system-vhost",
+				map[string]interface{}{
+					"hostname":         "$default",
+					"allowUnknownUser": true,
+					Groups: map[string]interface{}{
+						"$default": map[string]interface{}{
+							"remoteHosts":          "*",
+							"sources":              "*",
+							"targets":              "*",
+							"allowDynamicSource":   true,
+							"allowAnonymousSender": true,
+						},
+					},
+				},
+			},
 		},
 	}
 }

--- a/pkg/controller/messaginginfra/router/router_config.go
+++ b/pkg/controller/messaginginfra/router/router_config.go
@@ -131,8 +131,11 @@ func generateConfig(i *v1.MessagingInfrastructure, router *v1.MessagingInfrastru
 				// Enable policy
 				"vhost",
 				map[string]interface{}{
-					"hostname":         "$default",
-					"allowUnknownUser": true,
+					"hostname":              "$default",
+					"allowUnknownUser":      true,
+					"maxConnections":        65535,
+					"maxConnectionsPerUser": 65535,
+					"maxConnectionsPerHost": 65535,
 					"groups": map[string]interface{}{
 						"$default": map[string]interface{}{
 							"remoteHosts":          "*",

--- a/pkg/controller/messaginginfra/router/router_config.go
+++ b/pkg/controller/messaginginfra/router/router_config.go
@@ -120,6 +120,11 @@ func generateConfig(i *v1.MessagingInfrastructure, router *v1.MessagingInfrastru
 					"port":       authServicePort,
 					"realm":      globalAuthHost,
 					"sslProfile": "infra_tls",
+			[]interface{}{
+				// Enable policy
+				"policy",
+				map[string]interface{}{
+					"enableVhostPolicy": true,
 				},
 			},
 		},

--- a/pkg/state/infra.go
+++ b/pkg/state/infra.go
@@ -944,11 +944,15 @@ func (i *infraClient) buildRouterVhostPolicies(endpointsByNamespace map[string][
 		}
 		if len(aliases) > 0 {
 			aliasesStr := strings.Join(aliases[:], ",")
+			// TODO: Configure based on plan
 			routerEntities = append(routerEntities, &RouterVhost{
-				Name:             fmt.Sprintf("vhost-%s", namespace),
-				Hostname:         namespace,
-				Aliases:          aliasesStr,
-				AllowUnknownUser: true,
+				Name:                  fmt.Sprintf("vhost-%s", namespace),
+				Hostname:              namespace,
+				Aliases:               aliasesStr,
+				AllowUnknownUser:      true,
+				MaxConnections:        65535,
+				MaxConnectionsPerUser: 65535,
+				MaxConnectionsPerHost: 65535,
 				Groups: map[string]RouterVhostGroup{
 					"$default": RouterVhostGroup{
 						RemoteHosts:          "*",

--- a/pkg/state/infra.go
+++ b/pkg/state/infra.go
@@ -936,13 +936,19 @@ func (i *infraClient) buildRouterVhostPolicies(endpointsByNamespace map[string][
 	// Update policy to include all endpoints
 	routerEntities := make([]RouterEntity, 0)
 	for namespace, endpoints := range endpointsByNamespace {
-		aliases := make([]string, 0, len(endpoints))
+		aliasMap := make(map[string]bool, 0)
 		for _, endpoint := range endpoints {
 			if endpoint.Status.Host != "" {
-				aliases = append(aliases, endpoint.Status.Host)
+				aliasMap[endpoint.Status.Host] = true
 			}
 		}
-		if len(aliases) > 0 {
+		if len(aliasMap) > 0 {
+			aliases := make([]string, len(aliasMap))
+			i := 0
+			for alias, _ := range aliasMap {
+				aliases[i] = alias
+				i += 1
+			}
 			aliasesStr := strings.Join(aliases[:], ",")
 			// TODO: Configure based on plan
 			routerEntities = append(routerEntities, &RouterVhost{

--- a/pkg/state/infra.go
+++ b/pkg/state/infra.go
@@ -945,7 +945,7 @@ func (i *infraClient) buildRouterVhostPolicies(endpointsByNamespace map[string][
 		if len(aliases) > 0 {
 			aliasesStr := strings.Join(aliases[:], ",")
 			routerEntities = append(routerEntities, &RouterVhost{
-				Name:             namespace,
+				Name:             fmt.Sprintf("vhost-%s", namespace),
 				Hostname:         namespace,
 				Aliases:          aliasesStr,
 				AllowUnknownUser: true,

--- a/pkg/state/infra.go
+++ b/pkg/state/infra.go
@@ -10,6 +10,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"math/rand"
+	"strings"
 	"sync"
 	"time"
 
@@ -477,27 +478,7 @@ func (i *infraClient) syncConfiguration(ctx context.Context) error {
 
 	for _, endpoint := range i.endpoints {
 		if endpoint.Status.Phase == v1.MessagingEndpointActive && endpoint.Status.Host != "" {
-			for _, address := range i.addresses {
-				if endpoint.Namespace == address.Namespace {
-					resultRouter, err := i.buildRouterAddressEntities(endpoint, address)
-					if err != nil {
-						return err
-					}
 
-					resultBroker, err := i.buildBrokerAddressEntities(endpoint, address)
-					if err != nil {
-						return err
-					}
-					for broker, entities := range resultBroker {
-						if brokerEntities[broker] == nil {
-							brokerEntities[broker] = entities
-						} else {
-							brokerEntities[broker] = append(brokerEntities[broker], entities...)
-						}
-					}
-					routerEntities = append(routerEntities, resultRouter...)
-				}
-			}
 			e, err := i.buildRouterEndpointEntities(endpoint)
 			if err != nil {
 				return err
@@ -505,6 +486,30 @@ func (i *infraClient) syncConfiguration(ctx context.Context) error {
 			routerEntities = append(routerEntities, e...)
 		}
 	}
+
+	for _, address := range i.addresses {
+		resultRouter, err := i.buildRouterAddressEntities(address)
+		if err != nil {
+			return err
+		}
+
+		resultBroker, err := i.buildBrokerAddressEntities(address)
+		if err != nil {
+			return err
+		}
+		for broker, entities := range resultBroker {
+			if brokerEntities[broker] == nil {
+				brokerEntities[broker] = entities
+			} else {
+				brokerEntities[broker] = append(brokerEntities[broker], entities...)
+			}
+		}
+		routerEntities = append(routerEntities, resultRouter...)
+	}
+
+	// Build vhost policies
+	endpointsByNamespace := i.getEndpointsWithHosts()
+	routerEntities = append(routerEntities, i.buildRouterVhostPolicies(endpointsByNamespace)...)
 
 	return i.syncEntities(ctx, routerEntities, brokerEntities)
 }
@@ -584,17 +589,17 @@ func (i *infraClient) applyBrokers(ctx context.Context, fn func(broker *BrokerSt
 /**
  * Return map of endpoints that are in the active state (phase Active) and hostname set.
  */
-func (i *infraClient) getActiveEndpoints() map[string][]*v1.MessagingEndpoint {
-	activeEndpoints := make(map[string][]*v1.MessagingEndpoint, 0)
+func (i *infraClient) getEndpointsWithHosts() map[string][]*v1.MessagingEndpoint {
+	endpointsWithHosts := make(map[string][]*v1.MessagingEndpoint, 0)
 	for _, endpoint := range i.endpoints {
-		if endpoint.IsActive() {
-			if activeEndpoints[endpoint.Namespace] == nil {
-				activeEndpoints[endpoint.Namespace] = make([]*v1.MessagingEndpoint, 0)
+		if endpoint.Status.Host != "" {
+			if endpointsWithHosts[endpoint.Namespace] == nil {
+				endpointsWithHosts[endpoint.Namespace] = make([]*v1.MessagingEndpoint, 0)
 			}
-			activeEndpoints[endpoint.Namespace] = append(activeEndpoints[endpoint.Namespace], endpoint)
+			endpointsWithHosts[endpoint.Namespace] = append(endpointsWithHosts[endpoint.Namespace], endpoint)
 		}
 	}
-	return activeEndpoints
+	return endpointsWithHosts
 }
 
 func (i *infraClient) requestSync(object metav1.Object) error {
@@ -811,7 +816,6 @@ func (i *infraClient) syncEntities(ctx context.Context, entities []RouterEntity,
  * be created is returned.
  */
 func (i *infraClient) buildEntities(requests []*request) (built []*request, routerEntities []RouterEntity, brokerEntities map[Host][]BrokerEntity) {
-	activeEndpoints := i.getActiveEndpoints()
 	routerEntities = make([]RouterEntity, 0, len(requests))
 	brokerEntities = make(map[Host][]BrokerEntity, len(i.brokers))
 	for _, broker := range i.brokers {
@@ -823,41 +827,27 @@ func (i *infraClient) buildEntities(requests []*request) (built []*request, rout
 		switch v := req.resource.(type) {
 		case *v1.MessagingAddress:
 			address := v
-			endpoints := activeEndpoints[address.Namespace]
-			if endpoints == nil {
-				req.done <- NoEndpointsError
+			resultRouter, err := i.buildRouterAddressEntities(address)
+			if err != nil {
+				req.done <- err
 				continue
 			}
 
-			failed := false
-			for _, endpoint := range endpoints {
-				resultRouter, err := i.buildRouterAddressEntities(endpoint, address)
-				if err != nil {
-					req.done <- err
-					failed = true
-					break
-				}
-
-				resultBroker, err := i.buildBrokerAddressEntities(endpoint, address)
-				if err != nil {
-					req.done <- err
-					failed = true
-					break
-				}
-
-				routerEntities = append(routerEntities, resultRouter...)
-				for broker, entities := range resultBroker {
-					if brokerEntities[broker] == nil {
-						brokerEntities[broker] = entities
-					} else {
-						brokerEntities[broker] = append(brokerEntities[broker], entities...)
-					}
-				}
+			resultBroker, err := i.buildBrokerAddressEntities(address)
+			if err != nil {
+				req.done <- err
+				continue
 			}
 
-			if !failed {
-				built = append(built, req)
+			routerEntities = append(routerEntities, resultRouter...)
+			for broker, entities := range resultBroker {
+				if brokerEntities[broker] == nil {
+					brokerEntities[broker] = entities
+				} else {
+					brokerEntities[broker] = append(brokerEntities[broker], entities...)
+				}
 			}
+			built = append(built, req)
 
 		case *v1.MessagingEndpoint:
 			endpoint := v
@@ -883,13 +873,96 @@ func (i *infraClient) buildEntities(requests []*request) (built []*request, rout
 
 	}
 
+	// Ensure that we update vhost policy aliases with all endpoints
+	endpointsByNamespace := i.getEndpointsWithHosts()
+	for _, req := range built {
+		switch v := req.resource.(type) {
+		case *v1.MessagingEndpoint:
+			endpoint := v
+			endpoints := make([]*v1.MessagingEndpoint, 1)
+			endpoints[0] = endpoint
+
+			existing := endpointsByNamespace[endpoint.Namespace]
+			if existing != nil {
+				for _, e := range existing {
+					if e.Name == endpoint.Name {
+						continue
+					}
+					endpoints = append(endpoints, e)
+				}
+			}
+		}
+	}
+
+	routerEntities = append(routerEntities, i.buildRouterVhostPolicies(endpointsByNamespace)...)
+
 	return built, routerEntities, brokerEntities
 }
 
 func (i *infraClient) buildRouterProjectEntities(project *v1.MessagingProject) ([]RouterEntity, error) {
 	routerEntities := make([]RouterEntity, 0)
-	// TODO: Create vhost policy based on status (plan settings)
+	// Transactional means that we create a link route based on the project prefix,
+	// and all broker addresses go through that route.
+	projectId := project.Namespace
+
+	if project.Status.Broker != nil {
+		broker := *project.Status.Broker
+		host := i.hostMap[broker.Host]
+		brokerState := i.brokers[host]
+		if brokerState == nil {
+			return nil, fmt.Errorf("unable to configure transactional linkroute (project %s) for unknown broker %s", projectId, broker.Host)
+		}
+		connector := connectorName(brokerState)
+		routerEntities = append(routerEntities, &RouterLinkRoute{
+			Name:       globalLinkRouteName(projectId, host.Hostname, "out"),
+			Prefix:     projectId,
+			Direction:  "out",
+			Connection: connector,
+		})
+
+		routerEntities = append(routerEntities, &RouterLinkRoute{
+			Name:       globalLinkRouteName(projectId, host.Hostname, "in"),
+			Prefix:     projectId,
+			Direction:  "in",
+			Connection: connector,
+		})
+		return routerEntities, nil
+	}
+
 	return routerEntities, nil
+}
+
+func (i *infraClient) buildRouterVhostPolicies(endpointsByNamespace map[string][]*v1.MessagingEndpoint) []RouterEntity {
+	// Update policy to include all endpoints
+	routerEntities := make([]RouterEntity, 0)
+	for namespace, endpoints := range endpointsByNamespace {
+		aliases := make([]string, 0, len(endpoints))
+		for _, endpoint := range endpoints {
+			if endpoint.Status.Host != "" {
+				aliases = append(aliases, endpoint.Status.Host)
+			}
+		}
+		if len(aliases) > 0 {
+			aliasesStr := strings.Join(aliases[:], ",")
+			routerEntities = append(routerEntities, &RouterVhost{
+				Name:             namespace,
+				Hostname:         namespace,
+				Aliases:          aliasesStr,
+				AllowUnknownUser: true,
+				Groups: map[string]RouterVhostGroup{
+					"$default": RouterVhostGroup{
+						RemoteHosts:          "*",
+						Sources:              "*",
+						Targets:              "*",
+						AllowDynamicSource:   true,
+						AllowAnonymousSender: true,
+					},
+				},
+			})
+		}
+	}
+
+	return routerEntities
 }
 
 func (i *infraClient) buildRouterEndpointEntities(endpoint *v1.MessagingEndpoint) ([]RouterEntity, error) {
@@ -938,6 +1011,7 @@ func (i *infraClient) buildRouterEndpointEntities(endpoint *v1.MessagingEndpoint
 			RequireSsl:         false,
 			AuthenticatePeer:   true,
 			IdleTimeoutSeconds: idleTimeoutSeconds,
+			PolicyVhost:        endpoint.Namespace,
 			// LinkCapacity:       TODO: Make configurable?
 			MultiTenant: true,
 			Websockets:  websockets,
@@ -960,42 +1034,15 @@ func (i *infraClient) buildRouterEndpointEntities(endpoint *v1.MessagingEndpoint
 /**
  * Add router entities that should exist for a given address for a given endpoint.
  */
-func (i *infraClient) buildRouterAddressEntities(endpoint *v1.MessagingEndpoint, address *v1.MessagingAddress) ([]RouterEntity, error) {
+func (i *infraClient) buildRouterAddressEntities(address *v1.MessagingAddress) ([]RouterEntity, error) {
 	// Skip endpoints that are not active or do not have hosts defined
-	if !endpoint.IsActive() {
-		return nil, fmt.Errorf("inactive endpoint")
-	}
-
 	routerEntities := make([]RouterEntity, 0)
 
 	project := i.projects[resourceKey{Name: "default", Namespace: address.Namespace}]
-	projectId := endpoint.Status.Host
+	projectId := project.Namespace
 
 	// If transactional, rely on link route to be created
-	// TODO: Move this to buildRouterProjectEntities once endpoint is not needed.
 	if project.Status.Broker != nil {
-		// Transactional means that we create a link route based on the project prefix,
-		// and all broker addresses go through that route.
-		broker := *project.Status.Broker
-		host := i.hostMap[broker.Host]
-		brokerState := i.brokers[host]
-		if brokerState == nil {
-			return nil, fmt.Errorf("unable to configure transactional linkroute (project %s) for unknown broker %s", projectId, broker.Host)
-		}
-		connector := connectorName(brokerState)
-		routerEntities = append(routerEntities, &RouterLinkRoute{
-			Name:       globalLinkRouteName(projectId, host.Hostname, "out"),
-			Prefix:     projectId,
-			Direction:  "out",
-			Connection: connector,
-		})
-
-		routerEntities = append(routerEntities, &RouterLinkRoute{
-			Name:       globalLinkRouteName(projectId, host.Hostname, "in"),
-			Prefix:     projectId,
-			Direction:  "in",
-			Connection: connector,
-		})
 		return routerEntities, nil
 	}
 
@@ -1127,14 +1174,11 @@ func (i *infraClient) buildRouterAddressEntities(endpoint *v1.MessagingEndpoint,
 /**
  * Add broker entities to be created for a given addresss
  */
-func (i *infraClient) buildBrokerAddressEntities(endpoint *v1.MessagingEndpoint, address *v1.MessagingAddress) (map[Host][]BrokerEntity, error) {
-
-	if !endpoint.IsActive() {
-		return nil, fmt.Errorf("inactive endpoint")
-	}
+func (i *infraClient) buildBrokerAddressEntities(address *v1.MessagingAddress) (map[Host][]BrokerEntity, error) {
 
 	brokerEntities := make(map[Host][]BrokerEntity, 0)
-	projectId := endpoint.Status.Host
+	project := i.projects[resourceKey{Name: "default", Namespace: address.Namespace}]
+	projectId := project.Namespace
 
 	// Build desired state
 	fullAddress := qualifiedAddress(projectId, address.GetAddress())
@@ -1331,13 +1375,6 @@ func (i *infraClient) doDelete() {
 	for _, req := range toDelete {
 		switch req.resource.(type) {
 		case *v1.MessagingProject:
-			err := checkDelete(req.resource)
-			if err != nil {
-				req.done <- err
-				continue
-			}
-			valid = append(valid, req)
-		case *v1.MessagingEndpoint:
 			err := checkDelete(req.resource)
 			if err != nil {
 				req.done <- err

--- a/pkg/state/router/router.go
+++ b/pkg/state/router/router.go
@@ -581,6 +581,22 @@ func (e *RouterLinkRoute) Order() int {
 	return 0
 }
 
+func (e *RouterVhost) Type() RouterEntityType {
+	return RouterVhostEntity
+}
+
+func (e *RouterVhost) GetName() string {
+	return e.Name
+}
+
+func (e *RouterVhost) Equals(other RouterEntity) bool {
+	return reflect.DeepEqual(e, other)
+}
+
+func (e *RouterVhost) Order() int {
+	return 0
+}
+
 func (e *NamedEntity) Type() RouterEntityType {
 	return e.EntityType
 }

--- a/pkg/state/router/router.go
+++ b/pkg/state/router/router.go
@@ -162,6 +162,8 @@ func (r *RouterState) readEntities(entityType RouterEntityType) (map[string]Rout
 		entities[entity.GetName()] = entity
 	}
 
+	log.Info(fmt.Sprintf("[Router %s] Found these entities of type %s: %+v", string(entityType), entities))
+
 	return entities, nil
 }
 

--- a/pkg/state/router/router.go
+++ b/pkg/state/router/router.go
@@ -162,7 +162,7 @@ func (r *RouterState) readEntities(entityType RouterEntityType) (map[string]Rout
 		entities[entity.GetName()] = entity
 	}
 
-	log.Info(fmt.Sprintf("[Router %s] Found these entities of type %s: %+v", string(entityType), entities))
+	log.Info(fmt.Sprintf("[Router %s] Found these entities of type %s: %+v", r.host, string(entityType), entities))
 
 	return entities, nil
 }

--- a/pkg/state/router/types.go
+++ b/pkg/state/router/types.go
@@ -32,6 +32,7 @@ const (
 	RouterLinkRouteEntity         RouterEntityType = "org.apache.qpid.dispatch.router.config.linkRoute"
 	RouterSslProfileEntity        RouterEntityType = "org.apache.qpid.dispatch.sslProfile"
 	RouterAuthServicePluginEntity RouterEntityType = "org.apache.qpid.dispatch.authServicePlugin"
+	RouterVhostEntity             RouterEntityType = "org.apache.qpid.dispatch.vhost"
 )
 
 type RouterEntity interface {
@@ -90,7 +91,19 @@ type RouterListener struct {
 }
 
 type RouterVhost struct {
-	Host string `json:"host"`
+	Name             string                      `json:"name"`
+	Hostname         string                      `json:"hostname"`
+	Aliases          string                      `json:"aliases"`
+	AllowUnknownUser bool                        `json:"allowUnknownUser"`
+	Groups           map[string]RouterVhostGroup `json:"groups"`
+}
+
+type RouterVhostGroup struct {
+	RemoteHosts          string `json:"remoteHosts,omitempty"`
+	Sources              string `json:"sources,omitempty"`
+	Targets              string `json:"targets,omitempty"`
+	AllowDynamicSource   bool   `json:"allowDynamicSource,omitempty"`
+	AllowAnonymousSender bool   `json:"allowAnonymousSender,omitempty"`
 }
 
 type RouterAddress struct {

--- a/pkg/state/router/types.go
+++ b/pkg/state/router/types.go
@@ -91,11 +91,14 @@ type RouterListener struct {
 }
 
 type RouterVhost struct {
-	Name             string                      `json:"name"`
-	Hostname         string                      `json:"hostname"`
-	Aliases          string                      `json:"aliases"`
-	AllowUnknownUser bool                        `json:"allowUnknownUser"`
-	Groups           map[string]RouterVhostGroup `json:"groups"`
+	Name                  string                      `json:"name"`
+	Hostname              string                      `json:"hostname"`
+	Aliases               string                      `json:"aliases"`
+	AllowUnknownUser      bool                        `json:"allowUnknownUser"`
+	MaxConnectionsPerUser int32                       `json:"maxConnectionsPerUser"`
+	MaxConnections        int32                       `json:"maxConnections"`
+	MaxConnectionsPerHost int32                       `json:"maxConnectionsPerHost"`
+	Groups                map[string]RouterVhostGroup `json:"groups"`
 }
 
 type RouterVhostGroup struct {

--- a/systemtests/pom.xml
+++ b/systemtests/pom.xml
@@ -168,7 +168,7 @@
                     <groups>${groups}</groups>
                     <excludedGroups>${excludeGroups}</excludedGroups>
                     <skipTests>${skip.tests}</skipTests>
-                    <forkCount>1</forkCount>
+                    <forkCount>0</forkCount>
                     <reuseForks>true</reuseForks>
                     <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
                     <systemProperties>

--- a/systemtests/pom.xml
+++ b/systemtests/pom.xml
@@ -168,7 +168,7 @@
                     <groups>${groups}</groups>
                     <excludedGroups>${excludeGroups}</excludedGroups>
                     <skipTests>${skip.tests}</skipTests>
-                    <forkCount>0</forkCount>
+                    <forkCount>1</forkCount>
                     <reuseForks>true</reuseForks>
                     <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
                     <systemProperties>

--- a/systemtests/src/main/java/io/enmasse/systemtest/condition/AssumeKubernetesCondition.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/condition/AssumeKubernetesCondition.java
@@ -20,7 +20,8 @@ public class AssumeKubernetesCondition implements ExecutionCondition {
         if (annotation.isPresent()) {
             ClusterType cluster = annotation.get().type();
             MultinodeCluster multinode = annotation.get().multinode();
-            if (!io.enmasse.systemtest.platform.Kubernetes.getInstance().getCluster().toString().equals(cluster.toString().toLowerCase()) &&
+            boolean isOpenshift = io.enmasse.systemtest.platform.Kubernetes.isOpenShift();
+            if (isOpenshift || (cluster != ClusterType.WHATEVER && !io.enmasse.systemtest.platform.Kubernetes.getInstance().getCluster().toString().equals(cluster.toString().toLowerCase())) &&
                     (multinode == MultinodeCluster.WHATEVER || multinode == io.enmasse.systemtest.platform.Kubernetes.getInstance().isClusterMultinode())) {
                 return ConditionEvaluationResult.disabled("Test is not supported on current cluster");
             } else {

--- a/systemtests/src/main/java/io/enmasse/systemtest/condition/Kubernetes.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/condition/Kubernetes.java
@@ -16,6 +16,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @ExtendWith(AssumeKubernetesCondition.class)
 public @interface Kubernetes {
-    ClusterType type() default ClusterType.MINIKUBE;
+    ClusterType type() default ClusterType.WHATEVER;
     MultinodeCluster multinode() default MultinodeCluster.WHATEVER;
 }

--- a/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/MessagingClientRunner.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/MessagingClientRunner.java
@@ -61,7 +61,7 @@ public class MessagingClientRunner {
     public void receive(MessagingEndpoint endpoint, String address) throws Exception {
         Endpoint e = new Endpoint(endpoint.getStatus().getHost(), MessagingEndpointResourceType.getPort("AMQP", endpoint));
         try (ExternalMessagingClient receiverClient = new ExternalMessagingClient(false)
-                .withClientEngine(new RheaClientReceiver())
+                .withClientEngine(new ProtonJMSClientReceiver())
                     .withMessagingRoute(e)
                     .withAddress(address)
                     .withCount(10)
@@ -83,7 +83,7 @@ public class MessagingClientRunner {
         try {
             Endpoint e = new Endpoint(endpoint.getStatus().getHost(), MessagingEndpointResourceType.getPort("AMQP", endpoint));
             ExternalMessagingClient senderClient = new ExternalMessagingClient(false)
-                    .withClientEngine(new RheaClientSender())
+                    .withClientEngine(new ProtonJMSClientSender())
                     .withMessagingRoute(e)
                     .withAddress(senderAddress)
                     .withCount(expectedMsgCount)
@@ -99,7 +99,7 @@ public class MessagingClientRunner {
 
             for (String receiverAddress : receiverAddresses) {
                 ExternalMessagingClient receiverClient = new ExternalMessagingClient(false)
-                        .withClientEngine(new RheaClientReceiver())
+                        .withClientEngine(new ProtonJMSClientReceiver())
                         .withMessagingRoute(e)
                         .withAddress(receiverAddress)
                         .withCount(expectedMsgCount)

--- a/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/MessagingClientRunner.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/messagingclients/MessagingClientRunner.java
@@ -61,10 +61,11 @@ public class MessagingClientRunner {
     public void receive(MessagingEndpoint endpoint, String address) throws Exception {
         Endpoint e = new Endpoint(endpoint.getStatus().getHost(), MessagingEndpointResourceType.getPort("AMQP", endpoint));
         try (ExternalMessagingClient receiverClient = new ExternalMessagingClient(false)
-                .withClientEngine(new ProtonJMSClientReceiver())
+                    .withClientEngine(new RheaClientReceiver())
                     .withMessagingRoute(e)
                     .withAddress(address)
                     .withCount(10)
+                    .withAdditionalArgument(ClientArgument.USERNAME, "trace")
                     .withAdditionalArgument(ClientArgument.CONN_AUTH_MECHANISM, "ANONYMOUS")
                     .withTimeout(60)) {
             clients.add(receiverClient);
@@ -83,11 +84,12 @@ public class MessagingClientRunner {
         try {
             Endpoint e = new Endpoint(endpoint.getStatus().getHost(), MessagingEndpointResourceType.getPort("AMQP", endpoint));
             ExternalMessagingClient senderClient = new ExternalMessagingClient(false)
-                    .withClientEngine(new ProtonJMSClientSender())
+                    .withClientEngine(new RheaClientSender())
                     .withMessagingRoute(e)
                     .withAddress(senderAddress)
                     .withCount(expectedMsgCount)
                     .withMessageBody("msg no. %d")
+                    .withAdditionalArgument(ClientArgument.USERNAME, "trace")
                     .withAdditionalArgument(ClientArgument.CONN_AUTH_MECHANISM, "ANONYMOUS")
                     .withTimeout(60);
 
@@ -99,10 +101,11 @@ public class MessagingClientRunner {
 
             for (String receiverAddress : receiverAddresses) {
                 ExternalMessagingClient receiverClient = new ExternalMessagingClient(false)
-                        .withClientEngine(new ProtonJMSClientReceiver())
+                        .withClientEngine(new RheaClientReceiver())
                         .withMessagingRoute(e)
                         .withAddress(receiverAddress)
                         .withCount(expectedMsgCount)
+                        .withAdditionalArgument(ClientArgument.USERNAME, "trace")
                         .withAdditionalArgument(ClientArgument.CONN_AUTH_MECHANISM, "ANONYMOUS")
                         .withTimeout(60);
 

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/Kubernetes.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/Kubernetes.java
@@ -32,6 +32,7 @@ import io.enmasse.systemtest.Environment;
 import io.enmasse.systemtest.OLMInstallationType;
 import io.enmasse.systemtest.condition.MultinodeCluster;
 import io.enmasse.systemtest.condition.OpenShiftVersion;
+import io.enmasse.systemtest.executor.Exec;
 import io.enmasse.systemtest.framework.LoggerUtils;
 import io.enmasse.systemtest.platform.cluster.ClusterType;
 import io.enmasse.systemtest.platform.cluster.KubeCluster;
@@ -91,6 +92,7 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
@@ -205,7 +207,7 @@ public abstract class Kubernetes {
      * Check if tests are running on OpenShift (excluding CRC).
      */
     public static boolean isOpenShift() {
-        return Kubernetes.getInstance().getCluster().toString().equals(ClusterType.OPENSHIFT.toString().toLowerCase());
+        return Exec.execute(Arrays.asList(Kubernetes.getInstance().getCluster().getKubeCmd(), "api-resources"), false).getStdOut().contains("openshift.io");
     }
 
     /**

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/cluster/ClusterType.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/cluster/ClusterType.java
@@ -7,5 +7,7 @@ package io.enmasse.systemtest.platform.cluster;
 public enum ClusterType {
     MINIKUBE,
     OPENSHIFT,
-    CRC
+    CRC,
+    KUBERNETES,
+    WHATEVER,
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/sharedinfra/MessagingEndpointTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/sharedinfra/MessagingEndpointTest.java
@@ -400,7 +400,6 @@ public class MessagingEndpointTest extends TestBase {
     }
 
     @Test
-    @Disabled("Awaiting fixes in DISPATCH-1585 to allow endpoints to use same addresses")
     public void testMultipleEndpoints(ExtensionContext extensionContext) throws Exception {
         MessagingProject project = resourceManager.getDefaultMessagingProject();
 

--- a/systemtests/src/test/java/io/enmasse/systemtest/sharedinfra/MessagingInfrastructureTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/sharedinfra/MessagingInfrastructureTest.java
@@ -166,6 +166,8 @@ public class MessagingInfrastructureTest extends TestBase {
                 .build();
 
         resourceManager.createResource(extensionContext, endpoint, anycast, queue);
+        MessagingInfrastructure defaultInfra = resourceManager.getDefaultInfra();
+        waitForConditionsTrue(defaultInfra, endpoint, anycast, queue);
 
         // Make sure endpoints work first
         LOGGER.info("Running initial client check");
@@ -175,10 +177,10 @@ public class MessagingInfrastructureTest extends TestBase {
         clientRunner.cleanClients();
 
         // Restart router and broker pods
-        MessagingInfrastructure defaultInfra = resourceManager.getDefaultInfra();
         kubernetes.deletePod(defaultInfra.getMetadata().getNamespace(), Collections.singletonMap("infra", defaultInfra.getMetadata().getName()));
 
-        Thread.sleep(60_000);
+        // TODO: Look into why sleep is needed
+        Thread.sleep(120_000);
 
         // Wait for the operator state to be green again.
         assertTrue(resourceManager.waitResourceCondition(defaultInfra, i -> i.getStatus() != null && i.getStatus().getBrokers() != null && i.getStatus().getBrokers().size() == 1));


### PR DESCRIPTION
### Type of change


- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

This modifies the infra to access a messaging project from multiple endpoints. This also allows the IoT to start using the internal listener using the namespace as the prefix for addresses @ctron 

Until there is a new router release, I have built a custom router image from qpid dispatch master source.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
