### PR TITLE
Add iot job to smoke job

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -126,3 +126,63 @@ jobs:
         with:
           name: smoke-test-logs
           path: test-logs.zip
+
+  iottests:
+    #if: contains(github.event.pull_request.labels.*.name, 'component/iot')
+    env:
+      SKIP_TESTS: true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Clean disk
+        run: ./.github/scripts/clean_disk.sh
+
+      - name: Set version
+        run: |
+          echo "::set-env name=VERSION::$(grep "release.version" pom.properties| cut -d'=' -f2)"
+
+      - name: Install dependencies
+        run: ./.github/scripts/install_dep.sh
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.14.3'
+      - run: go version
+
+      - name: setup-docker
+        run: ./.github/scripts/setup_docker.sh
+
+      - name: setup-kind
+        run: ./.github/scripts/setup_kind.sh
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11.0.2
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Build images
+        run: ./.github/scripts/build.sh
+
+      - name: IoT systemtests
+        run: |
+          make TESTCASE=iot.isolated.http.HttpAdapterTest PROFILE=iot systemtests
+
+      - name: Collect logs
+        if: failure()
+        run: ./.github/scripts/collectLogs.sh
+
+      - name: Upload artifacts
+        if: failure()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: smoke-test-logs
+          path: test-logs.zip

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -185,4 +185,4 @@ jobs:
         uses: actions/upload-artifact@v1.0.0
         with:
           name: smoke-test-logs
-          path: test-logs.zip
+          path: iot-logs.zip

--- a/systemtests/src/main/java/io/enmasse/systemtest/iot/HttpAdapterClient.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/iot/HttpAdapterClient.java
@@ -116,7 +116,6 @@ public class HttpAdapterClient extends ApiClient {
         } else {
             this.keyStoreBuffer = null;
         }
-
     }
 
     private static String contentType(final Buffer payload) {

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/Kind.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/Kind.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2018-2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.systemtest.platform;
+
+import io.enmasse.systemtest.Endpoint;
+import io.enmasse.systemtest.Environment;
+import io.enmasse.systemtest.framework.LoggerUtils;
+import io.fabric8.kubernetes.api.model.NodeAddress;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.kubernetes.api.model.ServicePort;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.utils.HttpClientUtils;
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+public class Kind extends Kubernetes{
+
+    private static final String OLM_NAMESPACE = "operators";
+
+    protected Kind() {
+        super(() -> {
+            Config config = new ConfigBuilder().build();
+            OkHttpClient httpClient = HttpClientUtils.createHttpClient(config);
+            // Workaround https://github.com/square/okhttp/issues/3146
+            httpClient = httpClient.newBuilder()
+                    .protocols(Collections.singletonList(Protocol.HTTP_1_1))
+                    .connectTimeout(Environment.getInstance().getKubernetesApiConnectTimeout())
+                    .writeTimeout(Environment.getInstance().getKubernetesApiWriteTimeout())
+                    .readTimeout(Environment.getInstance().getKubernetesApiReadTimeout())
+                    .build();
+            return new DefaultKubernetesClient(httpClient, config);
+        });
+    }
+
+    @Override
+    public void createExternalEndpoint(String name, String namespace, Service service, ServicePort targetPort) {
+        name = getName(name);
+        ServiceBuilder builder = new ServiceBuilder()
+                .editOrNewMetadata()
+                .withName(name)
+                .withNamespace(namespace)
+                .endMetadata()
+                .editOrNewSpec()
+                .withType("LoadBalancer")
+                .addToPorts(targetPort)
+                .withSelector(service.getSpec().getSelector())
+                .endSpec();
+
+        client.services().inNamespace(namespace).withName(name).createOrReplace(builder.build());
+    }
+
+    @Override
+    public void deleteExternalEndpoint(String namespace, String name) {
+        name = getName(name);
+        client.services().inNamespace(name).withName(name).cascading(true).delete();
+    }
+
+    @Override
+    public String getOlmNamespace() {
+        return OLM_NAMESPACE;
+    }
+
+    @Override
+    public Endpoint getMasterEndpoint() {
+        return new Endpoint(client.getMasterUrl());
+    }
+
+    @Override
+    public Endpoint getRestEndpoint() {
+        return new Endpoint(client.getMasterUrl());
+    }
+
+    @Override
+    public Endpoint getKeycloakEndpoint() {
+        return null;
+    }
+
+    @Override
+    public Endpoint getExternalEndpoint(String name) {
+        return getExternalEndpoint(name, infraNamespace);
+    }
+
+    @Override
+    public Endpoint getExternalEndpoint(String name, String namespace) {
+        String externalName = getName(name);
+
+        Service service = Kubernetes.getInstance().client.services().inNamespace(namespace).list()
+                .getItems().stream().filter(p -> p.getMetadata().getName().equals(externalName)).findAny().orElseThrow();
+
+        Endpoint endpoint = new Endpoint(this.getHost(), service.getSpec().getPorts().get(0).getNodePort());
+        return endpoint;
+    }
+
+    @Override
+    public String getClusterExternalImageRegistry() {
+        return null;
+    }
+
+    @Override
+    public String getClusterInternalImageRegistry() {
+        return null;
+    }
+
+    @Override
+    public String getHost() {
+        List<NodeAddress> addresses = client.nodes().list().getItems().stream()
+                .peek(n -> LoggerUtils.getLogger().info("Found node: {}", n.getMetadata().getName()))
+                .flatMap(n -> n.getStatus().getAddresses().stream()
+                        .peek(a -> LoggerUtils.getLogger().info("Found address: {}", a))
+                        .filter(a -> a.getType().equals("InternalIP")))
+                .collect(Collectors.toList());
+        if (addresses.isEmpty()) {
+            return null;
+        }
+        return addresses.get(0).getAddress();
+    }
+
+    private String getName(String name) {
+        String externalName = name;
+        if (!name.endsWith("-external")) {
+            externalName += "-external";
+        }
+        return externalName;
+    }
+}

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/Kubernetes.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/Kubernetes.java
@@ -35,6 +35,7 @@ import io.enmasse.systemtest.condition.OpenShiftVersion;
 import io.enmasse.systemtest.executor.Exec;
 import io.enmasse.systemtest.framework.LoggerUtils;
 import io.enmasse.systemtest.platform.cluster.ClusterType;
+import io.enmasse.systemtest.platform.cluster.KindCluster;
 import io.enmasse.systemtest.platform.cluster.KubeCluster;
 import io.enmasse.systemtest.platform.cluster.KubernetesCluster;
 import io.enmasse.systemtest.platform.cluster.MinikubeCluster;
@@ -142,6 +143,8 @@ public abstract class Kubernetes {
             }
             if (cluster.toString().equals(MinikubeCluster.IDENTIFIER)) {
                 instance = new Minikube();
+            } else if (cluster.toString().equals(KindCluster.IDENTIFIER)) {
+                instance = new Kind();
             } else if (cluster.toString().equals(KubernetesCluster.IDENTIFIER)) {
                 instance = new GenericKubernetes();
             } else {

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/cluster/ClusterType.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/cluster/ClusterType.java
@@ -6,6 +6,7 @@ package io.enmasse.systemtest.platform.cluster;
 
 public enum ClusterType {
     MINIKUBE,
+    KIND,
     OPENSHIFT,
     CRC,
     KUBERNETES,

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/cluster/KindCluster.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/cluster/KindCluster.java
@@ -15,12 +15,12 @@ public class KindCluster implements KubeCluster{
     @Override
     public boolean isAvailable() {
         return Exec.isExecutableOnPath(IDENTIFIER)
-                && !Exec.execute(IDENTIFIER, "get", "clusters").getStdOut().contains("No kind clusters found.");
+                && !Exec.execute(Arrays.asList(IDENTIFIER, "get", "clusters"), false).getStdOut().contains("No kind clusters found.");
     }
 
     @Override
     public boolean isClusterUp() {
-        return Exec.execute(Arrays.asList(IDENTIFIER, "get", "nodes")).getStdOut().contains("kind-control-plane");
+        return Exec.execute(Arrays.asList(IDENTIFIER, "get", "nodes"), false).getStdOut().contains("kind-control-plane");
     }
 
     @Override

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/cluster/KindCluster.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/cluster/KindCluster.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018-2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.systemtest.platform.cluster;
+
+import io.enmasse.systemtest.executor.Exec;
+
+import java.util.Arrays;
+
+public class KindCluster implements KubeCluster{
+
+    public static final String IDENTIFIER = "kind";
+
+    @Override
+    public boolean isAvailable() {
+        return Exec.isExecutableOnPath(IDENTIFIER)
+                && !Exec.execute(IDENTIFIER, "get", "clusters").getStdOut().contains("No kind clusters found.");
+    }
+
+    @Override
+    public boolean isClusterUp() {
+        return Exec.execute(Arrays.asList(IDENTIFIER, "get", "nodes")).getStdOut().contains("kind-control-plane");
+    }
+
+    @Override
+    public String getKubeCmd() {
+        return "kubectl";
+    }
+
+    @Override
+    public String toString() {
+        return IDENTIFIER;
+    }
+}

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/cluster/KubeCluster.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/cluster/KubeCluster.java
@@ -22,7 +22,7 @@ public interface KubeCluster {
     static KubeCluster detect() {
         Logger LOGGER = LoggerUtils.getLogger();
 
-        KubeCluster[] clusters = new KubeCluster[]{new MinikubeCluster(), new KubernetesCluster(), new CRCCluster(), new OpenShiftCluster()};
+        KubeCluster[] clusters = new KubeCluster[]{new MinikubeCluster(), new KindCluster(), new KubernetesCluster(), new CRCCluster(), new OpenShiftCluster()};
         KubeCluster cluster = null;
         String overrideCluster = Environment.getInstance().getOverrideClusterType();
         if (!Strings.isNullOrEmpty(overrideCluster)) {

--- a/systemtests/src/test/java/io/enmasse/systemtest/iot/http/StandardIoTHttpTests.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/iot/http/StandardIoTHttpTests.java
@@ -61,7 +61,6 @@ public interface StandardIoTHttpTests extends StandardIoTTests {
     @ParameterizedTest(name = "testHttpEventSingle-{0}")
     @MethodSource("getDevices")
     default void testHttpEventSingle(final DeviceSupplier device) throws Exception {
-
         try (HttpAdapterClient client = device.get().createHttpAdapterClient()) {
             new MessageSendTester()
                     .type(MessageSendTester.Type.EVENT)


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Enhancement / new feature

### Description
Add ability to run IoT job on all PR builds.
IoT will run only HttpAdapterTest for now, we can add other tests in the future, but I don't want to let queue fill and let other PR runs wait.
<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
