### PR TITLE
[Console-iot] - Unify all projects list results

### DIFF
--- a/console/console-init/ui/mock-console-server/README.md
+++ b/console/console-init/ui/mock-console-server/README.md
@@ -416,89 +416,115 @@ query single_address_with_links_and_metrics {
 }
 ```
 
-## Retrieve all Iot projects
+## Retrieve list of Iot tenants and messaging projects
 
 ```
-query allProjects {
-  allProjects(
-    projectType: iotProject
-  ) {
+query {
+  allProjects {
     total
-    iotProjects {
-      metadata {
-        name
-        namespace
-        creationTimestamp
-      }
-      enabled
-      spec {
-        tenantId
-        configuration
-        addresses {
-              Telemetry {
-                name
-              }
-              Event {
-                name
-              }
-              Command {
-                name
-              }
+    objects {
+      ... on AddressSpace_consoleapi_enmasse_io_v1beta1 {
+        kind
+        metadata {
+          name
+          namespace
         }
       }
-      status {
-        phase
-        phaseReason
+      ... on IoTProject_iot_enmasse_io_v1alpha1 {
+        kind
+        metadata {
+          name
+          namespace
+        }
+        enabled
       }
-      endpoints {
-        name
-        url
-        host
+    }
+  }
+}
+
+```
+
+## Retrieve a list of iot project
+
+```
+query {
+  allProjects (
+     filter: "`$.kind`='IoTProject'"
+  ) {
+    total
+    objects {
+      ... on AddressSpace_consoleapi_enmasse_io_v1beta1 {
+        kind
+        metadata {
+          name
+          namespace
+        }
+      }
+      ... on IoTProject_iot_enmasse_io_v1alpha1 {
+        kind
+        metadata {
+          name
+          namespace
+        }
+        enabled
       }
     }
   }
 }
 ```
 
-## Retrieve a filtered iot project
+## Retrieve a list of iot project and filter by state
 
 ```
-query allProjects {
-  allProjects(
-    filter: "`$.metadata.name`='iotProjectFrance'"
-    projectType: iotProject
+query {
+  allProjects (
+     filter: "`$.kind`='IoTProject' AND `$.enabled` = true"
   ) {
     total
-    iotProjects {
-      metadata {
-        name
-        namespace
-        creationTimestamp
-      }
-      enabled
-      spec {
-        tenantId
-        configuration
-        addresses {
-              Telemetry {
-                name
-              }
-              Event {
-                name
-              }
-              Command {
-                name
-              }
+    objects {
+      ... on AddressSpace_consoleapi_enmasse_io_v1beta1 {
+        kind
+        metadata {
+          name
+          namespace
         }
       }
-      status {
-        phase
-        phaseReason
+      ... on IoTProject_iot_enmasse_io_v1alpha1 {
+        kind
+        metadata {
+          name
+          namespace
+        }
+        enabled
       }
-      endpoints {
-        name
-        url
-        host
+    }
+  }
+}
+```
+
+## Retrieve a list of AddressSpace
+
+```
+query {
+  allProjects (
+     filter: "`$.kind`='AddressSpace'"
+  ) {
+    total
+    objects {
+      ... on AddressSpace_consoleapi_enmasse_io_v1beta1 {
+        kind
+        metadata {
+          name
+          namespace
+        }
+      }
+      ... on IoTProject_iot_enmasse_io_v1alpha1 {
+        kind
+        metadata {
+          name
+          namespace
+        }
+        enabled
       }
     }
   }

--- a/console/console-init/ui/mock-console-server/schema.js
+++ b/console/console-init/ui/mock-console-server/schema.js
@@ -249,6 +249,7 @@ const typeDefs = gql`
 
   type AddressSpace_consoleapi_enmasse_io_v1beta1 {
     metadata: ObjectMeta_v1!
+    kind: String!  
     spec: AddressSpaceSpec_enmasse_io_v1beta1!
     status: AddressSpaceStatus_enmasse_io_v1beta1
     connections(
@@ -524,15 +525,14 @@ const typeDefs = gql`
 
     # iot queries
 
-    "Returns the namespaces and iotprojects visible to this user, optionaly filtered by project type"
+    "Returns the messaging projects and iot tenants visible to this user."
     #This extends the existing "addressSpaces" query
     allProjects(
       first: Int
       offset: Int
       filter: String
       orderBy: String
-      projectType: ProjectQueryType
-    ): AddressSpaceAndIotProjectsQueryResult_consoleapi_iot_enmasse_io_v1alpha1!
+    ): ProjectListQueryResult_consoleapi_iot_enmasse_io_v1alpha1!
 
     "Returns the devices in the given iot project visible to this user, optionally filtering"
     devices(
@@ -751,6 +751,7 @@ const typeDefs = gql`
 
   type IoTProject_iot_enmasse_io_v1alpha1 {
     metadata: ObjectMeta_v1!
+    kind: String!
     enabled: Boolean!
     spec: IotProjectSpec_iot_enmasse_io_v1alpha1!
     status: IoTProjectStatus_iot_enmasse_io_v1alpha1!
@@ -793,16 +794,13 @@ const typeDefs = gql`
     credentials: String! #The Json representation of the credentials for device.
   }
 
-  type AddressSpaceAndIotProjectsQueryResult_consoleapi_iot_enmasse_io_v1alpha1 {
+  type ProjectListQueryResult_consoleapi_iot_enmasse_io_v1alpha1 {
     total: Int!
-    addressSpaces: [AddressSpace_consoleapi_enmasse_io_v1beta1!]
-    iotProjects: [IoTProject_iot_enmasse_io_v1alpha1!]
+    objects: [ProjectListResult_consoleapi_iot_enmasse_io_v1alpha1!]!
   }
 
-  enum ProjectQueryType {
-    iotProject
-    addressSpace
-  }
+  union ProjectListResult_consoleapi_iot_enmasse_io_v1alpha1 =
+      AddressSpace_consoleapi_enmasse_io_v1beta1 | IoTProject_iot_enmasse_io_v1alpha1
 
   #
   # Inputs Types

--- a/console/console-server/src/main/resources/iot.schema.graphql
+++ b/console/console-server/src/main/resources/iot.schema.graphql
@@ -52,6 +52,7 @@ type IotProjectSpec_iot_enmasse_io_v1alpha1 {
 type IoTProject_iot_enmasse_io_v1alpha1 {
 
   metadata: ObjectMeta_v1! @goField(name: "ObjectMeta")
+  kind: String!
   enabled: Boolean!
   spec: IotProjectSpec_iot_enmasse_io_v1alpha1!
   status: IoTProjectStatus_iot_enmasse_io_v1alpha1!
@@ -87,23 +88,19 @@ type CredentialsQueryResult_consoleapi_iot_enmasse_io_v1alpha1 {
   total: Int!
   credentials: [String!]! #The Json representation of the credentials for device.
 }
-
-type AddressSpaceAndIotProjectsQueryResult_consoleapi_iot_enmasse_io_v1alpha1 {
+type projectListQueryResult_consoleapi_iot_enmasse_io_v1alpha1 {
   total: Int!
-  addressSpaces: [AddressSpace_consoleapi_enmasse_io_v1beta1!]
-  iotProjects: [IoTProject_iot_enmasse_io_v1alpha1!]
+  objects: [ProjectListResult_consoleapi_iot_enmasse_io_v1alpha1!]!
 }
 
-enum ProjectQueryType {
-  iotProject
-  addressSpace
-}
+union ProjectListResult_consoleapi_iot_enmasse_io_v1alpha1 =
+  AddressSpace_consoleapi_enmasse_io_v1beta1 | IoTProject_iot_enmasse_io_v1alpha1
 
 type Query {
 
   "Returns the namespaces and iotprojects visible to this user, optionaly filtered by project type"
   #This extends the existing "addressSpaces" query
-  allProjects(first: Int, offset: Int, filter: String, orderBy: String, projectType: ProjectQueryType): AddressSpaceAndIotProjectsQueryResult_consoleapi_iot_enmasse_io_v1alpha1!
+  allProjects(first: Int, offset: Int, filter: String, orderBy: String): ProjectListQueryResult_consoleapi_iot_enmasse_io_v1alpha1!
 
   devices(iotproject: ObjectMeta_v1_Input!, first: Int, offset: Int, filter: String, orderBy: String): DevicesQueryResult_consoleapi_iot_enmasse_io_v1alpha1
   credentials(iotproject: ObjectMeta_v1_Input!, deviceId: String!): CredentialsQueryResult_consoleapi_iot_enmasse_io_v1alpha1!


### PR DESCRIPTION
### Type of change

Unifying the results to create a list of resources that contains `iotptojects` and `addressSpaces` and can be filtered and paged through.
This is done with adding a `kind` field to both of the objects.

- Enhancement

See README for how to use it.