### PR TITLE
downgrade version of frontend-maven-plugin to fix logging during build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
         <mycila-license-maven-plugin.version>2.11</mycila-license-maven-plugin.version>
         <codehaus-license-maven-plugin.version>2.0.0</codehaus-license-maven-plugin.version>
-        <frontend-maven-plugin.version>1.9.1</frontend-maven-plugin.version>
+        <frontend-maven-plugin.version>1.7.6</frontend-maven-plugin.version>
         <properties-maven-plugin.version>1.0.0</properties-maven-plugin.version>
         <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
         <maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description
To help see why the jenkins build is failing in PR #4912, we need the yarn output in the logs.
https://github.com/eirslett/frontend-maven-plugin/issues/791 has stopped the maven build from logging the yarn output.
Downgrading to version 1.7.6 (where logging still works)

Confirmed that versions: 1.8.0, 1.9.1 and 1.10.0 do not provide output
### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
