### PR TITLE
[RouterConfigControllerTest] use alternative method withValueFromSecret

### DIFF
--- a/address-space-controller/src/test/java/io/enmasse/controller/RouterConfigControllerTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/RouterConfigControllerTest.java
@@ -15,6 +15,7 @@ import io.enmasse.k8s.api.LogEventLogger;
 import io.enmasse.model.CustomResourceDefinitions;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretKeySelector;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import org.junit.jupiter.api.BeforeAll;
@@ -217,13 +218,13 @@ public class RouterConfigControllerTest {
 
                 .withNewTls()
                 .withNewCaCert()
-                .withNewValueFromSecret("ca.crt", "remote-certs", false)
+                .withValueFromSecret(new SecretKeySelector("ca.crt", "remote-certs", false))
                 .endCaCert()
                 .withNewClientCert()
-                .withNewValueFromSecret("tls.crt", "remote-certs", false)
+                .withValueFromSecret(new SecretKeySelector("tls.crt", "remote-certs", false))
                 .endClientCert()
                 .withNewClientKey()
-                .withNewValueFromSecret("tls.key", "remote-certs", false)
+                .withValueFromSecret(new SecretKeySelector("tls.key", "remote-certs", false))
                 .endClientKey()
                 .endTls()
                 .withNewCredentials()


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fixes odd compile error appearing on some CI environments.


### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
