### PR TITLE
Fix console-server docker entrypoint

### DIFF
--- a/console/console-server/Dockerfile
+++ b/console/console-server/Dockerfile
@@ -12,4 +12,4 @@ ENV VERSION=${version} MAVEN_VERSION=${maven_version} REVISION=${revision}
 
 ADD target/console-server-${maven_version}-dist.tar.gz /
 
-ENTRYPOINT /console-server
+ENTRYPOINT ["/console-server"]


### PR DESCRIPTION
### Type of change


- Bugfix

### Description

The refactoring of the base-images exposed this defect.  Note that the console is not currently functional as it still needs to be wired to the new model.


### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
