### PR TITLE
Bump RESTeasy from 3.6.1.SP2 to 4.5.3.Final

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 
 ## 1.0.0
+* #5013: Bump RESTeasy from 3.6.1.SP2 to 4.5.3.Final
 
 ## 0.32.2
 * #4839: [Agent] ensure that router disconnect cancels the timer and doesn't accumulate Rhea listeners (#4840)

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <jboss.el.api.version>1.0.13.Final</jboss.el.api.version>
         <json-patch.version>1.9</json-patch.version>
         <glassfish.el.version>3.0.1-b08</glassfish.el.version>
-        <resteasy.version>3.6.1.SP2</resteasy.version>
+        <resteasy.version>4.5.3.Final</resteasy.version>
         <mockito.version>2.21.0</mockito.version>
         <guava.version>25.0-jre</guava.version>
         <hamcrest.version>2.2</hamcrest.version>
@@ -230,11 +230,6 @@
                 <version>${fabric8.kubernetes-client.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.jboss.resteasy</groupId>
-                <artifactId>resteasy-multipart-provider</artifactId>
-                <version>${resteasy.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.jsonschema2pojo</groupId>
                 <artifactId>jsonschema2pojo-core</artifactId>
                 <version>${jsonschema2pojo.version}</version>
@@ -316,22 +311,9 @@
             </dependency>
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
-                <artifactId>resteasy-jaxrs</artifactId>
-                <version>${resteasy.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>net.jcip</groupId>
-                        <artifactId>jcip-annotations</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-vertx</artifactId>
                 <version>${resteasy.version}</version>
             </dependency>
-
-
             <dependency>
                 <groupId>org.jboss.logging</groupId>
                 <artifactId>jboss-logging</artifactId>


### PR DESCRIPTION
### Type of change


- Enhancement / new feature

### Description

Bump RESTeasy from 3.6.1.SP2 to 4.5.3.Final

### Checklist


- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
