### PR TITLE
Enable upgrade tests for 1.4

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/upgrade/UpgradeTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/upgrade/UpgradeTest.java
@@ -199,11 +199,6 @@ class UpgradeTest extends TestBase implements ITestIsolatedStandard {
                 log.warn("Skipping OLM test from version {} , because replaces version is {}", version, environment.enmasseOlmReplaces());
                 return;
             }
-            if (olmType == OLMInstallationType.DEFAULT && (version.equals("0.31.0") || version.equals("1.4.0"))) {
-                //versions with known fsgroup issue
-                log.warn("Skipping OLM test for version {}, because of known issue without fix", version);
-                return;
-            }
             installEnmasseOLM(Paths.get(templates), version);
         } else {
             installEnmasseBundle(Paths.get(templates), version);


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

This fix enables running OLM upgrade tests for 1.4/0.31 versions.
<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
