### PR TITLE
Ensure that application of end user network policy does not affect traffic between EnMasse components

### DIFF
--- a/address-space-controller/src/test/java/io/enmasse/controller/NetworkPolicyControllerTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/NetworkPolicyControllerTest.java
@@ -6,12 +6,16 @@ package io.enmasse.controller;
 
 import static junit.framework.TestCase.assertNotNull;
 import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
+import java.util.List;
 
+import io.fabric8.kubernetes.api.model.networking.NetworkPolicyIngressRule;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -72,7 +76,13 @@ public class NetworkPolicyControllerTest extends JULInitializingTest {
         assertEquals("enmasse", networkPolicy.getMetadata().getLabels().get(LabelKeys.APP));
         assertEquals("1234", networkPolicy.getMetadata().getLabels().get(LabelKeys.INFRA_UUID));
         assertThat(networkPolicy.getSpec().getPolicyTypes(), hasItem("Ingress"));
-        assertEquals("label", networkPolicy.getSpec().getIngress().get(0).getFrom().get(0).getPodSelector().getMatchLabels().get("my"));
+        assertThat(networkPolicy.getSpec().getPolicyTypes(), not(hasItem("Egress")));
+        assertTrue(networkPolicy.getSpec().getEgress().isEmpty());
+
+        List<NetworkPolicyIngressRule> ingresses = networkPolicy.getSpec().getIngress();
+        assertEquals(2, ingresses.size());
+        assertEquals("label", ingresses.get(0).getFrom().get(0).getPodSelector().getMatchLabels().get("my"));
+        assertEquals("enmasse", ingresses.get(1).getFrom().get(0).getPodSelector().getMatchLabels().get(LabelKeys.APP), "should permit enmasse traffic");
     }
 
     @Test
@@ -89,7 +99,13 @@ public class NetworkPolicyControllerTest extends JULInitializingTest {
         assertEquals("enmasse", networkPolicy.getMetadata().getLabels().get(LabelKeys.APP));
         assertEquals("1234", networkPolicy.getMetadata().getLabels().get(LabelKeys.INFRA_UUID));
         assertThat(networkPolicy.getSpec().getPolicyTypes(), hasItem("Ingress"));
-        assertEquals("label", networkPolicy.getSpec().getIngress().get(0).getFrom().get(0).getPodSelector().getMatchLabels().get("my"));
+        assertThat(networkPolicy.getSpec().getPolicyTypes(), not(hasItem("Egress")));
+        assertTrue(networkPolicy.getSpec().getEgress().isEmpty());
+
+        List<NetworkPolicyIngressRule> ingresses = networkPolicy.getSpec().getIngress();
+        assertEquals(2, ingresses.size());
+        assertEquals("label", ingresses.get(0).getFrom().get(0).getPodSelector().getMatchLabels().get("my"));
+        assertEquals("enmasse", ingresses.get(1).getFrom().get(0).getPodSelector().getMatchLabels().get(LabelKeys.APP), "should permit enmasse traffic");
     }
 
     @Test

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/policy/NetworkPolicyTestBrokered.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/policy/NetworkPolicyTestBrokered.java
@@ -45,7 +45,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -70,14 +70,16 @@ class NetworkPolicyTestBrokered extends TestBase implements ITestIsolatedBrokere
     @Test
     void testNetworkPolicyWithPodSelector() throws Exception {
         int expectedMsgCount = 5;
-        HashMap<String, String> map = new HashMap<>();
-        map.put("app", allowedSpace);
 
+        LabelSelector namespace = new LabelSelectorBuilder()
+                .withMatchLabels(Collections.singletonMap("allowed", "true"))
+                .build();
         LabelSelector pod = new LabelSelectorBuilder()
-                .withMatchLabels(map)
+                .withMatchLabels(Map.of("app", allowedSpace))
                 .build();
         NetworkPolicyPeer networkPolicyPeer = new NetworkPolicyPeerBuilder()
                 .withPodSelector(pod)
+                .withNamespaceSelector(namespace)
                 .build();
 
         BrokeredInfraConfig standardInfraConfig = prepareConfig(networkPolicyPeer);

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/policy/NetworkPolicyTestStandard.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/policy/NetworkPolicyTestStandard.java
@@ -48,6 +48,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -76,14 +77,15 @@ class NetworkPolicyTestStandard extends TestBase implements ITestIsolatedStandar
     @Tag(ACCEPTANCE)
     void testNetworkPolicyWithPodSelector() throws Exception {
         int expectedMsgCount = 5;
-        HashMap<String, String> map = new HashMap<>();
-        map.put("app", allowedSpace);
-
+        LabelSelector namespace = new LabelSelectorBuilder()
+                .withMatchLabels(Collections.singletonMap("allowed", "true"))
+                .build();
         LabelSelector pod = new LabelSelectorBuilder()
-                .withMatchLabels(map)
+                .withMatchLabels(Map.of("app", allowedSpace))
                 .build();
         NetworkPolicyPeer networkPolicyPeer = new NetworkPolicyPeerBuilder()
                 .withPodSelector(pod)
+                .withNamespaceSelector(namespace)
                 .build();
 
         StandardInfraConfig standardInfraConfig = prepareConfig(networkPolicyPeer);
@@ -121,7 +123,7 @@ class NetworkPolicyTestStandard extends TestBase implements ITestIsolatedStandar
         int expectedMsgCount = 5;
 
         LabelSelector namespace = new LabelSelectorBuilder()
-                .withMatchLabels(Collections.singletonMap("allowed", "true"))
+                .withMatchLabels(Map.of("allowed", "true"))
                 .build();
         NetworkPolicyPeer networkPolicyPeer = new NetworkPolicyPeerBuilder()
                 .withNamespaceSelector(namespace)


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The NetworkPolicyConntroller now ensures that the network policy permits traffic between the EnMasse pods (those with `app=enmasse`) on the infra-namespace.   I think the previous implementation was incorrect and meant the traffic between EnMasse's own pods was impeded.  I suspect that a defect fix included in OpenShift 4.5 allowed the issue to surface.

There was also a defect in `testNetworkPolicyWithPodSelector`.  When specifying a `podSelector`,  a `namespaceSelector` has to be included unless the target pod happens to be in the  infra namespace. See https://kubernetes.io/docs/concepts/services-networking/network-policies/


### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
