### PR TITLE
Remove okhttp3 workaround for fabric8

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/Environment.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/Environment.java
@@ -39,9 +39,6 @@ public class Environment {
     private static final String ENMASSE_DOCS_SYSTEM_PROPERTY = "enmasse.docs";
     private static final String ENMASSE_OLM_REPLACES_SYSTEM_PROPERTY = "enmasse.olm.replaces";
     private static final String K8S_DOMAIN_ENV = "KUBERNETES_DOMAIN";
-    private static final String K8S_API_CONNECT_TIMEOUT = "KUBERNETES_API_CONNECT_TIMEOUT";
-    private static final String K8S_API_READ_TIMEOUT = "KUBERNETES_API_READ_TIMEOUT";
-    private static final String K8S_API_WRITE_TIMEOUT = "KUBERNETES_API_WRITE_TIMEOUT";
     private static final String UPGRADE_TEPLATES_ENV = "UPGRADE_TEMPLATES";
     private static final String START_TEMPLATES_ENV = "START_TEMPLATES";
     private static final String TEMPLATES_PATH = "TEMPLATES";
@@ -93,9 +90,6 @@ public class Environment {
     private final String infinispanProject = getOrDefault(jsonEnv, INFINISPAN_PROJECT, "systemtests-infinispan");
     private final String postgresqlProject = getOrDefault(jsonEnv, POSTGRESQL_PROJECT, "systemtests-postgresql");
     private final String h2Project = getOrDefault(jsonEnv, H2_PROJECT, "systemtests-h2");
-    private final Duration kubernetesApiConnectTimeout = getOrDefault(jsonEnv, K8S_API_CONNECT_TIMEOUT, i -> Duration.ofSeconds(Long.parseLong(i)), Duration.ofSeconds(60));
-    private final Duration kubernetesApiReadTimeout = getOrDefault(jsonEnv, K8S_API_READ_TIMEOUT, i -> Duration.ofSeconds(Long.parseLong(i)), Duration.ofSeconds(60));
-    private final Duration kubernetesApiWriteTimeout = getOrDefault(jsonEnv, K8S_API_WRITE_TIMEOUT, i -> Duration.ofSeconds(Long.parseLong(i)), Duration.ofSeconds(60));
     private final EnmasseInstallType installType = getOrDefault(jsonEnv, INSTALL_TYPE, value -> EnmasseInstallType.valueOf(value.toUpperCase()), EnmasseInstallType.BUNDLE);
     private final OLMInstallationType olmInstallType = Optional.ofNullable(getOrDefault(jsonEnv, OLM_INSTALL_TYPE, "")).map(s -> s.isEmpty() ? OLMInstallationType.SPECIFIC.name() : s).map(value -> OLMInstallationType.valueOf(value.toUpperCase())).orElse(OLMInstallationType.SPECIFIC);
     private final String templatesPath = getOrDefault(jsonEnv, TEMPLATES_PATH, Paths.get(System.getProperty("user.dir"), "..", "templates", "build", "enmasse-latest").toString());
@@ -285,18 +279,6 @@ public class Environment {
 
     public String getTemplatesPath() {
         return templatesPath;
-    }
-
-    public Duration getKubernetesApiConnectTimeout() {
-        return kubernetesApiConnectTimeout;
-    }
-
-    public Duration getKubernetesApiReadTimeout() {
-        return kubernetesApiReadTimeout;
-    }
-
-    public Duration getKubernetesApiWriteTimeout() {
-        return kubernetesApiWriteTimeout;
     }
 
     public String getInfinispanProject() {

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/GenericKubernetes.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/GenericKubernetes.java
@@ -24,15 +24,7 @@ public class GenericKubernetes extends Kubernetes {
     protected GenericKubernetes() {
         super(() -> {
             Config config = new ConfigBuilder().build();
-            OkHttpClient httpClient = HttpClientUtils.createHttpClient(config);
-            // Workaround https://github.com/square/okhttp/issues/3146
-            httpClient = httpClient.newBuilder()
-                    .protocols(Collections.singletonList(Protocol.HTTP_1_1))
-                    .connectTimeout(Environment.getInstance().getKubernetesApiConnectTimeout())
-                    .writeTimeout(Environment.getInstance().getKubernetesApiWriteTimeout())
-                    .readTimeout(Environment.getInstance().getKubernetesApiReadTimeout())
-                    .build();
-            return new DefaultKubernetesClient(httpClient, config);
+            return new DefaultKubernetesClient(config);
         });
     }
 

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/Kind.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/Kind.java
@@ -30,15 +30,7 @@ public class Kind extends Kubernetes{
     protected Kind() {
         super(() -> {
             Config config = new ConfigBuilder().build();
-            OkHttpClient httpClient = HttpClientUtils.createHttpClient(config);
-            // Workaround https://github.com/square/okhttp/issues/3146
-            httpClient = httpClient.newBuilder()
-                    .protocols(Collections.singletonList(Protocol.HTTP_1_1))
-                    .connectTimeout(Environment.getInstance().getKubernetesApiConnectTimeout())
-                    .writeTimeout(Environment.getInstance().getKubernetesApiWriteTimeout())
-                    .readTimeout(Environment.getInstance().getKubernetesApiReadTimeout())
-                    .build();
-            return new DefaultKubernetesClient(httpClient, config);
+            return new DefaultKubernetesClient(config);
         });
     }
 

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/Minikube.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/Minikube.java
@@ -30,15 +30,7 @@ public class Minikube extends Kubernetes {
     protected Minikube() {
         super(() -> {
             Config config = new ConfigBuilder().build();
-            OkHttpClient httpClient = HttpClientUtils.createHttpClient(config);
-            // Workaround https://github.com/square/okhttp/issues/3146
-            httpClient = httpClient.newBuilder()
-                    .protocols(Collections.singletonList(Protocol.HTTP_1_1))
-                    .connectTimeout(Environment.getInstance().getKubernetesApiConnectTimeout())
-                    .writeTimeout(Environment.getInstance().getKubernetesApiWriteTimeout())
-                    .readTimeout(Environment.getInstance().getKubernetesApiReadTimeout())
-                    .build();
-            return new DefaultKubernetesClient(httpClient, config);
+            return new DefaultKubernetesClient(config);
         });
     }
 

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/OpenShift.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/OpenShift.java
@@ -40,15 +40,7 @@ public class OpenShift extends Kubernetes {
             Config config = new ConfigBuilder().withMasterUrl(Environment.getInstance().getApiUrl())
                     .withOauthToken(Environment.getInstance().getApiToken())
                     .build();
-            OkHttpClient httpClient = HttpClientUtils.createHttpClient(config);
-            // Workaround https://github.com/square/okhttp/issues/3146
-            httpClient = httpClient.newBuilder()
-                    .protocols(Collections.singletonList(Protocol.HTTP_1_1))
-                    .connectTimeout(Environment.getInstance().getKubernetesApiConnectTimeout())
-                    .writeTimeout(Environment.getInstance().getKubernetesApiWriteTimeout())
-                    .readTimeout(Environment.getInstance().getKubernetesApiReadTimeout())
-                    .build();
-            return new DefaultOpenShiftClient(httpClient, new OpenShiftConfig(config));
+            return new DefaultOpenShiftClient(new OpenShiftConfig(config));
         });
     }
 


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Refactoring

### Description

<!--

_Please describe your pull request_

-->

Remove fabric8 workaround, this should be fixed in latest fabric8 client which we use

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
