### PR TITLE
Console Iot - proposal to align device input schema with JSON editor view

### DIFF
--- a/console/console-init/ui/mock-console-server/README.md
+++ b/console/console-init/ui/mock-console-server/README.md
@@ -1116,9 +1116,11 @@ mutation {
        namespace: "app1_ns"
     },
     device: {
-      deviceId: "Jens-phone"
-      enabled: true
-      ext: "{brand: samsung}"
+      deviceId: "Jens-phone",
+      registration : {
+        enabled: true
+        ext: "{brand: samsung}"
+      },
       credentials: "[{auth-id: \"pin\", type: \"password\", pwd-plain: \"1234\"}]"
     }
 	) {
@@ -1145,9 +1147,11 @@ mutation {
   updateIotDevice(
     iotproject: { name: "iotProjectFrance", namespace:"app1_ns" },
     device: {
-      deviceId: "Jens-phone"
-      enabled: true
-      ext: "{brand: apple, headphone-jack: false}"
+      deviceId: "Jens-phone",
+      registration : {
+        enabled: true
+        ext: "{brand: apple, headphone-jack: false}"
+      }
     }
 	) {
     deviceId

--- a/console/console-init/ui/mock-console-server/mock-console-server.js
+++ b/console/console-init/ui/mock-console-server/mock-console-server.js
@@ -2509,7 +2509,17 @@ const resolvers = {
     },
 
     createIotDevice: (parent, args) => {
-      return createIotDevice(args.iotproject.name, args.device);
+      let reg = args.device.registration;
+      reg.deviceId = args.device.deviceId;
+      let creds = args.device.credentials;
+
+      let result = createIotDevice(args.iotproject.name, args.device);
+      if (result != undefined) {
+        setCredentials(args.iotproject.name, result.deviceId, creds);
+        return result;
+      } else {
+        throw "Device could not be updated";
+      }
     },
     deleteIotDevices: (parent, args) => {
       var errors = [];
@@ -2528,7 +2538,17 @@ const resolvers = {
     },
     updateIotDevice: (parent, args) => {
       deleteIotDevice(args.iotproject.name, args.device.deviceId);
-      return createIotDevice(args.iotproject.name, args.device);
+      let reg = args.device.registration;
+      reg.deviceId = args.device.deviceId;
+      let creds = args.device.credentials;
+
+      let result = createIotDevice(args.iotproject.name, args.device);
+      if (result != undefined) {
+        setCredentials(args.iotproject.name, result.deviceId, creds);
+        return result;
+      } else {
+        throw "Device could not be updated";
+      }
     },
     setCredentialsForDevice: (parent, args) => {
       setCredentials(args.iotproject.name, args.deviceId, args.jsonData);

--- a/console/console-init/ui/mock-console-server/schema.js
+++ b/console/console-init/ui/mock-console-server/schema.js
@@ -821,7 +821,7 @@ const typeDefs = gql`
   input Device_iot_console_input {
     deviceId: String
     registration: Device_registration_iot_console_input
-    credentials: String! #A Json array with the devices credentials.
+    credentials: String #A Json array with the devices credentials.
   }
 
   input Device_registration_iot_console_input {

--- a/console/console-init/ui/mock-console-server/schema.js
+++ b/console/console-init/ui/mock-console-server/schema.js
@@ -786,7 +786,6 @@ const typeDefs = gql`
     status: Device_status!
     ext: String! #The Json representation of the ext field for this device.
     defaults: String
-    credentials: String! #A Json array with the devices credentials.
   }
 
   type Device_status {
@@ -820,13 +819,17 @@ const typeDefs = gql`
   #
 
   input Device_iot_console_input {
-    deviceId: String!
-    enabled: Boolean!
-    via: [String!]
-    viaGroups: [String!]
-    memberOf: [String!]
-    ext: String! #The Json representation of the ext field for this device.
+    deviceId: String
+    registration: Device_registration_iot_console_input
     credentials: String! #A Json array with the devices credentials.
+  }
+
+  input Device_registration_iot_console_input {
+    enabled: Boolean
+    via: [String]
+    viaGroups: [String]
+    memberOf: [String]
+    ext: String #The Json representation of the ext field for this device.
   }
 
   input IotProject_iot_enmasse_io_v1alpha1_input {

--- a/console/console-server/src/main/resources/iot.schema.graphql
+++ b/console/console-server/src/main/resources/iot.schema.graphql
@@ -80,7 +80,6 @@ type Device {
   memberOf: [String!]
   status: Device_status!
   ext: String! #The Json representation of the ext field for this device.
-  credentials: String! #A Json array with the devices credentials.
 }
 
 type Device_status {
@@ -125,13 +124,17 @@ type Query {
 #
 
 input Device_iot_console_input {
-  deviceId: String!
-  enabled: Boolean!
-  via: [String!]
-  viaGroups: [String!]
-  memberOf: [String!]
-  ext: String! #The Json representation of the ext field for this device.
+  deviceId: String
+  registration : Device_registration_iot_console_input
   credentials: String! #A Json array with the devices credentials.
+}
+
+input Device_registration_iot_console_input {
+  enabled: Boolean
+  via: [String]
+  viaGroups: [String]
+  memberOf: [String]
+  ext: String #The Json representation of the ext field for this device.
 }
 
 input IotProject_iot_enmasse_io_v1alpha1_input {

--- a/console/console-server/src/main/resources/iot.schema.graphql
+++ b/console/console-server/src/main/resources/iot.schema.graphql
@@ -126,7 +126,7 @@ type Query {
 input Device_iot_console_input {
   deviceId: String
   registration : Device_registration_iot_console_input
-  credentials: String! #A Json array with the devices credentials.
+  credentials: String #A Json array with the devices credentials.
 }
 
 input Device_registration_iot_console_input {


### PR DESCRIPTION
The idea is to have the JSON editor for device to have the following template : 

```
{
  "id": "<optional-id>",
  "registration" : 
    {
      "enabled": true, 
      "defaults": {},
      "ext": {},
    },
  "credentials": []
}
```

This align the graphQL schemas to match this. 