### PR TITLE
Prevent stale record from cache leading to incomplete address space deletion

### DIFF
--- a/address-space-controller/src/main/java/io/enmasse/controller/ControllerChain.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/ControllerChain.java
@@ -85,11 +85,9 @@ public class ControllerChain implements Watcher<AddressSpace> {
             return;
         }
 
-        List<AddressSpace> updatedResources = new ArrayList<>();
-
-
         boolean requeue;
         do {
+            List<AddressSpace> updatedResources = new ArrayList<>();
             requeue = false;
             for (final AddressSpace original : resources) {
 
@@ -100,7 +98,7 @@ public class ControllerChain implements Watcher<AddressSpace> {
 
                     log.debug("Controller chain input: {}", original);
 
-                    log.info("Checking address space {}", addressSpaceName);
+                    log.info("Checking address space : {} creationTimestamp: {} deletionTimestamp: {}", addressSpaceName, addressSpace.getMetadata().getCreationTimestamp(), addressSpace.getMetadata().getDeletionTimestamp());
                     for (Controller controller : chain) {
                         log.info("Controller {}", controller);
                         log.debug("Address space input: {}", addressSpace);

--- a/address-space-controller/src/main/java/io/enmasse/controller/RouterStatusCache.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/RouterStatusCache.java
@@ -83,6 +83,7 @@ public class RouterStatusCache implements Runnable, Controller {
             // Take a deep copy of address spaces to ensure stable data
             currentAddressSpaces.addAll(addressSpaces.stream()
                     .filter(addressSpace -> "standard".equals(addressSpace.getSpec().getType()))
+                    .filter(addressSpace -> !Controller.isDeleted(addressSpace))
                     .map(addressSpace -> new AddressSpaceBuilder(addressSpace).build())
                     .collect(Collectors.toList()));
         }

--- a/address-space-controller/src/main/java/io/enmasse/controller/keycloak/RealmController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/keycloak/RealmController.java
@@ -103,12 +103,15 @@ public class RealmController implements Controller {
             Set<String> actualRealms = keycloak.getRealmNames(authenticationService);
 
             for (AddressSpace addressSpace : addressSpaces) {
-                String realmName = addressSpace.getAnnotation(AnnotationKeys.REALM_NAME);
-                if (actualRealms.contains(realmName)) {
-                    continue;
+                if (!Controller.isDeleted(addressSpace)) {
+                    String realmName = addressSpace.getAnnotation(AnnotationKeys.REALM_NAME);
+                    if (actualRealms.contains(realmName)) {
+                        continue;
+                    }
+                    log.info("Creating realm {} in authentication service {}", realmName, authenticationService.getMetadata().getName());
+
+                    keycloak.createRealm(authenticationService, addressSpace.getMetadata().getNamespace(), realmName);
                 }
-                log.info("Creating realm {} in authentication service {}", realmName, authenticationService.getMetadata().getName());
-                keycloak.createRealm(authenticationService, addressSpace.getMetadata().getNamespace(), realmName);
             }
         }
     }


### PR DESCRIPTION
### Type of change


- Bugfix

### Description

A race condition meant that stale values from the `EventCache` could cause the AddressSpaceController to partially recreate the address space controller during deletion.

The issue occurs as follows:

1. the Controller thread blocks trying to acquire mutex in method `ResourceChecker#onUpdate` (called from `EventCache#pop`).
2. The mutex is already held by `ResourceChecker#doWork` which is the controller's main loop.
3. By the time the controller's main loop terminates, the records in `io.enmasse.k8s.api.cache.EventCache#store` are stale.  Watcher updates *have* arrived (stored in the intermediate io.enmasse.k8s.api.cache.EventCache#queue) but these can't be processed as the Controller thread is blocked awaiting the mutex.
4. In the unlucky case, after the controller's loop terminates, `ResourceChecker#doWork` immediate reacquires the mutex.  It then releases the mutex as `Object#wait` is called.  This allows the Controller thread to acquire the mutex and notify the ResourceChecker. The ResourceChecker calls io.enmasse.k8s.api.ResourceCache#getItems which returns stale items which is then used as input to the Controller.
5. As the stale input has `metadata.deletionTimestamp` null, the controller proceeds to recreate secrets/configmaps of the address space.

The fix avoids the need for the Controller thread to block.  This will mean that the incoming updates from the watch are processed in timely way, and `#getItems` will be fresh. 

Also made two small changes to avoid noise in the log:

* prevent realm recreation for terminating address spaces
* prevent router status for terminating address spaces to avoid logged warnings



<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
