### PR TITLE
CVE-2020-14319: Deny mutation operations unless an existing session exists

### DIFF
--- a/pkg/consolegraphql/server/metrics.go
+++ b/pkg/consolegraphql/server/metrics.go
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ *
+ */
+
+package server
+
+import "github.com/prometheus/client_golang/prometheus"
+
+func CreateMetrics() (*prometheus.HistogramVec, *prometheus.CounterVec, prometheus.Gauge) {
+	queryTimeMetric := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "console_query_time_seconds",
+		Help:    "The query time in seconds",
+		Buckets: prometheus.DefBuckets,
+	}, []string{"operationName"})
+	queryErrorCountMetric := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "console_query_error_total",
+		Help: "Number of queries that have ended in error",
+	}, []string{"operationName"})
+	sessionCountMetric := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "console_active_sessions",
+		Help: "Number of active HTTP sessions",
+	})
+	return queryTimeMetric, queryErrorCountMetric, sessionCountMetric
+}
+

--- a/pkg/consolegraphql/server/query/handler_test.go
+++ b/pkg/consolegraphql/server/query/handler_test.go
@@ -4,7 +4,7 @@
  *
  */
 
-package server
+package query
 
 import (
 	"github.com/stretchr/testify/assert"

--- a/pkg/consolegraphql/server/query/query.go
+++ b/pkg/consolegraphql/server/query/query.go
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ *
+ */
+
+package query
+
+import (
+	"context"
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/extension"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/99designs/gqlgen/graphql/playground"
+	"github.com/alexedwards/scs/v2"
+	"github.com/enmasseproject/enmasse/pkg/consolegraphql/resolvers"
+	"github.com/enmasseproject/enmasse/pkg/consolegraphql/server"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+	"k8s.io/client-go/rest"
+	"log"
+	"net/http"
+	"time"
+)
+
+func CreateQueryServer(resolver resolvers.Resolver, playMode bool, devMode bool, sessionManager *scs.SessionManager, errorCountMetric *prometheus.CounterVec, timeMetric *prometheus.HistogramVec, config *rest.Config, impersonationConfig *ImpersonationConfig, setsCreator clientSetsCreator) *http.ServeMux {
+	queryServer := http.NewServeMux()
+
+	gqlServer := handler.New(resolvers.NewExecutableSchema(resolvers.Config{Resolvers: &resolver}))
+
+	queryEndpoint := "/graphql/query"
+	if playMode || devMode {
+		playgroundHandler := playground.Handler("GraphQL playground", queryEndpoint)
+		queryServer.Handle("/graphql/", playgroundHandler)
+		gqlServer.Use(extension.Introspection{})
+	}
+
+	gqlServer.AddTransport(transport.POST{})
+
+	gqlServer.SetErrorPresenter(func(ctx context.Context, err error) *gqlerror.Error {
+		rctx := graphql.GetOperationContext(ctx)
+		if rctx != nil {
+			log.Printf("Query error - op: %s query: %s vars: %+v error: %s\n", rctx.OperationName, rctx.RawQuery, rctx.Variables, err)
+		}
+		errorCountMetric.WithLabelValues(rctx.OperationName).Inc()
+		return graphql.DefaultErrorPresenter(ctx, err)
+	})
+
+	gqlServer.AroundOperations(func(ctx context.Context, next graphql.OperationHandler) graphql.ResponseHandler {
+		octx := graphql.GetOperationContext(ctx)
+		requestState := server.GetRequestStateFromContext(ctx)
+		if requestState == nil {
+			panic("missing request state")
+		}
+
+		// CVE-2020-14319 defence
+		if octx.Operation.Operation == ast.Mutation && requestState.NewSession {
+			return func(ctx context.Context) *graphql.Response {
+				log.Printf("[%s] Query error - op: %s query: %s vars: %+v", requestState.User.Name, octx.Operation.Name, octx.RawQuery, octx.Variables)
+				return graphql.ErrorResponse(ctx, "unable to invoke mutation %s at this time", octx.Operation.Name)
+			}
+		}
+
+		return next(ctx)
+	})
+
+	gqlServer.AroundResponses(func(ctx context.Context, next graphql.ResponseHandler) *graphql.Response {
+		loggedOnUser := "<unknown>"
+		start := time.Now()
+		rctx := graphql.GetOperationContext(ctx)
+
+		result := next(ctx)
+		loggedOnUser = UpdateAccessControllerState(ctx, loggedOnUser, sessionManager)
+		if rctx != nil {
+			since := time.Since(start)
+			log.Printf("[%s] Query execution - op: %s %s\n", loggedOnUser, rctx.OperationName, since)
+			timeMetric.WithLabelValues(rctx.OperationName).Observe(since.Seconds())
+		}
+		return result
+	})
+
+	if devMode {
+		queryServer.Handle(queryEndpoint, DevelopmentHandler(gqlServer, sessionManager, config.BearerToken, setsCreator))
+	} else {
+		queryServer.Handle(queryEndpoint, AuthHandler(gqlServer, sessionManager, impersonationConfig, setsCreator))
+	}
+	return queryServer
+}

--- a/pkg/consolegraphql/server/query/query_test.go
+++ b/pkg/consolegraphql/server/query/query_test.go
@@ -45,7 +45,7 @@ func setUp() (http.Handler, v1beta1api.EnmasseV1beta1Interface) {
 	return sessionManager.LoadAndSave(queryServer), enmasseClientSet
 }
 
-func TestWhoAmI(t *testing.T) {
+func XTestWhoAmI(t *testing.T) {
 	queryServer, _ := setUp()
 
 	resp := post(queryServer, nil, `{"query": "query whoami { whoami { metadata { name } } }"}`)
@@ -55,7 +55,7 @@ func TestWhoAmI(t *testing.T) {
 	assert.Equal(t, 1, len(resp.Result().Cookies()))
 }
 
-func TestMutationWithoutExistingSessionRejected(t *testing.T) {
+func XTestMutationWithoutExistingSessionRejected(t *testing.T) {
 	queryServer, _ := setUp()
 
 	resp := post(queryServer, nil, `{"query": "mutation delAddr($addrs:[ObjectMeta_v1_Input!]!) { deleteAddresses(input:$addrs) }", "variables" : { "addrs": [{"name": "cbf3d7c5-e39a-54c5-8328-2bb6f24d3010", "namespace": "enmasse-infra" }] }}`)
@@ -65,7 +65,7 @@ func TestMutationWithoutExistingSessionRejected(t *testing.T) {
 	assert.Equal(t, 1, len(resp.Result().Cookies()))
 }
 
-func TestMutationWithExistingSessionAllowed(t *testing.T) {
+func XTestMutationWithExistingSessionAllowed(t *testing.T) {
 	queryServer, client := setUp()
 
 	_, err := client.Addresses("myns").Create(&v1beta1.Address{

--- a/pkg/consolegraphql/server/query/query_test.go
+++ b/pkg/consolegraphql/server/query/query_test.go
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ *
+ */
+
+package query
+
+import (
+	"github.com/alexedwards/scs/v2"
+	"github.com/enmasseproject/enmasse/pkg/consolegraphql/server"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/enmasseproject/enmasse/pkg/apis/enmasse/v1beta1"
+	"github.com/enmasseproject/enmasse/pkg/client/clientset/versioned/fake"
+	v1beta1api "github.com/enmasseproject/enmasse/pkg/client/clientset/versioned/typed/enmasse/v1beta1"
+	"github.com/enmasseproject/enmasse/pkg/consolegraphql/resolvers"
+	userv1 "github.com/openshift/client-go/user/clientset/versioned/typed/user/v1"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func setUp() (http.Handler, v1beta1api.EnmasseV1beta1Interface) {
+	clientset := fake.NewSimpleClientset(&v1beta1.Address{})
+	enmasseClientSet := clientset.EnmasseV1beta1()
+
+	sessionManager := scs.New()
+
+	queryTime, queryError, _ := server.CreateMetrics()
+
+	setCreator := func(config *restclient.Config) (kubeClient kubernetes.Interface, userClient userv1.UserV1Interface, coreClient v1beta1api.EnmasseV1beta1Interface, err error) {
+
+		return nil, nil, enmasseClientSet, nil
+	}
+
+	queryServer := CreateQueryServer(resolvers.Resolver{},
+		false, false, sessionManager, queryError, queryTime,
+		nil, nil, setCreator)
+
+	return sessionManager.LoadAndSave(queryServer), enmasseClientSet
+}
+
+func TestWhoAmI(t *testing.T) {
+	queryServer, _ := setUp()
+
+	resp := post(queryServer, nil, `{"query": "query whoami { whoami { metadata { name } } }"}`)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, `{"data":{"whoami":{"metadata":{"name":"foouser"}}}}`, resp.Body.String())
+	assert.Equal(t, 1, len(resp.Result().Cookies()))
+}
+
+func TestMutationWithoutExistingSessionRejected(t *testing.T) {
+	queryServer, _ := setUp()
+
+	resp := post(queryServer, nil, `{"query": "mutation delAddr($addrs:[ObjectMeta_v1_Input!]!) { deleteAddresses(input:$addrs) }", "variables" : { "addrs": [{"name": "cbf3d7c5-e39a-54c5-8328-2bb6f24d3010", "namespace": "enmasse-infra" }] }}`)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, `{"errors":[{"message":"unable to invoke mutation delAddr at this time"}],"data":null}`, resp.Body.String())
+	assert.Equal(t, 1, len(resp.Result().Cookies()))
+}
+
+func TestMutationWithExistingSessionAllowed(t *testing.T) {
+	queryServer, client := setUp()
+
+	_, err := client.Addresses("myns").Create(&v1beta1.Address{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "foo",
+		},
+	})
+	assert.NoError(t, err)
+
+	// first non mutation request will establish the session
+	resp := post(queryServer, nil, `{"query": "query whoami { whoami { metadata { name } } }"}`)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.Code)
+	cookies := resp.Result().Cookies()
+	assert.Equal(t, 1, len(cookies))
+
+	resp = post(queryServer, cookies, `{"query": "mutation del($addrs:[ObjectMeta_v1_Input!]!) { deleteAddresses(input:$addrs) }", "variables" : { "addrs": [{"name": "foo", "namespace": "myns" }] }}`)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, `{"data":{"deleteAddresses":true}}`, resp.Body.String())
+}
+
+func post(handler http.Handler, cookies []*http.Cookie, body string) *httptest.ResponseRecorder {
+	r := httptest.NewRequest("POST", "/graphql/query", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	r.Header.Set("Authorization", "Bearer: foo")
+	r.Header.Set("X-Forwarded-Preferred-Username", "foouser")
+	if cookies != nil {
+		for _, c := range cookies {
+			r.AddCookie(c)
+		}
+	}
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+	return w
+}

--- a/pkg/consolegraphql/server/request_context.go
+++ b/pkg/consolegraphql/server/request_context.go
@@ -18,6 +18,7 @@ type RequestState struct {
 	User                 userapiv1.User
 	UserAccessToken      string
 	UseSession           bool
+	NewSession           bool
 	ImpersonatedUser     string
 }
 

--- a/pkg/consolegraphql/server/session.go
+++ b/pkg/consolegraphql/server/session.go
@@ -10,6 +10,7 @@ import (
 	"github.com/alexedwards/scs/v2"
 	"github.com/enmasseproject/enmasse/pkg/consolegraphql/server/session"
 	"github.com/prometheus/client_golang/prometheus"
+	"net/http"
 	"sync/atomic"
 	"time"
 )
@@ -50,6 +51,7 @@ func CreateSessionManager(sessionLifetime time.Duration, sessionIdleTimeout time
 	sessionManager.Cookie.HttpOnly = true
 	sessionManager.Cookie.Persist = false
 	sessionManager.Cookie.Secure = true
+	sessionManager.Cookie.SameSite = http.SameSiteStrictMode
 	sessionManager.Store = store
 	return sessionManager
 }


### PR DESCRIPTION

### Type of change

- Bugfix

### Description

To guard against a possible CSRF with some older browsers, apply the same-site cookie option strict to the console-server's session cookie, and deny mutation operations for requests that don't already have a session.


### Checklist


- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
