### PR TITLE
[Console-iot] Add manage columns in device list 

### DIFF
--- a/console/console-init/ui/src/modules/iot-device-detail/dialogs/CloneDevice/CloneDevicePage.tsx
+++ b/console/console-init/ui/src/modules/iot-device-detail/dialogs/CloneDevice/CloneDevicePage.tsx
@@ -77,7 +77,7 @@ export default function CloneDevicePage() {
 
   const addGateway = {
     name: "Add gateways",
-    component: <AddGateways returnGateways={getGateways} />
+    component: <AddGateways />
   };
 
   const AddCredentialWrapper = () => (

--- a/console/console-init/ui/src/modules/iot-device/DeviceListPage.tsx
+++ b/console/console-init/ui/src/modules/iot-device/DeviceListPage.tsx
@@ -21,14 +21,16 @@ import {
   DeviceListAlert,
   DeviceListToolbar,
   IDevice,
-  IDeviceFilter
+  IDeviceFilter,
+  ManageColumnModal
 } from "modules/iot-device/components";
 import {
   getHeaderForDialog,
   getDetailForDialog,
   MAX_DEVICE_LIST_COUNT,
   getInitialAlert,
-  getInitialFilter
+  getInitialFilter,
+  getInitialSelectedColumns
 } from "modules/iot-device/utils";
 import {
   DeviceListContainer,
@@ -68,7 +70,13 @@ export default function DeviceListPage() {
     title: string;
     description: string;
   }>(getInitialAlert());
-
+  const [selectedColumns, setSelectedColumns] = useState<string[]>(
+    getInitialSelectedColumns()
+  );
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const handleToggleModal = () => {
+    setIsModalOpen(!isModalOpen);
+  };
   const { dispatch } = useStoreContext();
 
   const [setDeleteDeviceQueryVariables] = useMutationQuery(DELETE_IOT_DEVICE, [
@@ -360,6 +368,7 @@ export default function DeviceListPage() {
                 items={[]}
                 onChange={() => {}}
                 onSelectAllDevices={onSelectAllDevices}
+                handleToggleModal={handleToggleModal}
               />
             </GridItem>
             <GridItem span={7}>{renderPagination()}</GridItem>
@@ -379,10 +388,16 @@ export default function DeviceListPage() {
             appliedFilter={appliedFilter}
             resetFilter={resetFilter}
             namespace={namespace}
+            selectedColumns={selectedColumns}
           />
           <br />
           {renderPagination()}
         </PageSection>
+        <ManageColumnModal
+          isModalOpen={isModalOpen}
+          handleModalToggle={handleToggleModal}
+          setSelectedColumns={setSelectedColumns}
+        />
       </GridItem>
     </Grid>
   );

--- a/console/console-init/ui/src/modules/iot-device/components/DeviceListToolbar/DeviceListToolbar.tsx
+++ b/console/console-init/ui/src/modules/iot-device/components/DeviceListToolbar/DeviceListToolbar.tsx
@@ -9,7 +9,12 @@ import {
   DropdownWithKebabToggle,
   IDropdownWithBulkSelectProps
 } from "components";
-import { ToolbarContent, Toolbar, ToolbarItem } from "@patternfly/react-core";
+import {
+  ToolbarContent,
+  Toolbar,
+  ToolbarItem,
+  Button
+} from "@patternfly/react-core";
 import {
   CreateDeviceButton,
   ICreateDeviceButtonProps
@@ -24,6 +29,7 @@ export interface IDeviceListToolbarProps
   kebabItems: React.ReactNode[];
   onSelectAllDevices: (val: boolean) => void;
   onChange: (val: boolean) => void;
+  handleToggleModal: () => void;
 }
 
 export const DeviceListToolbar: React.FunctionComponent<IDeviceListToolbarProps &
@@ -32,7 +38,8 @@ export const DeviceListToolbar: React.FunctionComponent<IDeviceListToolbarProps 
   handleJSONUpload,
   onSelectAllDevices,
   isChecked,
-  kebabItems
+  kebabItems,
+  handleToggleModal
 }) => {
   return (
     <Toolbar id="device-data-toolbar" data-codemods="true">
@@ -76,6 +83,15 @@ export const DeviceListToolbar: React.FunctionComponent<IDeviceListToolbarProps 
             handleInputDeviceInfo={handleInputDeviceInfo}
             handleJSONUpload={handleJSONUpload}
           />
+        </ToolbarItem>
+        <ToolbarItem>
+          <Button
+            id="device-list-toolbar-manage-column-button"
+            variant="link"
+            onClick={handleToggleModal}
+          >
+            Manage columns
+          </Button>
         </ToolbarItem>
       </ToolbarContent>
     </Toolbar>

--- a/console/console-init/ui/src/modules/iot-device/components/MangeColumnModal/ManageColumnModal.tsx
+++ b/console/console-init/ui/src/modules/iot-device/components/MangeColumnModal/ManageColumnModal.tsx
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+import React, { useState } from "react";
+import {
+  Modal,
+  TextContent,
+  TextVariants,
+  Text,
+  Button,
+  DataList,
+  DataListItem,
+  DataListItemRow,
+  DataListCheck,
+  DataListItemCells,
+  DataListCell
+} from "@patternfly/react-core";
+import { getInitialManageColumnsForDevices } from "modules/iot-device/utils";
+import { createDeepCopy } from "utils";
+
+export interface IManageCoulmnOption {
+  key: string;
+  value: string;
+  label: string;
+  isChecked: boolean;
+}
+interface IManageColumnModalProps {
+  isModalOpen: boolean;
+  handleModalToggle: () => void;
+  setSelectedColumns: (columns: string[]) => void;
+}
+
+const ManageColumnModal: React.FunctionComponent<IManageColumnModalProps> = ({
+  isModalOpen,
+  handleModalToggle,
+  setSelectedColumns
+}) => {
+  const [manageColumnsOptions, setManageColumnsOptions] = useState<
+    IManageCoulmnOption[]
+  >(getInitialManageColumnsForDevices);
+
+  const handleChange = (checked: boolean, event: any) => {
+    const manageColumnsOptionsCopy: IManageCoulmnOption[] = createDeepCopy(
+      manageColumnsOptions
+    );
+    manageColumnsOptionsCopy.forEach((column: IManageCoulmnOption) => {
+      if (column.value.toLowerCase() === event.target.name?.toLowerCase()) {
+        column.isChecked = checked;
+      }
+    });
+    setManageColumnsOptions(manageColumnsOptionsCopy);
+  };
+  const onSave = () => {
+    const columns = manageColumnsOptions
+      .filter((column: IManageCoulmnOption) => column.isChecked === true)
+      .map((column: IManageCoulmnOption) => column.value);
+    setSelectedColumns(columns);
+    handleModalToggle();
+  };
+
+  const renderDataListItem = (
+    isChecked: boolean,
+    label: string,
+    name: string,
+    key: string
+  ) => {
+    return (
+      <DataListItem
+        id={`device-list-col-mangmnt-${key}`}
+        aria-labelledby={`table column management ${label.toLowerCase()}`}
+      >
+        <DataListItemRow>
+          <DataListCheck
+            aria-labelledby={`device list table column management ${label.toLowerCase()}`}
+            id={`device-list-col-mangmnt-${key}-checkbox`}
+            isChecked={isChecked}
+            name={name}
+            onChange={handleChange}
+          />
+          <DataListItemCells
+            dataListCells={[
+              <DataListCell
+                id={`device-list-column-management-${key}`}
+                key={`device-list-column-management-${key}`}
+              >
+                {label}
+              </DataListCell>
+            ]}
+          />
+        </DataListItemRow>
+      </DataListItem>
+    );
+  };
+
+  return (
+    <>
+      <Modal
+        title="Manage columns"
+        isOpen={isModalOpen}
+        id="device-list-manage-column-modal"
+        variant="small"
+        description={
+          <TextContent>
+            <Text component={TextVariants.p}>
+              Checked categories will be displayed in the table.
+            </Text>
+          </TextContent>
+        }
+        onClose={handleModalToggle}
+        actions={[
+          <Button
+            key="save"
+            id="manage-column-modal-save-button"
+            variant="primary"
+            onClick={onSave}
+          >
+            Save
+          </Button>,
+          <Button
+            key="cancel"
+            id="manage-column-modal-cancel-button"
+            variant="secondary"
+            onClick={handleModalToggle}
+          >
+            Cancel
+          </Button>
+        ]}
+      >
+        <DataList
+          aria-label="table column management"
+          id="device-list-column-management-datalist"
+          isCompact
+        >
+          {manageColumnsOptions.map((column: IManageCoulmnOption) =>
+            renderDataListItem(
+              column.isChecked,
+              column.label,
+              column.value,
+              column.key
+            )
+          )}
+        </DataList>
+      </Modal>
+    </>
+  );
+};
+
+export { ManageColumnModal };

--- a/console/console-init/ui/src/modules/iot-device/components/MangeColumnModal/index.ts
+++ b/console/console-init/ui/src/modules/iot-device/components/MangeColumnModal/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+export * from "./ManageColumnModal";

--- a/console/console-init/ui/src/modules/iot-device/components/index.ts
+++ b/console/console-init/ui/src/modules/iot-device/components/index.ts
@@ -18,3 +18,4 @@ export * from "./CreateMetadata";
 export * from "./AddGateways";
 export * from "./AddDeviceWithJson";
 export * from "./ReviewDevice";
+export * from "./MangeColumnModal";

--- a/console/console-init/ui/src/modules/iot-device/containers/DeviceListContainer/DeviceListContainer.tsx
+++ b/console/console-init/ui/src/modules/iot-device/containers/DeviceListContainer/DeviceListContainer.tsx
@@ -49,6 +49,7 @@ export interface IDeviceListContainerProps {
   resetFilter: () => void;
   projectname: string;
   namespace: string;
+  selectedColumns?: string[];
   setIsAllSelected: (value: boolean) => void;
 }
 
@@ -66,7 +67,8 @@ export const DeviceListContainer: React.FC<IDeviceListContainerProps> = ({
   resetFilter,
   projectname,
   namespace,
-  setIsAllSelected
+  setIsAllSelected,
+  selectedColumns
 }) => {
   const [sortBy, setSortBy] = useState<ISortBy>();
 

--- a/console/console-init/ui/src/modules/iot-device/utils/constant.ts
+++ b/console/console-init/ui/src/modules/iot-device/utils/constant.ts
@@ -102,6 +102,59 @@ const getInitialAlert = () => {
   return alert;
 };
 
+const getInitialSelectedColumns = () => {
+  return [
+    "deviceId",
+    "connectionType",
+    "status",
+    "lastUpdated",
+    "lastSeen",
+    "addedDate"
+  ];
+};
+
+const getInitialManageColumnsForDevices = () => {
+  return [
+    { key: "deviceid", value: "deviceId", label: "Device ID", isChecked: true },
+    {
+      key: "connection-type",
+      value: "connectionType",
+      label: "Connection Type",
+      isChecked: true
+    },
+    { key: "status", value: "status", label: "Status", isChecked: true },
+    {
+      key: "last-updated",
+      value: "lastUpdated",
+      label: "Last updated",
+      isChecked: true
+    },
+    {
+      key: "last-seen",
+      value: "lastSeen",
+      label: "Last Seen",
+      isChecked: true
+    },
+    {
+      key: "added-date",
+      value: "addedDate",
+      label: "Added Date",
+      isChecked: true
+    },
+    {
+      key: "memberof",
+      value: "memberOf",
+      label: "Member Of",
+      isChecked: false
+    },
+    {
+      key: "via-gateways",
+      value: "viaGateways",
+      label: "Via Gateways",
+      isChecked: false
+    }
+  ];
+};
 /**
  * key value constants
  */
@@ -136,6 +189,8 @@ export {
   credentialTypeOptions,
   gatewayTypeOptions,
   deviceRegistrationTypeOptions,
+  getInitialSelectedColumns,
+  getInitialManageColumnsForDevices,
   MAX_DEVICE_LIST_COUNT,
   ValidationStatusType
 };

--- a/console/console-init/ui/src/stories/DeviceList.stories.tsx
+++ b/console/console-init/ui/src/stories/DeviceList.stories.tsx
@@ -145,6 +145,7 @@ export const deviceToolbar = () => {
         items={bulkSelectItems}
         onChange={action("checkbox dropdown changed")}
         onSelectAllDevices={action("All devices selected")}
+        handleToggleModal={action("on toggle manage columns")}
       />
     </MemoryRouter>
   );

--- a/console/console-init/ui/src/stories/DeviceListPage.stories.tsx
+++ b/console/console-init/ui/src/stories/DeviceListPage.stories.tsx
@@ -126,6 +126,7 @@ const Data = (
         items={bulkSelectItems}
         onSelectAllDevices={action("All devices selected")}
         onChange={action("checkbox dropdown changed")}
+        handleToggleModal={action("on toggle manage columns")}
       />
       <Divider />
       <DeviceList


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->
- Enhancement / new feature

### Description

<!--

_Please describe your pull request_

-->

Add manage columns section in modal to manage multiple columns in device list

Design link :- https://marvelapp.com/prototype/5gbji22/screen/69081888
![image](https://user-images.githubusercontent.com/29524461/86923680-fb3cdf80-c14b-11ea-8a28-70fd84086b82.png)

![image](https://user-images.githubusercontent.com/29524461/86923704-01cb5700-c14c-11ea-858c-4c7f5638481b.png)

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
