### PR TITLE
Improve openshift 4 detection logic

### DIFF
--- a/pkg/util/openshift.go
+++ b/pkg/util/openshift.go
@@ -226,7 +226,8 @@ func detectOpenshift4() bool {
 		return false
 	}
 
-	return v.Major == "1" && minor > 11
+	// server version can be Openshift or Kubernetes version, so we need to account for both cases
+	return v.Major == "4" || (v.Major == "1" && minor > 11)
 
 }
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Server version call can return either Kubernetes or Openshift version, so we must account for both cases.
