### PR TITLE
[Documentation] Document changing broker logging level at runtime

### DIFF
--- a/documentation/assemblies/assembly-ops-procedures.adoc
+++ b/documentation/assemblies/assembly-ops-procedures.adoc
@@ -20,5 +20,7 @@ include::../modules/proc-enable-protocol-trace-broker.adoc[leveloffset=+1]
 
 include::../modules/proc-examine-broker-state.adoc[leveloffset=+1]
 
+include::../modules/proc-change-logging-level-broker.adoc[leveloffset=+1]
+
 :context: {parent-context}
 

--- a/documentation/modules/proc-change-logging-level-broker.adoc
+++ b/documentation/modules/proc-change-logging-level-broker.adoc
@@ -1,0 +1,73 @@
+// Module included in the following assemblies:
+//
+// assembly-ops-procedures.adoc
+
+[id='change-logging-level-broker-{context}']
+= Change the logging level for the Broker at runtime
+
+For diagnostic purposes, you can change the logging level of the broker at runtime. This can be helpful
+when troubleshooting issues with sending or receiving messages.
+
+To do this, you `{cmdcli} rsh` into the broker pod and adjust the `logging.properties` file used by
+the broker.  The broker automatically reloads this file and applies the changes immediately without
+interrupting established messaging connections.
+
+The changes made to `logging.properties` are transient.  The logging level will be reverted to default levels
+next time the broker pod restarts.
+
+WARNING: Increasing the logging verbosity increases the CPU overhead of the broker(s) and may decrease
+messaging performance. It may also increase the disk space requirements associated with any log retention system.
+Therefore, it is recommended that you increase the logging verbosity for as short a time as possible.
+
+.Procedure
+
+ifeval::["{cmdcli}" == "oc"]
+. Log in as a service operator:
++
+[subs="attributes",options="nowrap"]
+----
+{cmdcli} login -u developer
+----
+
+. Change to the project where {ProductName} is installed:
++
+[subs="+quotes,attributes",options="nowrap"]
+----
+{cmdcli} project _{ProductNamespace}_
+----
+endif::[]
+
+. List all broker Pods and choose the Pod for the relevant address space:
++
+[options="nowrap",subs="+quotes,attributes"]
+----
+{cmdcli} get pods -l role=broker -o go-template --template '{{range .items}}{{.metadata.name}}{{"\t"}}{{.metadata.annotations.addressSpace}}{{"\n"}}{{end}}'
+----
+
+. Change the logging level for a single broker by `{cmdcli} rsh` into the broker pod and editing the
+`logging.properties`.  The broker uses the JBoss Logging framework.   Adjust the logging levels of the packages
+corresponding to the area of interest.  There are comments in the file to guide you.
++
+[options="nowrap",subs="+quotes,attributes"]
+----
+{cmdcli} rsh _pod_
+cp /var/run/artemis/split-1/broker/etc/logging.properties /tmp/logging.properties
+vi /var/run/artemis/split-1/broker/etc/logging.properties
+exit
+----
+
+. Display the logs for the Pod that will include the protocol trace:
++
+[options="nowrap",subs="+quotes,attributes"]
+----
+{cmdcli} logs _pod_
+----
+
+. To revert to normal logging levels, revert the contents of the `logging.properties` file.
++
+[options="nowrap",subs="+quotes,attributes"]
+----
+{cmdcli} rsh _pod_
+cp /tmp/logging.properties /var/run/artemis/split-1/broker/etc/logging.properties
+exit
+----


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Document changing broker logging level at runtime### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
