### PR TITLE
[Console-UI] remove blank string workaround for dropdown alignment issue

### DIFF
--- a/console/console-init/ui/src/components/DropdownWithToggle/DropdownWithToggle.tsx
+++ b/console/console-init/ui/src/components/DropdownWithToggle/DropdownWithToggle.tsx
@@ -37,7 +37,7 @@ export interface IDropdownWithToggleProps
   toggleIcon?: React.ReactElement<any>;
   component?: React.ReactNode;
   toggleClass?: string;
-  value: string;
+  value?: string;
   onSelectItem?: (value: string, event?: any) => void;
   dropdownItemIdPrefix?: string;
   dropdownItemClass?: string;

--- a/console/console-init/ui/src/modules/address/components/AddressConfiguration/AddressConfiguration.tsx
+++ b/console/console-init/ui/src/modules/address/components/AddressConfiguration/AddressConfiguration.tsx
@@ -32,9 +32,9 @@ export interface IAddressConfigurationProps {
   addressName: string;
   isNameValid: boolean;
   handleAddressChange: (name: string) => void;
-  type: string;
-  plan: string;
-  topic: string;
+  type?: string;
+  plan?: string;
+  topic?: string;
   onTypeSelect?: (value: string) => void;
   onPlanSelect?: (value: string) => void;
   onTopicSelect?: (value: string) => void;
@@ -134,7 +134,7 @@ const AddressConfiguration: React.FunctionComponent<IAddressConfigurationProps> 
                 value={plan}
                 dropdownItems={planOptions}
                 dropdownItemIdPrefix="address-definition-plan-dropdown-item"
-                isDisabled={type.trim() === ""}
+                isDisabled={type?.trim() === ""}
               />
             </FormGroup>
             {type && type.toLowerCase() === "subscription" && (

--- a/console/console-init/ui/src/modules/address/containers/AddressDefinitionContainer/AddressDefinitionContainer.tsx
+++ b/console/console-init/ui/src/modules/address/containers/AddressDefinitionContainer/AddressDefinitionContainer.tsx
@@ -22,10 +22,10 @@ export interface IAddressDefinition extends IAddressConfigurationProps {
   addressspaceName: string;
   namespace: string;
   addressSpacePlan: string | null;
-  setType: (value: any) => void;
-  setPlan: (value: any) => void;
+  setType: (value?: any) => void;
+  setPlan: (value?: any) => void;
   addressSpaceType?: string;
-  setTopic: (value: string) => void;
+  setTopic: (value?: string) => void;
   setTypeOptions: (values: IDropdownOption[]) => void;
   setPlanOptions: (values: IDropdownOption[]) => void;
   setTopicForSubscripitons: (values: IDropdownOption[]) => void;
@@ -106,9 +106,9 @@ export const AddressDefinitionContainer: React.FunctionComponent<IAddressDefinit
             description: plan.spec.shortDescription || plan.spec.longDescription
           };
         });
-        setTopic(" ");
+        setTopic(undefined);
         setPlanOptions(planOptions);
-        setPlan(" ");
+        setPlan(undefined);
       }
 
       if (type.toLowerCase() === "subscription") {

--- a/console/console-init/ui/src/modules/address/dialogs/CreateAddress/CreateAddress.tsx
+++ b/console/console-init/ui/src/modules/address/dialogs/CreateAddress/CreateAddress.tsx
@@ -26,9 +26,9 @@ export const CreateAddress: React.FunctionComponent = () => {
     modalProps || {};
 
   const [addressName, setAddressName] = useState("");
-  const [addressType, setAddressType] = useState(" ");
-  const [plan, setPlan] = useState(" ");
-  const [topic, setTopic] = useState(" ");
+  const [addressType, setAddressType] = useState<string>();
+  const [plan, setPlan] = useState<string>();
+  const [topic, setTopic] = useState<string>();
   const [addressTypes, setAddressTypes] = useState<IDropdownOption[]>([]);
   const [addressPlans, setAddressPlans] = useState<IDropdownOption[]>([]);
   const [topicsForSubscription, setTopicForSubscription] = useState<
@@ -85,9 +85,12 @@ export const CreateAddress: React.FunctionComponent = () => {
     if (
       addressName.trim() !== "" &&
       isNameValid &&
+      plan &&
       plan.trim() !== "" &&
+      addressType &&
       addressType.trim() !== "" &&
-      (addressType.toLowerCase() === "subscription") === (topic.trim() !== "")
+      (addressType && addressType.toLowerCase() === "subscription") ===
+        (topic && topic.trim() !== "")
     ) {
       return true;
     }
@@ -97,10 +100,12 @@ export const CreateAddress: React.FunctionComponent = () => {
   const isFinishButtonEnabled = () => {
     if (
       addressName.trim() !== "" &&
+      plan &&
       plan.trim() !== "" &&
+      addressType &&
       addressType.trim() !== "" &&
-      (addressType.toLowerCase() === "subscription") ===
-        (topic.trim() !== "") &&
+      (addressType && addressType.toLowerCase() === "subscription") ===
+        (topic && topic.trim() !== "") &&
       isNameValid
     ) {
       return true;
@@ -116,7 +121,7 @@ export const CreateAddress: React.FunctionComponent = () => {
             namespace: namespace
           },
           spec: {
-            type: addressType.toLowerCase(),
+            type: addressType?.toLowerCase(),
             plan: plan,
             address: addressName
           }


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->
- Refactoring

### Description

<!--

_Please describe your pull request_

-->
In recent PF update the issue related to alignment got fixed. Remove the work around for that alignment issue
### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
