### PR TITLE
Fix: error while creating a new IoT project

### DIFF
--- a/console/console-init/ui/src/modules/project/dailogs/CreateProject/CreateProject.tsx
+++ b/console/console-init/ui/src/modules/project/dailogs/CreateProject/CreateProject.tsx
@@ -109,6 +109,8 @@ const initialMessageProject: IMessagingProject = {
 };
 
 const initialIoTProject: IIoTProjectInput = {
+  iotProjectName: "",
+  namespace: "",
   isNameValid: true,
   isEnabled: true
 };


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

A server error was thrown whenever a new project was created.

### Screenshot

![Screenshot from 2020-08-25 21-30-11](https://user-images.githubusercontent.com/23582438/91214995-7aed3080-e731-11ea-838d-2e2478d831cf.png)


- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
