### PR TITLE
Improve default redelivery settings when a deadletter address is set

### DIFF
--- a/agent/lib/broker_controller.js
+++ b/agent/lib/broker_controller.js
@@ -776,6 +776,13 @@ BrokerController.prototype.generate_address_settings = function (address, global
         if (notTopic) {
             if (address.deadletter) {
                 addressSettings.DLA = address.deadletter;
+                // Specify default redelivery settings by default when using a DLQ. These are based
+                // on Artemis defaults.
+                addressSettings.maxDeliveryAttempts = 10;
+                addressSettings.redeliveryDelay = 0;
+                addressSettings.redeliveryMultiplier = 1.0;
+                addressSettings.maxRedeliveryDelay = 0;
+
                 upd++;
             }
             if (address.expiry) {


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Default address settings will now be set to original Artemis defaults. I am not sure if it is better to use those, or to come up with a different set of settings.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
