### PR TITLE
Fix defect that prevented expiry address being assigned correctly

### DIFF
--- a/agent/lib/artemis.js
+++ b/agent/lib/artemis.js
@@ -564,7 +564,17 @@ Artemis.prototype.removeAddressSettings = function (match) {
 
 Artemis.prototype.getAddressSettings = function (match) {
     return this._request('broker', 'getAddressSettingsAsJSON', [match]).then(function (result) {
-        return JSON.parse(result);
+        var settings = JSON.parse(result);
+
+        // The broker handles expiryAddress and DLA differently to the other attributes: they are missing from the
+        // result when they are not present.
+        if (settings && !"expiryAddress" in settings) {
+            settings.expiryAddress = null;
+        }
+        if (settings && !"DLA" in settings) {
+            settings.DLA = null;
+        }
+        return settings;
     });
 };
 


### PR DESCRIPTION


### Type of change

- Bugfix

### Description

Root cause was the Broker's handling of the `expiryAdress` element in the `getAddressSettingsAsJSON` response.  It omits the value from the address settings if there is no assignment.  `compare_address_settings` assumed that all elements were present in the `orig_address_settings` map and this meant that `expiryAdresss` changes could go unnoticed. 

For the DLA field, the problem was masked by the assignment of the !GLOBAL_DLQ at the root level.  The meant that the `getAddressSettingsAsJSON` response always included the DLQ field.


### Checklist


- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
