### PR TITLE
Fix deadletter & expiry-address for durable subscriptions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## 0.33.0
 
+* #5183: Fix expiry-address & TTL for durable subscriptions
 * Remove IoT and shared infra preview
 * Remove MQTT Gateway and MQTT LwT
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## 0.33.0
 
-* #5183: Fix expiry-address & TTL for durable subscriptions
+* #5183: Fix expiry-address & dead-letter for durable subscriptions
 * Remove IoT and shared infra preview
 * Remove MQTT Gateway and MQTT LwT
 

--- a/agent/lib/broker_controller.js
+++ b/agent/lib/broker_controller.js
@@ -772,8 +772,13 @@ BrokerController.prototype.generate_address_settings = function (address, global
                 upd++;
             }
         }
-        var notTopic = address.type === 'subscription' || address.type === 'queue' || address.type === 'deadletter';
 
+        if (address.expiry && (address.type === 'queue' || address.type === 'deadletter' || 'topic')) {
+            addressSettings.expiryAddress = address.expiry;
+            upd++;
+        }
+
+        var notTopic = address.type === 'subscription' || address.type === 'queue' || address.type === 'deadletter';
         if (notTopic) {
             if (address.deadletter) {
                 addressSettings.DLA = address.deadletter;
@@ -784,10 +789,6 @@ BrokerController.prototype.generate_address_settings = function (address, global
                 addressSettings.redeliveryMultiplier = 1.0;
                 addressSettings.maxRedeliveryDelay = 0;
 
-                upd++;
-            }
-            if (address.expiry) {
-                addressSettings.expiryAddress = address.expiry;
                 upd++;
             }
             if (address.status.messageRedelivery) {

--- a/agent/lib/broker_controller.js
+++ b/agent/lib/broker_controller.js
@@ -773,13 +773,8 @@ BrokerController.prototype.generate_address_settings = function (address, global
             }
         }
 
-        if (address.expiry && (address.type === 'queue' || address.type === 'deadletter' || 'topic')) {
-            addressSettings.expiryAddress = address.expiry;
-            upd++;
-        }
-
-        var notTopic = address.type === 'subscription' || address.type === 'queue' || address.type === 'deadletter';
-        if (notTopic) {
+        var notSubscription = address.type === 'topic' || address.type === 'queue' || address.type === 'deadletter';
+        if (notSubscription) {
             if (address.deadletter) {
                 addressSettings.DLA = address.deadletter;
                 // Specify default redelivery settings by default when using a DLQ. These are based
@@ -789,6 +784,10 @@ BrokerController.prototype.generate_address_settings = function (address, global
                 addressSettings.redeliveryMultiplier = 1.0;
                 addressSettings.maxRedeliveryDelay = 0;
 
+                upd++;
+            }
+            if (address.expiry) {
+                addressSettings.expiryAddress = address.expiry;
                 upd++;
             }
             if (address.status.messageRedelivery) {

--- a/agent/test/broker_controller.js
+++ b/agent/test/broker_controller.js
@@ -206,4 +206,14 @@ describe('broker controller', function() {
         });
     });
 
+    it('get address settings async - returns ttl settings for topics', function(done) {
+        this.timeout(15000);
+        var brokerAddressSettings =  new broker_controller.BrokerController(undefined, config);
+        brokerAddressSettings.get_address_settings_async({address:'mytopic',type:'topic', plan: 'small-topic', status: {messageTtl: {minimum: 1000, maximum: 2000}}}, Promise.resolve(undefined)).then(function (result) {
+            assert.equal(1000, result.minExpiryDelay);
+            assert.equal(2000, result.maxExpiryDelay);
+            done();
+        });
+    });
+
 });

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/AddressController.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/AddressController.java
@@ -874,7 +874,9 @@ public class AddressController implements Watcher<Address> {
                             Set<String> addressNames = clusterAddresses.get(brokerStatus.getClusterId());
                             Set<String> queueNames = clusterQueues.get(brokerStatus.getClusterId());
                             ok += checkAddressAndQueue(address, brokerStatus, addressNames, address.getSpec().getAddress(), null, null);
-
+                            if (address.getSpec().getDeadletter() != null) {
+                                ok += checkAddressAndQueue(address, brokerStatus, addressNames, address.getSpec().getDeadletter(), queueNames, address.getSpec().getDeadletter());
+                            }
                             if (address.getSpec().getExpiry() != null) {
                                 ok += checkAddressAndQueue(address, brokerStatus, addressNames, address.getSpec().getExpiry(), queueNames, address.getSpec().getExpiry());
                             }

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/AddressController.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/AddressController.java
@@ -378,7 +378,7 @@ public class AddressController implements Watcher<Address> {
 
             String expiry = address.getSpec().getExpiry();
             if (expiry != null) {
-                if (!Set.of("queue", "subscription").contains(address.getSpec().getType())) {
+                if (!Set.of("queue", "topic").contains(address.getSpec().getType())) {
                     String errorMessage = String.format(
                             "Address '%s' (resource name '%s') of type '%s' cannot reference an expiry address.",
                             address.getSpec().getAddress(),
@@ -864,9 +864,6 @@ public class AddressController implements Watcher<Address> {
                         if (address.getSpec().getDeadletter() != null) {
                             ok += checkAddressAndQueue(address, brokerStatus, addressNames, address.getSpec().getDeadletter(), queueNames, address.getSpec().getDeadletter());
                         }
-                        if (address.getSpec().getExpiry() != null) {
-                            ok += checkAddressAndQueue(address, brokerStatus, addressNames, address.getSpec().getExpiry(), queueNames, address.getSpec().getExpiry());
-                        }
                     }
                     ok += RouterStatus.checkForwarderLinks(address, routerStatusList);
                     updateMessageRedeliveryStatus(addressPlan, address);
@@ -879,7 +876,12 @@ public class AddressController implements Watcher<Address> {
                     if (isPooled(addressPlan)) {
                         for (BrokerStatus brokerStatus : address.getStatus().getBrokerStatuses()) {
                             Set<String> addressNames = clusterAddresses.get(brokerStatus.getClusterId());
+                            Set<String> queueNames = clusterQueues.get(brokerStatus.getClusterId());
                             ok += checkAddressAndQueue(address, brokerStatus, addressNames, address.getSpec().getAddress(), null, null);
+
+                            if (address.getSpec().getExpiry() != null) {
+                                ok += checkAddressAndQueue(address, brokerStatus, addressNames, address.getSpec().getExpiry(), queueNames, address.getSpec().getExpiry());
+                            }
                         }
                         ok += RouterStatus.checkActiveLinkRoute(address, routerStatusList);
                     } else {

--- a/standard-controller/src/main/java/io/enmasse/controller/standard/AddressController.java
+++ b/standard-controller/src/main/java/io/enmasse/controller/standard/AddressController.java
@@ -340,7 +340,7 @@ public class AddressController implements Watcher<Address> {
 
             String deadletter = address.getSpec().getDeadletter();
             if (deadletter != null) {
-                if (!Set.of("queue", "subscription").contains(address.getSpec().getType())) {
+                if (!Set.of("queue", "topic").contains(address.getSpec().getType())) {
                     String errorMessage = String.format(
                             "Address '%s' (resource name '%s') of type '%s' cannot reference a dead letter address.",
                             address.getSpec().getAddress(),
@@ -861,12 +861,8 @@ public class AddressController implements Watcher<Address> {
                         Set<String> addressNames = clusterAddresses.get(brokerStatus.getClusterId());
                         Set<String> queueNames = clusterQueues.get(brokerStatus.getClusterId());
                         ok += checkAddressAndQueue(address, brokerStatus, addressNames, address.getSpec().getTopic(), queueNames, address.getSpec().getAddress());
-                        if (address.getSpec().getDeadletter() != null) {
-                            ok += checkAddressAndQueue(address, brokerStatus, addressNames, address.getSpec().getDeadletter(), queueNames, address.getSpec().getDeadletter());
-                        }
                     }
                     ok += RouterStatus.checkForwarderLinks(address, routerStatusList);
-                    updateMessageRedeliveryStatus(addressPlan, address);
                     break;
                 case "topic":
                     ok += checkBrokerStatus(brokerStatusCollector, address, clusterOk, clusterAddresses, clusterQueues);
@@ -888,6 +884,7 @@ public class AddressController implements Watcher<Address> {
                         ok += RouterStatus.checkConnection(address, routerStatusList);
                     }
                     updateMessageTtlStatus(addressPlan, address);
+                    updateMessageRedeliveryStatus(addressPlan, address);
                     break;
                 case "anycast":
                 case "multicast":

--- a/standard-controller/src/test/java/io/enmasse/controller/standard/AddressControllerTest.java
+++ b/standard-controller/src/test/java/io/enmasse/controller/standard/AddressControllerTest.java
@@ -790,7 +790,7 @@ public class AddressControllerTest {
                 .endMetadata()
                 .withNewSpec()
                 .withAddress("a1")
-                .withExpiry("illegal")
+                .withExpiry("legal")
                 .withType("topic")
                 .withPlan("small-topic")
                 .endSpec()
@@ -802,7 +802,7 @@ public class AddressControllerTest {
 
         sub = captured.get(0);
         assertEquals(Phase.Pending, sub.getStatus().getPhase());
-        assertThat(sub.getStatus().getMessages(), is(singletonList("Address 'a1' (resource name 'myspace.a1') of type 'topic' cannot reference an expiry address.")));
+        assertThat(sub.getStatus().getMessages(), is(singletonList("Address 'a1' (resource name 'myspace.a1') references an expiry address 'legal' that does not exist.")));
     }
 
     @Test

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/dlq/DeadLetterTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/dlq/DeadLetterTest.java
@@ -203,9 +203,9 @@ class DeadLetterTest extends TestBase implements ITestBaseIsolated {
                 .endMetadata()
                 .withNewSpec()
                 .withType(addressType.toString())
-                .withMessageRedelivery(addressType == AddressType.TOPIC ? null : addrRedelivery)
+                .withMessageRedelivery(addrRedelivery)
                 .withAddress("message-redelivery")
-                .withDeadletter(addressType == AddressType.TOPIC ? null : deadletter.getSpec().getAddress())
+                .withDeadletter(deadletter.getSpec().getAddress())
                 .withPlan(addrPlan.getMetadata().getName())
                 .endSpec()
                 .build();
@@ -221,9 +221,7 @@ class DeadLetterTest extends TestBase implements ITestBaseIsolated {
                         .endMetadata()
                         .withNewSpec()
                         .withType(AddressType.SUBSCRIPTION.toString())
-                        .withMessageRedelivery(addrRedelivery)
                         .withAddress("message-redelivery-sub")
-                        .withDeadletter(deadletter.getSpec().getAddress())
                         .withTopic(addr.getSpec().getAddress())
                         .withPlan(DestinationPlan.STANDARD_SMALL_SUBSCRIPTION)
                         .endSpec()
@@ -233,7 +231,7 @@ class DeadLetterTest extends TestBase implements ITestBaseIsolated {
             recvAddr = addr;
         }
 
-        assertRedeliveryStatus(recvAddr, expectedRedelivery);
+        assertRedeliveryStatus(addressType == AddressType.TOPIC ? addr : recvAddr, expectedRedelivery);
         awaitAddressSettingsSync(addressSpace, recvAddr);
 
         UserCredentials user = new UserCredentials("user", "passwd");

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/ttl/MessageTtlTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/ttl/MessageTtlTest.java
@@ -219,7 +219,6 @@ class MessageTtlTest extends TestBase implements ITestBaseIsolated {
                         .endMetadata()
                         .withNewSpec()
                         .withType(AddressType.SUBSCRIPTION.toString())
-                        .withMessageTtl(addrTtl)
                         .withAddress("message-ttl-sub")
                         .withTopic(addr.getSpec().getAddress())
                         .withPlan(DestinationPlan.STANDARD_SMALL_SUBSCRIPTION)


### PR DESCRIPTION

### Type of change

- Bugfix

### Description

Fixes: #5183 The broker needs the expiry-address and the TTL to be set on the topic (not on the subscription).

### Checklist

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
