### PR TITLE
Modify address name to be different from address

### DIFF
--- a/pkg/consolegraphql/agent/agent.go
+++ b/pkg/consolegraphql/agent/agent.go
@@ -32,7 +32,7 @@ type Delegate interface {
 }
 
 type CommandDelegate interface {
-	PurgeAddress(address v1.ObjectMeta) error
+	PurgeAddress(address string) error
 	CloseConnection(address v1.ObjectMeta) error
 	Shutdown()
 }
@@ -380,19 +380,19 @@ func (aad *amqpAgentDelegate) newAgentDelegate(token string, impersonateUser str
 	return a
 }
 
-func (ad *amqpAgentCommandDelegate) PurgeAddress(address v1.ObjectMeta) error {
+func (ad *amqpAgentCommandDelegate) PurgeAddress(address string) error {
 	request := &amqp.Message{
 		Properties: &amqp.MessageProperties{
 			Subject: "purge_address",
 		},
 		Value: map[interface{}]interface{}{
-			"address": address.Name,
+			"address": address,
 		},
 	}
 
 	response, err := ad.commandClient.Request(request)
 	if err != nil {
-		return fmt.Errorf("failed to purge address %s : %s", address.Name, err)
+		return fmt.Errorf("failed to purge address %s : %s", address, err)
 	}
 
 	if outcome, present := response.ApplicationProperties["outcome"]; present {
@@ -400,11 +400,11 @@ func (ad *amqpAgentCommandDelegate) PurgeAddress(address v1.ObjectMeta) error {
 			return nil
 		} else {
 			if e, present := response.ApplicationProperties["error"]; present && e != nil {
-				return fmt.Errorf("failed to purge address %s : %s", address.Name, e)
+				return fmt.Errorf("failed to purge address %s : %s", address, e)
 			}
 		}
 	}
-	return fmt.Errorf("failed to purge address %s : command %+v failed for unknown reason", address.Name, request)
+	return fmt.Errorf("failed to purge address %s : command %+v failed for unknown reason", address, request)
 }
 
 func (ad *amqpAgentCommandDelegate) CloseConnection(connection v1.ObjectMeta) error {

--- a/pkg/consolegraphql/resolvers/resolver_address.go
+++ b/pkg/consolegraphql/resolvers/resolver_address.go
@@ -268,7 +268,7 @@ func (r *mutationResolver) PurgeAddresses(ctx context.Context, inputs []*metav1.
 			continue
 		}
 
-		e = commandDelegate.PurgeAddress(*input)
+		e = commandDelegate.PurgeAddress(address.Spec.Address)
 		if e != nil {
 			graphql.AddErrorf(ctx, "failed to purge address: '%s' in namespace '%s', %+v", input.Name, input.Namespace, e)
 		}

--- a/pkg/consolegraphql/resolvers/resolver_address_test.go
+++ b/pkg/consolegraphql/resolvers/resolver_address_test.go
@@ -436,7 +436,7 @@ func TestPurgeQueue(t *testing.T) {
 	infraUuid := "abcd1234"
 	as := createAddressSpace(addressspace, namespace, withAddressSpaceAnnotation("enmasse.io/infra-uuid", infraUuid))
 
-	addr := createAddress(namespace, addressspace+".myaddr", withAddressType("queue"))
+	addr := createAddress(namespace, addressspace+".myaddr", withAddressType("queue"), withAddress("myaddr"))
 
 	err := r.Cache.Add(as, addr)
 	assert.NoError(t, err)
@@ -449,7 +449,7 @@ func TestPurgeQueue(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(graphql.GetErrors(ctx)))
 
-	assert.ElementsMatch(t, []metav1.ObjectMeta{addr.ObjectMeta}, delegate.(*mockCommandDelegate).purged)
+	assert.ElementsMatch(t, []string{"myaddr"}, delegate.(*mockCommandDelegate).purged)
 }
 
 func TestPurgeQueues(t *testing.T) {
@@ -463,8 +463,8 @@ func TestPurgeQueues(t *testing.T) {
 	infraUuid := "abcd1235"
 	as := createAddressSpace(addressspace, namespace, withAddressSpaceAnnotation("enmasse.io/infra-uuid", infraUuid))
 
-	addr1 := createAddress(namespace, addressspace+".myaddr", withAddressType("queue"))
-	addr2 := createAddress(namespace, addressspace+".myaddr", withAddressType("queue"))
+	addr1 := createAddress(namespace, addressspace+".myaddr1", withAddressType("queue"), withAddress("myaddr1"))
+	addr2 := createAddress(namespace, addressspace+".myaddr2", withAddressType("queue"), withAddress("my_addr2"))
 
 	err := r.Cache.Add(as, addr1, addr2)
 	assert.NoError(t, err)
@@ -477,7 +477,7 @@ func TestPurgeQueues(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(graphql.GetErrors(ctx)))
 
-	assert.ElementsMatch(t, []metav1.ObjectMeta{addr1.ObjectMeta, addr2.ObjectMeta}, delegate.(*mockCommandDelegate).purged)
+	assert.ElementsMatch(t, []string{"myaddr1", "my_addr2"}, delegate.(*mockCommandDelegate).purged)
 }
 
 func TestPurgeQueuesSomeFail(t *testing.T) {
@@ -491,10 +491,10 @@ func TestPurgeQueuesSomeFail(t *testing.T) {
 	infraUuid := "abcd1236"
 	as := createAddressSpace(addressspace, namespace, withAddressSpaceAnnotation("enmasse.io/infra-uuid", infraUuid))
 
-	addr1 := createAddress(namespace, addressspace+".myaddr1", withAddressType("queue"))
-	addr2 := createAddress(namespace, addressspace+".myaddr2", withAddressType("queue"))
-	absent := createAddress(namespace, addressspace+".absent", withAddressType("queue"))
-	wrongType := createAddress(namespace, addressspace+".wrongType", withAddressType("anycast"))
+	addr1 := createAddress(namespace, addressspace+".myaddr1", withAddressType("queue"), withAddress("myaddr1"))
+	addr2 := createAddress(namespace, addressspace+".myaddr2", withAddressType("queue"), withAddress("myaddr2"))
+	absent := createAddress(namespace, addressspace+".absent", withAddressType("queue"), withAddress("absent"))
+	wrongType := createAddress(namespace, addressspace+".wrongType", withAddressType("anycast"), withAddress("wrongType"))
 
 	err := r.Cache.Add(as, addr1, addr2, wrongType)
 	assert.NoError(t, err)
@@ -511,7 +511,7 @@ func TestPurgeQueuesSomeFail(t *testing.T) {
 	assert.Contains(t, graphql.GetErrors(ctx)[1].Message,
 		"failed to purge address: 'myaddrspace.absent' in namespace: 'mynamespace' - address not found")
 
-	assert.ElementsMatch(t, []metav1.ObjectMeta{addr1.ObjectMeta, addr2.ObjectMeta}, delegate.(*mockCommandDelegate).purged)
+	assert.ElementsMatch(t, []string{"myaddr1", "myaddr2"}, delegate.(*mockCommandDelegate).purged)
 }
 
 func createAddressLink(namespace string, addressspace string, addr string, role string) *consolegraphql.Link {

--- a/pkg/consolegraphql/resolvers/test_utils.go
+++ b/pkg/consolegraphql/resolvers/test_utils.go
@@ -144,11 +144,11 @@ type mockCollector struct {
 }
 
 type mockCommandDelegate struct {
-	purged []metav1.ObjectMeta
+	purged []string
 	closed []metav1.ObjectMeta
 }
 
-func (mcd *mockCommandDelegate) PurgeAddress(a metav1.ObjectMeta) error {
+func (mcd *mockCommandDelegate) PurgeAddress(a string) error {
 	mcd.purged = append(mcd.purged, a)
 	return nil
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/web/ConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/web/ConsoleTest.java
@@ -1068,7 +1068,7 @@ public abstract class ConsoleTest extends TestBase {
         Address queue3 = new AddressBuilder()
                 .withNewMetadata()
                 .withNamespace(addressSpace.getMetadata().getNamespace())
-                .withName(AddressUtils.generateAddressMetadataName(addressSpace, "test-queue3"))
+                .withName(AddressUtils.generateAddressMetadataName(addressSpace, "test-queue-3"))
                 .endMetadata()
                 .withNewSpec()
                 .withType("queue")


### PR DESCRIPTION
The agent uses the .spec.address as the key in its internal map, but the
purge request uses the .metadata.name as the key when doing the lookup.
This causes purge to fail if .metadata.name and .spec.address differ.

This fix changes the console server to pass the .spec.address instead of
.metadata.name and also using this as the lookup in agent.

An alternative would be to change the mapping internally to use
.metadata.name as the key, but this would complicate other uses of the
map that assumes it is keyed by .spec.address (such as router stats
retrieval).

The systemtest is updated to test purge with one address that has .metadata.name different from .spec.address.