### PR TITLE
Update infra test for #5130

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/infra/standard/InfraTestStandard.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/infra/standard/InfraTestStandard.java
@@ -22,7 +22,6 @@ import io.enmasse.admin.model.v1.StandardInfraConfigSpecBroker;
 import io.enmasse.admin.model.v1.StandardInfraConfigSpecBrokerBuilder;
 import io.enmasse.admin.model.v1.StandardInfraConfigSpecRouter;
 import io.enmasse.admin.model.v1.StandardInfraConfigSpecRouterBuilder;
-import io.enmasse.systemtest.amqp.AmqpClient;
 import io.enmasse.systemtest.annotations.ExternalClients;
 import io.enmasse.systemtest.bases.infra.InfraTestBase;
 import io.enmasse.systemtest.bases.isolated.ITestIsolatedStandard;
@@ -34,7 +33,6 @@ import io.enmasse.systemtest.messagingclients.proton.java.ProtonJMSClientReceive
 import io.enmasse.systemtest.messagingclients.proton.java.ProtonJMSClientSender;
 import io.enmasse.systemtest.model.address.AddressType;
 import io.enmasse.systemtest.model.addressspace.AddressSpaceType;
-import io.enmasse.systemtest.shared.standard.QueueTest;
 import io.enmasse.systemtest.time.TimeoutBudget;
 import io.enmasse.systemtest.utils.AddressSpaceUtils;
 import io.enmasse.systemtest.utils.AddressUtils;


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Enhancement / new feature


### Description

Updated infra test to check if address if working properly when it's connected to infra config which has omitted globalMaxSize. 
Address status is changed to ready even with NaN error on Agent so we have to test if address is working properly with sender&receiver attached.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [* ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
