### PR TITLE
Update monitoring resources when operator restarts

### DIFF
--- a/pkg/util/templatehelper.go
+++ b/pkg/util/templatehelper.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ghodss/yaml"
 	"io/ioutil"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"os"
 	"text/template"
 )
@@ -92,7 +91,7 @@ func (h *TemplateHelper) loadTemplate(name string) ([]byte, error) {
 	return buffer.Bytes(), nil
 }
 
-func (h *TemplateHelper) CreateResource(template string) (runtime.Object, error) {
+func (h *TemplateHelper) CreateResource(template string) (*unstructured.Unstructured, error) {
 	tpl, err := h.loadTemplate(template)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Update monitoring resources (PrometheusRules and ServiceMonitors) when the EnMasse operator restarts. This ensures that monitoring resources are updated when EnMasse is upgrade to newer version.

Fixes #4580 

### Checklist

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
