### PR TITLE
Fixed issue where pods are not detected as ready

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
@@ -654,7 +654,7 @@ public class TestUtils {
                 }
             }
             log.info("All current ReplicaSets are ready");
-            List<Pod> pods = Kubernetes.getInstance().listPods(namespace, Collections.singletonMap("app", "enmasse"));
+            List<Pod> pods = Kubernetes.getInstance().listPods(namespace);
             for (String expectedPod : expectedPods) {
                 if (pods.stream().noneMatch(pod -> pod.getMetadata().getName().contains(expectedPod))) {
                     log.info("Pod {} is still not deployed", expectedPod);


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Monitoring tests are failing when run on OpenShift 3.x because the pods are never detected as being in a ready state. This is because the monitoring stack is installed on OpenShit 3.x using the Application Monitoring Operator so the pods are not labelled with `app:enmasse`. This means the test wasn't finding the pods. Removing the labels from the call to listPods fixes this issue.

### Checklist

- [ ] Update/write design documentation in `./documentation/design`
- [X] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
