### PR TITLE
Fix issue in detecting Kubernetes version

### DIFF
--- a/pkg/util/openshift.go
+++ b/pkg/util/openshift.go
@@ -209,9 +209,13 @@ func detectOpenshift4() bool {
 		return false
 	}
 
+	return evalIsOpenShift4(v)
+}
+
+func evalIsOpenShift4(v *version.Info) bool {
 	log.Info("Version Info", "version", v, "major", v.Major, "minor", v.Minor)
 
-	m, err := regexp.MatchString(`^\d+\+$`, v.Minor)
+	m, err := regexp.MatchString(`^\d+\+?$`, v.Minor)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to compile regexp for version check: %v", err))
 	}

--- a/pkg/util/openshift_test.go
+++ b/pkg/util/openshift_test.go
@@ -7,6 +7,7 @@ package util
 
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/version"
 	"os"
 	"testing"
 )
@@ -61,6 +62,32 @@ func TestHasApiWithEnvFalse(t *testing.T) {
 	if err := os.Unsetenv(name); err != nil {
 		t.Error(err)
 		return
+	}
+
+}
+
+func TestIsOpenShift4(t *testing.T) {
+
+	var data = []struct {
+		major  string
+		minor  string
+		isFour bool
+	}{
+		{"1", "9+", false},
+		{"1", "9", false},
+		{"1", "18+", true},
+		{"1", "19", true},
+	}
+
+	for _, d := range data {
+		v := version.Info{
+			Major: d.major,
+			Minor: d.minor,
+		}
+		r := evalIsOpenShift4(&v)
+		if r != d.isFour {
+			t.Errorf("Failed result - version: %v, expectedResult: %v (was: %v)", v, d.isFour, r)
+		}
 	}
 
 }


### PR DESCRIPTION

### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

It looks like in Kubernetes version 1.19 they changed
the minor version to e.g. "18+" to "19" (without the '+')
suffix.

However the reg-exp used to validate the minor version string
expected a plus in the end. This make the + optional.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
