### PR TITLE
Fix olm test waiting for only enmasse pods

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/utils/TestUtils.java
@@ -654,7 +654,7 @@ public class TestUtils {
                 }
             }
             log.info("All current ReplicaSets are ready");
-            List<Pod> pods = Kubernetes.getInstance().listPods(namespace);
+            List<Pod> pods = Kubernetes.getInstance().listPods(namespace, Collections.singletonMap("app", "enmasse"));
             for (String expectedPod : expectedPods) {
                 if (pods.stream().noneMatch(pod -> pod.getMetadata().getName().contains(expectedPod))) {
                     log.info("Pod {} is still not deployed", expectedPod);


### PR DESCRIPTION
without this change enmasse systemtests are stuck in waiting to ready phase becasue custom catalog creates pods in enmasse-infra namespace which are in state completed