### PR TITLE
Fix collecting routes on kubernetes 1.11

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/logs/GlobalLogCollector.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/logs/GlobalLogCollector.java
@@ -347,8 +347,8 @@ public class GlobalLogCollector {
             Files.writeString(path.resolve("pvs.txt"), KubeCMDClient.runOnClusterWithoutLogger("describe", "pv").getStdOut());
             Files.writeString(path.resolve("storageclass.yml"), KubeCMDClient.runOnClusterWithoutLogger("get", "storageclass", "-o", "yaml").getStdOut());
             if (Kubernetes.isOpenShiftCompatible()) {
-                Files.writeString(path.resolve("routes.yml"), KubeCMDClient.runOnClusterWithoutLogger("get", "-A", "routes", "-o", "yaml").getStdOut());
-                Files.writeString(path.resolve("routes.yml"), KubeCMDClient.runOnClusterWithoutLogger("get", "-A", "routes", "-o", "yaml").getStdOut());
+                Files.writeString(path.resolve("routes.yml"), KubeCMDClient.runOnClusterWithoutLogger("get", "routes", "--all-namespaces", "-o", "yaml").getStdOut());
+                Files.writeString(path.resolve("routes.yml"), KubeCMDClient.runOnClusterWithoutLogger("get", "routes", "--all-namespaces", "-o", "yaml").getStdOut());
 
             }
             Files.writeString(path.resolve("events.txt"), KubeCMDClient.getAllEvents().getStdOut());


### PR DESCRIPTION
### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

<!--

_Please describe your pull request_

-->

Allow to collect routes on kubernetes 1.11 (ocp 3.11), this PR should be also picked into release 0.33 and 0.32

