### PR TITLE
Fix #5221: Periodically check outgoing broker connections for idleness

### DIFF
--- a/broker-plugin/amqp-connector/src/main/java/org/apache/activemq/artemis/integration/amqp/AMQPConnectorService.java
+++ b/broker-plugin/amqp-connector/src/main/java/org/apache/activemq/artemis/integration/amqp/AMQPConnectorService.java
@@ -58,7 +58,9 @@ public class AMQPConnectorService implements ConnectorService, BaseConnectionLif
    private final ScheduledExecutorService scheduledExecutorService;
    private final ProtonClientConnectionManager lifecycleHandler;
    private volatile boolean started = false;
+   private volatile ScheduledFuture<?> connectionCheckFuture;
    private final Map<String, Object> connectorConfig;
+   private final int idleTimeout;
    private final boolean treatRejectAsUnmodifiedDeliveryFailed;
    private final boolean useModifiedForTransientDeliveryErrors;
    private final int minLargeMessageSize;
@@ -69,6 +71,7 @@ public class AMQPConnectorService implements ConnectorService, BaseConnectionLif
       this.server = server;
       this.scheduledExecutorService = scheduledExecutorService;
       this.nettyThreadPool = nettyThreadPool;
+      this.idleTimeout = idleTimeout;
       this.treatRejectAsUnmodifiedDeliveryFailed = treatRejectAsUnmodifiedDeliveryFailed;
       this.useModifiedForTransientDeliveryErrors = useModifiedForTransientDeliveryErrors;
       this.minLargeMessageSize = minLargeMessageSize;
@@ -132,6 +135,13 @@ public class AMQPConnectorService implements ConnectorService, BaseConnectionLif
 
          if (connection != null) {
             started = true;
+            if (idleTimeout > 0 && connectionCheckFuture == null) {
+               long connCheckTimeout = idleTimeout * 2;
+               connectionCheckFuture = scheduledExecutorService.scheduleAtFixedRate(() -> lifecycleHandler.checkIdleConnections(connCheckTimeout),
+                       connCheckTimeout,
+                       connCheckTimeout,
+                       TimeUnit.MILLISECONDS);
+            }
          } else {
             ActiveMQAMQPLogger.LOGGER.infov("Error starting connector {0}, retrying in 5 seconds", name);
             scheduledExecutorService.schedule(() -> {
@@ -154,6 +164,11 @@ public class AMQPConnectorService implements ConnectorService, BaseConnectionLif
             closeExecutor.shutdown();
             nettyThreadPool.shutdown();
             ActiveMQAMQPLogger.LOGGER.infov("Stopped connector {0}", name);
+
+            if (connectionCheckFuture != null) {
+               connectionCheckFuture.cancel(false);
+               connectionCheckFuture = null;
+            }
          } catch (Throwable t) {
             // Note - the scheduledExecutorService supplied by Artemis ignores exceptions.  Ensure the cause of the failure is logged..
             ActiveMQAMQPLogger.LOGGER.errorv(t, "Error stopping connector {0}", name);

--- a/broker-plugin/amqp-connector/src/main/java/org/apache/activemq/artemis/integration/amqp/AMQPConnectorService.java
+++ b/broker-plugin/amqp-connector/src/main/java/org/apache/activemq/artemis/integration/amqp/AMQPConnectorService.java
@@ -137,7 +137,10 @@ public class AMQPConnectorService implements ConnectorService, BaseConnectionLif
             started = true;
             if (idleTimeout > 0 && connectionCheckFuture == null) {
                long connCheckTimeout = idleTimeout * 2;
-               connectionCheckFuture = scheduledExecutorService.scheduleAtFixedRate(() -> lifecycleHandler.checkIdleConnections(connCheckTimeout),
+               connectionCheckFuture = scheduledExecutorService.scheduleAtFixedRate(() -> {
+                          ActiveMQAMQPLogger.LOGGER.infov("Checking connections on connector {0}", name);
+                          lifecycleHandler.checkIdleConnections(connCheckTimeout);
+                       },
                        connCheckTimeout,
                        connCheckTimeout,
                        TimeUnit.MILLISECONDS);

--- a/broker-plugin/amqp-connector/src/main/java/org/apache/activemq/artemis/integration/amqp/ProtonClientConnectionManager.java
+++ b/broker-plugin/amqp-connector/src/main/java/org/apache/activemq/artemis/integration/amqp/ProtonClientConnectionManager.java
@@ -20,9 +20,9 @@ import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.ActiveMQRemoteDisconnectException;
 import org.apache.activemq.artemis.core.server.ActiveMQComponent;
+import org.apache.activemq.artemis.core.server.ActiveMQMessageBundle;
 import org.apache.activemq.artemis.protocol.amqp.broker.ActiveMQProtonRemotingConnection;
 import org.apache.activemq.artemis.protocol.amqp.broker.ProtonProtocolManager;
-import org.apache.activemq.artemis.protocol.amqp.proton.handler.EventHandler;
 import org.apache.activemq.artemis.protocol.amqp.sasl.ClientSASLFactory;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
 import org.apache.activemq.artemis.spi.core.remoting.BaseConnectionLifeCycleListener;
@@ -30,6 +30,7 @@ import org.apache.activemq.artemis.spi.core.remoting.BufferHandler;
 import org.apache.activemq.artemis.spi.core.remoting.Connection;
 import org.jboss.logging.Logger;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -112,5 +113,16 @@ public class ProtonClientConnectionManager implements BaseConnectionLifeCycleLis
 
    public RemotingConnection getConnection(Object connectionId) {
       return connectionMap.get(connectionId);
+   }
+
+   public void checkIdleConnections(long ttl) {
+      Collection<ActiveMQProtonRemotingConnection> values = connectionMap.values();
+      log.infof("Checking %d connection(s)", values.size());
+      for (ActiveMQProtonRemotingConnection conn : values) {
+         boolean dataReceived = conn.checkDataReceived();
+         if (!dataReceived) {
+            conn.asyncFail(ActiveMQMessageBundle.BUNDLE.clientExited(conn.getLocalAddress(), ttl));
+         }
+      }
    }
 }

--- a/broker-plugin/amqp-connector/src/main/java/org/apache/activemq/artemis/integration/amqp/ProtonClientConnectionManager.java
+++ b/broker-plugin/amqp-connector/src/main/java/org/apache/activemq/artemis/integration/amqp/ProtonClientConnectionManager.java
@@ -117,7 +117,7 @@ public class ProtonClientConnectionManager implements BaseConnectionLifeCycleLis
 
    public void checkIdleConnections(long ttl) {
       Collection<ActiveMQProtonRemotingConnection> values = connectionMap.values();
-      log.infof("Checking %d connection(s)", values.size());
+      log.debugf("Checking %d connection(s)", values.size());
       for (ActiveMQProtonRemotingConnection conn : values) {
          boolean dataReceived = conn.checkDataReceived();
          if (!dataReceived) {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This mimics the approach taken by Artemis itself for detecting 'idleness'.  Artemis uses FailureCheckAndFlushThread#run to periodically check all connections are ensure that they continue to see traffic.  Unfortunately, this doesn't apply to connections created by EnMasse's AMQPConnectorService as it does know about them.

I've added a period check for connections that works in the same way.  
Note: This is separate from AMQP's notion of idleness, which Artemis doesn't act upon directly.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
