### PR TITLE
Avoid some expensive log.debug() AP evaluations

### DIFF
--- a/agent/lib/broker_controller.js
+++ b/agent/lib/broker_controller.js
@@ -631,8 +631,10 @@ BrokerController.prototype._sync_broker_addresses = function (retry) {
 
         var stale = values(difference(actual, self.addresses, same_address));
         var missing = values(difference(self.addresses, actual, same_address));
-        log.debug('[%s] checking addresses, desired=%j, actual=%j => delete %j and create %j', self.id, values(self.addresses).map(address_and_type), values(actual),
-            stale.map(address_and_type), missing.map(address_and_type));
+        if (log.isDebugEnabled()) {
+            log.debug('[%s] checking addresses, desired=%j, actual=%j => delete %j and create %j', self.id, values(self.addresses).map(address_and_type), values(actual),
+                stale.map(address_and_type), missing.map(address_and_type));
+        }
         self._set_sync_status(stale.length, missing.length);
         return addrSettings.then(() => {
                 return self.delete_addresses(stale).then(

--- a/agent/lib/log.js
+++ b/agent/lib/log.js
@@ -48,9 +48,13 @@ function formatLevel(level, spaces) {
 
 Logger.prototype.log = function (level, str) {
     var args = Array.prototype.slice.call(arguments, 2);
-    if (levels[level] !== undefined && levels[level] <= this.level) {
+    if (this.isEnabled(level)) {
         this.logger.apply(this.logger, [formatLevel(level, 5) + " " + str].concat(args));
     }
+}
+
+Logger.prototype.isEnabled = function (level) {
+    return (levels[level] !== undefined && levels[level] <= this.level);
 }
 
 module.exports.logger = function() {
@@ -63,5 +67,9 @@ module.exports.logger = function() {
     logger.info  = logger.log.bind(logger, "info");
     logger.warn  = logger.log.bind(logger, "warn");
     logger.error = logger.log.bind(logger, "error");
+    logger.isDebugEnabled = logger.isEnabled.bind(logger, "debug");
+    logger.isInfoEnabled = logger.isEnabled.bind(logger, "info");
+    logger.isWarnEnabled = logger.isEnabled.bind(logger, "warn");
+    logger.isErrorEnabled = logger.isEnabled.bind(logger, "error");
     return logger;
 }

--- a/agent/lib/ragent.js
+++ b/agent/lib/ragent.js
@@ -276,7 +276,9 @@ function get_address (a) { return a.address; }
 
 Ragent.prototype.sync_broker = function (broker) {
     var allocated = this.addresses.filter(if_allocated_to(broker.id));
-    log.debug('syncing broker %s with %j', broker.id, allocated.map(get_address));
+    if (log.isDebugEnabled()) {
+        log.debug('syncing broker %s with %j', broker.id, allocated.map(get_address));
+    }
     broker.sync_addresses(allocated);
 }
 

--- a/agent/lib/registry.js
+++ b/agent/lib/registry.js
@@ -60,13 +60,17 @@ Registry.prototype.update = function (id, latest) {
     var current = this.objects[id];
     if (current === undefined) {
         this.objects[id] = latest;
-        log.debug('setting ' + id + ' to ' + JSON.stringify(latest));
+        if (log.isDebugEnabled()) {
+            log.debug('setting ' + id + ' to ' + JSON.stringify(latest));
+        }
         this.emit('updated', latest);
     } else {
         var changed = false;
         for (var s in latest) {
             if (!equals(current[s], latest[s])) {
-                log.debug('changing ' + s + ' on ' + id + ' from ' + JSON.stringify(current[s]) + ' to ' + JSON.stringify(latest[s]));
+                if (log.isDebugEnabled()) {
+                    log.debug('changing ' + s + ' on ' + id + ' from ' + JSON.stringify(current[s]) + ' to ' + JSON.stringify(latest[s]));
+                }
                 current[s] = latest[s];
                 changed = true;
             }
@@ -83,7 +87,9 @@ Registry.prototype.update_if_exists = function (id, latest) {
         var changed = false;
         for (var s in latest) {
             if (!equals(current[s], latest[s])) {
-                log.debug('changing ' + s + ' on ' + id + ' from ' + JSON.stringify(current[s]) + ' to ' + JSON.stringify(latest[s]));
+                if (log.isDebugEnabled()) {
+                    log.debug('changing ' + s + ' on ' + id + ' from ' + JSON.stringify(current[s]) + ' to ' + JSON.stringify(latest[s]));
+                }
                 current[s] = latest[s];
                 changed = true;
             }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Avoid some expensive log.debug() AP evaluations.  This avoids pointless n operations (filters, maps etc), where n is the number of connections or addresses, generating needless garbage.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
