### PR TITLE
Fix #5228: Guard empty MIN_LARGE_MESSAGE_SIZE

### DIFF
--- a/broker-plugin/amqp-connector/pom.xml
+++ b/broker-plugin/amqp-connector/pom.xml
@@ -82,5 +82,15 @@
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/broker-plugin/amqp-connector/src/main/java/org/apache/activemq/artemis/integration/amqp/AMQPConnectorServiceFactory.java
+++ b/broker-plugin/amqp-connector/src/main/java/org/apache/activemq/artemis/integration/amqp/AMQPConnectorServiceFactory.java
@@ -172,5 +172,4 @@ public class AMQPConnectorServiceFactory implements ConnectorServiceFactory {
       return requiredProperties;
    }
 
-
 }

--- a/broker-plugin/amqp-connector/src/main/java/org/apache/activemq/artemis/integration/amqp/Util.java
+++ b/broker-plugin/amqp-connector/src/main/java/org/apache/activemq/artemis/integration/amqp/Util.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2018, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package org.apache.activemq.artemis.integration.amqp;
+
+public class Util {
+    public static Integer parseIntOrNull(String s) {
+       try {
+          return Integer.parseInt(s);
+       } catch (NumberFormatException e) {
+          return null;
+       }
+    }
+}

--- a/broker-plugin/amqp-connector/src/test/java/org/apache/activemq/artemis/integration/amqp/UtilTest.java
+++ b/broker-plugin/amqp-connector/src/test/java/org/apache/activemq/artemis/integration/amqp/UtilTest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package org.apache.activemq.artemis.integration.amqp;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+public class UtilTest {
+
+    @Test
+    public void parseIntOrNullWorksWithStreams() {
+        Assertions.assertEquals(1, Optional.ofNullable("1").map(Util::parseIntOrNull).orElse(-1));
+        Assertions.assertEquals(-1, Optional.ofNullable((String)null).map(Util::parseIntOrNull).orElse(-1));
+        Assertions.assertEquals(-1, Optional.ofNullable("").map(Util::parseIntOrNull).orElse(-1));
+        Assertions.assertEquals(-1, Optional.ofNullable("bang").map(Util::parseIntOrNull).orElse(-1));
+    }
+}


### PR DESCRIPTION
### Type of change


- Bugfix

### Description

Treat an empty MIN_LARGE_MESSAGE_SIZE value as if it were the default (-1).

### Checklist


- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
