### PR TITLE
Fix #5238: Console receiver grants too little credit to agent_data receiving link

### DIFF
--- a/pkg/consolegraphql/agent/agent.go
+++ b/pkg/consolegraphql/agent/agent.go
@@ -168,6 +168,7 @@ func (aad *amqpAgentDelegate) doCollect() error {
 	// Create a receiver
 	receiver, err := session.NewReceiver(
 		amqp.LinkSourceAddress(agentDataAddress),
+		amqp.LinkCredit(500),
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION

### Type of change


- Bugfix

### Description

Receiving link was granting credit 1, so messages were effectively being polled.

### Checklist


- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
