### PR TITLE
Use quay.io for selenium, postgres and busybox

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/apps/SystemtestsKubernetesApps.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/apps/SystemtestsKubernetesApps.java
@@ -175,6 +175,10 @@ public class SystemtestsKubernetesApps {
             "-url",
             "jdbc:h2:tcp://localhost:9092//data/device-registry"
     };
+    private static final String POSTGRES_IMAGE = "quay.io/enmasse/postgres:10.4";
+    private static final String SELENIUM_STANDALONE_CHROME_IMAGE = "quay.io/enmasse/selenium-standalone-chrome";
+    private static final String SELENIUM_STANDALONE_FIREFOX_IMAGE = "quay.io/enmasse/selenium-standalone-firefox";
+    private static final String BUSYBOX_IMAGE = "quay.io/enmasse/busybox:latest";
 
     static {
 
@@ -276,7 +280,7 @@ public class SystemtestsKubernetesApps {
         kubeClient.createServiceFromResource(namespace, getSystemtestsServiceResource(SystemtestsKubernetesApps.SELENIUM_FIREFOX, 4444));
         kubeClient.createConfigmapFromResource(namespace, getRheaConfigMap());
         kubeClient.createDeploymentFromResource(namespace,
-                getSeleniumNodeDeploymentResource(SELENIUM_FIREFOX, "selenium/standalone-firefox"));
+                getSeleniumNodeDeploymentResource(SELENIUM_FIREFOX, SELENIUM_STANDALONE_FIREFOX_IMAGE));
         kubeClient.createIngressFromResource(namespace, getSystemtestsIngressResource(SELENIUM_FIREFOX, 4444));
         TestUtils.waitForExpectedReadyPods(kube, namespace, 1, new TimeoutBudget(1, TimeUnit.MINUTES));
     }
@@ -286,7 +290,7 @@ public class SystemtestsKubernetesApps {
         kubeClient.createServiceFromResource(namespace, getSystemtestsServiceResource(SELENIUM_CHROME, 4444));
         kubeClient.createConfigmapFromResource(namespace, getRheaConfigMap());
         kubeClient.createDeploymentFromResource(namespace,
-                getSeleniumNodeDeploymentResource(SystemtestsKubernetesApps.SELENIUM_CHROME, "selenium/standalone-chrome"));
+                getSeleniumNodeDeploymentResource(SystemtestsKubernetesApps.SELENIUM_CHROME, SELENIUM_STANDALONE_CHROME_IMAGE));
         kubeClient.createIngressFromResource(namespace, getSystemtestsIngressResource(SELENIUM_CHROME, 4444));
         TestUtils.waitForExpectedReadyPods(kube, namespace, 1, new TimeoutBudget(1, TimeUnit.MINUTES));
     }
@@ -847,7 +851,7 @@ public class SystemtestsKubernetesApps {
                 .withNewSpec()
                 .withInitContainers(new ContainerBuilder()
                         .withName("set-up-workspace")
-                        .withImage("busybox:latest")
+                        .withImage(BUSYBOX_IMAGE)
                         .withCommand("sh", "-c")
                         .withArgs(command)
                         .withVolumeMounts(
@@ -1298,7 +1302,7 @@ public class SystemtestsKubernetesApps {
                 .withNewSpec()
                 .addNewContainer()
                 .withName(POSTGRES_APP)
-                .withImage("postgres:10.4")
+                .withImage(POSTGRES_IMAGE)
                 .withImagePullPolicy("IfNotPresent")
                 .addNewPort()
                 .withContainerPort(5432)


### PR DESCRIPTION
### Type of change


- Bugfix

### Description

Use project enmasse quay images for selenium, postgres and busybox to avoid docker pull limits.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
