### PR TITLE
Fix #5228: Guard MIN_LARGE_MESSAGE_SIZE II

### DIFF
--- a/broker-plugin/amqp-connector/src/main/java/org/apache/activemq/artemis/integration/amqp/AMQPConnectorServiceFactory.java
+++ b/broker-plugin/amqp-connector/src/main/java/org/apache/activemq/artemis/integration/amqp/AMQPConnectorServiceFactory.java
@@ -129,13 +129,13 @@ public class AMQPConnectorServiceFactory implements ConnectorServiceFactory {
 
       String containerId = Optional.ofNullable((String)configuration.get(CONTAINER_ID)).orElse(clusterId);
 
-      int nettyThreads = Optional.ofNullable((String)configuration.get(NETTY_THREADS)).map(Integer::parseInt).orElse(4);
-      int idleTimeout = Optional.ofNullable((String)configuration.get(IDLE_TIMEOUT)).map(Integer::parseInt).orElse(16_000);
-      Integer consumerPriority = Optional.ofNullable((String)configuration.get(CONSUMER_PRIORITY)).map(Integer::parseInt).orElse(null);
+      int nettyThreads = Optional.ofNullable((String)configuration.get(NETTY_THREADS)).map(Util::parseIntOrNull).orElse(4);
+      int idleTimeout = Optional.ofNullable((String)configuration.get(IDLE_TIMEOUT)).map(Util::parseIntOrNull).orElse(16_000);
+      Integer consumerPriority = Optional.ofNullable((String)configuration.get(CONSUMER_PRIORITY)).map(Util::parseIntOrNull).orElse(null);
 
       boolean treatRejectAsUnmodifiedDeliveryFailed = Optional.ofNullable((String)configuration.get(TREAT_REJECT_AS_UNMODIFIED_DELIVERY_FAILED)).map(Boolean::parseBoolean).orElse(true);
       boolean useModifiedForTransientDeliveryErrors = Optional.ofNullable((String)configuration.get(USE_MODIFIED_FOR_TRANSIENT_DELIVERY_ERRORS)).map(Boolean::parseBoolean).orElse(true);
-      int minLargeMessageSize = Optional.ofNullable((String)configuration.get(MIN_LARGE_MESSAGE_SIZE)).map(Integer::parseInt).orElse(-1);
+      int minLargeMessageSize = Optional.ofNullable((String)configuration.get(MIN_LARGE_MESSAGE_SIZE)).map(Util::parseIntOrNull).orElse(-1);
 
       Optional<LinkInfo> linkInfo = sourceAddress.flatMap(s ->
               targetAddress.flatMap(t ->


### PR DESCRIPTION
### Type of change

- Bugfix

### Description


Actually calling the new method might actually help!


### Checklist

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
