### PR TITLE
[System tests] Avoid NPE if test user is not defined

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/web/ConsoleTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/web/ConsoleTest.java
@@ -350,9 +350,11 @@ public abstract class ConsoleTest extends TestBase {
         } finally {
             try {
                 if (!success) {
-                    GlobalLogCollector testDirLogCollector = new GlobalLogCollector(kubernetes, TestUtils.getFailedTestLogsPath(TestInfo.getInstance().getActualTest()), environment.namespace(), false);
-                    testDirLogCollector.collectLogsOfPodsByLabels(environment.namespace(), null,
-                            Collections.singletonMap(LabelKeys.INFRA_UUID, AddressSpaceUtils.getAddressSpaceInfraUuid(addressSpace)));
+                    if (addressSpace != null) {
+                        GlobalLogCollector testDirLogCollector = new GlobalLogCollector(kubernetes, TestUtils.getFailedTestLogsPath(TestInfo.getInstance().getActualTest()), environment.namespace(), false);
+                        testDirLogCollector.collectLogsOfPodsByLabels(environment.namespace(), null,
+                                Collections.singletonMap(LabelKeys.INFRA_UUID, AddressSpaceUtils.getAddressSpaceInfraUuid(addressSpace)));
+                    }
                 }
                 consolePage.deleteAddressSpace(addressSpace);
             } finally {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Avoid NPE during cleanup if expected test user is not defined.

### Checklist


- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
