### PR TITLE
Clean up v1beta1 crds schemas

### DIFF
--- a/templates/crds/addressspaceplans.crd.yaml
+++ b/templates/crds/addressspaceplans.crd.yaml
@@ -46,6 +46,7 @@ spec:
       description: AddressSpacePlan describes the allowed resource usage of an address space. This resource is created by the service administrator.
       properties:
         status:
+          type: object
           properties:
             phase:
               type: string

--- a/templates/crds/brokeredinfraconfigs.crd.yaml
+++ b/templates/crds/brokeredinfraconfigs.crd.yaml
@@ -37,8 +37,12 @@ spec:
               properties:
                 ingress:
                   type: array
+                  items:
+                    type: object
                 egress:
                   type: array
+                  items:
+                    type: object
             admin:
               type: object
               properties:
@@ -95,6 +99,8 @@ spec:
                           type: object
                         tolerations:
                           type: array
+                          items:
+                            type: object
                         priorityClassName:
                           type: string
                         securityContext:

--- a/templates/crds/messagingusers.crd.yaml
+++ b/templates/crds/messagingusers.crd.yaml
@@ -49,6 +49,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
+      type: object
       description: MessagingUser is a user that can be used to authenticate and authorize a messaging application. This resource is created by messaging tenants.
       properties:
         status:

--- a/templates/crds/standardinfraconfigs.crd.yaml
+++ b/templates/crds/standardinfraconfigs.crd.yaml
@@ -37,8 +37,12 @@ spec:
               properties:
                 ingress:
                   type: array
+                  items:
+                    type: object
                 egress:
                   type: array
+                  items:
+                    type: object
             admin:
               type: object
               properties:
@@ -103,6 +107,8 @@ spec:
                           type: object
                         tolerations:
                           type: array
+                          items:
+                            type: object
                         priorityClassName:
                           type: string
                         securityContext:
@@ -166,6 +172,8 @@ spec:
                           type: object
                         tolerations:
                           type: array
+                          items:
+                            type: object
                         priorityClassName:
                           type: string
                         securityContext:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Cleanup the v1beta1 schemas in preparation for conversion to CRD v1s by removing some unstructural schema warnings.
These changes have no functional impact.

### Checklist


- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
