### PR TITLE
[Tests] Fix TopicTest.testSharedDurableSubscription

### DIFF
--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/TopicTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/TopicTest.java
@@ -155,7 +155,7 @@ class TopicTest extends TestBase implements ITestSharedBrokered {
         MessageConsumer subscriber1 = session.createConsumer(testTopic);
         MessageProducer messageProducer = session.createProducer(testTopic);
 
-        int count = 1000;
+        int count = 100;
         List<javax.jms.Message> listMsgs = jmsProvider.generateMessages(session, count);
 
         CompletableFuture<List<javax.jms.Message>> received = new CompletableFuture<>();
@@ -358,7 +358,6 @@ class TopicTest extends TestBase implements ITestSharedBrokered {
         subscriber1.close();
         subscriber2.close();
         session.unsubscribe(subID);
-        session2.unsubscribe(subID);
         connection1.stop();
         connection2.stop();
         session.close();


### PR DESCRIPTION

### Type of change


- Bugfix

### Description

JMS allows a durable subscription to be deleted only once, regardless of the connection/session


### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
