### PR TITLE
Enable user workload monitoring on OCP 4.6

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/condition/OpenShiftVersion.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/condition/OpenShiftVersion.java
@@ -28,7 +28,8 @@ public enum OpenShiftVersion {
 
     public enum Openshift4MinorVersion {
         OCP4_PRIOR_4_4(v -> v >= 1.13 && v<1.17),
-        OCP4_AFTER_4_4(v -> v>=1.17);
+        OCP4_AFTER_4_4(v -> v >= 1.17 && v<1.19),
+        OCP4_AFTER_4_6(v -> v >= 1.19);
 
         private final Predicate<Double> versionChecker;
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

User workload monitoring is no longer in tech preview in OpenShift 4.6 or later so it the config to enable it has changed. 

### Checklist

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
