### PR TITLE
Make add-crc-insecure-registry support id_ecdsa ssh identities

### DIFF
--- a/scripts/add-crc-insecure-registry.sh
+++ b/scripts/add-crc-insecure-registry.sh
@@ -10,7 +10,13 @@ oc patch --type=merge --patch="{ \"spec\": { \"registrySources\": { \"insecureRe
 
 IP=$(crc ip)
 
-ssh -i ~/.crc/machines/crc/id_rsa -o StrictHostKeyChecking=no core@${IP} sudo cat /etc/containers/registries.conf > /tmp/registries.conf
+ID_FILE=~/.crc/machines/crc/id_ecdsa
+if [[ ! -f "${ID_FILE}" ]]; then
+    ID_FILE=~/.crc/machines/crc/id_rsa
+fi
+
+
+ssh -i "${ID_FILE}" -o StrictHostKeyChecking=no core@${IP} sudo cat /etc/containers/registries.conf > /tmp/registries.conf
 
 
 cat <<EOF >> /tmp/registries.conf
@@ -27,7 +33,8 @@ cat /tmp/registries.conf
 echo "Press ENTER to copy to CRC VM"
 read
 
-scp -i ~/.crc/machines/crc/id_rsa -o StrictHostKeyChecking=no /tmp/registries.conf core@${IP}:/tmp/registries.conf
-ssh -i ~/.crc/machines/crc/id_rsa -o StrictHostKeyChecking=no core@${IP} sudo cp /tmp/registries.conf /etc/containers/registries.conf
-ssh -i ~/.crc/machines/crc/id_rsa -o StrictHostKeyChecking=no core@${IP} sudo systemctl restart crio
-ssh -i ~/.crc/machines/crc/id_rsa -o StrictHostKeyChecking=no core@${IP} sudo systemctl restart kubelet
+scp -i "${ID_FILE}" -o StrictHostKeyChecking=no /tmp/registries.conf core@${IP}:/tmp/registries.conf
+ssh -i "${ID_FILE}" -o StrictHostKeyChecking=no core@${IP} sudo cp /tmp/registries.conf /etc/containers/registries.conf
+echo "Restarting crio/kublet"
+ssh -i "${ID_FILE}" -o StrictHostKeyChecking=no core@${IP} sudo systemctl restart crio
+ssh -i "${ID_FILE}" -o StrictHostKeyChecking=no core@${IP} sudo systemctl restart kubelet


### PR DESCRIPTION
### Type of change


- Bugfix

### Description

Seems newer CRC versions use the newer key form.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
