### PR TITLE
Bump minikube/kube versions

### DIFF
--- a/.github/scripts/install_dep.sh
+++ b/.github/scripts/install_dep.sh
@@ -5,6 +5,9 @@ echo "Update archives"
 sudo add-apt-repository ppa:longsleep/golang-backports
 sudo apt-get update
 
+# Depedenncy of newer minikube
+sudo apt-get install -y conntrack
+
 echo "Install maven"
 
 sudo apt install maven

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -46,8 +46,8 @@ jobs:
       - name: setup-docker
         run: ./.github/scripts/setup_docker.sh
 
-      - name: Minikube setup with registry
-        uses: EnMasseProject/minikube-setup@V1.0.2
+      - name: Minikube setup with registry V1.0.2-2
+        uses: EnMasseProject/minikube-setup@V1.0.2-2
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,8 +46,8 @@ jobs:
       - name: setup-docker
         run: ./.github/scripts/setup_docker.sh
 
-      - name: Minikube setup with registry
-        uses: EnMasseProject/minikube-setup@V1.0.2
+      - name: Minikube setup with registry V1.0.2-2
+        uses: EnMasseProject/minikube-setup@V1.0.2-2
 
       - name: Set up JDK 11
         uses: actions/setup-java@v1

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -36,8 +36,8 @@ jobs:
       - name: setup-docker
         run: ./.github/scripts/setup_docker.sh
 
-      - name: Minikube setup with registry V1.0.2-1
-        uses: EnMasseProject/minikube-setup@V1.0.2-1
+      - name: Minikube setup with registry V1.0.2-2
+        uses: EnMasseProject/minikube-setup@V1.0.2-2
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 


### PR DESCRIPTION
### Type of change


- Enhancement / new feature

### Description

Bump minikube/kube versions used by GiHub Actions.  This is required now as it we need a version of minikube that supports V1 CRD.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
