### PR TITLE
Fix test regression introduced by #5265

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/utils/UserUtils.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/utils/UserUtils.java
@@ -37,16 +37,8 @@ public class UserUtils {
 
     public static JsonObject userToJson(String addressspace, User user) throws Exception {
         return new JsonObject(new ObjectMapper().writeValueAsString(new UserBuilder(user)
-                .editMetadata()
+                .editOrNewMetadata()
                 .withName(String.format("%s.%s", addressspace, Pattern.compile(".*:").matcher(user.getSpec().getUsername()).replaceAll("")))
-                .endMetadata()
-                .build()));
-    }
-
-    public static JsonObject userToJson(String addressspace, String metaUserName, User user) throws Exception {
-        return new JsonObject(new ObjectMapper().writeValueAsString(new UserBuilder(user)
-                .editMetadata()
-                .withName(String.format("%s.%s", addressspace, Pattern.compile(".*:").matcher(metaUserName).replaceAll("")))
                 .endMetadata()
                 .build()));
     }


### PR DESCRIPTION
### Type of change


- Bugfix

### Description

Difference in the semantics of `new *Builder(original).editMetadata()` when `original` does not have metadata. Triggered by the update of fabric8 by #5265.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
