### PR TITLE
Fix defect exposed by #5252

### DIFF
--- a/pkg/apis/enmasse/v1beta1/types.go
+++ b/pkg/apis/enmasse/v1beta1/types.go
@@ -177,12 +177,12 @@ const (
 type ExposeSpec struct {
 	Type ExposeType `json:"type"`
 
-	RouteHost           string              `json:"routeHost"`
-	RouteServicePort    RouteServicePort    `json:"routeServicePort"`
-	RouteTlsTermination RouteTlsTermination `json:"routeTlsTermination"`
+	RouteHost           string              `json:"routeHost,omitempty"`
+	RouteServicePort    RouteServicePort    `json:"routeServicePort,omitempty"`
+	RouteTlsTermination RouteTlsTermination `json:"routeTlsTermination,omitempty"`
 
-	LoadBalancerPorts        []string `json:"loadBalancerPorts"`
-	LoadBalancerSourceRanges []string `json:"loadBalancerSourceRanges"`
+	LoadBalancerPorts        []string `json:"loadBalancerPorts,omitempty"`
+	LoadBalancerSourceRanges []string `json:"loadBalancerSourceRanges,omitempty"`
 }
 
 type ConnectorSpec struct {


### PR DESCRIPTION

### Type of change

- Bugfix

### Description

CRD v1 fixed a schema validation issue (bad indentation).  With proper schema validation
missing omitempty became apparent in the expose spec Go-serialisers.



### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
