### PR TITLE
[Docs] Document behaviour of disposition undeliverable-here=true for users of the standard address space

### DIFF
--- a/documentation/modules/con-standard-address-space.adoc
+++ b/documentation/modules/con-standard-address-space.adoc
@@ -11,7 +11,7 @@ The standard address space is the default address space in {ProductName}. It con
 * No selectors on queues
 * No browsing on queues
 * No message groups
-* Restrictions affecting the use of some AMQP delivery states, such as the `undeliverable-here=true` modified delivery state when there are competing consumers attached to the same message route.
+* Restrictions affecting the use of some AMQP delivery states, such as the `undeliverable-here=true` modified delivery state when there are competing consumers attached to the same message router.
 
 
 Clients connect and send and receive messages in this address space using the AMQP protocol.


### PR DESCRIPTION

### Type of change


- Documentation

Document behaviour of disposition undeliverable-here=true for users of the standard address space
Relates to to https://github.com/apache/qpid-dispatch/pull/867

### Description

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
