### PR TITLE
Fix #5272 - Support router configuration maxMessageSize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * #5253: Enable user workload monitoring on OCP 4.6
 * #5263: Reimplement server initiated connections. (#5266)
 * #5265: Update fabric8 kubernetes-client from 4.6.4 to 5.0.2
+* #5272: Support router configuration maxMessageSize
 
 
 ## 0.33.0

--- a/address-space-controller/src/main/java/io/enmasse/controller/RouterConfigController.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/RouterConfigController.java
@@ -691,6 +691,10 @@ public class RouterConfigController implements Controller {
             vhostPolicy.setMaxConnectionsPerUser(policy.getMaxConnectionsPerUser());
         }
 
+        if (policy.getMaxMessageSize() != null) {
+            vhostPolicy.setMaxMessageSize(policy.getMaxMessageSize());
+        }
+
         vhostPolicy.setGroups(Collections.singletonMap("$default", group));
 
         VhostPolicyGroup internalGroup = new VhostPolicyGroup();

--- a/address-space-controller/src/main/java/io/enmasse/controller/router/config/VhostPolicy.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/router/config/VhostPolicy.java
@@ -16,6 +16,7 @@ public class VhostPolicy {
     private Integer maxConnections;
     private Integer maxConnectionsPerUser;
     private Integer maxConnectionsPerHost;
+    private Integer maxMessageSize;
     private Map<String, VhostPolicyGroup> groups;
 
     public String getHostname() {
@@ -66,6 +67,15 @@ public class VhostPolicy {
         this.groups = groups;
     }
 
+
+    public Integer getMaxMessageSize() {
+        return maxMessageSize;
+    }
+
+    public void setMaxMessageSize(Integer maxMessageSize) {
+        this.maxMessageSize = maxMessageSize;
+    }
+
     @Override
     public String toString() {
         return "VhostPolicy{" +
@@ -74,6 +84,7 @@ public class VhostPolicy {
                 ", maxConnections=" + maxConnections +
                 ", maxConnectionsPerUser=" + maxConnectionsPerUser +
                 ", maxConnectionsPerHost=" + maxConnectionsPerHost +
+                ", maxMessageSize=" + maxMessageSize +
                 ", groups=" + groups +
                 '}';
     }
@@ -88,11 +99,12 @@ public class VhostPolicy {
                 Objects.equals(maxConnections, that.maxConnections) &&
                 Objects.equals(maxConnectionsPerUser, that.maxConnectionsPerUser) &&
                 Objects.equals(maxConnectionsPerHost, that.maxConnectionsPerHost) &&
+                Objects.equals(maxMessageSize, that.maxMessageSize) &&
                 Objects.equals(groups, that.groups);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(hostname, allowUnknownUser, maxConnections, maxConnectionsPerUser, maxConnectionsPerHost, groups);
+        return Objects.hash(hostname, allowUnknownUser, maxConnections, maxConnectionsPerUser, maxConnectionsPerHost, groups, maxMessageSize);
     }
 }

--- a/address-space-controller/src/test/java/io/enmasse/controller/RouterConfigControllerTest.java
+++ b/address-space-controller/src/test/java/io/enmasse/controller/RouterConfigControllerTest.java
@@ -85,6 +85,7 @@ public class RouterConfigControllerTest {
                 .withLinkCapacity(50)
                 .withHandshakeTimeout(20)
                 .withNewPolicy()
+                .withMaxMessageSize(40_000)
                 .withMaxConnections(30)
                 .withMaxConnectionsPerHost(10)
                 .withMaxConnectionsPerUser(10)
@@ -137,6 +138,7 @@ public class RouterConfigControllerTest {
 
         VhostPolicy internal = getPolicyForHostname("$default", actual.getVhosts());
         assertNotNull(internal);
+        assertNull(internal.getMaxMessageSize());
         assertNull(internal.getMaxConnections());
         assertNull(internal.getMaxConnectionsPerHost());
         assertNull(internal.getMaxConnectionsPerUser());
@@ -146,6 +148,7 @@ public class RouterConfigControllerTest {
 
         VhostPolicy pub = getPolicyForHostname("public", actual.getVhosts());
         assertNotNull(pub);
+        assertEquals(40_000, pub.getMaxMessageSize());
         assertEquals(30, pub.getMaxConnections());
         assertEquals(10, pub.getMaxConnectionsPerUser());
         assertEquals(10, pub.getMaxConnectionsPerHost());

--- a/api-model/src/main/java/io/enmasse/admin/model/v1/RouterPolicySpec.java
+++ b/api-model/src/main/java/io/enmasse/admin/model/v1/RouterPolicySpec.java
@@ -17,7 +17,7 @@ import java.util.Objects;
 )
 @JsonPropertyOrder({"maxConnections", "maxConnectionsPerUser", "maxConnectionsPerHost", "maxSessionsPerConnection", "maxSendersPerConnection", "maxReceiversPerConnection", "maxMessageSize"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class RouterPolicySpec {
+public class RouterPolicySpec extends AbstractWithAdditionalProperties {
     private Integer maxConnections;
     private Integer maxConnectionsPerUser;
     private Integer maxConnectionsPerHost;

--- a/api-model/src/main/java/io/enmasse/admin/model/v1/RouterPolicySpec.java
+++ b/api-model/src/main/java/io/enmasse/admin/model/v1/RouterPolicySpec.java
@@ -15,7 +15,7 @@ import java.util.Objects;
         generateBuilderPackage = false,
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
-@JsonPropertyOrder({"maxConnections", "maxConnectionsPerUser", "maxConnectionsPerHost", "maxSessionsPerConnection", "maxSendersPerConnection", "maxReceiversPerConnection"})
+@JsonPropertyOrder({"maxConnections", "maxConnectionsPerUser", "maxConnectionsPerHost", "maxSessionsPerConnection", "maxSendersPerConnection", "maxReceiversPerConnection", "maxMessageSize"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class RouterPolicySpec {
     private Integer maxConnections;
@@ -24,6 +24,7 @@ public class RouterPolicySpec {
     private Integer maxSessionsPerConnection;
     private Integer maxSendersPerConnection;
     private Integer maxReceiversPerConnection;
+    private Integer maxMessageSize;
 
     public Integer getMaxConnections() {
         return maxConnections;
@@ -73,6 +74,14 @@ public class RouterPolicySpec {
         this.maxReceiversPerConnection = maxReceiversPerConnection;
     }
 
+    public Integer getMaxMessageSize() {
+        return maxMessageSize;
+    }
+
+    public void setMaxMessageSize(Integer maxMessageSize) {
+        this.maxMessageSize = maxMessageSize;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -83,12 +92,14 @@ public class RouterPolicySpec {
                 Objects.equals(maxConnectionsPerHost, that.maxConnectionsPerHost) &&
                 Objects.equals(maxSessionsPerConnection, that.maxSessionsPerConnection) &&
                 Objects.equals(maxSendersPerConnection, that.maxSendersPerConnection) &&
-                Objects.equals(maxReceiversPerConnection, that.maxReceiversPerConnection);
+                Objects.equals(maxReceiversPerConnection, that.maxReceiversPerConnection) &&
+                Objects.equals(maxMessageSize, that.maxMessageSize);
     }
+
 
     @Override
     public int hashCode() {
-        return Objects.hash(maxConnections, maxConnectionsPerUser, maxConnectionsPerHost, maxSessionsPerConnection, maxSendersPerConnection, maxReceiversPerConnection);
+        return Objects.hash(maxConnections, maxConnectionsPerUser, maxConnectionsPerHost, maxSessionsPerConnection, maxSendersPerConnection, maxReceiversPerConnection, maxMessageSize);
     }
 
     @Override
@@ -100,6 +111,7 @@ public class RouterPolicySpec {
                 ", maxSessionsPerConnection=" + maxSessionsPerConnection +
                 ", maxSendersPerConnection=" + maxSendersPerConnection +
                 ", maxReceiversPerConnection=" + maxReceiversPerConnection +
+                ", maxMessageSize=" + maxMessageSize +
                 '}';
     }
 }

--- a/documentation/modules/ref-standard-infra-config-example.adoc
+++ b/documentation/modules/ref-standard-infra-config-example.adoc
@@ -37,6 +37,7 @@ spec:
       maxSessionsPerConnection: 10
       maxSendersPerConnection: 5
       maxReceiversPerConnection: 5
+      maxMessageSize: 1048576
     podTemplate: <5>
       spec:
         affinity:

--- a/documentation/modules/ref-standard-infra-config-fields.adoc
+++ b/documentation/modules/ref-standard-infra-config-fields.adoc
@@ -68,5 +68,5 @@ This table shows the fields available for the standard infrastructure configurat
 |`router.policy.maxSessionsPerConnection` |Specifies the maximum number of sessions allowed per router connection.
 |`router.policy.maxSendersPerConnection` |Specifies the maximum number of senders allowed per router connection.
 |`router.policy.maxReceiversPerConnection` |Specifies the maximum number of receivers allowed per router connection.
-|`router.policy.maxMessageSize` |The maximum size in bytes of AMQP message transfers allowed for this router. This limit is applied to transfers to/from client connections. A value of zero disables this limit.
+|`router.policy.maxMessageSize` |Specifies the maximum size in bytes of AMQP message transfers allowed for this router. This limit is applied to transfers to/from client connections. A value of zero disables this limit.
 |===

--- a/documentation/modules/ref-standard-infra-config-fields.adoc
+++ b/documentation/modules/ref-standard-infra-config-fields.adoc
@@ -68,4 +68,5 @@ This table shows the fields available for the standard infrastructure configurat
 |`router.policy.maxSessionsPerConnection` |Specifies the maximum number of sessions allowed per router connection.
 |`router.policy.maxSendersPerConnection` |Specifies the maximum number of senders allowed per router connection.
 |`router.policy.maxReceiversPerConnection` |Specifies the maximum number of receivers allowed per router connection.
+|`router.policy.maxMessageSize` |The maximum size in bytes of AMQP message transfers allowed for this router. This limit is applied to transfers to/from client connections. A value of zero disables this limit.
 |===

--- a/systemtests/src/test/java/io/enmasse/systemtest/isolated/api/CustomResourceDefinitionTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/isolated/api/CustomResourceDefinitionTest.java
@@ -299,6 +299,7 @@ public class CustomResourceDefinitionTest extends TestBase implements ITestBaseI
                     .withLinkCapacity(500)
                     .withNewPolicy()
                     .withMaxConnections(1000)
+                    .withMaxMessageSize(2000)
                     .endPolicy()
                     .endRouter()
 

--- a/templates/crds/v1/standardinfraconfigs.crd.yaml
+++ b/templates/crds/v1/standardinfraconfigs.crd.yaml
@@ -395,6 +395,8 @@ spec:
                           type: integer
                         maxSessionsPerConnection:
                           type: integer
+                        maxMessageSize:
+                          type: integer
                       type: object
                     resources:
                       properties:

--- a/templates/crds/v1beta1/standardinfraconfigs.crd.yaml
+++ b/templates/crds/v1beta1/standardinfraconfigs.crd.yaml
@@ -218,3 +218,5 @@ spec:
                       type: integer
                     maxReceiversPerConnection:
                       type: integer
+                    maxMessageSize:
+                      type: integer


### PR DESCRIPTION
### Type of change


- Enhancement / new feature

### Description

Support router policy maxMessageSize

### Checklist


- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
