### PR TITLE
Avoid reliance of deprecated service-ca.crt (OpenShift4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * #5263: Reimplement server initiated connections. (#5266)
 * #5265: Update fabric8 kubernetes-client from 4.6.4 to 5.0.2
 * #5272: Support router configuration maxMessageSize
+* #5275: Avoid reliance of deprecated service-ca.crt (OpenShift4)
 
 
 ## 0.33.0

--- a/api-common/src/main/java/io/enmasse/api/common/OpenShift.java
+++ b/api-common/src/main/java/io/enmasse/api/common/OpenShift.java
@@ -5,7 +5,10 @@
 
 package io.enmasse.api.common;
 
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import io.fabric8.kubernetes.client.VersionInfo;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -19,8 +22,9 @@ import java.io.UncheckedIOException;
 public class OpenShift {
     private static final Logger log = LoggerFactory.getLogger(OpenShift.class);
     public static final String ENMASSE_OPENSHIFT = "ENMASSE_OPENSHIFT";
+    public static final String ENMASSE_OPENSHIFT4 = "ENMASSE_OPENSHIFT4";
 
-    public static boolean isOpenShift(NamespacedKubernetesClient client) throws InterruptedException {
+    public static boolean isOpenShift(KubernetesClient client) {
         if (System.getenv().containsKey(ENMASSE_OPENSHIFT)) {
             return Boolean.parseBoolean(System.getenv().get(ENMASSE_OPENSHIFT));
         }
@@ -43,8 +47,69 @@ public class OpenShift {
                     log.warn("Exception when checking API availability, retrying {} times", retries, e);
                 }
             }
-            Thread.sleep(5000);
+            try {
+                Thread.sleep(5000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
         }
+    }
+
+    public static boolean isOpenShift4(KubernetesClient client) {
+        if (!isOpenShift(client)) {
+            return false;
+        }
+        if (System.getenv().containsKey(ENMASSE_OPENSHIFT4)) {
+            return Boolean.parseBoolean(System.getenv().get(ENMASSE_OPENSHIFT4));
+        }
+
+        int retries = 10;
+        while (true) {
+            try {
+                VersionInfo version = client.getVersion();
+                if (version == null) {
+                    // We got an non error response, but there is no version info available from the endpoint. Assume
+                    // OpenShift < 4.
+                    return false;
+                }
+                return isOpenShift4(version);
+            } catch (KubernetesClientException e) {
+                retries--;
+                if (retries <= 0) {
+                    throw new RuntimeException(e);
+                } else {
+                    log.warn("Exception when checking API availability, retrying {} times", retries, e);
+                }
+            }
+            try {
+                Thread.sleep(5000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+        }
+    }
+
+    static boolean isOpenShift4(VersionInfo version) {
+
+        if (version == null) {
+            return false;
+        }
+
+        String major = version.getMajor();
+        String minor = version.getMinor();
+
+        int majorInt = 0;
+        int minorInt = 0;
+        try {
+            majorInt = Integer.parseInt(String.valueOf(major));
+            minorInt = Integer.parseInt(String.valueOf(minor).replaceAll("\\+*$", ""));
+        } catch (NumberFormatException e) {
+            return false;
+        }
+
+        return majorInt == 1 && minorInt > 11;
     }
 
 }

--- a/api-common/src/test/java/io/enmasse/api/common/OpenShiftTest.java
+++ b/api-common/src/test/java/io/enmasse/api/common/OpenShiftTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.enmasse.api.common;
+
+import io.fabric8.kubernetes.client.VersionInfo;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+public class OpenShiftTest {
+
+    @Test
+    public void testOpenShift4() {
+
+        VersionInfo openshift3 = new VersionInfo.Builder().withMajor("1").withMinor("11").build();
+        assertFalse(OpenShift.isOpenShift4(openshift3));
+        VersionInfo openshift4 = new VersionInfo.Builder().withMajor("1").withMinor("21").build();
+        assertTrue(OpenShift.isOpenShift4(openshift4));
+        VersionInfo openshift4WithPlus = new VersionInfo.Builder().withMajor("1").withMinor("21+").build();
+        assertTrue(OpenShift.isOpenShift4(openshift4WithPlus));
+    }
+
+}

--- a/api-model/src/main/java/io/enmasse/config/AnnotationKeys.java
+++ b/api-model/src/main/java/io/enmasse/config/AnnotationKeys.java
@@ -25,7 +25,8 @@ public interface AnnotationKeys {
     String QUEUE_TEMPLATE_NAME = "enmasse.io/queue-template-name";
     String TOPIC_TEMPLATE_NAME = "enmasse.io/topic-template-name";
     String APPLIED_INFRA_CONFIG = "enmasse.io/applied-infra-config";
-    String OPENSHIFT_SERVING_CERT_SECRET_NAME = "service.alpha.openshift.io/serving-cert-secret-name";
+    String OPENSHIFT_SERVING_CERT_SECRET_NAME_ALPHA = "service.alpha.openshift.io/serving-cert-secret-name";
+    String OPENSHIFT_SERVING_CERT_SECRET_NAME_BETA = "service.beta.openshift.io/serving-cert-secret-name";
     String OPENSHIFT_CONNECTS_TO = "app.openshift.io/connects-to";
     String GENERATION = "enmasse.io/generation";
     String VERSION = "enmasse.io/version";

--- a/console/console-init/oauth-proxy/cfg/oauth-proxy-openshift.cfg
+++ b/console/console-init/oauth-proxy/cfg/oauth-proxy-openshift.cfg
@@ -17,10 +17,6 @@ upstreams = [
     "file:/apps/www/#/",
 ]
 
-upstream_ca = [
-    "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
-    ]
-
 # openshift_ca not supported in the config file.
 
 request_logging = true

--- a/keycloak-plugin/src/main/sh/init-keycloak.sh
+++ b/keycloak-plugin/src/main/sh/init-keycloak.sh
@@ -2,7 +2,7 @@
 set -e
 KEYCLOAK_CONFIG=${KEYCLOAK_DIR}/standalone/configuration/
 OPENSHIFT_CA=${OPENSHIFT_CA:-/var/run/secrets/kubernetes.io/serviceaccount/ca.crt}
-SERVICE_CA=${OPENSHIFT_CA:-/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt}
+SERVICE_CA=${SERVICE_CA:-${OPENSHIFT_CA:-/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt}}
 
 cp ${KEYCLOAK_PLUGIN_DIR}/configuration/* ${KEYCLOAK_CONFIG}/
 cp ${KEYCLOAK_PLUGIN_DIR}/configuration/${KEYCLOAK_CONFIG_FILE} ${KEYCLOAK_CONFIG}/standalone-openshift.xml
@@ -20,8 +20,8 @@ echo "Keystore ${KEYSTORE_PATH} created"
 rm -rf ${TRUSTSTORE_PATH}
 cp /etc/pki/java/cacerts ${TRUSTSTORE_PATH}
 chmod 644 ${TRUSTSTORE_PATH}
-echo "Copied system trust store. Importing OpenShift CA"
+echo "Copied system trust store. Importing OpenShift CA ${OPENSHIFT_CA}"
 keytool -import -noprompt -file ${OPENSHIFT_CA} -alias firstCA -deststorepass changeit -keystore $TRUSTSTORE_PATH
-echo "Importing OpenShift Service CA"
+echo "Importing OpenShift Service CA ${SERVICE_CA}"
 keytool -import -noprompt -file ${SERVICE_CA} -alias secondCA -deststorepass changeit -keystore $TRUSTSTORE_PATH
 echo "Truststore ${TRUSTSTORE_PATH} created"

--- a/keycloak-user-api/src/main/java/io/enmasse/user/keycloak/KubeKeycloakFactory.java
+++ b/keycloak-user-api/src/main/java/io/enmasse/user/keycloak/KubeKeycloakFactory.java
@@ -41,7 +41,7 @@ public class KubeKeycloakFactory implements KeycloakFactory {
 
     private final ExecutorService executorService = Executors.newSingleThreadExecutor();
     private final NamespacedKubernetesClient kubeClient;
-    private static final File serviceCaFile = new File("/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt");
+    private static final File serviceCaFile = new File(System.getenv().getOrDefault("SERVICE_CA", "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"));
 
     public KubeKeycloakFactory(NamespacedKubernetesClient kubeClient) {
         this.kubeClient = kubeClient;
@@ -75,9 +75,10 @@ public class KubeKeycloakFactory implements KeycloakFactory {
 
         byte []serviceCa = null;
         try {
+            log.info("Loading service CA {}", serviceCaFile);
             serviceCa = Files.readAllBytes(serviceCaFile.toPath());
         } catch (IOException e) {
-            log.warn("Unable to load service CA, ignoring", e);
+            log.warn("Unable to load service CA {}, ignoring", serviceCaFile, e);
         }
         KeyStore trustStore = createKeyStore(b64dec.decode(certificate.getData().get("tls.crt")), serviceCa);
         ResteasyJackson2Provider provider = new ResteasyJackson2Provider() {

--- a/olm-manifest/src/main/resources/enmasse.clusterserviceversion.yaml
+++ b/olm-manifest/src/main/resources/enmasse.clusterserviceversion.yaml
@@ -519,10 +519,18 @@ spec:
                             values:
                               - "true"
               serviceAccountName: enmasse-operator
+              volumes:
+                - name: ca-bundle
+                  configMap:
+                    name: ca-bundle
+                    optional: true
               containers:
               - name: controller
                 image: ${env.CONTROLLER_MANAGER_IMAGE}
                 imagePullPolicy: ${env.IMAGE_PULL_POLICY}
+                volumeMounts:
+                  - name: ca-bundle
+                    mountPath: /var/run/secrets/enmasse.io/ca-bundle
                 env:
                 - name: POD_NAME
                   valueFrom:
@@ -551,6 +559,8 @@ spec:
                 - name: CONTROLLER_ENABLE_ADDRESS_SPACE_CONTROLLER
                   value: "true"
                 - name: CONTROLLER_ENABLE_MESSAGING_USER
+                  value: "true"
+                - name: CONTROLLER_ENABLE_CA_BUNDLE
                   value: "true"
                 - name: RELATED_IMAGE_ADDRESS_SPACE_CONTROLLER
                   value: ${env.ADDRESS_SPACE_CONTROLLER_IMAGE}

--- a/olm-manifest/src/main/resources/enmasse.clusterserviceversion.yaml
+++ b/olm-manifest/src/main/resources/enmasse.clusterserviceversion.yaml
@@ -530,7 +530,7 @@ spec:
                 imagePullPolicy: ${env.IMAGE_PULL_POLICY}
                 volumeMounts:
                   - name: ca-bundle
-                    mountPath: /var/run/secrets/enmasse.io/ca-bundle
+                    mountPath: /var/run/secrets/enmasse.io
                 env:
                 - name: POD_NAME
                   valueFrom:

--- a/olm-manifest/src/main/resources/latest/enmasse.clusterserviceversion.yaml
+++ b/olm-manifest/src/main/resources/latest/enmasse.clusterserviceversion.yaml
@@ -520,10 +520,18 @@ spec:
                             values:
                               - "true"
               serviceAccountName: enmasse-operator
+              volumes:
+                - name: ca-bundle
+                  configMap:
+                    name: ca-bundle
+                    optional: true
               containers:
               - name: controller
                 image: ${env.CONTROLLER_MANAGER_IMAGE}
                 imagePullPolicy: ${env.IMAGE_PULL_POLICY}
+                volumeMounts:
+                  - name: ca-bundle
+                    mountPath: /var/run/secrets/enmasse.io/ca-bundle
                 env:
                 - name: POD_NAME
                   valueFrom:
@@ -552,6 +560,8 @@ spec:
                 - name: CONTROLLER_ENABLE_ADDRESS_SPACE_CONTROLLER
                   value: "true"
                 - name: CONTROLLER_ENABLE_MESSAGING_USER
+                  value: "true"
+                - name: CONTROLLER_ENABLE_CA_BUNDLE
                   value: "true"
                 - name: RELATED_IMAGE_ADDRESS_SPACE_CONTROLLER
                   value: ${env.ADDRESS_SPACE_CONTROLLER_IMAGE}

--- a/olm-manifest/src/main/resources/latest/enmasse.clusterserviceversion.yaml
+++ b/olm-manifest/src/main/resources/latest/enmasse.clusterserviceversion.yaml
@@ -531,7 +531,7 @@ spec:
                 imagePullPolicy: ${env.IMAGE_PULL_POLICY}
                 volumeMounts:
                   - name: ca-bundle
-                    mountPath: /var/run/secrets/enmasse.io/ca-bundle
+                    mountPath: /var/run/secrets/enmasse.io
                 env:
                 - name: POD_NAME
                   valueFrom:

--- a/pkg/controller/add_cabundle.go
+++ b/pkg/controller/add_cabundle.go
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2018, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package controller
+
+import (
+	"github.com/enmasseproject/enmasse/pkg/controller/ca_bundle"
+	"github.com/enmasseproject/enmasse/pkg/util"
+)
+
+func init() {
+
+	// add ourselves to the list of controllers
+	if util.IsModuleEnabled("CA_BUNDLE") && util.IsOpenshift4() {
+		AddToManagerFuncs = append(AddToManagerFuncs, ca_bundle.Add)
+	}
+}

--- a/pkg/controller/address_space_controller/controller.go
+++ b/pkg/controller/address_space_controller/controller.go
@@ -205,6 +205,9 @@ func ApplyDeployment(deployment *appsv1.Deployment) error {
 		applyImageEnv(container, "TOPIC_FORWARDER_IMAGE", "topic-forwarder")
 		if util.IsOpenshift() {
 			install.ApplyEnvSimple(container, util.EnMasseOpenshiftEnvVar, "true")
+			if util.IsOpenshift4() {
+				install.ApplyEnvSimple(container, util.EnMasseOpenshift4EnvVar, "true")
+			}
 		}
 
 		if value, ok := os.LookupEnv("ENABLE_MONITORING_ANNOTATIONS"); ok && value == "true" {

--- a/pkg/controller/authenticationservice/none.go
+++ b/pkg/controller/authenticationservice/none.go
@@ -104,7 +104,9 @@ func applyNoneAuthServiceService(authservice *adminv1beta1.AuthenticationService
 	if service.Annotations == nil {
 		service.Annotations = make(map[string]string)
 	}
-	service.Annotations["service.alpha.openshift.io/serving-cert-secret-name"] = authservice.Spec.None.CertificateSecret.Name
+
+	install.ApplyOpenShiftServingCertAnnotation(service.Annotations, authservice.Spec.None.CertificateSecret.Name, util.IsOpenshift, util.IsOpenshift4)
+
 	service.Spec.Ports = []corev1.ServicePort{
 		{
 			Port:       5671,

--- a/pkg/controller/authenticationservice/standard.go
+++ b/pkg/controller/authenticationservice/standard.go
@@ -6,8 +6,8 @@ package authenticationservice
 
 import (
 	"fmt"
-
 	adminv1beta1 "github.com/enmasseproject/enmasse/pkg/apis/admin/v1beta1"
+	"github.com/enmasseproject/enmasse/pkg/controller/ca_bundle"
 	"github.com/enmasseproject/enmasse/pkg/util"
 	"github.com/enmasseproject/enmasse/pkg/util/install"
 	oauthv1 "github.com/openshift/api/oauth/v1"
@@ -114,8 +114,16 @@ func applyStandardAuthServiceCert(authservice *adminv1beta1.AuthenticationServic
 func applyStandardAuthServiceDeployment(authservice *adminv1beta1.AuthenticationService, deployment *appsv1.Deployment) error {
 
 	install.ApplyDeploymentDefaults(deployment, "standard-authservice", *authservice.Spec.Standard.DeploymentName)
-
 	install.OverrideSecurityContextFsGroup("standard-authservice", authservice.Spec.Standard.SecurityContext, deployment)
+
+	if util.IsOpenshift4() {
+		install.ApplyConfigMapVolumeItems(&deployment.Spec.Template.Spec, ca_bundle.CaBundleVolumeName, ca_bundle.CaBundleConfigmapName, []corev1.KeyToPath{
+			{
+				Key:  ca_bundle.CaBundleKey,
+				Path: ca_bundle.ServiceCaFilename,
+			},
+		})
+	}
 
 	if err := install.ApplyInitContainerWithError(deployment, "keycloak-plugin", func(container *corev1.Container) error {
 		if err := install.ApplyContainerImage(container, "keycloak-plugin", authservice.Spec.Standard.InitImage); err != nil {
@@ -127,10 +135,21 @@ func applyStandardAuthServiceDeployment(authservice *adminv1beta1.Authentication
 		install.ApplyVolumeMountSimple(container, "standard-authservice-cert", "/opt/enmasse/cert", false)
 		install.ApplyEnvSimple(container, "KEYCLOAK_CONFIG_FILE", "standalone-"+string(authservice.Spec.Standard.Datasource.Type)+".xml")
 
+		if util.IsOpenshift() {
+			var serviceCaPath string
+			if util.IsOpenshift4() {
+				serviceCaPath = fmt.Sprintf("%s/%s", ca_bundle.ServiceCaPathOcp4, ca_bundle.ServiceCaFilename)
+				install.ApplyVolumeMountSimple(container, ca_bundle.CaBundleVolumeName, ca_bundle.ServiceCaPathOcp4, true)
+			} else {
+				serviceCaPath = fmt.Sprintf("%s/%s", ca_bundle.ServiceCaPathOcp311, ca_bundle.ServiceCaFilename)
+			}
+			install.ApplyEnvSimple(container, "SERVICE_CA", serviceCaPath)
+		}
 		return nil
 	}); err != nil {
 		return err
 	}
+
 
 	if err := install.ApplyDeploymentContainerWithError(deployment, "keycloak", func(container *corev1.Container) error {
 		if err := install.ApplyContainerImage(container, "keycloak", authservice.Spec.Standard.Image); err != nil {
@@ -146,6 +165,10 @@ func applyStandardAuthServiceDeployment(authservice *adminv1beta1.Authentication
 		install.ApplyEnvSimple(container, "JAVA_OPTS", jvmOptions)
 		install.ApplyEnvSecret(container, "KEYCLOAK_USER", "admin.username", authservice.Spec.Standard.CredentialsSecret.Name)
 		install.ApplyEnvSecret(container, "KEYCLOAK_PASSWORD", "admin.password", authservice.Spec.Standard.CredentialsSecret.Name)
+
+		if util.IsOpenshift() {
+			install.ApplyEnvSimple(container, "SERVICE_CA", "/var/run/secrets/enmasse.io/service-ca.crt")
+		}
 
 		if authservice.Spec.Standard.Datasource.Type == adminv1beta1.PostgresqlDatasource {
 			install.ApplyEnvSimple(container, "DB_HOST", authservice.Spec.Standard.Datasource.Host)
@@ -189,7 +212,9 @@ func applyStandardAuthServiceDeployment(authservice *adminv1beta1.Authentication
 		install.ApplyVolumeMountSimple(container, "keycloak-configuration", "/opt/jboss/keycloak/standalone/configuration", false)
 		install.ApplyVolumeMountSimple(container, "keycloak-persistence", "/opt/jboss/keycloak/standalone/data", false)
 		install.ApplyVolumeMountSimple(container, "standard-authservice-cert", "/opt/enmasse/cert", true)
-
+		if util.IsOpenshift() {
+			install.ApplyVolumeMountSimple(container, ca_bundle.CaBundleVolumeName, "/var/run/secrets/enmasse.io/", true)
+		}
 		return nil
 	}); err != nil {
 		return err
@@ -232,7 +257,9 @@ func applyStandardAuthServiceService(authservice *adminv1beta1.AuthenticationSer
 	if service.Annotations == nil {
 		service.Annotations = make(map[string]string)
 	}
-	service.Annotations["service.alpha.openshift.io/serving-cert-secret-name"] = authservice.Spec.Standard.CertificateSecret.Name
+
+	install.ApplyOpenShiftServingCertAnnotation(service.Annotations, authservice.Spec.Standard.CertificateSecret.Name, util.IsOpenshift, util.IsOpenshift4)
+
 	service.Spec.Ports = []corev1.ServicePort{
 		{
 			Port:       8443,

--- a/pkg/controller/ca_bundle/controller.go
+++ b/pkg/controller/ca_bundle/controller.go
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2021, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package ca_bundle
+
+import (
+	"context"
+	"time"
+
+	"github.com/enmasseproject/enmasse/pkg/util"
+	"github.com/enmasseproject/enmasse/pkg/util/install"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	corev1 "k8s.io/api/core/v1"
+	k8errors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	controllertypes "k8s.io/apimachinery/pkg/types"
+)
+
+var log = logf.Log.WithName("ca_bundle")
+
+const ServiceCaPathOcp311 = "/var/run/secrets/kubernetes.io/serviceaccount"
+const ServiceCaPathOcp4 = "/var/run/secrets/enmasse.io/"
+const ServiceCaFilename = "service-ca.crt"
+const CaBundleConfigmapName = "ca-bundle"
+const CaBundleVolumeName = "ca-bundle"
+const CaBundleKey = "service-ca.crt"
+
+var _ reconcile.Reconciler = &ReconcileCaBundle{}
+
+type ReconcileCaBundle struct {
+	client    client.Client
+	reader    client.Reader
+	scheme    *runtime.Scheme
+	namespace string
+}
+
+// Gets called by parent "init", adding as to the manager
+func Add(mgr manager.Manager) error {
+	reconciler, err := newReconciler(mgr)
+	if err != nil {
+		return err
+	}
+	return add(mgr, reconciler)
+}
+
+func newReconciler(mgr manager.Manager) (*ReconcileCaBundle, error) {
+	return &ReconcileCaBundle{
+		client:    mgr.GetClient(),
+		reader:    mgr.GetAPIReader(),
+		scheme:    mgr.GetScheme(),
+		namespace: util.GetEnvOrDefault("NAMESPACE", "enmasse-infra"),
+	}, nil
+}
+
+func add(mgr manager.Manager, r *ReconcileCaBundle) error {
+	cm := &corev1.ConfigMap{}
+	err := r.reader.Get(context.TODO(), controllertypes.NamespacedName{Namespace: r.namespace, Name: CaBundleConfigmapName}, cm)
+	if err != nil {
+		if k8errors.IsNotFound(err) {
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Namespace: r.namespace, Name: CaBundleConfigmapName},
+			}
+			err = ApplyConfigMap(cm, CaBundleConfigmapName)
+			if err != nil {
+				return err
+			}
+			err = r.client.Create(context.TODO(), cm)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+
+	// Start reconciler for ca-bundle deployment
+	c, err := controller.New("ca-bundle", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	return c.Watch(&source.Kind{Type: &corev1.ConfigMap{}}, &handler.EnqueueRequestForObject{})
+}
+
+func (r *ReconcileCaBundle) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+
+	expectedName := controllertypes.NamespacedName{
+		Namespace: r.namespace,
+		Name:      CaBundleConfigmapName,
+	}
+
+	if expectedName == request.NamespacedName {
+		reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+		reqLogger.Info("Reconciling ca-bundle")
+
+		ctx := context.TODO()
+
+		_, err := r.reconcileCabundleConfigMap(ctx)
+		if err != nil {
+			reqLogger.Error(err, "Error reconciling ca-bundle configmap")
+			return reconcile.Result{}, err
+		}
+	}
+	return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
+}
+
+func (r *ReconcileCaBundle) reconcileCabundleConfigMap(ctx context.Context) (reconcile.Result, error) {
+
+	name := CaBundleConfigmapName
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: r.namespace, Name: name},
+	}
+	_, err := controllerutil.CreateOrUpdate(ctx, r.client, configMap, func() error {
+		return ApplyConfigMap(configMap, name)
+	})
+
+	if err != nil {
+		log.Error(err, "Failed reconciling cabundle configmap")
+		return reconcile.Result{}, err
+	}
+	return reconcile.Result{}, nil
+}
+
+func ApplyConfigMap(configMap *corev1.ConfigMap, name string) error {
+	configMap.SetLabels(install.CreateDefaultLabels(configMap.GetLabels(), "operator", name))
+	install.ApplyAnnotation(&configMap.ObjectMeta, "service.beta.openshift.io/inject-cabundle", "true")
+	return nil
+}
+

--- a/pkg/controller/messaginguser/messaginguser_controller_test.go
+++ b/pkg/controller/messaginguser/messaginguser_controller_test.go
@@ -80,7 +80,7 @@ func setup(t *testing.T) *ReconcileMessagingUser {
 	r := &ReconcileMessagingUser{
 		client: cl,
 		reader: cl,
-		newKeycloakClientFunc: func(host string, port int, user string, password string, cert []byte) (keycloak.KeycloakClient, error) {
+		newKeycloakClientFunc: func(host string, port int, user string, password string, cert []byte, _ *string) (keycloak.KeycloakClient, error) {
 			return &keycloak.FakeClient{
 				Users: map[string][]*userv1beta1.MessagingUser{
 					"realm1": make([]*userv1beta1.MessagingUser, 0),

--- a/pkg/util/install/utils_test.go
+++ b/pkg/util/install/utils_test.go
@@ -243,3 +243,75 @@ func TestAppendEnvVar(t *testing.T) {
 	assert.Equal(t, "foo bar", container.Env[0].Value)
 
 }
+
+func TestApplyServiceAnnotationDefaults(t *testing.T) {
+	annotations := make(map[string]string)
+	ApplyOpenShiftServingCertAnnotation(annotations, "bar",
+		func() bool {return true},
+		func() bool {return true})
+	assert.Len(t, annotations, 1)
+	assert.Equal(t, "bar", annotations[ServingCertSecretNameBeta])
+
+	annotations = make(map[string]string)
+	annotations[ServingCertSecretNameBeta] = "bar"
+	ApplyOpenShiftServingCertAnnotation(annotations, "bar",
+		func() bool {return true},
+		func() bool {return true})
+	assert.Len(t, annotations, 1)
+	assert.Equal(t, "bar", annotations[ServingCertSecretNameBeta])
+
+	annotations = make(map[string]string)
+	annotations[ServingCertSecretNameBeta] = "baz"
+	ApplyOpenShiftServingCertAnnotation(annotations, "bar",
+		func() bool {return true},
+		func() bool {return true})
+	assert.Len(t, annotations, 1)
+	assert.Equal(t, "bar", annotations[ServingCertSecretNameBeta])
+
+	annotations = make(map[string]string)
+	annotations[ServingCertSecretNameAlpha] = "baz"
+	ApplyOpenShiftServingCertAnnotation(annotations, "bar",
+		func() bool {return true},
+		func() bool {return true})
+	assert.Len(t, annotations, 1)
+	assert.Equal(t, "bar", annotations[ServingCertSecretNameBeta])
+
+	annotations = make(map[string]string)
+	annotations[ServingCertSecretNameAlpha] = "bar"
+	ApplyOpenShiftServingCertAnnotation(annotations, "bar",
+		func() bool {return true},
+		func() bool {return true})
+	assert.Len(t, annotations, 1)
+	assert.Equal(t, "bar", annotations[ServingCertSecretNameAlpha])
+
+	annotations = make(map[string]string)
+	annotations["foo"] = "goo"
+	annotations[ServingCertSecretNameAlpha] = "bar"
+	ApplyOpenShiftServingCertAnnotation(annotations, "bar",
+		func() bool {return true},
+		func() bool {return true})
+	assert.Len(t, annotations, 2)
+	assert.Equal(t, "bar", annotations[ServingCertSecretNameAlpha])
+	assert.Equal(t, "goo", annotations["foo"])
+
+	annotations = make(map[string]string)
+	ApplyOpenShiftServingCertAnnotation(annotations, "bar",
+		func() bool {return true},
+		func() bool {return false})
+	assert.Len(t, annotations, 1)
+	assert.Equal(t, "bar", annotations[ServingCertSecretNameAlpha])
+
+	annotations = make(map[string]string)
+	annotations[ServingCertSecretNameAlpha] = "baz"
+	ApplyOpenShiftServingCertAnnotation(annotations, "bar",
+		func() bool {return true},
+		func() bool {return false})
+	assert.Len(t, annotations, 1)
+	assert.Equal(t, "bar", annotations[ServingCertSecretNameAlpha])
+
+	annotations = make(map[string]string)
+	ApplyOpenShiftServingCertAnnotation(annotations, "bar",
+		func() bool {return false},
+		func() bool {return false})
+	assert.Len(t, annotations, 0)
+}

--- a/templates/enmasse-operator/050-Deployment-enmasse-operator.yaml
+++ b/templates/enmasse-operator/050-Deployment-enmasse-operator.yaml
@@ -42,7 +42,7 @@ spec:
         imagePullPolicy: ${IMAGE_PULL_POLICY}
         volumeMounts:
           - name: ca-bundle
-            mountPath: /var/run/secrets/enmasse.io/ca-bundle
+            mountPath: /var/run/secrets/enmasse.io
         env:
         - name: POD_NAME
           valueFrom:

--- a/templates/enmasse-operator/050-Deployment-enmasse-operator.yaml
+++ b/templates/enmasse-operator/050-Deployment-enmasse-operator.yaml
@@ -31,10 +31,18 @@ spec:
                     values:
                       - "true"
       serviceAccountName: enmasse-operator
+      volumes:
+        - name: ca-bundle
+          configMap:
+            name: ca-bundle
+            optional: true
       containers:
       - name: controller
         image: ${CONTROLLER_MANAGER_IMAGE}
         imagePullPolicy: ${IMAGE_PULL_POLICY}
+        volumeMounts:
+          - name: ca-bundle
+            mountPath: /var/run/secrets/enmasse.io/ca-bundle
         env:
         - name: POD_NAME
           valueFrom:
@@ -63,6 +71,8 @@ spec:
         - name: CONTROLLER_ENABLE_ADDRESS_SPACE_CONTROLLER
           value: "true"
         - name: CONTROLLER_ENABLE_MESSAGING_USER
+          value: "true"
+        - name: CONTROLLER_ENABLE_CA_BUNDLE
           value: "true"
         - name: RELATED_IMAGE_ADDRESS_SPACE_CONTROLLER
           value: ${ADDRESS_SPACE_CONTROLLER_IMAGE}


### PR DESCRIPTION
### Type of change


- Enhancement / new feature

### Description

Avoid reliance of deprecated service-ca.crt (OpenShift 4).  On OpenShift 3.11, the existing behaviour must be maintained.

### Checklist

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
