### PR TITLE
Fix more test regressions introduced by #5265 (fabric8 kubernetes-client)

### DIFF
--- a/systemtests/src/main/java/io/enmasse/systemtest/manager/ResourceManager.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/manager/ResourceManager.java
@@ -14,6 +14,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import io.fabric8.kubernetes.api.model.ObjectMeta;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.slf4j.Logger;
 
@@ -462,6 +463,9 @@ public abstract class ResourceManager {
     }
 
     public User createOrUpdateUser(AddressSpace addressSpace, User user, boolean wait) throws Exception {
+        if (user.getMetadata() == null) {
+            user.setMetadata(new ObjectMeta());
+        }
         if (user.getMetadata().getName() == null || !user.getMetadata().getName().contains(addressSpace.getMetadata().getName())) {
             user.getMetadata().setName(addressSpace.getMetadata().getName() + "." + user.getSpec().getUsername());
         }

--- a/systemtests/src/main/java/io/enmasse/systemtest/utils/UserUtils.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/utils/UserUtils.java
@@ -26,6 +26,8 @@ public class UserUtils {
     private static Logger log = CustomLogger.getLogger();
     public static UserBuilder createUserResource(UserCredentials cred) {
         return new UserBuilder()
+                .withNewMetadata()
+                .endMetadata()
                 .withNewSpec()
                 .withUsername(cred.getUsername())
                 .withNewAuthentication()

--- a/systemtests/src/test/java/io/enmasse/systemtest/bases/authz/AuthorizationTestBase.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/bases/authz/AuthorizationTestBase.java
@@ -203,7 +203,8 @@ public abstract class AuthorizationTestBase extends TestBase implements ITestBas
                 .build());
         assertReceive(user);
         resourcesManager.removeUser(getSharedAddressSpace(), user.getUsername());
-        Thread.sleep(5000);
+        // Seems the delete be racy on the keycloak side?  If we don't wait the permission change can be ineffective.
+        Thread.sleep(10_000);
 
         resourcesManager.createOrUpdateUser(getSharedAddressSpace(), UserUtils.createUserResource(user)
                 .editSpec()

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/authz/AuthorizationTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/brokered/authz/AuthorizationTest.java
@@ -26,12 +26,12 @@ class AuthorizationTest extends AuthorizationTestBase implements ITestSharedBrok
     }
 
     @Test
-    void testSendAuthzWithWIldcards() throws Exception {
+    void testSendAuthzWithWildcards() throws Exception {
         doTestSendAuthzWithWIldcards();
     }
 
     @Test
-    void testReceiveAuthzWithWIldcards() throws Exception {
+    void testReceiveAuthzWithWildcards() throws Exception {
         doTestReceiveAuthzWithWIldcards();
     }
 }

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/authz/AuthorizationTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/authz/AuthorizationTest.java
@@ -30,13 +30,13 @@ class AuthorizationTest extends AuthorizationTestBase implements ITestSharedStan
 
     @Test
     @Tag(NON_PR)
-    void testSendAuthzWithWIldcards() throws Exception {
+    void testSendAuthzWithWildcards() throws Exception {
         doTestSendAuthzWithWIldcards();
     }
 
     @Test
     @Tag(NON_PR)
-    void testReceiveAuthzWithWIldcards() throws Exception {
+    void testReceiveAuthzWithWildcards() throws Exception {
         doTestReceiveAuthzWithWIldcards();
     }
 }


### PR DESCRIPTION
### Type of change


- Bugfix

### Description

 Fix test regression introduced by #5265 (the fabric8 kubernetes-client upgrade)


### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
