### PR TITLE
[Docs] Alternative download bundle for older Kube/OCP 3.11

### DIFF
--- a/documentation/common/proc-download-procedure.adoc
+++ b/documentation/common/proc-download-procedure.adoc
@@ -24,7 +24,7 @@ otherwise take `enmasse-<version>.tgz`.
 endif::Downloading[]
 
 ifndef::Downloading[]
-* Download and extract the `{ZipInstallFile}` file (for {KubePlatform} 4 and above) or `{ZipInstallFileOcp311}` file (for {KubePlatform} 3.11) from the {ZipDownload}. 
+* Download and extract the `{ZipInstallFile}` file (for {KubePlatform} 4 and above) or `{ZipInstallFileOcp311}` file (for {KubePlatform} 3.11) from the {ZipDownload}.
 
 NOTE: Although container images for {ProductName} are available in the {DockerRepository}, we recommend that you use the YAML files provided instead.
 

--- a/documentation/common/proc-download-procedure.adoc
+++ b/documentation/common/proc-download-procedure.adoc
@@ -19,7 +19,7 @@ endif::[]
 ifeval::["{cmdcli}" == "kubectl"]
 On {KubePlatform} 1.15 and below, choose `enmasse-prekube1_16-<version>.tgz`.
 endif::[]
-otherwise take `enmasse-<version>.tgz`.
+Otherwise, choose `enmasse-<version>.tgz`.
 * Unnpack the bundle.
 endif::Downloading[]
 

--- a/documentation/common/proc-download-procedure.adoc
+++ b/documentation/common/proc-download-procedure.adoc
@@ -17,7 +17,7 @@ ifeval::["{cmdcli}" == "oc"]
 On {KubePlatform} 3.11 and before choose `enmasse-prekube1_16-<version>.tgz`
 endif::[]
 ifeval::["{cmdcli}" == "kubectl"]
-On {KubePlatform} 1.15 and below choose `enmasse-prekube1_16-<version>.tgz`
+On {KubePlatform} 1.15 and below, choose `enmasse-prekube1_16-<version>.tgz`.
 endif::[]
 otherwise take `enmasse-<version>.tgz`.
 * Unnpack the bundle.

--- a/documentation/common/proc-download-procedure.adoc
+++ b/documentation/common/proc-download-procedure.adoc
@@ -10,11 +10,21 @@
 
 .Procedure
 ifdef::Downloading[]
-* Download one of the releases from the link:https://github.com/EnMasseProject/enmasse/releases[GitHub repository] and unpack it.
+
+
+* Download one of the releases from the link:https://github.com/EnMasseProject/enmasse/releases[GitHub repository]. There are two versions bundles of the bundle provided: `enmasse-<version>.tgz` and `enmasse-prekube1_16-<version>.tgz`.
+ifeval::["{cmdcli}" == "oc"]
+On {KubePlatform} 3.11 and before choose `enmasse-prekube1_16-<version>.tgz`
+endif::[]
+ifeval::["{cmdcli}" == "kubectl"]
+On {KubePlatform} 1.15 and below choose `enmasse-prekube1_16-<version>.tgz`
+endif::[]
+otherwise take `enmasse-<version>.tgz`.
+* Unnpack the bundle.
 endif::Downloading[]
 
 ifndef::Downloading[]
-* Download and extract the `{ZipInstallFile}` file from the {ZipDownload}.
+* Download and extract the `{ZipInstallFile}` file (for {KubePlatform} 4 and above) or `{ZipInstallFileOcp311}` file (for {KubePlatform} 3.11) from the {ZipDownload}. 
 
 NOTE: Although container images for {ProductName} are available in the {DockerRepository}, we recommend that you use the YAML files provided instead.
 

--- a/documentation/common/proc-download-procedure.adoc
+++ b/documentation/common/proc-download-procedure.adoc
@@ -12,7 +12,7 @@
 ifdef::Downloading[]
 
 
-* Download one of the releases from the link:https://github.com/EnMasseProject/enmasse/releases[GitHub repository]. There are two versions bundles of the bundle provided: `enmasse-<version>.tgz` and `enmasse-prekube1_16-<version>.tgz`.
+* Download one of the releases from the link:https://github.com/EnMasseProject/enmasse/releases[GitHub repository]. There are two versions of the bundle provided: `enmasse-<version>.tgz` and `enmasse-prekube1_16-<version>.tgz`.
 ifeval::["{cmdcli}" == "oc"]
 On {KubePlatform} 3.11 and before choose `enmasse-prekube1_16-<version>.tgz`
 endif::[]
@@ -29,4 +29,3 @@ ifndef::Downloading[]
 NOTE: Although container images for {ProductName} are available in the {DockerRepository}, we recommend that you use the YAML files provided instead.
 
 endif::Downloading[]
-

--- a/documentation/common/proc-download-procedure.adoc
+++ b/documentation/common/proc-download-procedure.adoc
@@ -14,7 +14,7 @@ ifdef::Downloading[]
 
 * Download one of the releases from the link:https://github.com/EnMasseProject/enmasse/releases[GitHub repository]. There are two versions of the bundle provided: `enmasse-<version>.tgz` and `enmasse-prekube1_16-<version>.tgz`.
 ifeval::["{cmdcli}" == "oc"]
-On {KubePlatform} 3.11 and before choose `enmasse-prekube1_16-<version>.tgz`
+On {KubePlatform} 3.11 and before, choose `enmasse-prekube1_16-<version>.tgz`.
 endif::[]
 ifeval::["{cmdcli}" == "kubectl"]
 On {KubePlatform} 1.15 and below, choose `enmasse-prekube1_16-<version>.tgz`.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

For this release there will be two bundles, one suitable for < Kube 1.16 (and OpenShift 3.11) and another suitable for newer Kubernetes and all OpenShift 4 versions. The documentation needs to reflect this.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
