### PR TITLE
Fix regression associated with the fabric8 kc upgrade

### DIFF
--- a/service-broker/src/main/java/io/enmasse/osb/api/OSBServiceBase.java
+++ b/service-broker/src/main/java/io/enmasse/osb/api/OSBServiceBase.java
@@ -104,6 +104,13 @@ public abstract class OSBServiceBase {
                     .build();
         }
 
+        if (addressSpace.getMetadata().getAnnotations() == null) {
+            addressSpace.getMetadata().setAnnotations(new LinkedHashMap<>());
+        }
+        if (addressSpace.getMetadata().getLabels() == null) {
+            addressSpace.getMetadata().setLabels(new LinkedHashMap<>());
+        }
+
         final Map<String, String> annotations = addressSpace.getMetadata().getAnnotations();
         final Map<String, String> labels = addressSpace.getMetadata().getLabels();
 


### PR DESCRIPTION
### Type of change


- Bugfix

### Description

There's a regression in the service broker associated with the upgrade of fabric8 kubernetes-client.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
