### PR TITLE
[wip] use snapshot vertx to avoid netty 4.1.60 incompatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <avro.version>1.9.0</avro.version>
         <fabric8.kubernetes-client.version>5.0.2</fabric8.kubernetes-client.version>
         <sundrio.version>0.24.2</sundrio.version>
-        <vertx.version>3.9.0</vertx.version>
+        <vertx.version>3.9.6</vertx.version>
         <slf4j.version>1.7.21</slf4j.version>
         <logback.version>1.2.3</logback.version>
         <lucene.version>7.7.1</lucene.version>
@@ -576,6 +576,12 @@
                 <version>${vertx.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>io.vertx</groupId>
+                <artifactId>vertx-core</artifactId>
+                <version>3.9.7-SNAPSHOT</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
### Type of change


- Bugfix

### Description

The upgrade to Netty 4.1.60 caused an incompatibility with Vertx 3.9.  This causes a problem with provisioning requests from the Service Broker.

This PR refs a Vertx SNAPSHOT.


### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
