### PR TITLE
Update BookUrlBase for new website URL

### DIFF
--- a/documentation/common/attributes.adoc
+++ b/documentation/common/attributes.adoc
@@ -61,7 +61,7 @@
 
 // Book links
 
-:BookUrlBase: http://enmasse.io/documentation/
+:BookUrlBase: https://enmasseproject.github.io/documentation/
 :OCPBookURLBase: https://docs.openshift.com/container-platform/
 
 


### PR DESCRIPTION
### Type of change

- Documentation

### Description

The documentation on the website contains hyperlinks to the old URL. For example, in [this table](https://enmasseproject.github.io/documentation/0.33.0/kubernetes.html#ref-resources-table-service-admin-messaging) the links to more information about _brokered/standard infrastructure configuration fields_ point to enmasse.io instead of enmasseproject.github.io. This Pull Request would update the base URL.

I think this would also resolve the second part of #5296.
