### PR TITLE
make verify codegen macosx compatible

### DIFF
--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -9,6 +9,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+case "$OSTYPE" in
+  darwin*)  CP=gcp;;
+  *)        CP=cp;;
+esac
+
+
 SCRIPTPATH="$(cd "$(dirname "$0")" && pwd -P)"
 
 TMPBASE="$(mktemp -d)"
@@ -24,7 +30,7 @@ echo "Using tmp base: $TMPBASE"
 trap "cleanup" EXIT SIGINT
 
 mkdir -p "$TMPPROJ"
-cp -dR "$SCRIPTPATH/../" "$TMPPROJ"
+${CP} -dR "$SCRIPTPATH/../" "$TMPPROJ"
 
 "$SCRIPTPATH/run-codegen.sh" --output-base "$TMPBASE"
 


### PR DESCRIPTION
### Type of change


- Bugfix

### Description

Make build-time utility script run on Mac OS X.

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
