### PR TITLE
Make util script add-crc-insecure-registry compatible with newer CRC release

### DIFF
--- a/scripts/add-crc-insecure-registry.sh
+++ b/scripts/add-crc-insecure-registry.sh
@@ -9,6 +9,10 @@ fi
 oc patch --type=merge --patch="{ \"spec\": { \"registrySources\": { \"insecureRegistries\": [ \"${REGISTRY}\" ] } } }" image.config.openshift.io/cluster
 
 IP=$(crc ip)
+PORT=22
+if [[ "${IP}" == "127.0.0.1" ]]; then
+   PORT=2222
+fi
 
 ID_FILE=~/.crc/machines/crc/id_ecdsa
 if [[ ! -f "${ID_FILE}" ]]; then
@@ -16,7 +20,7 @@ if [[ ! -f "${ID_FILE}" ]]; then
 fi
 
 
-ssh -i "${ID_FILE}" -o StrictHostKeyChecking=no core@${IP} sudo cat /etc/containers/registries.conf > /tmp/registries.conf
+ssh -p ${PORT} -i "${ID_FILE}" -o StrictHostKeyChecking=no core@${IP} sudo cat /etc/containers/registries.conf > /tmp/registries.conf
 
 
 cat <<EOF >> /tmp/registries.conf
@@ -33,8 +37,8 @@ cat /tmp/registries.conf
 echo "Press ENTER to copy to CRC VM"
 read
 
-scp -i "${ID_FILE}" -o StrictHostKeyChecking=no /tmp/registries.conf core@${IP}:/tmp/registries.conf
-ssh -i "${ID_FILE}" -o StrictHostKeyChecking=no core@${IP} sudo cp /tmp/registries.conf /etc/containers/registries.conf
+scp -P ${PORT} -i "${ID_FILE}" -o StrictHostKeyChecking=no /tmp/registries.conf core@${IP}:/tmp/registries.conf
+ssh -p ${PORT} -i "${ID_FILE}" -o StrictHostKeyChecking=no core@${IP} sudo cp /tmp/registries.conf /etc/containers/registries.conf
 echo "Restarting crio/kublet"
-ssh -i "${ID_FILE}" -o StrictHostKeyChecking=no core@${IP} sudo systemctl restart crio
-ssh -i "${ID_FILE}" -o StrictHostKeyChecking=no core@${IP} sudo systemctl restart kubelet
+ssh -p ${PORT} -i "${ID_FILE}" -o StrictHostKeyChecking=no core@${IP} sudo systemctl restart crio
+ssh -p ${PORT} -i "${ID_FILE}" -o StrictHostKeyChecking=no core@${IP} sudo systemctl restart kubelet


### PR DESCRIPTION


### Type of change

Development utility script - add-crc-insecure-registry .
Newer CRC releases seem to run ssh on port 2222 bound to loopback.

- Bugfix

### Description

<!--

_Please describe your pull request_

-->

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
