### PR TITLE
Use tokenreview v1 when authenticating against service accounts

### DIFF
--- a/keycloak-plugin/sasl-plugin/src/main/java/io/enmasse/keycloak/spi/K8sServiceAccountCredentialProvider.java
+++ b/keycloak-plugin/sasl-plugin/src/main/java/io/enmasse/keycloak/spi/K8sServiceAccountCredentialProvider.java
@@ -76,7 +76,7 @@ public class K8sServiceAccountCredentialProvider implements CredentialProvider, 
         JsonObject body = new JsonObject();
         String userName = null;
         body.put("kind", "TokenReview");
-        body.put("apiVersion", "authentication.k8s.io/v1beta1");
+        body.put("apiVersion", "authentication.k8s.io/v1");
 
         JsonObject spec = new JsonObject();
         spec.put("token", token);
@@ -84,7 +84,7 @@ public class K8sServiceAccountCredentialProvider implements CredentialProvider, 
 
         JsonObject result;
 
-        HttpUrl url = HttpUrl.get(client.getOpenshiftUrl()).resolve("/apis/authentication.k8s.io/v1beta1/tokenreviews");
+        HttpUrl url = HttpUrl.get(client.getOpenshiftUrl()).resolve("/apis/authentication.k8s.io/v1/tokenreviews");
         Request.Builder requestBuilder = new Request.Builder()
                 .url(url)
                 .addHeader("Content-Type", "application/json")
@@ -97,7 +97,7 @@ public class K8sServiceAccountCredentialProvider implements CredentialProvider, 
                 if (response.isSuccessful()) {
                     result = new JsonObject(responseString);
                 } else {
-                    String errorMessage = String.format("Error performing POST on /apis/authentication.k8s.io/v1beta1/tokenreviews: %d, %s", response.code(), responseString);
+                    String errorMessage = String.format("Error performing POST on /apis/authentication.k8s.io/v1/tokenreviews: %d, %s", response.code(), responseString);
                     throw new RuntimeException(errorMessage);
                 }
             }

--- a/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/api/UserApiTest.java
+++ b/systemtests/src/test/java/io/enmasse/systemtest/shared/standard/api/UserApiTest.java
@@ -103,6 +103,7 @@ public class UserApiTest extends TestBase implements ITestSharedStandard {
     }
 
     @Test
+    @Tag(ACCEPTANCE)
     void testServiceaccountUser() throws Exception {
         Address queue = new AddressBuilder()
                 .withNewMetadata()


### PR DESCRIPTION
Use tokenreview v1 when authenticating against service accounts (for kube 1.22 compatibility)

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#tokenreview-v122

### Type of change

<!--

_Select the type of your PR_

-->

- Bugfix

### Description

```
 2022-04-01T13:06:08.611Z WARN  [PlainSaslServerMechanism] Exception when authenticating @@serviceaccount@@: java.lang.RuntimeException: Error performing POST on /apis/authentication.k8s.io/v1beta1/tokenreviews: 404, {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"the server could not find the requested resource","reason":"NotFound","details":{},"code":404} at io.enmasse.keycloak.spi.K8sServiceAccountCredentialProvider.authenticateToken(K8sServiceAccountCredentialProvider.java:101) 
```

### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
