### PR TITLE
Fix #5328 : trigger reconfiguration of address space on change of authentication service trust

### DIFF
--- a/address-space-controller/src/main/java/io/enmasse/controller/common/Kubernetes.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/common/Kubernetes.java
@@ -41,4 +41,6 @@ public interface Kubernetes {
     AppliedConfig getAppliedConfig(AddressSpace addressSpace) throws IOException;
 
     String getInfraUuid(AddressSpace addressSpace);
+
+    byte[] getClusterCaCertAsBytes() throws IOException;
 }

--- a/address-space-controller/src/main/java/io/enmasse/controller/common/KubernetesHelper.java
+++ b/address-space-controller/src/main/java/io/enmasse/controller/common/KubernetesHelper.java
@@ -28,8 +28,10 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.openshift.client.OpenShiftClient;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
@@ -256,6 +258,11 @@ public class KubernetesHelper implements Kubernetes {
         }
 
         return InfraConfigs.parseCurrentInfraConfig(messaging.getMetadata().getAnnotations().get(AnnotationKeys.APPLIED_INFRA_CONFIG));
+    }
+
+    @Override
+    public byte[] getClusterCaCertAsBytes() throws IOException {
+        return Files.readAllBytes(new File("/etc/ssl/certs/ca-bundle.crt").toPath());
     }
 
 }

--- a/api-model/src/main/java/io/enmasse/admin/model/v1/BrokeredInfraConfig.java
+++ b/api-model/src/main/java/io/enmasse/admin/model/v1/BrokeredInfraConfig.java
@@ -89,7 +89,7 @@ public class BrokeredInfraConfig extends CustomResourceWithAdditionalProperties<
     @Override
     @JsonIgnore
     public boolean getUpdatePersistentVolumeClaim() {
-        return spec.getBroker().getUpdatePersistentVolumeClaim() != null ? spec.getBroker().getUpdatePersistentVolumeClaim() : false;
+        return spec.getBroker() != null && spec.getBroker().getUpdatePersistentVolumeClaim() != null ? spec.getBroker().getUpdatePersistentVolumeClaim() : false;
     }
 
 }

--- a/api-model/src/main/java/io/enmasse/admin/model/v1/StandardInfraConfig.java
+++ b/api-model/src/main/java/io/enmasse/admin/model/v1/StandardInfraConfig.java
@@ -89,7 +89,7 @@ public class StandardInfraConfig extends CustomResourceWithAdditionalProperties<
     @Override
     @JsonIgnore
     public boolean getUpdatePersistentVolumeClaim() {
-        return spec.getBroker().getUpdatePersistentVolumeClaim() != null ? spec.getBroker().getUpdatePersistentVolumeClaim() : false;
+        return spec.getBroker() != null && spec.getBroker().getUpdatePersistentVolumeClaim() != null ? spec.getBroker().getUpdatePersistentVolumeClaim() : false;
     }
 
 }

--- a/systemtests/src/main/java/io/enmasse/systemtest/platform/Kubernetes.java
+++ b/systemtests/src/main/java/io/enmasse/systemtest/platform/Kubernetes.java
@@ -1109,6 +1109,10 @@ public abstract class Kubernetes {
         log.info("Secret {} deleted", secret);
     }
 
+    public Secret getSecret(String namespace, String secret)  {
+        return client.secrets().inNamespace(namespace).withName(secret).get();
+    }
+
     /**
      * Test if secret already exists
      *


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fix ##5328 : Adds digest of the authentication service CA (which may be platform trust from the container) onto applied config, so that any change to trust will trigger a reconcile and the internal `authservice-ca` to be repopulated.


### Checklist

<!--

_Please go through this checklist and make sure all applicable tasks have been done_

-->

- [ ] Update/write design documentation in `./documentation/design`
- [ ] Write tests and make sure they pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
